### PR TITLE
Nina regularisation

### DIFF
--- a/geomstats/backend/numpy.py
+++ b/geomstats/backend/numpy.py
@@ -275,3 +275,7 @@ def eval(x):
 
 def ndim(x):
     return x.ndim
+
+
+def copy(x):
+    return np.copy(x)

--- a/geomstats/special_orthogonal_group.py
+++ b/geomstats/special_orthogonal_group.py
@@ -148,7 +148,7 @@ class SpecialOrthogonalGroup(LieGroup, EmbeddedManifold):
         assert self.belongs(point)
         n_points, vec_dim = point.shape
 
-        regularized_point = point  # .astype('float64')
+        regularized_point = gs.copy(point)
         if vec_dim == 3:
             angle = gs.linalg.norm(regularized_point, axis=1)
             mask_0 = gs.isclose(angle, 0)

--- a/tests/test_special_euclidean_group.py
+++ b/tests/test_special_euclidean_group.py
@@ -165,7 +165,7 @@ class TestSpecialEuclideanGroupMethods(unittest.TestCase):
         result = self.group.regularize(point)
 
         expected = gs.zeros(6)
-        expected[:3] = - point[:3]
+        expected[:3] = point[:3]
         expected[3:6] = point[3:6]
         expected = helper.to_vector(expected)
 
@@ -178,9 +178,15 @@ class TestSpecialEuclideanGroupMethods(unittest.TestCase):
                             point,
                             result,
                             expected))
+        angle_type = 'with_angle_close_pi_high'
+        point = self.elements[angle_type]
+        result = self.group.regularize(point)
+        expected = gs.zeros(6)
+        expected[:3] = point[:3] / gs.linalg.norm(point[:3]) * gs.pi
+        expected[3:6] = point[3:6]
+        self.assertTrue(gs.allclose(result, expected), angle_type)
 
-        in_pi_2pi = ['with_angle_close_pi_high',
-                     'with_angle_in_pi_2pi',
+        in_pi_2pi = ['with_angle_in_pi_2pi',
                      'with_angle_close_2pi_low']
 
         for angle_type in in_pi_2pi:

--- a/tests/test_special_orthogonal_group.py
+++ b/tests/test_special_orthogonal_group.py
@@ -215,7 +215,12 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
                     point = self.elements[3][angle_type]
                     result = group.regularize(point)
                     expected = point
-                    self.assertTrue(gs.allclose(result, expected), angle_type)
+                    self.assertTrue(gs.allclose(result, expected),
+                                    'angle_type = {};'
+                                    'result = {};'
+                                    ' expected = {}.'.format(angle_type,
+                                                             result,
+                                                             expected))
 
                 # Note: by default, the rotation vector is inverted by
                 # the function regularize when the angle of the rotation is pi.
@@ -223,21 +228,52 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
                 angle_type = 'with_angle_pi'
                 point = self.elements[3][angle_type]
                 result = group.regularize(point)
-                expected = - point
+                expected = point
                 self.assertTrue(gs.allclose(result, expected), angle_type)
 
-                in_pi_2pi = ['with_angle_close_pi_high',
-                             'with_angle_in_pi_2pi',
+                angle_type = 'with_angle_close_pi_high'
+                point = self.elements[3][angle_type]
+                result = group.regularize(point)
+                expected = point / gs.linalg.norm(point) * gs.pi
+                self.assertTrue(gs.allclose(result, expected), angle_type)
+
+                in_pi_2pi = ['with_angle_in_pi_2pi',
                              'with_angle_close_2pi_low']
 
                 for angle_type in in_pi_2pi:
                     point = self.elements[3][angle_type]
+                    point_initial = point
                     angle = gs.linalg.norm(point)
+                    print('gs norm = {}'.format(gs.linalg.norm(point)))
                     new_angle = gs.pi - (angle - gs.pi)
 
+                    point_initial = point
+                    print('before point = {}'.format(point))
+                    print('before point_initial = {}'.format(point_initial))
                     result = group.regularize(point)
-                    expected = - new_angle * (point / angle)
-                    self.assertTrue(gs.allclose(result, expected), angle_type)
+                    print('after point = {}'.format(point))
+                    print('after point_initial = {}'.format(point_initial))
+                    print('result gs norm = {}'.format(gs.linalg.norm(result)))
+                    print('point gs norm = {}'.format(gs.linalg.norm(point)))
+
+                    expected = - (new_angle / angle) * point_initial
+                    self.assertTrue(gs.allclose(result, expected),
+                                    'angle_type = {}\n'
+                                    'point = {}\n'
+                                    'angle = {}\n'
+                                    'new_angle = {}\n'
+                                    'result = {}\n'
+                                    'norm(result) = {}\n'
+                                    'expected = {}\n'
+                                    'norm(expected) = {}'.format(
+                                        angle_type,
+                                        point,
+                                        angle,
+                                        new_angle,
+                                        result,
+                                        gs.linalg.norm(result),
+                                        expected,
+                                        gs.linalg.norm(expected)))
 
                 angle_type = 'with_angle_2pi'
                 point = self.elements[3][angle_type]

--- a/tests/test_special_orthogonal_group.py
+++ b/tests/test_special_orthogonal_group.py
@@ -244,17 +244,10 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
                     point = self.elements[3][angle_type]
                     point_initial = point
                     angle = gs.linalg.norm(point)
-                    print('gs norm = {}'.format(gs.linalg.norm(point)))
                     new_angle = gs.pi - (angle - gs.pi)
 
                     point_initial = point
-                    print('before point = {}'.format(point))
-                    print('before point_initial = {}'.format(point_initial))
                     result = group.regularize(point)
-                    print('after point = {}'.format(point))
-                    print('after point_initial = {}'.format(point_initial))
-                    print('result gs norm = {}'.format(gs.linalg.norm(result)))
-                    print('point gs norm = {}'.format(gs.linalg.norm(point)))
 
                     expected = - (new_angle / angle) * point_initial
                     self.assertTrue(gs.allclose(result, expected),


### PR DESCRIPTION
- Remove cast in special_orthogonal_group's regularize function
- Change convention for regularizing a rotation vector of norm pi : doesn't change the sign anymore