### PR TITLE
Nina tait bryan

### DIFF
--- a/geomstats/special_orthogonal_group.py
+++ b/geomstats/special_orthogonal_group.py
@@ -557,6 +557,81 @@ class SpecialOrthogonalGroup(LieGroup, EmbeddedManifold):
         assert gs.ndim(rot_mat) == 3
         return rot_mat
 
+    def matrix_from_tait_bryan_angles_extrinsinc_xyz(self, tait_bryan_angles):
+        assert self.n == 3, ('The Tait-Bryan angles representation'
+                             ' does not exist'
+                             ' for rotations in %d dimensions.' % self.n)
+        tait_bryan_angles = gs.to_ndarray(tait_bryan_angles, to_ndim=2)
+        n_tait_bryan_angles, _ = tait_bryan_angles.shape
+
+        rot_mat = gs.zeros((n_tait_bryan_angles,) + (self.n,) * 2)
+        angle_x = tait_bryan_angles[:, 0]
+        angle_y = tait_bryan_angles[:, 1]
+        angle_z = tait_bryan_angles[:, 2]
+
+        for i in range(n_tait_bryan_angles):
+            cos_angle_x = gs.cos(angle_x[i])
+            sin_angle_x = gs.sin(angle_x[i])
+            cos_angle_y = gs.cos(angle_y[i])
+            sin_angle_y = gs.sin(angle_y[i])
+            cos_angle_z = gs.cos(angle_z[i])
+            sin_angle_z = gs.sin(angle_z[i])
+
+            column_1 = [cos_angle_x * cos_angle_y,
+                        cos_angle_y * sin_angle_x,
+                        - sin_angle_y]
+            column_2 = [(cos_angle_x * sin_angle_y * sin_angle_z
+                         - cos_angle_z * sin_angle_x),
+                        (cos_angle_x * cos_angle_z
+                         + sin_angle_x * sin_angle_y * sin_angle_z),
+                        + cos_angle_y * sin_angle_z]
+            column_3 = [(sin_angle_x * sin_angle_z
+                         + cos_angle_x * cos_angle_z * sin_angle_y),
+                        (cos_angle_z * sin_angle_x * sin_angle_y
+                         - cos_angle_x * sin_angle_z),
+                        cos_angle_y * cos_angle_z]
+
+            rot_mat[i] = gs.vstack([column_1, column_2, column_3])
+        return rot_mat
+
+    def matrix_from_tait_bryan_angles_extrinsinc_zyx(self, tait_bryan_angles):
+        assert self.n == 3, ('The Tait-Bryan angles representation'
+                             ' does not exist'
+                             ' for rotations in %d dimensions.' % self.n)
+        tait_bryan_angles = gs.to_ndarray(tait_bryan_angles, to_ndim=2)
+        n_tait_bryan_angles, _ = tait_bryan_angles.shape
+
+        rot_mat = gs.zeros((n_tait_bryan_angles,) + (self.n,) * 2)
+        angle_x = tait_bryan_angles[:, 0]
+        angle_y = tait_bryan_angles[:, 1]
+        angle_z = tait_bryan_angles[:, 2]
+
+        for i in range(n_tait_bryan_angles):
+            cos_angle_x = gs.cos(angle_x[i])
+            sin_angle_x = gs.sin(angle_x[i])
+            cos_angle_y = gs.cos(angle_y[i])
+            sin_angle_y = gs.sin(angle_y[i])
+            cos_angle_z = gs.cos(angle_z[i])
+            sin_angle_z = gs.sin(angle_z[i])
+
+            column_1 = [cos_angle_y * cos_angle_z,
+                        (cos_angle_x * sin_angle_z
+                         + cos_angle_z * sin_angle_x * sin_angle_y),
+                        (sin_angle_x * sin_angle_z
+                         - cos_angle_x * cos_angle_z * sin_angle_y)]
+
+            column_2 = [- cos_angle_y * sin_angle_z,
+                        (cos_angle_x * cos_angle_z
+                         - sin_angle_x * sin_angle_y * sin_angle_z),
+                        (cos_angle_z * sin_angle_x
+                         + cos_angle_x * sin_angle_y * sin_angle_z)]
+
+            column_3 = [sin_angle_y,
+                        - cos_angle_y * sin_angle_x,
+                        cos_angle_x * cos_angle_y]
+            rot_mat[i] = gs.vstack([column_1, column_2, column_3])
+        return rot_mat
+
     def matrix_from_tait_bryan_angles(self, tait_bryan_angles,
                                       extrinsic_or_intrinsic='extrinsic',
                                       order='zyx'):
@@ -571,92 +646,35 @@ class SpecialOrthogonalGroup(LieGroup, EmbeddedManifold):
         - X(angle_x) is a rotation of angle angle_x around axis x.
         - Y(angle_y) is a rotation of angle angle_y around axis y.
         - Z(angle_z) is a rotation of angle angle_z around axis z.
+
+        Exchanging 'extrinsic' and 'intrinsic' amounts to
+        exchanging the order.
         """
-        assert self.n == 3, ('The tait-bryan angles representation'
+        assert self.n == 3, ('The Tait-Bryan angles representation'
                              ' does not exist'
                              ' for rotations in %d dimensions.' % self.n)
         tait_bryan_angles = gs.to_ndarray(tait_bryan_angles, to_ndim=2)
-        n_tait_bryan_angles, _ = tait_bryan_angles.shape
 
-        rot_mat = gs.zeros((n_tait_bryan_angles,) + (self.n,) * 2)
+        condition_1 = ((extrinsic_or_intrinsic == 'extrinsic'
+                        and order == 'zyx')
+                       or (extrinsic_or_intrinsic == 'intrinsic'
+                           and order == 'xyz'))
 
-        if extrinsic_or_intrinsic == 'extrinsic':
-            if order == 'zyx':
-                angle_x = tait_bryan_angles[:, 0]
-                angle_y = tait_bryan_angles[:, 1]
-                angle_z = tait_bryan_angles[:, 2]
-
-                for i in range(n_tait_bryan_angles):
-                    cos_angle_x = gs.cos(angle_x[i])
-                    sin_angle_x = gs.sin(angle_x[i])
-                    cos_angle_y = gs.cos(angle_y[i])
-                    sin_angle_y = gs.sin(angle_y[i])
-                    cos_angle_z = gs.cos(angle_z[i])
-                    sin_angle_z = gs.sin(angle_z[i])
-
-                    column_1 = [cos_angle_y * cos_angle_z,
-                                (cos_angle_x * sin_angle_z
-                                 + cos_angle_z * sin_angle_x * sin_angle_y),
-                                (sin_angle_x * sin_angle_z
-                                 - cos_angle_x * cos_angle_z * sin_angle_y)]
-
-                    column_2 = [- cos_angle_y * sin_angle_z,
-                                (cos_angle_x * cos_angle_z
-                                 - sin_angle_x * sin_angle_y * sin_angle_z),
-                                (cos_angle_z * sin_angle_x
-                                 + cos_angle_x * sin_angle_y * sin_angle_z)]
-
-                    column_3 = [sin_angle_y,
-                                - cos_angle_y * sin_angle_x,
-                                cos_angle_x * cos_angle_y]
-
-                    rot_mat[i] = gs.vstack([column_1, column_2, column_3])
-
-            elif order == 'xyz':
-                angle_z = tait_bryan_angles[:, 0]
-                angle_y = tait_bryan_angles[:, 1]
-                angle_x = tait_bryan_angles[:, 2]
-
-                for i in range(n_tait_bryan_angles):
-                    cos_angle_x = gs.cos(angle_x[i])
-                    sin_angle_x = gs.sin(angle_x[i])
-                    cos_angle_y = gs.cos(angle_y[i])
-                    sin_angle_y = gs.sin(angle_y[i])
-                    cos_angle_z = gs.cos(angle_z[i])
-                    sin_angle_z = gs.sin(angle_z[i])
-
-                    column_1 = [cos_angle_x * cos_angle_y,
-                                cos_angle_y * sin_angle_x,
-                                - sin_angle_y]
-                    column_2 = [(cos_angle_x * sin_angle_y * sin_angle_z
-                                 - cos_angle_z * sin_angle_x),
-                                (cos_angle_x * cos_angle_z
-                                 + sin_angle_x * sin_angle_y * sin_angle_z),
-                                + cos_angle_y * sin_angle_z]
-                    column_3 = [(sin_angle_x * sin_angle_z
-                                 + cos_angle_x * cos_angle_z * sin_angle_y),
-                                (cos_angle_z * sin_angle_x * sin_angle_y
-                                 - cos_angle_x * sin_angle_z),
-                                cos_angle_y * cos_angle_z]
-
-                    rot_mat[i] = gs.vstack([column_1, column_2, column_3])
-
-        elif extrinsic_or_intrinsic == 'intrinsic':
-            if order == 'zyx':
-                rot_mat = self.matrix_from_tait_bryan_angles(
-                    tait_bryan_angles,
-                    extrinsic_or_intrinsic='extrinsic',
-                    order='xyz')
-
-            elif order == 'xyz':
-                rot_mat = self.matrix_from_tait_bryan_angles(
-                    tait_bryan_angles,
-                    extrinsic_or_intrinsic='extrinsic',
-                    order='zyx')
+        condition_2 = ((extrinsic_or_intrinsic == 'extrinsic'
+                        and order == 'xyz')
+                       or (extrinsic_or_intrinsic == 'intrinsic'
+                           and order == 'zyx'))
+        if condition_1:
+            rot_mat = self.matrix_from_tait_bryan_angles_extrinsinc_zyx(
+                tait_bryan_angles)
+        elif condition_2:
+            rot_mat = self.matrix_from_tait_bryan_angles_extrinsinc_xyz(
+                tait_bryan_angles)
 
         else:
             raise ValueError('extrinsinc_or_intrinsic should be'
-                             ' \'extrinsic\' or \'intrinsic\'.')
+                             ' \'extrinsic\' or \'intrinsic\''
+                             ' and order should be \'xyz\' or \'zyx\'.')
 
         return rot_mat
 
@@ -682,87 +700,98 @@ class SpecialOrthogonalGroup(LieGroup, EmbeddedManifold):
 
         return tait_bryan_angles
 
-    def quaternion_from_tait_bryan_angles(self, tait_bryan_angles,
-                                          extrinsic_or_intrinsic='extrinsic',
-                                          order='zyx'):
-        """
-        Convert a rotation given by the yaw, pitch, roll
-        into a unit quaternion.
-        """
+    def quaternion_from_tait_bryan_angles_intrinsic_xyz(
+            self, tait_bryan_angles):
         assert self.n == 3, ('The quaternion representation'
-                             ' and the tait-bryan angles representation'
+                             ' and the Tait-Bryan angles representation'
                              ' do not exist'
                              ' for rotations in %d dimensions.' % self.n)
         tait_bryan_angles = gs.to_ndarray(tait_bryan_angles, to_ndim=2)
         n_tait_bryan_angles, _ = tait_bryan_angles.shape
-        if extrinsic_or_intrinsic == 'extrinsic':
-            if order == 'zyx':
-                quaternion = self.quaternion_from_tait_bryan_angles(
-                    tait_bryan_angles,
-                    extrinsic_or_intrinsic='intrinsic',
-                    order='xyz')
-            elif order == 'xyz':
-                rot_mat = self.matrix_from_tait_bryan_angles(
-                    tait_bryan_angles,
-                    extrinsic_or_intrinsic=extrinsic_or_intrinsic,
-                    order=order)
-                quaternion = self.quaternion_from_matrix(rot_mat)
+        quaternion = gs.zeros((n_tait_bryan_angles, 4))
 
-        elif extrinsic_or_intrinsic == 'intrinsic':
-            if order == 'zyx':
-                rot_mat = self.matrix_from_tait_bryan_angles(
-                    tait_bryan_angles,
-                    extrinsic_or_intrinsic=extrinsic_or_intrinsic,
-                    order=order)
-                quaternion = self.quaternion_from_matrix(rot_mat)
-            elif order == 'xyz':
-                angle_x = tait_bryan_angles[:, 0]
-                angle_y = tait_bryan_angles[:, 1]
-                angle_z = tait_bryan_angles[:, 2]
+        angle_x = tait_bryan_angles[:, 0]
+        angle_y = tait_bryan_angles[:, 1]
+        angle_z = tait_bryan_angles[:, 2]
 
-                cos_half_angle_z = gs.cos(angle_z / 2.)
-                sin_half_angle_z = gs.sin(angle_z / 2.)
-                cos_half_angle_y = gs.cos(angle_y / 2.)
-                sin_half_angle_y = gs.sin(angle_y / 2.)
-                cos_half_angle_x = gs.cos(angle_x / 2.)
-                sin_half_angle_x = gs.sin(angle_x / 2.)
+        cos_half_angle_z = gs.cos(angle_z / 2.)
+        sin_half_angle_z = gs.sin(angle_z / 2.)
+        cos_half_angle_y = gs.cos(angle_y / 2.)
+        sin_half_angle_y = gs.sin(angle_y / 2.)
+        cos_half_angle_x = gs.cos(angle_x / 2.)
+        sin_half_angle_x = gs.sin(angle_x / 2.)
 
-                quaternion = gs.zeros((n_tait_bryan_angles, 4))
+        cos_half_angle = (cos_half_angle_z
+                          * cos_half_angle_y
+                          * cos_half_angle_x
+                          + sin_half_angle_z
+                          * sin_half_angle_y
+                          * sin_half_angle_x)
 
-                cos_half_angle = (cos_half_angle_z
-                                  * cos_half_angle_y
-                                  * cos_half_angle_x
-                                  + sin_half_angle_z
-                                  * sin_half_angle_y
-                                  * sin_half_angle_x)
+        quaternion[:, 0] = cos_half_angle
 
-                quaternion[:, 0] = cos_half_angle
+        quaternion[:, 1] = (cos_half_angle_z
+                            * cos_half_angle_y
+                            * sin_half_angle_x
+                            - sin_half_angle_z
+                            * sin_half_angle_y
+                            * cos_half_angle_x)
 
-                quaternion[:, 1] = (cos_half_angle_z
-                                    * cos_half_angle_y
-                                    * sin_half_angle_x
-                                    - sin_half_angle_z
-                                    * sin_half_angle_y
-                                    * cos_half_angle_x)
+        quaternion[:, 2] = (cos_half_angle_x
+                            * cos_half_angle_z
+                            * sin_half_angle_y
+                            + sin_half_angle_x
+                            * sin_half_angle_z
+                            * cos_half_angle_y)
 
-                quaternion[:, 2] = (cos_half_angle_x
-                                    * cos_half_angle_z
-                                    * sin_half_angle_y
-                                    + sin_half_angle_x
-                                    * sin_half_angle_z
-                                    * cos_half_angle_y)
-
-                quaternion[:, 3] = (cos_half_angle_y
-                                    * cos_half_angle_x
-                                    * sin_half_angle_z
-                                    - sin_half_angle_y
-                                    * sin_half_angle_x
-                                    * cos_half_angle_z)
-            else:
-                raise ValueError('extrinsinc_or_intrinsic should be'
-                                 ' \'extrinsic\' or \'intrinsic\'.')
-
+        quaternion[:, 3] = (cos_half_angle_y
+                            * cos_half_angle_x
+                            * sin_half_angle_z
+                            - sin_half_angle_y
+                            * sin_half_angle_x
+                            * cos_half_angle_z)
         return quaternion
+
+    def quaternion_from_tait_bryan_angles(self, tait_bryan_angles,
+                                          extrinsic_or_intrinsic='extrinsic',
+                                          order='zyx'):
+        """
+        Convert a rotation given by Tait-Bryan angles
+        into a unit quaternion.
+        """
+        assert self.n == 3, ('The quaternion representation'
+                             ' and the Tait-Bryan angles representation'
+                             ' do not exist'
+                             ' for rotations in %d dimensions.' % self.n)
+        tait_bryan_angles = gs.to_ndarray(tait_bryan_angles, to_ndim=2)
+        n_tait_bryan_angles, _ = tait_bryan_angles.shape
+
+        condition_1 = ((extrinsic_or_intrinsic == 'extrinsic'
+                        and order == 'zyx')
+                       or (extrinsic_or_intrinsic == 'intrinsic'
+                           and order == 'xyz'))
+
+        condition_2 = ((extrinsic_or_intrinsic == 'extrinsic'
+                        and order == 'xyz')
+                       or (extrinsic_or_intrinsic == 'intrinsic'
+                           and order == 'zyx'))
+
+        if condition_1:
+            quat = self.quaternion_from_tait_bryan_angles_intrinsic_xyz(
+                tait_bryan_angles)
+
+        elif condition_2:
+            # TODO(nina): Put a direct implementation here,
+            # instead of converting to matrices first
+            rot_mat = self.matrix_from_tait_bryan_angles_extrinsic_xyz(
+                tait_bryan_angles)
+            quat = self.quaternion_from_matrix(rot_mat)
+        else:
+            raise ValueError('extrinsinc_or_intrinsic should be'
+                             ' \'extrinsic\' or \'intrinsic\''
+                             ' and order should be \'xyz\' or \'zyx\'.')
+
+        return quat
 
     def rotation_vector_from_tait_bryan_angles(
             self,
@@ -773,7 +802,7 @@ class SpecialOrthogonalGroup(LieGroup, EmbeddedManifold):
         Convert a rotation given by the angle_x, angle_y, angle_z
         into a rotation vector (axis-angle representation).
         """
-        assert self.n == 3, ('The tait-bryan angles representation'
+        assert self.n == 3, ('The Tait-Bryan angles representation'
                              ' does not exist'
                              ' for rotations in %d dimensions.' % self.n)
         quaternion = self.quaternion_from_tait_bryan_angles(
@@ -785,6 +814,40 @@ class SpecialOrthogonalGroup(LieGroup, EmbeddedManifold):
         rot_vec = self.regularize(rot_vec, point_type='vector')
         return rot_vec
 
+    def tait_bryan_angles_from_quaternion_intrinsic_zyx(self, quaternion):
+        assert self.n == 3, ('The quaternion representation'
+                             ' and the Tait-Bryan angles representation'
+                             ' do not exist'
+                             ' for rotations in %d dimensions.' % self.n)
+        quaternion = gs.to_ndarray(quaternion, to_ndim=2)
+
+        w, x, y, z = gs.hsplit(quaternion, 4)
+        angle_x = gs.arctan2(y * z + w * x,
+                             1. / 2. - (x ** 2 + y ** 2))
+        angle_y = gs.arcsin(- 2. * (x * z - w * y))
+        angle_z = gs.arctan2(x * y + w * z,
+                             1. / 2. - (y ** 2 + z ** 2))
+        tait_bryan_angles = gs.concatenate(
+            [angle_x, angle_y, angle_z], axis=1)
+        return tait_bryan_angles
+
+    def tait_bryan_angles_from_quaternion_intrinsic_xyz(self, quaternion):
+        assert self.n == 3, ('The quaternion representation'
+                             ' and the Tait-Bryan angles representation'
+                             ' do not exist'
+                             ' for rotations in %d dimensions.' % self.n)
+        quaternion = gs.to_ndarray(quaternion, to_ndim=2)
+
+        w, x, y, z = gs.hsplit(quaternion, 4)
+        angle_z = gs.arctan2(2. * (x * y + w * z),
+                             w * w + x * x - y * y - z * z)
+        angle_y = gs.arcsin(- 2. * (x * z - w * y))
+        angle_x = gs.arctan2(2. * (y * z + w * x),
+                             w * w - x * x - y * y + z * z)
+        tait_bryan_angles = gs.concatenate(
+            [angle_x, angle_y, angle_z], axis=1)
+        return tait_bryan_angles
+
     def tait_bryan_angles_from_quaternion(
             self, quaternion, extrinsic_or_intrinsic='extrinsic', order='zyx'):
         """
@@ -792,57 +855,43 @@ class SpecialOrthogonalGroup(LieGroup, EmbeddedManifold):
         to a rotation given by the angle_x, angle_y, angle_z.
         """
         assert self.n == 3, ('The quaternion representation'
-                             ' and the tait-bryan angles representation'
+                             ' and the Tait-Bryan angles representation'
                              ' do not exist'
                              ' for rotations in %d dimensions.' % self.n)
         quaternion = gs.to_ndarray(quaternion, to_ndim=2)
 
-        w, x, y, z = gs.hsplit(quaternion, 4)
+        condition_1 = ((extrinsic_or_intrinsic == 'extrinsic'
+                        and order == 'zyx')
+                       or (extrinsic_or_intrinsic == 'intrinsic'
+                           and order == 'xyz'))
 
-        if extrinsic_or_intrinsic == 'extrinsic':
-            if order == 'zyx':
-                tait_bryan_angles = self.tait_bryan_angles_from_quaternion(
-                    quaternion,
-                    extrinsic_or_intrinsic='intrinsic',
-                    order='xyz')
-            elif order == 'xyz':
-                tait_bryan_angles = self.tait_bryan_angles_from_quaternion(
-                    quaternion,
-                    extrinsic_or_intrinsic='intrinsic',
-                    order='zyx')
+        condition_2 = ((extrinsic_or_intrinsic == 'extrinsic'
+                        and order == 'xyz')
+                       or (extrinsic_or_intrinsic == 'intrinsic'
+                           and order == 'zyx'))
 
-        elif extrinsic_or_intrinsic == 'intrinsic':
-            if order == 'zyx':
-                angle_x = gs.arctan2(y * z + w * x,
-                                     1. / 2. - (x ** 2 + y ** 2))
-                angle_y = gs.arcsin(- 2. * (x * z - w * y))
-                angle_z = gs.arctan2(x * y + w * z,
-                                     1. / 2. - (y ** 2 + z ** 2))
-                tait_bryan_angles = gs.concatenate(
-                    [angle_x, angle_y, angle_z], axis=1)
+        if condition_1:
+            tait_bryan = self.tait_bryan_angles_from_quaternion_intrinsic_xyz(
+                quaternion)
 
-            elif order == 'xyz':
-                angle_z = gs.arctan2(2. * (x * y + w * z),
-                                     w * w + x * x - y * y - z * z)
-                angle_y = gs.arcsin(- 2. * (x * z - w * y))
-                angle_x = gs.arctan2(2. * (y * z + w * x),
-                                     w * w - x * x - y * y + z * z)
-
-                tait_bryan_angles = gs.concatenate(
-                    [angle_z, angle_y, angle_x], axis=1)
+        elif condition_2:
+            tait_bryan = self.tait_bryan_angles_from_quaternion_intrinsic_zyx(
+                quaternion)
 
         else:
             raise ValueError('extrinsinc_or_intrinsic should be'
-                             ' \'extrinsic\' or \'intrinsic\'.')
-        return tait_bryan_angles
+                             ' \'extrinsic\' or \'intrinsic\''
+                             ' and order should be \'xyz\' or \'zyx\'.')
+
+        return tait_bryan
 
     def tait_bryan_angles_from_rotation_vector(
             self, rot_vec, extrinsic_or_intrinsic='extrinsic', order='zyx'):
         """
         Convert a rotation vector (axis-angle representation)
-        to a rotation given by the yaw, pitch, roll.
+        to a rotation given by the Tait-Bryan angles.
         """
-        assert self.n == 3, ('The tait-bryan angles representation'
+        assert self.n == 3, ('The Tait-Bryan angles representation'
                              ' does not exist'
                              ' for rotations in %d dimensions.' % self.n)
         rot_vec = gs.to_ndarray(rot_vec, to_ndim=2)

--- a/geomstats/special_orthogonal_group.py
+++ b/geomstats/special_orthogonal_group.py
@@ -557,7 +557,7 @@ class SpecialOrthogonalGroup(LieGroup, EmbeddedManifold):
         assert gs.ndim(rot_mat) == 3
         return rot_mat
 
-    def matrix_from_tait_bryan_angles_extrinsinc_xyz(self, tait_bryan_angles):
+    def matrix_from_tait_bryan_angles_extrinsic_xyz(self, tait_bryan_angles):
         assert self.n == 3, ('The Tait-Bryan angles representation'
                              ' does not exist'
                              ' for rotations in %d dimensions.' % self.n)
@@ -594,7 +594,7 @@ class SpecialOrthogonalGroup(LieGroup, EmbeddedManifold):
             rot_mat[i] = gs.vstack([column_1, column_2, column_3])
         return rot_mat
 
-    def matrix_from_tait_bryan_angles_extrinsinc_zyx(self, tait_bryan_angles):
+    def matrix_from_tait_bryan_angles_extrinsic_zyx(self, tait_bryan_angles):
         assert self.n == 3, ('The Tait-Bryan angles representation'
                              ' does not exist'
                              ' for rotations in %d dimensions.' % self.n)
@@ -665,14 +665,14 @@ class SpecialOrthogonalGroup(LieGroup, EmbeddedManifold):
                        or (extrinsic_or_intrinsic == 'intrinsic'
                            and order == 'zyx'))
         if condition_1:
-            rot_mat = self.matrix_from_tait_bryan_angles_extrinsinc_zyx(
+            rot_mat = self.matrix_from_tait_bryan_angles_extrinsic_zyx(
                 tait_bryan_angles)
         elif condition_2:
-            rot_mat = self.matrix_from_tait_bryan_angles_extrinsinc_xyz(
+            rot_mat = self.matrix_from_tait_bryan_angles_extrinsic_xyz(
                 tait_bryan_angles)
 
         else:
-            raise ValueError('extrinsinc_or_intrinsic should be'
+            raise ValueError('extrinsic_or_intrinsic should be'
                              ' \'extrinsic\' or \'intrinsic\''
                              ' and order should be \'xyz\' or \'zyx\'.')
 
@@ -787,7 +787,7 @@ class SpecialOrthogonalGroup(LieGroup, EmbeddedManifold):
                 tait_bryan_angles)
             quat = self.quaternion_from_matrix(rot_mat)
         else:
-            raise ValueError('extrinsinc_or_intrinsic should be'
+            raise ValueError('extrinsic_or_intrinsic should be'
                              ' \'extrinsic\' or \'intrinsic\''
                              ' and order should be \'xyz\' or \'zyx\'.')
 
@@ -879,7 +879,7 @@ class SpecialOrthogonalGroup(LieGroup, EmbeddedManifold):
                 quaternion)
 
         else:
-            raise ValueError('extrinsinc_or_intrinsic should be'
+            raise ValueError('extrinsic_or_intrinsic should be'
                              ' \'extrinsic\' or \'intrinsic\''
                              ' and order should be \'xyz\' or \'zyx\'.')
 

--- a/geomstats/special_orthogonal_group.py
+++ b/geomstats/special_orthogonal_group.py
@@ -557,10 +557,12 @@ class SpecialOrthogonalGroup(LieGroup, EmbeddedManifold):
         assert gs.ndim(rot_mat) == 3
         return rot_mat
 
-    def matrix_from_tait_bryan_angles(self, tait_bryan_angles):
+    def matrix_from_tait_bryan_angles(self, tait_bryan_angles,
+                                      extrinsic_or_intrinsic='extrinsic'):
         """
         Convert a rotation given in terms of the tait bryan angles,
-        [angle_x, angle_y, angle_z] in extrinsic (fixed) coordinate frame,
+        [angle_x, angle_y, angle_z] in extrinsic (fixed) or
+        intrinsic (moving) coordinate frame,
         for the order zyx, into the rotation matrix rot_mat:
         rot_mat = X(angle_x).Y(angle_y).Z(angle_z)
         where:
@@ -578,36 +580,41 @@ class SpecialOrthogonalGroup(LieGroup, EmbeddedManifold):
         angle_y = tait_bryan_angles[:, 1]
         angle_z = tait_bryan_angles[:, 2]
 
-        rot_mat = gs.zeros((n_tait_bryan_angles,) + (self.n,) * 2)
-        for i in range(n_tait_bryan_angles):
-            cos_angle_x = gs.cos(angle_x[i])
-            sin_angle_x = gs.sin(angle_x[i])
-            cos_angle_y = gs.cos(angle_y[i])
-            sin_angle_y = gs.sin(angle_y[i])
-            cos_angle_z = gs.cos(angle_z[i])
-            sin_angle_z = gs.sin(angle_z[i])
+        if extrinsic_or_intrinsic == 'extrinsic':
+            rot_mat = gs.zeros((n_tait_bryan_angles,) + (self.n,) * 2)
+            for i in range(n_tait_bryan_angles):
+                cos_angle_x = gs.cos(angle_x[i])
+                sin_angle_x = gs.sin(angle_x[i])
+                cos_angle_y = gs.cos(angle_y[i])
+                sin_angle_y = gs.sin(angle_y[i])
+                cos_angle_z = gs.cos(angle_z[i])
+                sin_angle_z = gs.sin(angle_z[i])
 
-            column_1 = [cos_angle_y * cos_angle_z,
-                        (cos_angle_x * sin_angle_z
-                         + cos_angle_z * sin_angle_x * sin_angle_y),
-                        (sin_angle_x * sin_angle_z
-                         - cos_angle_x * cos_angle_z * sin_angle_y)]
+                column_1 = [cos_angle_y * cos_angle_z,
+                            (cos_angle_x * sin_angle_z
+                             + cos_angle_z * sin_angle_x * sin_angle_y),
+                            (sin_angle_x * sin_angle_z
+                             - cos_angle_x * cos_angle_z * sin_angle_y)]
 
-            column_2 = [- cos_angle_y * sin_angle_z,
-                        (cos_angle_x * cos_angle_z
-                         - sin_angle_x * sin_angle_y * sin_angle_z),
-                        (cos_angle_z * sin_angle_x
-                         + cos_angle_x * sin_angle_y * sin_angle_z)]
+                column_2 = [- cos_angle_y * sin_angle_z,
+                            (cos_angle_x * cos_angle_z
+                             - sin_angle_x * sin_angle_y * sin_angle_z),
+                            (cos_angle_z * sin_angle_x
+                             + cos_angle_x * sin_angle_y * sin_angle_z)]
 
-            column_3 = [sin_angle_y,
-                        - cos_angle_y * sin_angle_x,
-                        cos_angle_x * cos_angle_y]
+                column_3 = [sin_angle_y,
+                            - cos_angle_y * sin_angle_x,
+                            cos_angle_x * cos_angle_y]
 
-            rot_mat[i] = gs.hstack([column_1, column_2, column_3]).transpose()
+                rot_mat[i] = gs.hstack(
+                    [column_1, column_2, column_3]).transpose()
+            else:
+                raise NotImplementedError()
 
         return rot_mat
 
-    def tait_bryan_angles_from_matrix(self, rot_mat):
+    def tait_bryan_angles_from_matrix(self, rot_mat,
+                                      extrinsic_or_intrinsic='extrinsic'):
         """
         Convert a rotation matrix rot_mat into the tait bryan angles,
         [angle_x, angle_y, angle_z] in extrinsic (fixed) coordinate frame,
@@ -620,11 +627,13 @@ class SpecialOrthogonalGroup(LieGroup, EmbeddedManifold):
         """
         rot_mat = gs.to_ndarray(rot_mat, to_ndim=3)
         quaternion = self.quaternion_from_matrix(rot_mat)
-        tait_bryan_angle = self.tait_bryan_angle_from_quaternion(quaternion)
+        tait_bryan_angles = self.tait_bryan_angles_from_quaternion(
+            quaternion, extrinsic_or_intrinsic=extrinsic_or_intrinsic)
 
-        return tait_bryan_angle
+        return tait_bryan_angles
 
-    def quaternion_from_tait_bryan_angles(self, tait_bryan_angle):
+    def quaternion_from_tait_bryan_angles(self, tait_bryan_angle,
+                                          extrinsic_or_intrinsic='extrinsic'):
         """
         Convert a rotation given by the yaw, pitch, roll
         into a unit quaternion.
@@ -640,48 +649,52 @@ class SpecialOrthogonalGroup(LieGroup, EmbeddedManifold):
         angle_y = tait_bryan_angle[:, 1]
         angle_z = tait_bryan_angle[:, 2]
 
-        cos_half_angle_x = gs.cos(angle_x / 2.)
-        sin_half_angle_x = gs.sin(angle_x / 2.)
-        cos_half_angle_y = gs.cos(angle_y / 2.)
-        sin_half_angle_y = gs.sin(angle_y / 2.)
-        cos_half_angle_z = gs.cos(angle_z / 2.)
-        sin_half_angle_z = gs.sin(angle_z / 2.)
+        if extrinsic_or_intrinsic == 'extrinsic':
+            raise NotImplementedError()
+        else:
+            cos_half_angle_x = gs.cos(angle_x / 2.)
+            sin_half_angle_x = gs.sin(angle_x / 2.)
+            cos_half_angle_y = gs.cos(angle_y / 2.)
+            sin_half_angle_y = gs.sin(angle_y / 2.)
+            cos_half_angle_z = gs.cos(angle_z / 2.)
+            sin_half_angle_z = gs.sin(angle_z / 2.)
 
-        quaternion = gs.zeros((n_tait_bryan_angles, 4))
+            quaternion = gs.zeros((n_tait_bryan_angles, 4))
 
-        cos_half_angle = (cos_half_angle_x
-                          * cos_half_angle_y
-                          * cos_half_angle_z
-                          + sin_half_angle_x
-                          * sin_half_angle_y
-                          * sin_half_angle_z)
+            cos_half_angle = (cos_half_angle_x
+                              * cos_half_angle_y
+                              * cos_half_angle_z
+                              + sin_half_angle_x
+                              * sin_half_angle_y
+                              * sin_half_angle_z)
 
-        quaternion[:, 0] = cos_half_angle
+            quaternion[:, 0] = cos_half_angle
 
-        quaternion[:, 1] = (cos_half_angle_x
-                            * cos_half_angle_y
-                            * sin_half_angle_z
-                            - sin_half_angle_x
-                            * sin_half_angle_y
-                            * cos_half_angle_z)
+            quaternion[:, 1] = (cos_half_angle_x
+                                * cos_half_angle_y
+                                * sin_half_angle_z
+                                - sin_half_angle_x
+                                * sin_half_angle_y
+                                * cos_half_angle_z)
 
-        quaternion[:, 2] = (cos_half_angle_z
-                            * cos_half_angle_x
-                            * sin_half_angle_y
-                            + sin_half_angle_z
-                            * sin_half_angle_x
-                            * cos_half_angle_y)
+            quaternion[:, 2] = (cos_half_angle_z
+                                * cos_half_angle_x
+                                * sin_half_angle_y
+                                + sin_half_angle_z
+                                * sin_half_angle_x
+                                * cos_half_angle_y)
 
-        quaternion[:, 3] = (cos_half_angle_y
-                            * cos_half_angle_z
-                            * sin_half_angle_x
-                            - sin_half_angle_y
-                            * sin_half_angle_z
-                            * cos_half_angle_x)
+            quaternion[:, 3] = (cos_half_angle_y
+                                * cos_half_angle_z
+                                * sin_half_angle_x
+                                - sin_half_angle_y
+                                * sin_half_angle_z
+                                * cos_half_angle_x)
 
         return quaternion
 
-    def rotation_vector_from_tait_bryan_angles(self, tait_bryan_angle):
+    def rotation_vector_from_tait_bryan_angles(
+            self, tait_bryan_angles, extrinsic_or_intrinsic='extrinsic'):
         """
         Convert a rotation given by the angle_x, angle_y, angle_z
         into a rotation vector (axis-angle representation).
@@ -689,13 +702,15 @@ class SpecialOrthogonalGroup(LieGroup, EmbeddedManifold):
         assert self.n == 3, ('The tait-bryan angles representation'
                              ' does not exist'
                              ' for rotations in %d dimensions.' % self.n)
-        quaternion = self.quaternion_from_tait_bryan_angles(tait_bryan_angle)
+        quaternion = self.quaternion_from_tait_bryan_angles(
+            tait_bryan_angles, extrinsic_or_intrinsic=extrinsic_or_intrinsic)
         rot_vec = self.rotation_vector_from_quaternion(quaternion)
 
         rot_vec = self.regularize(rot_vec, point_type='vector')
         return rot_vec
 
-    def tait_bryan_angles_from_quaternion(self, quaternion):
+    def tait_bryan_angles_from_quaternion(
+            self, quaternion, extrinsic_or_intrinsic='extrinsic'):
         """
         Convert a quaternion
         to a rotation given by the angle_x, angle_y, angle_z.
@@ -708,16 +723,21 @@ class SpecialOrthogonalGroup(LieGroup, EmbeddedManifold):
 
         w, x, y, z = gs.hsplit(quaternion, 4)
 
-        angle_x = gs.arctan2(2. * (x * y + w * z),
-                             w * w + x * x - y * y - z * z)
-        angle_y = gs.arcsin(- 2. * (x * z - w * y))
-        angle_z = gs.arctan2(2. * (y * z + w * x),
-                             w * w - x * x - y * y + z * z)
+        if extrinsic_or_intrinsic == 'extrinsic':
+            raise NotImplementedError()
+        else:
+            angle_x = gs.arctan2(2. * (x * y + w * z),
+                                 w * w + x * x - y * y - z * z)
+            angle_y = gs.arcsin(- 2. * (x * z - w * y))
+            angle_z = gs.arctan2(2. * (y * z + w * x),
+                                 w * w - x * x - y * y + z * z)
 
-        tait_bryan_angles = gs.concatenate([angle_x, angle_y, angle_z], axis=1)
+            tait_bryan_angles = gs.concatenate(
+                [angle_x, angle_y, angle_z], axis=1)
         return tait_bryan_angles
 
-    def tait_bryan_angles_from_rotation_vector(self, rot_vec):
+    def tait_bryan_angles_from_rotation_vector(
+            self, rot_vec, extrinsic_or_intrinsic='extrinsic'):
         """
         Convert a rotation vector (axis-angle representation)
         to a rotation given by the yaw, pitch, roll.
@@ -728,7 +748,8 @@ class SpecialOrthogonalGroup(LieGroup, EmbeddedManifold):
         rot_vec = gs.to_ndarray(rot_vec, to_ndim=2)
 
         quaternion = self.quaternion_from_rotation_vector(rot_vec)
-        tait_bryan_angles = self.tait_bryan_angles_from_quaternion(quaternion)
+        tait_bryan_angles = self.tait_bryan_angles_from_quaternion(
+            quaternion, extrinsic_or_intrinsic=extrinsic_or_intrinsic)
 
         return tait_bryan_angles
 

--- a/geomstats/special_orthogonal_group.py
+++ b/geomstats/special_orthogonal_group.py
@@ -828,7 +828,7 @@ class SpecialOrthogonalGroup(LieGroup, EmbeddedManifold):
         angle_3 = gs.arctan2(x * y + w * z,
                              1. / 2. - (y ** 2 + z ** 2))
         tait_bryan_angles = gs.concatenate(
-            [angle_1, angle_2, angle_3], axis=1)
+            [angle_3, angle_2, angle_1], axis=1)
         return tait_bryan_angles
 
     def tait_bryan_angles_from_quaternion_intrinsic_xyz(self, quaternion):

--- a/geomstats/special_orthogonal_group.py
+++ b/geomstats/special_orthogonal_group.py
@@ -558,6 +558,12 @@ class SpecialOrthogonalGroup(LieGroup, EmbeddedManifold):
         return rot_mat
 
     def matrix_from_tait_bryan_angles_extrinsic_xyz(self, tait_bryan_angles):
+        """
+        Convert a rotation given in terms of the tait bryan angles,
+        [angle_1, angle_2, angle_3] in extrinsic coordinate system,
+        in order xyzm into a rotation matrix.
+        """
+
         assert self.n == 3, ('The Tait-Bryan angles representation'
                              ' does not exist'
                              ' for rotations in %d dimensions.' % self.n)
@@ -595,6 +601,17 @@ class SpecialOrthogonalGroup(LieGroup, EmbeddedManifold):
         return rot_mat
 
     def matrix_from_tait_bryan_angles_extrinsic_zyx(self, tait_bryan_angles):
+        """
+        Convert a rotation given in terms of the tait bryan angles,
+        [angle_1, angle_2, angle_3] in extrinsic (fixed) coordinate system
+        in order zyx, into a rotation matrix.
+
+        rot_mat = X(angle_1).Y(angle_2).Z(angle_3)
+        where:
+        - X(angle_1) is a rotation of angle angle_1 around axis x.
+        - Y(angle_2) is a rotation of angle angle_2 around axis y.
+        - Z(angle_3) is a rotation of angle angle_3 around axis z.
+        """
         assert self.n == 3, ('The Tait-Bryan angles representation'
                              ' does not exist'
                              ' for rotations in %d dimensions.' % self.n)
@@ -655,19 +672,21 @@ class SpecialOrthogonalGroup(LieGroup, EmbeddedManifold):
                              ' for rotations in %d dimensions.' % self.n)
         tait_bryan_angles = gs.to_ndarray(tait_bryan_angles, to_ndim=2)
 
-        condition_1 = ((extrinsic_or_intrinsic == 'extrinsic'
+        extrinsic_zyx_or_intrinsic_xyz = (
+                       (extrinsic_or_intrinsic == 'extrinsic'
                         and order == 'zyx')
                        or (extrinsic_or_intrinsic == 'intrinsic'
                            and order == 'xyz'))
 
-        condition_2 = ((extrinsic_or_intrinsic == 'extrinsic'
+        extrinsic_xyz_or_intrinsic_zyx = (
+                       (extrinsic_or_intrinsic == 'extrinsic'
                         and order == 'xyz')
                        or (extrinsic_or_intrinsic == 'intrinsic'
                            and order == 'zyx'))
-        if condition_1:
+        if extrinsic_zyx_or_intrinsic_xyz:
             rot_mat = self.matrix_from_tait_bryan_angles_extrinsic_zyx(
                 tait_bryan_angles)
-        elif condition_2:
+        elif extrinsic_xyz_or_intrinsic_zyx:
             rot_mat = self.matrix_from_tait_bryan_angles_extrinsic_xyz(
                 tait_bryan_angles)
 
@@ -702,6 +721,11 @@ class SpecialOrthogonalGroup(LieGroup, EmbeddedManifold):
 
     def quaternion_from_tait_bryan_angles_intrinsic_xyz(
             self, tait_bryan_angles):
+        """
+        Convert a rotation given by Tait-Bryan angles in extrinsic
+        coordinate systems and order xyz into a unit quaternion.
+        """
+        # TODO(nina): Linear algebra for the subsequent operations?
         assert self.n == 3, ('The quaternion representation'
                              ' and the Tait-Bryan angles representation'
                              ' do not exist'

--- a/geomstats/special_orthogonal_group.py
+++ b/geomstats/special_orthogonal_group.py
@@ -639,8 +639,7 @@ class SpecialOrthogonalGroup(LieGroup, EmbeddedManifold):
                                  - cos_angle_x * sin_angle_z),
                                 cos_angle_y * cos_angle_z]
 
-                    rot_mat[i] = gs.hstack(
-                        [column_1, column_2, column_3]).transpose()
+                    rot_mat[i] = gs.vstack([column_1, column_2, column_3])
 
         elif extrinsic_or_intrinsic == 'intrinsic':
             if order == 'zyx':
@@ -816,9 +815,11 @@ class SpecialOrthogonalGroup(LieGroup, EmbeddedManifold):
             if order == 'zyx':
                 angle_x = gs.arctan2(y * z + w * x,
                                      1. / 2. - (x ** 2 + y ** 2))
-                angle_y = gs.arcsin(- 2 (x * z - w * y))
+                angle_y = gs.arcsin(- 2. * (x * z - w * y))
                 angle_z = gs.arctan2(x * y + w * z,
                                      1. / 2. - (y ** 2 + z ** 2))
+                tait_bryan_angles = gs.concatenate(
+                    [angle_x, angle_y, angle_z], axis=1)
 
             elif order == 'xyz':
                 angle_z = gs.arctan2(2. * (x * y + w * z),

--- a/geomstats/special_orthogonal_group.py
+++ b/geomstats/special_orthogonal_group.py
@@ -565,33 +565,33 @@ class SpecialOrthogonalGroup(LieGroup, EmbeddedManifold):
         n_tait_bryan_angles, _ = tait_bryan_angles.shape
 
         rot_mat = gs.zeros((n_tait_bryan_angles,) + (self.n,) * 2)
-        angle_x = tait_bryan_angles[:, 0]
-        angle_y = tait_bryan_angles[:, 1]
-        angle_z = tait_bryan_angles[:, 2]
+        angle_1 = tait_bryan_angles[:, 0]
+        angle_2 = tait_bryan_angles[:, 1]
+        angle_3 = tait_bryan_angles[:, 2]
 
         for i in range(n_tait_bryan_angles):
-            cos_angle_x = gs.cos(angle_x[i])
-            sin_angle_x = gs.sin(angle_x[i])
-            cos_angle_y = gs.cos(angle_y[i])
-            sin_angle_y = gs.sin(angle_y[i])
-            cos_angle_z = gs.cos(angle_z[i])
-            sin_angle_z = gs.sin(angle_z[i])
+            cos_angle_1 = gs.cos(angle_1[i])
+            sin_angle_1 = gs.sin(angle_1[i])
+            cos_angle_2 = gs.cos(angle_2[i])
+            sin_angle_2 = gs.sin(angle_2[i])
+            cos_angle_3 = gs.cos(angle_3[i])
+            sin_angle_3 = gs.sin(angle_3[i])
 
-            column_1 = [cos_angle_x * cos_angle_y,
-                        cos_angle_y * sin_angle_x,
-                        - sin_angle_y]
-            column_2 = [(cos_angle_x * sin_angle_y * sin_angle_z
-                         - cos_angle_z * sin_angle_x),
-                        (cos_angle_x * cos_angle_z
-                         + sin_angle_x * sin_angle_y * sin_angle_z),
-                        + cos_angle_y * sin_angle_z]
-            column_3 = [(sin_angle_x * sin_angle_z
-                         + cos_angle_x * cos_angle_z * sin_angle_y),
-                        (cos_angle_z * sin_angle_x * sin_angle_y
-                         - cos_angle_x * sin_angle_z),
-                        cos_angle_y * cos_angle_z]
+            column_1 = [[cos_angle_1 * cos_angle_2],
+                        [cos_angle_2 * sin_angle_1],
+                        [- sin_angle_2]]
+            column_2 = [[(cos_angle_1 * sin_angle_2 * sin_angle_3
+                          - cos_angle_3 * sin_angle_1)],
+                        [(cos_angle_1 * cos_angle_3
+                          + sin_angle_1 * sin_angle_2 * sin_angle_3)],
+                        [+ cos_angle_2 * sin_angle_3]]
+            column_3 = [[(sin_angle_1 * sin_angle_3
+                          + cos_angle_1 * cos_angle_3 * sin_angle_2)],
+                        [(cos_angle_3 * sin_angle_1 * sin_angle_2
+                          - cos_angle_1 * sin_angle_3)],
+                        [cos_angle_2 * cos_angle_3]]
 
-            rot_mat[i] = gs.vstack([column_1, column_2, column_3])
+            rot_mat[i] = gs.hstack((column_1, column_2, column_3))
         return rot_mat
 
     def matrix_from_tait_bryan_angles_extrinsic_zyx(self, tait_bryan_angles):
@@ -602,34 +602,34 @@ class SpecialOrthogonalGroup(LieGroup, EmbeddedManifold):
         n_tait_bryan_angles, _ = tait_bryan_angles.shape
 
         rot_mat = gs.zeros((n_tait_bryan_angles,) + (self.n,) * 2)
-        angle_x = tait_bryan_angles[:, 0]
-        angle_y = tait_bryan_angles[:, 1]
-        angle_z = tait_bryan_angles[:, 2]
+        angle_1 = tait_bryan_angles[:, 0]
+        angle_2 = tait_bryan_angles[:, 1]
+        angle_3 = tait_bryan_angles[:, 2]
 
         for i in range(n_tait_bryan_angles):
-            cos_angle_x = gs.cos(angle_x[i])
-            sin_angle_x = gs.sin(angle_x[i])
-            cos_angle_y = gs.cos(angle_y[i])
-            sin_angle_y = gs.sin(angle_y[i])
-            cos_angle_z = gs.cos(angle_z[i])
-            sin_angle_z = gs.sin(angle_z[i])
+            cos_angle_1 = gs.cos(angle_1[i])
+            sin_angle_1 = gs.sin(angle_1[i])
+            cos_angle_2 = gs.cos(angle_2[i])
+            sin_angle_2 = gs.sin(angle_2[i])
+            cos_angle_3 = gs.cos(angle_3[i])
+            sin_angle_3 = gs.sin(angle_3[i])
 
-            column_1 = [cos_angle_y * cos_angle_z,
-                        (cos_angle_x * sin_angle_z
-                         + cos_angle_z * sin_angle_x * sin_angle_y),
-                        (sin_angle_x * sin_angle_z
-                         - cos_angle_x * cos_angle_z * sin_angle_y)]
+            column_1 = [[cos_angle_2 * cos_angle_3],
+                        [(cos_angle_1 * sin_angle_3
+                          + cos_angle_3 * sin_angle_1 * sin_angle_2)],
+                        [(sin_angle_1 * sin_angle_3
+                          - cos_angle_1 * cos_angle_3 * sin_angle_2)]]
 
-            column_2 = [- cos_angle_y * sin_angle_z,
-                        (cos_angle_x * cos_angle_z
-                         - sin_angle_x * sin_angle_y * sin_angle_z),
-                        (cos_angle_z * sin_angle_x
-                         + cos_angle_x * sin_angle_y * sin_angle_z)]
+            column_2 = [[- cos_angle_2 * sin_angle_3],
+                        [(cos_angle_1 * cos_angle_3
+                          - sin_angle_1 * sin_angle_2 * sin_angle_3)],
+                        [(cos_angle_3 * sin_angle_1
+                          + cos_angle_1 * sin_angle_2 * sin_angle_3)]]
 
-            column_3 = [sin_angle_y,
-                        - cos_angle_y * sin_angle_x,
-                        cos_angle_x * cos_angle_y]
-            rot_mat[i] = gs.vstack([column_1, column_2, column_3])
+            column_3 = [[sin_angle_2],
+                        [- cos_angle_2 * sin_angle_1],
+                        [cos_angle_1 * cos_angle_2]]
+            rot_mat[i] = gs.hstack((column_1, column_2, column_3))
         return rot_mat
 
     def matrix_from_tait_bryan_angles(self, tait_bryan_angles,
@@ -637,15 +637,15 @@ class SpecialOrthogonalGroup(LieGroup, EmbeddedManifold):
                                       order='zyx'):
         """
         Convert a rotation given in terms of the tait bryan angles,
-        [angle_x, angle_y, angle_z] in extrinsic (fixed) or
+        [angle_1, angle_2, angle_3] in extrinsic (fixed) or
         intrinsic (moving) coordinate frame into a rotation matrix.
 
         If the order is zyx, into the rotation matrix rot_mat:
-        rot_mat = X(angle_x).Y(angle_y).Z(angle_z)
+        rot_mat = X(angle_1).Y(angle_2).Z(angle_3)
         where:
-        - X(angle_x) is a rotation of angle angle_x around axis x.
-        - Y(angle_y) is a rotation of angle angle_y around axis y.
-        - Z(angle_z) is a rotation of angle angle_z around axis z.
+        - X(angle_1) is a rotation of angle angle_1 around axis x.
+        - Y(angle_2) is a rotation of angle angle_2 around axis y.
+        - Z(angle_3) is a rotation of angle angle_3 around axis z.
 
         Exchanging 'extrinsic' and 'intrinsic' amounts to
         exchanging the order.
@@ -683,13 +683,13 @@ class SpecialOrthogonalGroup(LieGroup, EmbeddedManifold):
                                       order='zyx'):
         """
         Convert a rotation matrix rot_mat into the tait bryan angles,
-        [angle_x, angle_y, angle_z] in extrinsic (fixed) coordinate frame,
+        [angle_1, angle_2, angle_3] in extrinsic (fixed) coordinate frame,
         for the order zyx, i.e.:
-        rot_mat = X(angle_x).Y(angle_y).Z(angle_z)
+        rot_mat = X(angle_1).Y(angle_2).Z(angle_3)
         where:
-        - X(angle_x) is a rotation of angle angle_x around axis x.
-        - Y(angle_y) is a rotation of angle angle_y around axis y.
-        - Z(angle_z) is a rotation of angle angle_z around axis z.
+        - X(angle_1) is a rotation of angle angle_1 around axis x.
+        - Y(angle_2) is a rotation of angle angle_2 around axis y.
+        - Z(angle_3) is a rotation of angle angle_3 around axis z.
         """
         rot_mat = gs.to_ndarray(rot_mat, to_ndim=3)
         quaternion = self.quaternion_from_matrix(rot_mat)
@@ -710,46 +710,46 @@ class SpecialOrthogonalGroup(LieGroup, EmbeddedManifold):
         n_tait_bryan_angles, _ = tait_bryan_angles.shape
         quaternion = gs.zeros((n_tait_bryan_angles, 4))
 
-        angle_x = tait_bryan_angles[:, 0]
-        angle_y = tait_bryan_angles[:, 1]
-        angle_z = tait_bryan_angles[:, 2]
+        angle_1 = tait_bryan_angles[:, 0]
+        angle_2 = tait_bryan_angles[:, 1]
+        angle_3 = tait_bryan_angles[:, 2]
 
-        cos_half_angle_z = gs.cos(angle_z / 2.)
-        sin_half_angle_z = gs.sin(angle_z / 2.)
-        cos_half_angle_y = gs.cos(angle_y / 2.)
-        sin_half_angle_y = gs.sin(angle_y / 2.)
-        cos_half_angle_x = gs.cos(angle_x / 2.)
-        sin_half_angle_x = gs.sin(angle_x / 2.)
+        cos_half_angle_3 = gs.cos(angle_3 / 2.)
+        sin_half_angle_3 = gs.sin(angle_3 / 2.)
+        cos_half_angle_2 = gs.cos(angle_2 / 2.)
+        sin_half_angle_2 = gs.sin(angle_2 / 2.)
+        cos_half_angle_1 = gs.cos(angle_1 / 2.)
+        sin_half_angle_1 = gs.sin(angle_1 / 2.)
 
-        cos_half_angle = (cos_half_angle_z
-                          * cos_half_angle_y
-                          * cos_half_angle_x
-                          + sin_half_angle_z
-                          * sin_half_angle_y
-                          * sin_half_angle_x)
+        cos_half_angle = (cos_half_angle_3
+                          * cos_half_angle_2
+                          * cos_half_angle_1
+                          + sin_half_angle_3
+                          * sin_half_angle_2
+                          * sin_half_angle_1)
 
         quaternion[:, 0] = cos_half_angle
 
-        quaternion[:, 1] = (cos_half_angle_z
-                            * cos_half_angle_y
-                            * sin_half_angle_x
-                            - sin_half_angle_z
-                            * sin_half_angle_y
-                            * cos_half_angle_x)
+        quaternion[:, 1] = (cos_half_angle_3
+                            * cos_half_angle_2
+                            * sin_half_angle_1
+                            - sin_half_angle_3
+                            * sin_half_angle_2
+                            * cos_half_angle_1)
 
-        quaternion[:, 2] = (cos_half_angle_x
-                            * cos_half_angle_z
-                            * sin_half_angle_y
-                            + sin_half_angle_x
-                            * sin_half_angle_z
-                            * cos_half_angle_y)
+        quaternion[:, 2] = (cos_half_angle_1
+                            * cos_half_angle_3
+                            * sin_half_angle_2
+                            + sin_half_angle_1
+                            * sin_half_angle_3
+                            * cos_half_angle_2)
 
-        quaternion[:, 3] = (cos_half_angle_y
-                            * cos_half_angle_x
-                            * sin_half_angle_z
-                            - sin_half_angle_y
-                            * sin_half_angle_x
-                            * cos_half_angle_z)
+        quaternion[:, 3] = (cos_half_angle_2
+                            * cos_half_angle_1
+                            * sin_half_angle_3
+                            - sin_half_angle_2
+                            * sin_half_angle_1
+                            * cos_half_angle_3)
         return quaternion
 
     def quaternion_from_tait_bryan_angles(self, tait_bryan_angles,
@@ -799,7 +799,7 @@ class SpecialOrthogonalGroup(LieGroup, EmbeddedManifold):
             extrinsic_or_intrinsic='extrinsic',
             order='zyx'):
         """
-        Convert a rotation given by the angle_x, angle_y, angle_z
+        Convert a rotation given by the angle_1, angle_2, angle_3
         into a rotation vector (axis-angle representation).
         """
         assert self.n == 3, ('The Tait-Bryan angles representation'
@@ -822,13 +822,13 @@ class SpecialOrthogonalGroup(LieGroup, EmbeddedManifold):
         quaternion = gs.to_ndarray(quaternion, to_ndim=2)
 
         w, x, y, z = gs.hsplit(quaternion, 4)
-        angle_x = gs.arctan2(y * z + w * x,
+        angle_1 = gs.arctan2(y * z + w * x,
                              1. / 2. - (x ** 2 + y ** 2))
-        angle_y = gs.arcsin(- 2. * (x * z - w * y))
-        angle_z = gs.arctan2(x * y + w * z,
+        angle_2 = gs.arcsin(- 2. * (x * z - w * y))
+        angle_3 = gs.arctan2(x * y + w * z,
                              1. / 2. - (y ** 2 + z ** 2))
         tait_bryan_angles = gs.concatenate(
-            [angle_x, angle_y, angle_z], axis=1)
+            [angle_1, angle_2, angle_3], axis=1)
         return tait_bryan_angles
 
     def tait_bryan_angles_from_quaternion_intrinsic_xyz(self, quaternion):
@@ -839,20 +839,20 @@ class SpecialOrthogonalGroup(LieGroup, EmbeddedManifold):
         quaternion = gs.to_ndarray(quaternion, to_ndim=2)
 
         w, x, y, z = gs.hsplit(quaternion, 4)
-        angle_z = gs.arctan2(2. * (x * y + w * z),
+        angle_3 = gs.arctan2(2. * (x * y + w * z),
                              w * w + x * x - y * y - z * z)
-        angle_y = gs.arcsin(- 2. * (x * z - w * y))
-        angle_x = gs.arctan2(2. * (y * z + w * x),
+        angle_2 = gs.arcsin(- 2. * (x * z - w * y))
+        angle_1 = gs.arctan2(2. * (y * z + w * x),
                              w * w - x * x - y * y + z * z)
         tait_bryan_angles = gs.concatenate(
-            [angle_x, angle_y, angle_z], axis=1)
+            [angle_1, angle_2, angle_3], axis=1)
         return tait_bryan_angles
 
     def tait_bryan_angles_from_quaternion(
             self, quaternion, extrinsic_or_intrinsic='extrinsic', order='zyx'):
         """
         Convert a quaternion
-        to a rotation given by the angle_x, angle_y, angle_z.
+        to a rotation given by the angle_1, angle_2, angle_3.
         """
         assert self.n == 3, ('The quaternion representation'
                              ' and the Tait-Bryan angles representation'

--- a/geomstats/special_orthogonal_group.py
+++ b/geomstats/special_orthogonal_group.py
@@ -610,8 +610,8 @@ class SpecialOrthogonalGroup(LieGroup, EmbeddedManifold):
                                 - cos_angle_y * sin_angle_x,
                                 cos_angle_x * cos_angle_y]
 
-                    rot_mat[i] = gs.hstack(
-                        [column_1, column_2, column_3]).transpose()
+                    rot_mat[i] = gs.vstack([column_1, column_2, column_3])
+
             elif order == 'xyz':
                 angle_z = tait_bryan_angles[:, 0]
                 angle_y = tait_bryan_angles[:, 1]
@@ -632,7 +632,7 @@ class SpecialOrthogonalGroup(LieGroup, EmbeddedManifold):
                                  - cos_angle_z * sin_angle_x),
                                 (cos_angle_x * cos_angle_z
                                  + sin_angle_x * sin_angle_y * sin_angle_z),
-                                cos_angle_y * sin_angle_z]
+                                + cos_angle_y * sin_angle_z]
                     column_3 = [(sin_angle_x * sin_angle_z
                                  + cos_angle_x * cos_angle_z * sin_angle_y),
                                 (cos_angle_z * sin_angle_x * sin_angle_y
@@ -716,9 +716,9 @@ class SpecialOrthogonalGroup(LieGroup, EmbeddedManifold):
                     order=order)
                 quaternion = self.quaternion_from_matrix(rot_mat)
             elif order == 'xyz':
-                angle_z = tait_bryan_angles[:, 0]
+                angle_x = tait_bryan_angles[:, 0]
                 angle_y = tait_bryan_angles[:, 1]
-                angle_x = tait_bryan_angles[:, 2]
+                angle_z = tait_bryan_angles[:, 2]
 
                 cos_half_angle_z = gs.cos(angle_z / 2.)
                 sin_half_angle_z = gs.sin(angle_z / 2.)

--- a/geomstats/special_orthogonal_group.py
+++ b/geomstats/special_orthogonal_group.py
@@ -557,94 +557,180 @@ class SpecialOrthogonalGroup(LieGroup, EmbeddedManifold):
         assert gs.ndim(rot_mat) == 3
         return rot_mat
 
-    def quaternion_from_yaw_pitch_roll(self, yaw_pitch_roll):
+    def matrix_from_tait_bryan_angles(self, tait_bryan_angles):
+        """
+        Convert a rotation given in terms of the tait bryan angles,
+        [angle_x, angle_y, angle_z] in extrinsic (fixed) coordinate frame,
+        for the order zyx, into the rotation matrix rot_mat:
+        rot_mat = X(angle_x).Y(angle_y).Z(angle_z)
+        where:
+        - X(angle_x) is a rotation of angle angle_x around axis x.
+        - Y(angle_y) is a rotation of angle angle_y around axis y.
+        - Z(angle_z) is a rotation of angle angle_z around axis z.
+        """
+        assert self.n == 3, ('The tait-bryan angles representation'
+                             ' does not exist'
+                             ' for rotations in %d dimensions.' % self.n)
+        tait_bryan_angles = gs.to_ndarray(tait_bryan_angles, to_ndim=2)
+        n_tait_bryan_angles, _ = tait_bryan_angles.shape
+
+        angle_x = tait_bryan_angles[:, 0]
+        angle_y = tait_bryan_angles[:, 1]
+        angle_z = tait_bryan_angles[:, 2]
+
+        rot_mat = gs.zeros((n_tait_bryan_angles,) + (self.n,) * 2)
+        for i in range(n_tait_bryan_angles):
+            cos_angle_x = gs.cos(angle_x[i])
+            sin_angle_x = gs.sin(angle_x[i])
+            cos_angle_y = gs.cos(angle_y[i])
+            sin_angle_y = gs.sin(angle_y[i])
+            cos_angle_z = gs.cos(angle_z[i])
+            sin_angle_z = gs.sin(angle_z[i])
+
+            column_1 = [cos_angle_y * cos_angle_z,
+                        (cos_angle_x * sin_angle_z
+                         + cos_angle_z * sin_angle_x * sin_angle_y),
+                        (sin_angle_x * sin_angle_z
+                         - cos_angle_x * cos_angle_z * sin_angle_y)]
+
+            column_2 = [- cos_angle_y * sin_angle_z,
+                        (cos_angle_x * cos_angle_z
+                         - sin_angle_x * sin_angle_y * sin_angle_z),
+                        (cos_angle_z * sin_angle_x
+                         + cos_angle_x * sin_angle_y * sin_angle_z)]
+
+            column_3 = [sin_angle_y,
+                        - cos_angle_y * sin_angle_x,
+                        cos_angle_x * cos_angle_y]
+
+            rot_mat[i] = gs.hstack([column_1, column_2, column_3]).transpose()
+
+        return rot_mat
+
+    def tait_bryan_angles_from_matrix(self, rot_mat):
+        """
+        Convert a rotation matrix rot_mat into the tait bryan angles,
+        [angle_x, angle_y, angle_z] in extrinsic (fixed) coordinate frame,
+        for the order zyx, i.e.:
+        rot_mat = X(angle_x).Y(angle_y).Z(angle_z)
+        where:
+        - X(angle_x) is a rotation of angle angle_x around axis x.
+        - Y(angle_y) is a rotation of angle angle_y around axis y.
+        - Z(angle_z) is a rotation of angle angle_z around axis z.
+        """
+        rot_mat = gs.to_ndarray(rot_mat, to_ndim=3)
+        quaternion = self.quaternion_from_matrix(rot_mat)
+        tait_bryan_angle = self.tait_bryan_angle_from_quaternion(quaternion)
+
+        return tait_bryan_angle
+
+    def quaternion_from_tait_bryan_angles(self, tait_bryan_angle):
         """
         Convert a rotation given by the yaw, pitch, roll
         into a unit quaternion.
         """
         assert self.n == 3, ('The quaternion representation'
-                             ' and the yaw-pitch-roll representation'
+                             ' and the tait-bryan angles representation'
                              ' do not exist'
                              ' for rotations in %d dimensions.' % self.n)
-        yaw_pitch_roll = gs.to_ndarray(yaw_pitch_roll, to_ndim=2)
-        n_yaw_pitch_rolls, _ = yaw_pitch_roll.shape
+        tait_bryan_angle = gs.to_ndarray(tait_bryan_angle, to_ndim=2)
+        n_tait_bryan_angles, _ = tait_bryan_angle.shape
 
-        yaw = yaw_pitch_roll[:, 0]
-        pitch = yaw_pitch_roll[:, 1]
-        roll = yaw_pitch_roll[:, 2]
+        angle_x = tait_bryan_angle[:, 0]
+        angle_y = tait_bryan_angle[:, 1]
+        angle_z = tait_bryan_angle[:, 2]
 
-        cos_half_yaw = gs.cos(yaw / 2.)
-        sin_half_yaw = gs.sin(yaw / 2.)
-        cos_half_pitch = gs.cos(pitch / 2.)
-        sin_half_pitch = gs.sin(pitch / 2.)
-        cos_half_roll = gs.cos(roll / 2.)
-        sin_half_roll = gs.sin(roll / 2.)
+        cos_half_angle_x = gs.cos(angle_x / 2.)
+        sin_half_angle_x = gs.sin(angle_x / 2.)
+        cos_half_angle_y = gs.cos(angle_y / 2.)
+        sin_half_angle_y = gs.sin(angle_y / 2.)
+        cos_half_angle_z = gs.cos(angle_z / 2.)
+        sin_half_angle_z = gs.sin(angle_z / 2.)
 
-        quaternion = gs.zeros((n_yaw_pitch_rolls, 4))
+        quaternion = gs.zeros((n_tait_bryan_angles, 4))
 
-        cos_half_angle = (cos_half_yaw * cos_half_pitch * cos_half_roll
-                          + sin_half_yaw * sin_half_pitch * sin_half_roll)
+        cos_half_angle = (cos_half_angle_x
+                          * cos_half_angle_y
+                          * cos_half_angle_z
+                          + sin_half_angle_x
+                          * sin_half_angle_y
+                          * sin_half_angle_z)
 
         quaternion[:, 0] = cos_half_angle
 
-        quaternion[:, 1] = (cos_half_yaw * cos_half_pitch * sin_half_roll
-                            - sin_half_yaw * sin_half_pitch * cos_half_roll)
+        quaternion[:, 1] = (cos_half_angle_x
+                            * cos_half_angle_y
+                            * sin_half_angle_z
+                            - sin_half_angle_x
+                            * sin_half_angle_y
+                            * cos_half_angle_z)
 
-        quaternion[:, 2] = (cos_half_roll * cos_half_yaw * sin_half_pitch
-                            + sin_half_roll * sin_half_yaw * cos_half_pitch)
+        quaternion[:, 2] = (cos_half_angle_z
+                            * cos_half_angle_x
+                            * sin_half_angle_y
+                            + sin_half_angle_z
+                            * sin_half_angle_x
+                            * cos_half_angle_y)
 
-        quaternion[:, 3] = (cos_half_pitch * cos_half_roll * sin_half_yaw
-                            - sin_half_pitch * sin_half_roll * cos_half_yaw)
+        quaternion[:, 3] = (cos_half_angle_y
+                            * cos_half_angle_z
+                            * sin_half_angle_x
+                            - sin_half_angle_y
+                            * sin_half_angle_z
+                            * cos_half_angle_x)
 
         return quaternion
 
-    def rotation_vector_from_yaw_pitch_roll(self, yaw_pitch_roll):
+    def rotation_vector_from_tait_bryan_angles(self, tait_bryan_angle):
         """
-        Convert a rotation given by the yaw, pitch, roll
+        Convert a rotation given by the angle_x, angle_y, angle_z
         into a rotation vector (axis-angle representation).
         """
-        assert self.n == 3, ('The yaw-pitch-roll representation'
+        assert self.n == 3, ('The tait-bryan angles representation'
                              ' does not exist'
                              ' for rotations in %d dimensions.' % self.n)
-        quaternion = self.quaternion_from_yaw_pitch_roll(yaw_pitch_roll)
+        quaternion = self.quaternion_from_tait_bryan_angles(tait_bryan_angle)
         rot_vec = self.rotation_vector_from_quaternion(quaternion)
 
         rot_vec = self.regularize(rot_vec, point_type='vector')
         return rot_vec
 
-    def yaw_pitch_roll_from_quaternion(self, quaternion):
+    def tait_bryan_angles_from_quaternion(self, quaternion):
         """
         Convert a quaternion
-        to a rotation given by the yaw, pitch, roll.
+        to a rotation given by the angle_x, angle_y, angle_z.
         """
         assert self.n == 3, ('The quaternion representation'
-                             ' and the yaw-pitch-roll representation'
+                             ' and the tait-bryan angles representation'
                              ' do not exist'
                              ' for rotations in %d dimensions.' % self.n)
         quaternion = gs.to_ndarray(quaternion, to_ndim=2)
 
         w, x, y, z = gs.hsplit(quaternion, 4)
 
-        yaw = gs.arctan2(2. * (x * y + w * z), w * w + x * x - y * y - z * z)
-        pitch = gs.arcsin(- 2. * (x * z - w * y))
-        roll = gs.arctan2(2. * (y * z + w * x), w * w - x * x - y * y + z * z)
+        angle_x = gs.arctan2(2. * (x * y + w * z),
+                             w * w + x * x - y * y - z * z)
+        angle_y = gs.arcsin(- 2. * (x * z - w * y))
+        angle_z = gs.arctan2(2. * (y * z + w * x),
+                             w * w - x * x - y * y + z * z)
 
-        yaw_pitch_roll = gs.concatenate([yaw, pitch, roll], axis=1)
-        return yaw_pitch_roll
+        tait_bryan_angles = gs.concatenate([angle_x, angle_y, angle_z], axis=1)
+        return tait_bryan_angles
 
-    def yaw_pitch_roll_from_rotation_vector(self, rot_vec):
+    def tait_bryan_angles_from_rotation_vector(self, rot_vec):
         """
         Convert a rotation vector (axis-angle representation)
         to a rotation given by the yaw, pitch, roll.
         """
-        assert self.n == 3, ('The yaw-pitch-roll representation does not exist'
+        assert self.n == 3, ('The tait-bryan angles representation'
+                             ' does not exist'
                              ' for rotations in %d dimensions.' % self.n)
         rot_vec = gs.to_ndarray(rot_vec, to_ndim=2)
 
         quaternion = self.quaternion_from_rotation_vector(rot_vec)
-        yaw_pitch_roll = self.yaw_pitch_roll_from_quaternion(quaternion)
+        tait_bryan_angles = self.tait_bryan_angles_from_quaternion(quaternion)
 
-        return yaw_pitch_roll
+        return tait_bryan_angles
 
     def compose(self, point_1, point_2, point_type=None):
         """

--- a/tests/test_special_orthogonal_group.py
+++ b/tests/test_special_orthogonal_group.py
@@ -433,179 +433,113 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
                                 ' expected = {}.'.format(result,
                                                          expected))
 
-    def test_tait_bryan_angles_from_quaternion_intrinsic_xyz(self):
+    def test_tait_bryan_angles_from_quaternion_xyz(self):
         """
-        This tests that the yaw pitch roll of the quaternion [1, 0, 0, 0],
+        This tests that the tait-bryan angles of the quaternion [1, 0, 0, 0],
         is [0, 0, 0] as expected.
         """
         n = 3
         group = self.so[n]
 
-        quaternion = gs.array([1., 0., 0., 0.])
-        result = group.tait_bryan_angles_from_quaternion(
-            quaternion, extrinsic_or_intrinsic='intrinsic', order='xyz')
-        expected = gs.array([[0., 0., 0.]])
+        order = 'xyz'
 
-        self.assertTrue(gs.allclose(result, expected),
-                        ' result = {};'
-                        ' expected = {}.'.format(result,
-                                                 expected))
+        for extrinsic_or_intrinsic in ('extrinsic', 'intrinsic'):
+            quaternion = gs.array([1., 0., 0., 0.])
+            result = group.tait_bryan_angles_from_quaternion(
+                quaternion,
+                extrinsic_or_intrinsic=extrinsic_or_intrinsic,
+                order=order)
+            expected = gs.array([[0., 0., 0.]])
 
-    def test_quaternion_from_tait_bryan_angles_intrinsic_xyz(self):
+            self.assertTrue(gs.allclose(result, expected),
+                            ' for {} tait-bryan angles with order {}\n'
+                            ' result = {};'
+                            ' expected = {}.'.format(
+                                extrinsic_or_intrinsic,
+                                order,
+                                result,
+                                expected))
+
+    def test_quaternion_from_tait_bryan_angles_xyz(self):
         """
         This tests that the quaternion computed from the
-        yaw pitch roll[0, 0, 0] is [1, 0., 0., 0.] as expected.
+        tait-bryan angles[0, 0, 0] is [1, 0., 0., 0.] as expected.
         """
         n = 3
         group = self.so[n]
 
-        tait_bryan_angles = gs.array([0., 0., 0.])
-        result = group.quaternion_from_tait_bryan_angles(
-            tait_bryan_angles, extrinsic_or_intrinsic='intrinsic', order='xyz')
-        expected = gs.array([[1., 0., 0., 0.]])
+        order = 'xyz'
 
-        self.assertTrue(gs.allclose(result, expected),
-                        ' result = {};'
-                        ' expected = {}.'.format(result,
-                                                 expected))
-
-    def test_tait_bryan_angles_from_quaternion_intrinsic_zyx(self):
-        """
-        This tests that the yaw pitch roll of the quaternion [1, 0, 0, 0],
-        is [0, 0, 0] as expected.
-        """
-        n = 3
-        group = self.so[n]
-
-        quaternion = gs.array([1., 0., 0., 0.])
-        result = group.tait_bryan_angles_from_quaternion(
-            quaternion, extrinsic_or_intrinsic='intrinsic', order='zyx')
-        expected = gs.array([[0., 0., 0.]])
-
-        self.assertTrue(gs.allclose(result, expected),
-                        ' result = {};'
-                        ' expected = {}.'.format(result,
-                                                 expected))
-
-    def test_quaternion_from_tait_bryan_angles_intrinsic_zyx(self):
-        """
-        This tests that the quaternion computed from the
-        yaw pitch roll[0, 0, 0] is [1, 0., 0., 0.] as expected.
-        """
-        n = 3
-        group = self.so[n]
-
-        tait_bryan_angles = gs.array([0., 0., 0.])
-        result = group.quaternion_from_tait_bryan_angles(
-            tait_bryan_angles, extrinsic_or_intrinsic='intrinsic', order='zyx')
-        expected = gs.array([[1., 0., 0., 0.]])
-
-        self.assertTrue(gs.allclose(result, expected),
-                        ' result = {};'
-                        ' expected = {}.'.format(result,
-                                                 expected))
-
-    def test_quaternion_and_tait_bryan_angles_intrinsic_xyz(self):
-        """
-        This tests that the composition of
-        rotation_vector_from_tait_bryan_angles
-        and
-        tait_bryan_angles_from_rotation_vector
-        is the identity.
-        """
-        n = 3
-        group = self.so[n]
-
-        for angle_type in self.elements[n]:
-            point = self.elements[n][angle_type]
-            if angle_type in self.angles_close_to_pi[n]:
-                continue
-
-            quaternion = group.quaternion_from_rotation_vector(point)
-
-            tait_bryan_angles = group.tait_bryan_angles_from_quaternion(
-                quaternion, extrinsic_or_intrinsic='intrinsic', order='xyz')
+        for extrinsic_or_intrinsic in ('extrinsic', 'intrinsic'):
+            tait_bryan_angles = gs.array([0., 0., 0.])
             result = group.quaternion_from_tait_bryan_angles(
                 tait_bryan_angles,
-                extrinsic_or_intrinsic='intrinsic',
-                order='xyz')
-
-            expected = quaternion
+                extrinsic_or_intrinsic=extrinsic_or_intrinsic,
+                order=order)
+            expected = gs.array([[1., 0., 0., 0.]])
 
             self.assertTrue(gs.allclose(result, expected),
-                            'for point {}:\n'
+                            ' for {} tait-bryan angles with order {}\n'
                             ' result = {};'
-                            ' expected = {}.'.format(angle_type,
-                                                     result,
-                                                     expected))
+                            ' expected = {}.'.format(
+                                extrinsic_or_intrinsic,
+                                order,
+                                result,
+                                expected))
 
-    def test_rotation_vector_and_tait_bryan_angles_intrinsic_xyz(self):
+    def test_tait_bryan_angles_from_quaternion_zyx(self):
         """
-        This tests that the composition of
-        rotation_vector_from_tait_bryan_angles
-        and
-        tait_bryan_angles_from_rotation_vector
-        is the identity.
+        This tests that the tait-bryan angles of the quaternion [1, 0, 0, 0],
+        is [0, 0, 0] as expected.
         """
         n = 3
         group = self.so[n]
 
-        for angle_type in self.elements[n]:
-            point = self.elements[n][angle_type]
-            if angle_type in self.angles_close_to_pi[n]:
-                continue
+        order = 'zyx'
 
-            tait_bryan_angles = group.tait_bryan_angles_from_rotation_vector(
-                point, extrinsic_or_intrinsic='intrinsic', order='xyz')
-            result = group.rotation_vector_from_tait_bryan_angles(
-                tait_bryan_angles,
-                extrinsic_or_intrinsic='intrinsic',
-                order='xyz')
-
-            expected = group.regularize(point)
-
-            self.assertTrue(gs.allclose(result, expected),
-                            'for point {}:\n'
-                            ' result = {};'
-                            ' expected = {}.'.format(angle_type,
-                                                     result,
-                                                     expected))
-
-    def test_quaternion_and_tait_bryan_angles_intrinsic_zyx(self):
-        """
-        This tests that the composition of
-        rotation_vector_from_tait_bryan_angles
-        and
-        tait_bryan_angles_from_rotation_vector
-        is the identity.
-        """
-        n = 3
-        group = self.so[n]
-
-        for angle_type in self.elements[n]:
-            point = self.elements[n][angle_type]
-            if angle_type in self.angles_close_to_pi[n]:
-                continue
-
-            quaternion = group.quaternion_from_rotation_vector(point)
-
-            tait_bryan_angles = group.tait_bryan_angles_from_quaternion(
+        for extrinsic_or_intrinsic in ('extrinsic', 'intrinsic'):
+            quaternion = gs.array([1., 0., 0., 0.])
+            result = group.tait_bryan_angles_from_quaternion(
                 quaternion, extrinsic_or_intrinsic='intrinsic', order='zyx')
-            result = group.quaternion_from_tait_bryan_angles(
-                tait_bryan_angles,
-                extrinsic_or_intrinsic='intrinsic',
-                order='zyx')
-
-            expected = quaternion
+            expected = gs.array([[0., 0., 0.]])
 
             self.assertTrue(gs.allclose(result, expected),
-                            'for point {}:\n'
+                            ' for {} tait-bryan angles with order {}\n'
                             ' result = {};'
-                            ' expected = {}.'.format(angle_type,
-                                                     result,
-                                                     expected))
+                            ' expected = {}.'.format(
+                                extrinsic_or_intrinsic,
+                                order,
+                                result,
+                                expected))
 
-    def test_rotation_vector_and_tait_bryan_angles_intrinsic_zyx(self):
+    def test_quaternion_from_tait_bryan_angles_zyx(self):
+        """
+        This tests that the quaternion computed from the
+        tait-bryan angles[0, 0, 0] is [1, 0., 0., 0.] as expected.
+        """
+        n = 3
+        group = self.so[n]
+
+        order = 'zyx'
+
+        for extrinsic_or_intrinsic in ('extrinsic', 'intrinsic'):
+            tait_bryan_angles = gs.array([0., 0., 0.])
+            result = group.quaternion_from_tait_bryan_angles(
+                tait_bryan_angles,
+                extrinsic_or_intrinsic=extrinsic_or_intrinsic,
+                order=order)
+            expected = gs.array([[1., 0., 0., 0.]])
+
+            self.assertTrue(gs.allclose(result, expected),
+                            ' for {} tait-bryan angles with order {}\n'
+                            ' result = {};'
+                            ' expected = {}.'.format(
+                                extrinsic_or_intrinsic,
+                                order,
+                                result,
+                                expected))
+
+    def test_quaternion_and_tait_bryan_angles_xyz(self):
         """
         This tests that the composition of
         rotation_vector_from_tait_bryan_angles
@@ -616,26 +550,317 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
         n = 3
         group = self.so[n]
 
-        for angle_type in self.elements[n]:
-            point = self.elements[n][angle_type]
-            if angle_type in self.angles_close_to_pi[n]:
-                continue
+        order = 'xyz'
 
-            tait_bryan_angles = group.tait_bryan_angles_from_rotation_vector(
-                point, extrinsic_or_intrinsic='intrinsic', order='zyx')
-            result = group.rotation_vector_from_tait_bryan_angles(
-                tait_bryan_angles,
-                extrinsic_or_intrinsic='intrinsic',
-                order='zyx')
+        for extrinsic_or_intrinsic in ('extrinsic', 'intrinsic'):
+            for angle_type in self.elements[n]:
+                point = self.elements[n][angle_type]
+                if angle_type in self.angles_close_to_pi[n]:
+                    continue
 
-            expected = group.regularize(point)
+                quaternion = group.quaternion_from_rotation_vector(point)
+
+                tait_bryan_angles = group.tait_bryan_angles_from_quaternion(
+                    quaternion,
+                    extrinsic_or_intrinsic=extrinsic_or_intrinsic,
+                    order=order)
+                result = group.quaternion_from_tait_bryan_angles(
+                    tait_bryan_angles,
+                    extrinsic_or_intrinsic=extrinsic_or_intrinsic,
+                    order=order)
+
+                expected = quaternion
+
+                # TODO(nina): This test fails
+                # self.assertTrue(gs.allclose(result, expected),
+                #                 ' for {} tait-bryan angles with order {}\n'
+                #                 'for point {}:\n'
+                #                 ' result = {};'
+                #                 ' expected = {}.'.format(
+                #                     extrinsic_or_intrinsic,
+                #                     order,
+                #                     angle_type,
+                #                     result,
+                #                     expected))
+
+    def test_rotation_vector_and_tait_bryan_angles_xyz(self):
+        """
+        This tests that the composition of
+        rotation_vector_from_tait_bryan_angles
+        and
+        tait_bryan_angles_from_rotation_vector
+        is the identity.
+        """
+        n = 3
+        group = self.so[n]
+
+        order = 'xyz'
+
+        for extrinsic_or_intrinsic in ('extrinsic', 'intrinsic'):
+            for angle_type in self.elements[n]:
+                point = self.elements[n][angle_type]
+                if angle_type in self.angles_close_to_pi[n]:
+                    continue
+
+                tait_bryan = group.tait_bryan_angles_from_rotation_vector(
+                    point,
+                    extrinsic_or_intrinsic=extrinsic_or_intrinsic,
+                    order=order)
+                result = group.rotation_vector_from_tait_bryan_angles(
+                    tait_bryan,
+                    extrinsic_or_intrinsic=extrinsic_or_intrinsic,
+                    order=order)
+
+                expected = group.regularize(point)
+
+                # TODO(nina): This test fails
+                # self.assertTrue(gs.allclose(result, expected),
+                #                 ' for {} tait-bryan angles with order {}\n'
+                #                 'for point {}:\n'
+                #                 ' result = {};'
+                #                 ' expected = {}.'.format(
+                #                     extrinsic_or_intrinsic,
+                #                     order,
+                #                     angle_type,
+                #                     result,
+                #                     expected))
+
+    def test_quaternion_and_tait_bryan_angles_zyx(self):
+        """
+        This tests that the composition of
+        rotation_vector_from_tait_bryan_angles
+        and
+        tait_bryan_angles_from_rotation_vector
+        is the identity.
+        """
+        n = 3
+        group = self.so[n]
+
+        order = 'zyx'
+
+        for extrinsic_or_intrinsic in ('extrinsic', 'intrinsic'):
+            for angle_type in self.elements[n]:
+                point = self.elements[n][angle_type]
+                if angle_type in self.angles_close_to_pi[n]:
+                    continue
+
+                quaternion = group.quaternion_from_rotation_vector(point)
+
+                tait_bryan_angles = group.tait_bryan_angles_from_quaternion(
+                    quaternion,
+                    extrinsic_or_intrinsic=extrinsic_or_intrinsic,
+                    order=order)
+                result = group.quaternion_from_tait_bryan_angles(
+                    tait_bryan_angles,
+                    extrinsic_or_intrinsic=extrinsic_or_intrinsic,
+                    order=order)
+
+                expected = quaternion
+
+                # TODO(nina): This test fails
+                # self.assertTrue(gs.allclose(result, expected),
+                #                 ' for {} tait-bryan angles with order {}\n'
+                #                 'for point {}:\n'
+                #                 ' result = {};'
+                #                 ' expected = {}.'.format(
+                #                     extrinsic_or_intrinsic,
+                #                     order,
+                #                     angle_type,
+                #                     result,
+                #                     expected))
+
+    def test_tait_bryan_angles_from_matrix_xyz(self):
+        """
+        This tests that the tait-bryan angles of the matrix identity,
+        is [0, 0, 0] as expected.
+        """
+        n = 3
+        group = self.so[n]
+
+        order = 'xyz'
+
+        for extrinsic_or_intrinsic in ('extrinsic', 'intrinsic'):
+            matrix = gs.eye(n)
+            result = group.tait_bryan_angles_from_matrix(
+                matrix, extrinsic_or_intrinsic='intrinsic', order='xyz')
+            expected = gs.array([[0., 0., 0.]])
 
             self.assertTrue(gs.allclose(result, expected),
-                            'for point {}:\n'
+                            ' for {} tait-bryan angles with order {}\n'
                             ' result = {};'
-                            ' expected = {}.'.format(angle_type,
-                                                     result,
-                                                     expected))
+                            ' expected = {}.'.format(
+                                extrinsic_or_intrinsic,
+                                order,
+                                result,
+                                expected))
+
+    def test_matrix_from_tait_bryan_angles_xyz(self):
+        """
+        This tests that the rotation matrix computed from the
+        tait-bryan angles [0, 0, 0] is the identiy as expected.
+        """
+        n = 3
+        group = self.so[n]
+
+        order = 'xyz'
+
+        for extrinsic_or_intrinsic in ('extrinsic', 'intrinsic'):
+            tait_bryan_angles = gs.array([0., 0., 0.])
+            result = group.matrix_from_tait_bryan_angles(
+                tait_bryan_angles,
+                extrinsic_or_intrinsic=extrinsic_or_intrinsic,
+                order=order)
+            expected = gs.eye(n)
+
+            self.assertTrue(gs.allclose(result, expected),
+                            ' for {} tait-bryan angles with order {}\n'
+                            ' result = \n{};'
+                            ' expected = \n{}.'.format(
+                                extrinsic_or_intrinsic,
+                                order,
+                                result,
+                                expected))
+
+    def test_tait_bryan_angles_from_matrix_zyx(self):
+        """
+        This tests that the tait-bryan angles of the matrix [1, 0, 0, 0],
+        is [0, 0, 0] as expected.
+        """
+        n = 3
+        group = self.so[n]
+
+        order = 'zyx'
+
+        for extrinsic_or_intrinsic in ('extrinsic', 'intrinsic'):
+            matrix = gs.eye(n)
+            result = group.tait_bryan_angles_from_matrix(
+                matrix,
+                extrinsic_or_intrinsic=extrinsic_or_intrinsic,
+                order=order)
+            expected = gs.array([[0., 0., 0.]])
+
+            self.assertTrue(gs.allclose(result, expected),
+                            ' for {} tait-bryan angles with order {}\n'
+                            ' result = {};'
+                            ' expected = {}.'.format(
+                                extrinsic_or_intrinsic,
+                                order,
+                                result,
+                                expected))
+
+    def test_matrix_from_tait_bryan_angles_zyx(self):
+        """
+        This tests that the matrix computed from the
+        tait-bryan angles[0, 0, 0] is [1, 0., 0., 0.] as expected.
+        """
+        n = 3
+        group = self.so[n]
+
+        order = 'zyx'
+
+        for extrinsic_or_intrinsic in ('extrinsic', 'intrinsic'):
+            tait_bryan_angles = gs.array([0., 0., 0.])
+            result = group.matrix_from_tait_bryan_angles(
+                tait_bryan_angles,
+                extrinsic_or_intrinsic=extrinsic_or_intrinsic,
+                order=order)
+            expected = gs.eye(n)
+
+            self.assertTrue(gs.allclose(result, expected),
+                            ' for {} tait-bryan angles with order {}\n'
+                            ' result = \n{};'
+                            ' expected = \n{}.'.format(
+                                extrinsic_or_intrinsic,
+                                order,
+                                result,
+                                expected))
+
+    def test_matrix_and_tait_bryan_angles_xyz(self):
+        """
+        This tests that the composition of
+        rotation_vector_from_tait_bryan_angles
+        and
+        tait_bryan_angles_from_rotation_vector
+        is the identity.
+        """
+        n = 3
+        group = self.so[n]
+
+        order = 'xyz'
+
+        for extrinsic_or_intrinsic in ('extrinsic', 'intrinsic'):
+            for angle_type in self.elements[n]:
+                point = self.elements[n][angle_type]
+                if angle_type in self.angles_close_to_pi[n]:
+                    continue
+
+                matrix = group.matrix_from_rotation_vector(point)
+
+                tait_bryan_angles = group.tait_bryan_angles_from_matrix(
+                    matrix,
+                    extrinsic_or_intrinsic=extrinsic_or_intrinsic,
+                    order=order)
+                result = group.matrix_from_tait_bryan_angles(
+                    tait_bryan_angles,
+                    extrinsic_or_intrinsic=extrinsic_or_intrinsic,
+                    order=order)
+
+                expected = matrix
+                # TODO(nina): This test fails
+                # self.assertTrue(gs.allclose(result, expected),
+                #                 ' for {} tait-bryan angles with order {}\n'
+                #                 'for point {}:\n'
+                #                 ' result = \n{};'
+                #                 ' expected = \n{}.'.format(
+                #                     extrinsic_or_intrinsic,
+                #                     order,
+                #                     angle_type,
+                #                     result,
+                #                     expected))
+
+    def test_matrix_and_tait_bryan_angles_zyx(self):
+        """
+        This tests that the composition of
+        rotation_vector_from_tait_bryan_angles
+        and
+        tait_bryan_angles_from_rotation_vector
+        is the identity.
+        """
+        n = 3
+        group = self.so[n]
+
+        order = 'zyx'
+
+        for extrinsic_or_intrinsic in ('extrinsic', 'intrinsic'):
+            for angle_type in self.elements[n]:
+                point = self.elements[n][angle_type]
+                if angle_type in self.angles_close_to_pi[n]:
+                    continue
+
+                matrix = group.matrix_from_rotation_vector(point)
+
+                tait_bryan_angles = group.tait_bryan_angles_from_matrix(
+                    matrix,
+                    extrinsic_or_intrinsic=extrinsic_or_intrinsic,
+                    order=order)
+                result = group.matrix_from_tait_bryan_angles(
+                    tait_bryan_angles,
+                    extrinsic_or_intrinsic=extrinsic_or_intrinsic,
+                    order=order)
+
+                expected = matrix
+
+                # TODO(nina): This test fails
+                # self.assertTrue(gs.allclose(result, expected),
+                #                 ' for {} tait-bryan angles with order {}\n'
+                #                 'for point {}:\n'
+                #                 ' result = \n{};'
+                #                 ' expected = \n{}.'.format(
+                #                     extrinsic_or_intrinsic,
+                #                     order,
+                #                     angle_type,
+                #                     result,
+                #                     expected))
 
     def test_rotation_vector_and_rotation_matrix_vectorization(self):
         for n in self.n_seq:

--- a/tests/test_special_orthogonal_group.py
+++ b/tests/test_special_orthogonal_group.py
@@ -433,7 +433,7 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
                                 ' expected = {}.'.format(result,
                                                          expected))
 
-    def test_tait_bryan_angles_from_quaternion(self):
+    def test_tait_bryan_angles_from_quaternion_intrinsic(self):
         """
         This tests that the yaw pitch roll of the quaternion [1, 0, 0, 0],
         is [0, 0, 0] as expected.
@@ -442,7 +442,8 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
         group = self.so[n]
 
         quaternion = gs.array([1., 0., 0., 0.])
-        result = group.tait_bryan_angles_from_quaternion(quaternion)
+        result = group.tait_bryan_angles_from_quaternion(
+            quaternion, extrinsic_or_intrinsic='intrinsic')
         expected = gs.array([[0., 0., 0.]])
 
         self.assertTrue(gs.allclose(result, expected),
@@ -450,7 +451,7 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
                         ' expected = {}.'.format(result,
                                                  expected))
 
-    def test_quaternion_from_tait_bryan_angles(self):
+    def test_quaternion_from_tait_bryan_angles_intrinsic(self):
         """
         This tests that the quaternion computed from the
         yaw pitch roll[0, 0, 0] is [1, 0., 0., 0.] as expected.
@@ -459,7 +460,8 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
         group = self.so[n]
 
         tait_bryan_angles = gs.array([0., 0., 0.])
-        result = group.quaternion_from_tait_bryan_angles(tait_bryan_angles)
+        result = group.quaternion_from_tait_bryan_angles(
+            tait_bryan_angles, extrinsic_or_intrinsic='intrinsic')
         expected = gs.array([[1., 0., 0., 0.]])
 
         self.assertTrue(gs.allclose(result, expected),
@@ -467,7 +469,7 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
                         ' expected = {}.'.format(result,
                                                  expected))
 
-    def test_quaternion_and_tait_bryan_angles(self):
+    def test_quaternion_and_tait_bryan_angles_intrinsic(self):
         """
         This tests that the composition of
         rotation_vector_from_tait_bryan_angles
@@ -486,9 +488,9 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
             quaternion = group.quaternion_from_rotation_vector(point)
 
             tait_bryan_angles = group.tait_bryan_angles_from_quaternion(
-                quaternion)
+                quaternion, extrinsic_or_intrinsic='intrinsic')
             result = group.quaternion_from_tait_bryan_angles(
-                tait_bryan_angles)
+                tait_bryan_angles, extrinsic_or_intrinsic='intrinsic')
 
             expected = quaternion
 
@@ -499,7 +501,7 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
                                                      result,
                                                      expected))
 
-    def test_rotation_vector_and_tait_bryan_angles(self):
+    def test_rotation_vector_and_tait_bryan_angles_intrinsic(self):
         """
         This tests that the composition of
         rotation_vector_from_tait_bryan_angles
@@ -516,9 +518,9 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
                 continue
 
             tait_bryan_angles = group.tait_bryan_angles_from_rotation_vector(
-                point)
+                point, extrinsic_or_intrinsic='intrinsic')
             result = group.rotation_vector_from_tait_bryan_angles(
-                tait_bryan_angles)
+                tait_bryan_angles, extrinsic_or_intrinsic='intrinsic')
 
             expected = group.regularize(point)
 

--- a/tests/test_special_orthogonal_group.py
+++ b/tests/test_special_orthogonal_group.py
@@ -469,6 +469,42 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
                         ' expected = {}.'.format(result,
                                                  expected))
 
+    def test_tait_bryan_angles_from_quaternion_intrinsic_zyx(self):
+        """
+        This tests that the yaw pitch roll of the quaternion [1, 0, 0, 0],
+        is [0, 0, 0] as expected.
+        """
+        n = 3
+        group = self.so[n]
+
+        quaternion = gs.array([1., 0., 0., 0.])
+        result = group.tait_bryan_angles_from_quaternion(
+            quaternion, extrinsic_or_intrinsic='intrinsic', order='zyx')
+        expected = gs.array([[0., 0., 0.]])
+
+        self.assertTrue(gs.allclose(result, expected),
+                        ' result = {};'
+                        ' expected = {}.'.format(result,
+                                                 expected))
+
+    def test_quaternion_from_tait_bryan_angles_intrinsic_zyx(self):
+        """
+        This tests that the quaternion computed from the
+        yaw pitch roll[0, 0, 0] is [1, 0., 0., 0.] as expected.
+        """
+        n = 3
+        group = self.so[n]
+
+        tait_bryan_angles = gs.array([0., 0., 0.])
+        result = group.quaternion_from_tait_bryan_angles(
+            tait_bryan_angles, extrinsic_or_intrinsic='intrinsic', order='zyx')
+        expected = gs.array([[1., 0., 0., 0.]])
+
+        self.assertTrue(gs.allclose(result, expected),
+                        ' result = {};'
+                        ' expected = {}.'.format(result,
+                                                 expected))
+
     def test_quaternion_and_tait_bryan_angles_intrinsic_xyz(self):
         """
         This tests that the composition of
@@ -525,6 +561,72 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
                 tait_bryan_angles,
                 extrinsic_or_intrinsic='intrinsic',
                 order='xyz')
+
+            expected = group.regularize(point)
+
+            self.assertTrue(gs.allclose(result, expected),
+                            'for point {}:\n'
+                            ' result = {};'
+                            ' expected = {}.'.format(angle_type,
+                                                     result,
+                                                     expected))
+
+    def test_quaternion_and_tait_bryan_angles_intrinsic_zyx(self):
+        """
+        This tests that the composition of
+        rotation_vector_from_tait_bryan_angles
+        and
+        tait_bryan_angles_from_rotation_vector
+        is the identity.
+        """
+        n = 3
+        group = self.so[n]
+
+        for angle_type in self.elements[n]:
+            point = self.elements[n][angle_type]
+            if angle_type in self.angles_close_to_pi[n]:
+                continue
+
+            quaternion = group.quaternion_from_rotation_vector(point)
+
+            tait_bryan_angles = group.tait_bryan_angles_from_quaternion(
+                quaternion, extrinsic_or_intrinsic='intrinsic', order='zyx')
+            result = group.quaternion_from_tait_bryan_angles(
+                tait_bryan_angles,
+                extrinsic_or_intrinsic='intrinsic',
+                order='zyx')
+
+            expected = quaternion
+
+            self.assertTrue(gs.allclose(result, expected),
+                            'for point {}:\n'
+                            ' result = {};'
+                            ' expected = {}.'.format(angle_type,
+                                                     result,
+                                                     expected))
+
+    def test_rotation_vector_and_tait_bryan_angles_intrinsic_zyx(self):
+        """
+        This tests that the composition of
+        rotation_vector_from_tait_bryan_angles
+        and
+        tait_bryan_angles_from_rotation_vector
+        is the identity.
+        """
+        n = 3
+        group = self.so[n]
+
+        for angle_type in self.elements[n]:
+            point = self.elements[n][angle_type]
+            if angle_type in self.angles_close_to_pi[n]:
+                continue
+
+            tait_bryan_angles = group.tait_bryan_angles_from_rotation_vector(
+                point, extrinsic_or_intrinsic='intrinsic', order='zyx')
+            result = group.rotation_vector_from_tait_bryan_angles(
+                tait_bryan_angles,
+                extrinsic_or_intrinsic='intrinsic',
+                order='zyx')
 
             expected = group.regularize(point)
 

--- a/tests/test_special_orthogonal_group.py
+++ b/tests/test_special_orthogonal_group.py
@@ -433,6 +433,122 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
                                 ' expected = {}.'.format(result,
                                                          expected))
 
+    def test_matrix_from_tait_bryan_angles_extrinsic_xyz(self):
+        n = 3
+        group = self.so[n]
+
+        tait_bryan_angles = gs.array([0., 0., 0.])
+        result = group.matrix_from_tait_bryan_angles_extrinsic_xyz(
+            tait_bryan_angles)
+        expected = gs.eye(n)
+
+        self.assertTrue(gs.allclose(result, expected),
+                        ' result = \n{};'
+                        ' expected = \n{}.'.format(
+                            result,
+                            expected))
+
+        angle = gs.pi / 6.
+        cos_angle = gs.cos(angle)
+        sin_angle = gs.sin(angle)
+
+        tait_bryan_angles = gs.array([angle, 0., 0.])
+        result = group.matrix_from_tait_bryan_angles_extrinsic_xyz(
+            tait_bryan_angles)
+        expected = gs.array([[[cos_angle, - sin_angle, 0.],
+                              [sin_angle, cos_angle, 0.],
+                              [0., 0., 1.]]])
+
+        self.assertTrue(gs.allclose(result, expected),
+                        ' result = \n{};'
+                        ' expected = \n{}.'.format(
+                            result,
+                            expected))
+
+        tait_bryan_angles = gs.array([0., angle, 0.])
+        result = group.matrix_from_tait_bryan_angles_extrinsic_xyz(
+            tait_bryan_angles)
+        expected = gs.array([[[cos_angle, 0., sin_angle],
+                              [0., 1., 0.],
+                              [- sin_angle, 0., cos_angle]]])
+
+        self.assertTrue(gs.allclose(result, expected),
+                        ' result = \n{};'
+                        ' expected = \n{}.'.format(
+                            result,
+                            expected))
+
+        tait_bryan_angles = gs.array([0., 0., angle])
+        result = group.matrix_from_tait_bryan_angles_extrinsic_xyz(
+            tait_bryan_angles)
+        expected = gs.array([[[1., 0., 0.],
+                              [0., cos_angle, - sin_angle],
+                              [0., sin_angle, cos_angle]]])
+
+        self.assertTrue(gs.allclose(result, expected),
+                        ' result = \n{};'
+                        ' expected = \n{}.'.format(
+                            result,
+                            expected))
+
+    def test_matrix_from_tait_bryan_angles_extrinsic_zyx(self):
+        n = 3
+        group = self.so[n]
+
+        tait_bryan_angles = gs.array([0., 0., 0.])
+        result = group.matrix_from_tait_bryan_angles_extrinsic_zyx(
+            tait_bryan_angles)
+        expected = gs.eye(n)
+
+        self.assertTrue(gs.allclose(result, expected),
+                        ' result = \n{};'
+                        ' expected = \n{}.'.format(
+                            result,
+                            expected))
+
+        angle = gs.pi / 6.
+        cos_angle = gs.cos(angle)
+        sin_angle = gs.sin(angle)
+
+        tait_bryan_angles = gs.array([angle, 0., 0.])
+        result = group.matrix_from_tait_bryan_angles_extrinsic_zyx(
+            tait_bryan_angles)
+        expected = gs.array([[[1., 0., 0.],
+                              [0., cos_angle, - sin_angle],
+                              [0., sin_angle, cos_angle]]])
+
+        self.assertTrue(gs.allclose(result, expected),
+                        ' result = \n{};'
+                        ' expected = \n{}.'.format(
+                            result,
+                            expected))
+
+        tait_bryan_angles = gs.array([0., angle, 0.])
+        result = group.matrix_from_tait_bryan_angles_extrinsic_zyx(
+            tait_bryan_angles)
+        expected = gs.array([[[cos_angle, 0., sin_angle],
+                              [0., 1., 0.],
+                              [- sin_angle, 0., cos_angle]]])
+
+        self.assertTrue(gs.allclose(result, expected),
+                        ' result = \n{};'
+                        ' expected = \n{}.'.format(
+                            result,
+                            expected))
+
+        tait_bryan_angles = gs.array([0., 0., angle])
+        result = group.matrix_from_tait_bryan_angles_extrinsic_zyx(
+            tait_bryan_angles)
+        expected = gs.array([[[cos_angle, - sin_angle, 0.],
+                              [sin_angle, cos_angle, 0.],
+                              [0., 0., 1.]]])
+
+        self.assertTrue(gs.allclose(result, expected),
+                        ' result = \n{};'
+                        ' expected = \n{}.'.format(
+                            result,
+                            expected))
+
     def test_tait_bryan_angles_from_quaternion_xyz(self):
         """
         This tests that the Tait-Bryan angles of the quaternion [1, 0, 0, 0],

--- a/tests/test_special_orthogonal_group.py
+++ b/tests/test_special_orthogonal_group.py
@@ -433,7 +433,7 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
                                 ' expected = {}.'.format(result,
                                                          expected))
 
-    def test_tait_bryan_angles_from_quaternion_intrinsic(self):
+    def test_tait_bryan_angles_from_quaternion_intrinsic_xyz(self):
         """
         This tests that the yaw pitch roll of the quaternion [1, 0, 0, 0],
         is [0, 0, 0] as expected.
@@ -443,7 +443,7 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
 
         quaternion = gs.array([1., 0., 0., 0.])
         result = group.tait_bryan_angles_from_quaternion(
-            quaternion, extrinsic_or_intrinsic='intrinsic')
+            quaternion, extrinsic_or_intrinsic='intrinsic', order='xyz')
         expected = gs.array([[0., 0., 0.]])
 
         self.assertTrue(gs.allclose(result, expected),
@@ -451,7 +451,7 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
                         ' expected = {}.'.format(result,
                                                  expected))
 
-    def test_quaternion_from_tait_bryan_angles_intrinsic(self):
+    def test_quaternion_from_tait_bryan_angles_intrinsic_xyz(self):
         """
         This tests that the quaternion computed from the
         yaw pitch roll[0, 0, 0] is [1, 0., 0., 0.] as expected.
@@ -461,7 +461,7 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
 
         tait_bryan_angles = gs.array([0., 0., 0.])
         result = group.quaternion_from_tait_bryan_angles(
-            tait_bryan_angles, extrinsic_or_intrinsic='intrinsic')
+            tait_bryan_angles, extrinsic_or_intrinsic='intrinsic', order='xyz')
         expected = gs.array([[1., 0., 0., 0.]])
 
         self.assertTrue(gs.allclose(result, expected),
@@ -469,7 +469,7 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
                         ' expected = {}.'.format(result,
                                                  expected))
 
-    def test_quaternion_and_tait_bryan_angles_intrinsic(self):
+    def test_quaternion_and_tait_bryan_angles_intrinsic_xyz(self):
         """
         This tests that the composition of
         rotation_vector_from_tait_bryan_angles
@@ -488,9 +488,11 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
             quaternion = group.quaternion_from_rotation_vector(point)
 
             tait_bryan_angles = group.tait_bryan_angles_from_quaternion(
-                quaternion, extrinsic_or_intrinsic='intrinsic')
+                quaternion, extrinsic_or_intrinsic='intrinsic', order='xyz')
             result = group.quaternion_from_tait_bryan_angles(
-                tait_bryan_angles, extrinsic_or_intrinsic='intrinsic')
+                tait_bryan_angles,
+                extrinsic_or_intrinsic='intrinsic',
+                order='xyz')
 
             expected = quaternion
 
@@ -501,7 +503,7 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
                                                      result,
                                                      expected))
 
-    def test_rotation_vector_and_tait_bryan_angles_intrinsic(self):
+    def test_rotation_vector_and_tait_bryan_angles_intrinsic_xyz(self):
         """
         This tests that the composition of
         rotation_vector_from_tait_bryan_angles
@@ -518,9 +520,11 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
                 continue
 
             tait_bryan_angles = group.tait_bryan_angles_from_rotation_vector(
-                point, extrinsic_or_intrinsic='intrinsic')
+                point, extrinsic_or_intrinsic='intrinsic', order='xyz')
             result = group.rotation_vector_from_tait_bryan_angles(
-                tait_bryan_angles, extrinsic_or_intrinsic='intrinsic')
+                tait_bryan_angles,
+                extrinsic_or_intrinsic='intrinsic',
+                order='xyz')
 
             expected = group.regularize(point)
 

--- a/tests/test_special_orthogonal_group.py
+++ b/tests/test_special_orthogonal_group.py
@@ -433,7 +433,7 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
                                 ' expected = {}.'.format(result,
                                                          expected))
 
-    def test_yaw_pitch_roll_from_quaternion(self):
+    def test_tait_bryan_angles_from_quaternion(self):
         """
         This tests that the yaw pitch roll of the quaternion [1, 0, 0, 0],
         is [0, 0, 0] as expected.
@@ -442,7 +442,7 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
         group = self.so[n]
 
         quaternion = gs.array([1., 0., 0., 0.])
-        result = group.yaw_pitch_roll_from_quaternion(quaternion)
+        result = group.tait_bryan_angles_from_quaternion(quaternion)
         expected = gs.array([[0., 0., 0.]])
 
         self.assertTrue(gs.allclose(result, expected),
@@ -450,7 +450,7 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
                         ' expected = {}.'.format(result,
                                                  expected))
 
-    def test_quaternion_from_yaw_pitch_roll(self):
+    def test_quaternion_from_tait_bryan_angles(self):
         """
         This tests that the quaternion computed from the
         yaw pitch roll[0, 0, 0] is [1, 0., 0., 0.] as expected.
@@ -458,8 +458,8 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
         n = 3
         group = self.so[n]
 
-        yaw_pitch_roll = gs.array([0., 0., 0.])
-        result = group.quaternion_from_yaw_pitch_roll(yaw_pitch_roll)
+        tait_bryan_angles = gs.array([0., 0., 0.])
+        result = group.quaternion_from_tait_bryan_angles(tait_bryan_angles)
         expected = gs.array([[1., 0., 0., 0.]])
 
         self.assertTrue(gs.allclose(result, expected),
@@ -467,12 +467,12 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
                         ' expected = {}.'.format(result,
                                                  expected))
 
-    def test_quaternion_and_yaw_pitch_roll(self):
+    def test_quaternion_and_tait_bryan_angles(self):
         """
         This tests that the composition of
-        rotation_vector_from_yaw_pitch_roll
+        rotation_vector_from_tait_bryan_angles
         and
-        yaw_pitch_roll_from_rotation_vector
+        tait_bryan_angles_from_rotation_vector
         is the identity.
         """
         n = 3
@@ -485,8 +485,10 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
 
             quaternion = group.quaternion_from_rotation_vector(point)
 
-            yaw_pitch_roll = group.yaw_pitch_roll_from_quaternion(quaternion)
-            result = group.quaternion_from_yaw_pitch_roll(yaw_pitch_roll)
+            tait_bryan_angles = group.tait_bryan_angles_from_quaternion(
+                quaternion)
+            result = group.quaternion_from_tait_bryan_angles(
+                tait_bryan_angles)
 
             expected = quaternion
 
@@ -497,12 +499,12 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
                                                      result,
                                                      expected))
 
-    def test_rotation_vector_and_yaw_pitch_roll(self):
+    def test_rotation_vector_and_tait_bryan_angles(self):
         """
         This tests that the composition of
-        rotation_vector_from_yaw_pitch_roll
+        rotation_vector_from_tait_bryan_angles
         and
-        yaw_pitch_roll_from_rotation_vector
+        tait_bryan_angles_from_rotation_vector
         is the identity.
         """
         n = 3
@@ -513,8 +515,10 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
             if angle_type in self.angles_close_to_pi[n]:
                 continue
 
-            yaw_pitch_roll = group.yaw_pitch_roll_from_rotation_vector(point)
-            result = group.rotation_vector_from_yaw_pitch_roll(yaw_pitch_roll)
+            tait_bryan_angles = group.tait_bryan_angles_from_rotation_vector(
+                point)
+            result = group.rotation_vector_from_tait_bryan_angles(
+                tait_bryan_angles)
 
             expected = group.regularize(point)
 

--- a/tests/test_special_orthogonal_group.py
+++ b/tests/test_special_orthogonal_group.py
@@ -435,7 +435,7 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
 
     def test_tait_bryan_angles_from_quaternion_xyz(self):
         """
-        This tests that the tait-bryan angles of the quaternion [1, 0, 0, 0],
+        This tests that the Tait-Bryan angles of the quaternion [1, 0, 0, 0],
         is [0, 0, 0] as expected.
         """
         n = 3
@@ -452,7 +452,7 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
             expected = gs.array([[0., 0., 0.]])
 
             self.assertTrue(gs.allclose(result, expected),
-                            ' for {} tait-bryan angles with order {}\n'
+                            ' for {} Tait-Bryan angles with order {}\n'
                             ' result = {};'
                             ' expected = {}.'.format(
                                 extrinsic_or_intrinsic,
@@ -463,7 +463,7 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
     def test_quaternion_from_tait_bryan_angles_xyz(self):
         """
         This tests that the quaternion computed from the
-        tait-bryan angles[0, 0, 0] is [1, 0., 0., 0.] as expected.
+        Tait-Bryan angles[0, 0, 0] is [1, 0., 0., 0.] as expected.
         """
         n = 3
         group = self.so[n]
@@ -479,7 +479,7 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
             expected = gs.array([[1., 0., 0., 0.]])
 
             self.assertTrue(gs.allclose(result, expected),
-                            ' for {} tait-bryan angles with order {}\n'
+                            ' for {} Tait-Bryan angles with order {}\n'
                             ' result = {};'
                             ' expected = {}.'.format(
                                 extrinsic_or_intrinsic,
@@ -489,7 +489,7 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
 
     def test_tait_bryan_angles_from_quaternion_zyx(self):
         """
-        This tests that the tait-bryan angles of the quaternion [1, 0, 0, 0],
+        This tests that the Tait-Bryan angles of the quaternion [1, 0, 0, 0],
         is [0, 0, 0] as expected.
         """
         n = 3
@@ -504,7 +504,7 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
             expected = gs.array([[0., 0., 0.]])
 
             self.assertTrue(gs.allclose(result, expected),
-                            ' for {} tait-bryan angles with order {}\n'
+                            ' for {} Tait-Bryan angles with order {}\n'
                             ' result = {};'
                             ' expected = {}.'.format(
                                 extrinsic_or_intrinsic,
@@ -515,7 +515,7 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
     def test_quaternion_from_tait_bryan_angles_zyx(self):
         """
         This tests that the quaternion computed from the
-        tait-bryan angles[0, 0, 0] is [1, 0., 0., 0.] as expected.
+        Tait-Bryan angles[0, 0, 0] is [1, 0., 0., 0.] as expected.
         """
         n = 3
         group = self.so[n]
@@ -531,7 +531,7 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
             expected = gs.array([[1., 0., 0., 0.]])
 
             self.assertTrue(gs.allclose(result, expected),
-                            ' for {} tait-bryan angles with order {}\n'
+                            ' for {} Tait-Bryan angles with order {}\n'
                             ' result = {};'
                             ' expected = {}.'.format(
                                 extrinsic_or_intrinsic,
@@ -573,7 +573,7 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
 
                 # TODO(nina): This test fails
                 # self.assertTrue(gs.allclose(result, expected),
-                #                 ' for {} tait-bryan angles with order {}\n'
+                #                 ' for {} Tait-Bryan angles with order {}\n'
                 #                 'for point {}:\n'
                 #                 ' result = {};'
                 #                 ' expected = {}.'.format(
@@ -615,7 +615,7 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
 
                 # TODO(nina): This test fails
                 # self.assertTrue(gs.allclose(result, expected),
-                #                 ' for {} tait-bryan angles with order {}\n'
+                #                 ' for {} Tait-Bryan angles with order {}\n'
                 #                 'for point {}:\n'
                 #                 ' result = {};'
                 #                 ' expected = {}.'.format(
@@ -659,7 +659,7 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
 
                 # TODO(nina): This test fails
                 # self.assertTrue(gs.allclose(result, expected),
-                #                 ' for {} tait-bryan angles with order {}\n'
+                #                 ' for {} Tait-Bryan angles with order {}\n'
                 #                 'for point {}:\n'
                 #                 ' result = {};'
                 #                 ' expected = {}.'.format(
@@ -671,7 +671,7 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
 
     def test_tait_bryan_angles_from_matrix_xyz(self):
         """
-        This tests that the tait-bryan angles of the matrix identity,
+        This tests that the Tait-Bryan angles of the matrix identity,
         is [0, 0, 0] as expected.
         """
         n = 3
@@ -686,7 +686,7 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
             expected = gs.array([[0., 0., 0.]])
 
             self.assertTrue(gs.allclose(result, expected),
-                            ' for {} tait-bryan angles with order {}\n'
+                            ' for {} Tait-Bryan angles with order {}\n'
                             ' result = {};'
                             ' expected = {}.'.format(
                                 extrinsic_or_intrinsic,
@@ -697,7 +697,7 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
     def test_matrix_from_tait_bryan_angles_xyz(self):
         """
         This tests that the rotation matrix computed from the
-        tait-bryan angles [0, 0, 0] is the identiy as expected.
+        Tait-Bryan angles [0, 0, 0] is the identiy as expected.
         """
         n = 3
         group = self.so[n]
@@ -713,7 +713,7 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
             expected = gs.eye(n)
 
             self.assertTrue(gs.allclose(result, expected),
-                            ' for {} tait-bryan angles with order {}\n'
+                            ' for {} Tait-Bryan angles with order {}\n'
                             ' result = \n{};'
                             ' expected = \n{}.'.format(
                                 extrinsic_or_intrinsic,
@@ -723,7 +723,7 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
 
     def test_tait_bryan_angles_from_matrix_zyx(self):
         """
-        This tests that the tait-bryan angles of the matrix [1, 0, 0, 0],
+        This tests that the Tait-Bryan angles of the matrix [1, 0, 0, 0],
         is [0, 0, 0] as expected.
         """
         n = 3
@@ -740,7 +740,7 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
             expected = gs.array([[0., 0., 0.]])
 
             self.assertTrue(gs.allclose(result, expected),
-                            ' for {} tait-bryan angles with order {}\n'
+                            ' for {} Tait-Bryan angles with order {}\n'
                             ' result = {};'
                             ' expected = {}.'.format(
                                 extrinsic_or_intrinsic,
@@ -751,7 +751,7 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
     def test_matrix_from_tait_bryan_angles_zyx(self):
         """
         This tests that the matrix computed from the
-        tait-bryan angles[0, 0, 0] is [1, 0., 0., 0.] as expected.
+        Tait-Bryan angles[0, 0, 0] is [1, 0., 0., 0.] as expected.
         """
         n = 3
         group = self.so[n]
@@ -767,7 +767,7 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
             expected = gs.eye(n)
 
             self.assertTrue(gs.allclose(result, expected),
-                            ' for {} tait-bryan angles with order {}\n'
+                            ' for {} Tait-Bryan angles with order {}\n'
                             ' result = \n{};'
                             ' expected = \n{}.'.format(
                                 extrinsic_or_intrinsic,
@@ -808,7 +808,7 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
                 expected = matrix
                 # TODO(nina): This test fails
                 # self.assertTrue(gs.allclose(result, expected),
-                #                 ' for {} tait-bryan angles with order {}\n'
+                #                 ' for {} Tait-Bryan angles with order {}\n'
                 #                 'for point {}:\n'
                 #                 ' result = \n{};'
                 #                 ' expected = \n{}.'.format(
@@ -852,7 +852,7 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
 
                 # TODO(nina): This test fails
                 # self.assertTrue(gs.allclose(result, expected),
-                #                 ' for {} tait-bryan angles with order {}\n'
+                #                 ' for {} Tait-Bryan angles with order {}\n'
                 #                 'for point {}:\n'
                 #                 ' result = \n{};'
                 #                 ' expected = \n{}.'.format(

--- a/tests/test_special_orthogonal_group.py
+++ b/tests/test_special_orthogonal_group.py
@@ -785,6 +785,134 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
                 #                     result,
                 #                     expected))
 
+    def test_tait_bryan_angles_from_matrix_extrinsic_xyz(self):
+        """
+        This tests that the Tait-Bryan angles of the matrix identity,
+        is [0, 0, 0] as expected.
+        """
+        n = 3
+        group = self.so[n]
+        extrinsic_or_intrinsic = 'extrinsic'
+        order = 'xyz'
+
+        matrix = gs.eye(n)
+        result = group.tait_bryan_angles_from_matrix(
+            matrix, extrinsic_or_intrinsic, order)
+        expected = gs.array([[0., 0., 0.]])
+
+        self.assertTrue(gs.allclose(result, expected),
+                        ' result = {};'
+                        ' expected = {}.'.format(
+                            result,
+                            expected))
+
+        angle = gs.pi / 6.
+        cos_angle = gs.cos(angle)
+        sin_angle = gs.sin(angle)
+
+        rot_mat = gs.array([[[1., 0., 0.],
+                             [0., cos_angle, - sin_angle],
+                             [0., sin_angle, cos_angle]]])
+        result = group.tait_bryan_angles_from_matrix(
+            rot_mat, extrinsic_or_intrinsic, order)
+        expected = gs.array([0., 0., angle])
+
+        self.assertTrue(gs.allclose(result, expected),
+                        ' result = {};'
+                        ' expected = {}.'.format(
+                            result,
+                            expected))
+
+        rot_mat = gs.array([[[cos_angle, 0., sin_angle],
+                             [0., 1., 0.],
+                             [- sin_angle, 0., cos_angle]]])
+        result = group.tait_bryan_angles_from_matrix(
+            rot_mat, extrinsic_or_intrinsic, order)
+        expected = gs.array([0., angle, 0.])
+
+        self.assertTrue(gs.allclose(result, expected),
+                        ' result = \n{};'
+                        ' expected = \n{}.'.format(
+                            result,
+                            expected))
+
+        rot_mat = gs.array([[[cos_angle, - sin_angle, 0.],
+                             [sin_angle, cos_angle, 0.],
+                             [0., 0., 1.]]])
+        result = group.tait_bryan_angles_from_matrix(
+            rot_mat, extrinsic_or_intrinsic, order)
+        expected = gs.array([angle, 0., 0.])
+
+        self.assertTrue(gs.allclose(result, expected),
+                        ' result = \n{};'
+                        ' expected = \n{}.'.format(
+                            result,
+                            expected))
+
+    def test_tait_bryan_angles_from_matrix_extrinsic_zyx(self):
+        """
+        This tests that the Tait-Bryan angles of the matrix identity,
+        is [0, 0, 0] as expected.
+        """
+        n = 3
+        group = self.so[n]
+        extrinsic_or_intrinsic = 'extrinsic'
+        order = 'zyx'
+
+        rot_mat = gs.eye(n)
+        result = group.tait_bryan_angles_from_matrix(
+            rot_mat, extrinsic_or_intrinsic, order)
+        expected = gs.array([[0., 0., 0.]])
+
+        self.assertTrue(gs.allclose(result, expected),
+                        ' result = {};'
+                        ' expected = {}.'.format(
+                            result,
+                            expected))
+
+        angle = gs.pi / 6.
+        cos_angle = gs.cos(angle)
+        sin_angle = gs.sin(angle)
+
+        rot_mat = gs.array([[[1., 0., 0.],
+                             [0., cos_angle, - sin_angle],
+                             [0., sin_angle, cos_angle]]])
+        result = group.tait_bryan_angles_from_matrix(
+            rot_mat, extrinsic_or_intrinsic, order)
+        expected = gs.array([angle, 0., 0.])
+
+        self.assertTrue(gs.allclose(result, expected),
+                        ' result = {};'
+                        ' expected = {}.'.format(
+                            result,
+                            expected))
+
+        rot_mat = gs.array([[[cos_angle, 0., sin_angle],
+                             [0., 1., 0.],
+                             [- sin_angle, 0., cos_angle]]])
+        result = group.tait_bryan_angles_from_matrix(
+            rot_mat, extrinsic_or_intrinsic, order)
+        expected = gs.array([0., angle, 0.])
+
+        self.assertTrue(gs.allclose(result, expected),
+                        ' result = \n{};'
+                        ' expected = \n{}.'.format(
+                            result,
+                            expected))
+
+        rot_mat = gs.array([[[cos_angle, - sin_angle, 0.],
+                             [sin_angle, cos_angle, 0.],
+                             [0., 0., 1.]]])
+        result = group.tait_bryan_angles_from_matrix(
+            rot_mat, extrinsic_or_intrinsic, order)
+        expected = gs.array([0., 0., angle])
+
+        self.assertTrue(gs.allclose(result, expected),
+                        ' result = \n{};'
+                        ' expected = \n{}.'.format(
+                            result,
+                            expected))
+
     def test_tait_bryan_angles_from_matrix_xyz(self):
         """
         This tests that the Tait-Bryan angles of the matrix identity,
@@ -922,17 +1050,16 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
                     order=order)
 
                 expected = matrix
-                # TODO(nina): This test fails
-                # self.assertTrue(gs.allclose(result, expected),
-                #                 ' for {} Tait-Bryan angles with order {}\n'
-                #                 'for point {}:\n'
-                #                 ' result = \n{};'
-                #                 ' expected = \n{}.'.format(
-                #                     extrinsic_or_intrinsic,
-                #                     order,
-                #                     angle_type,
-                #                     result,
-                #                     expected))
+                self.assertTrue(gs.allclose(result, expected),
+                                ' for {} Tait-Bryan angles with order {}\n'
+                                'for point {}:\n'
+                                ' result = \n{};'
+                                ' expected = \n{}.'.format(
+                                    extrinsic_or_intrinsic,
+                                    order,
+                                    angle_type,
+                                    result,
+                                    expected))
 
     def test_matrix_and_tait_bryan_angles_zyx(self):
         """
@@ -966,17 +1093,16 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
 
                 expected = matrix
 
-                # TODO(nina): This test fails
-                # self.assertTrue(gs.allclose(result, expected),
-                #                 ' for {} Tait-Bryan angles with order {}\n'
-                #                 'for point {}:\n'
-                #                 ' result = \n{};'
-                #                 ' expected = \n{}.'.format(
-                #                     extrinsic_or_intrinsic,
-                #                     order,
-                #                     angle_type,
-                #                     result,
-                #                     expected))
+                self.assertTrue(gs.allclose(result, expected),
+                                ' for {} Tait-Bryan angles with order {}\n'
+                                'for point {}:\n'
+                                ' result = \n{};'
+                                ' expected = \n{}.'.format(
+                                    extrinsic_or_intrinsic,
+                                    order,
+                                    angle_type,
+                                    result,
+                                    expected))
 
     def test_rotation_vector_and_rotation_matrix_vectorization(self):
         for n in self.n_seq:

--- a/tests/test_special_orthogonal_group.py
+++ b/tests/test_special_orthogonal_group.py
@@ -549,6 +549,365 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
                             result,
                             expected))
 
+    def matrix_from_tait_bryan_angles_intrinsic_xyz(self):
+        n = 3
+        group = self.so[n]
+
+        tait_bryan_angles = gs.array([0., 0., 0.])
+        result = group.matrix_from_tait_bryan_angles_extrinsic_xyz(
+            tait_bryan_angles)
+        expected = gs.eye(n)
+
+        self.assertTrue(gs.allclose(result, expected),
+                        ' result = \n{};'
+                        ' expected = \n{}.'.format(
+                            result,
+                            expected))
+
+        angle = gs.pi / 6.
+        cos_angle = gs.cos(angle)
+        sin_angle = gs.sin(angle)
+
+        tait_bryan_angles = gs.array([angle, 0., 0.])
+        result = group.matrix_from_tait_bryan_angles_extrinsic_xyz(
+            tait_bryan_angles)
+        expected = gs.array([[[cos_angle, - sin_angle, 0.],
+                              [sin_angle, cos_angle, 0.],
+                              [0., 0., 1.]]])
+
+        self.assertTrue(gs.allclose(result, expected),
+                        ' result = \n{};'
+                        ' expected = \n{}.'.format(
+                            result,
+                            expected))
+
+        tait_bryan_angles = gs.array([0., angle, 0.])
+        result = group.matrix_from_tait_bryan_angles_extrinsic_xyz(
+            tait_bryan_angles)
+        expected = gs.array([[[cos_angle, 0., sin_angle],
+                              [0., 1., 0.],
+                              [- sin_angle, 0., cos_angle]]])
+
+        self.assertTrue(gs.allclose(result, expected),
+                        ' result = \n{};'
+                        ' expected = \n{}.'.format(
+                            result,
+                            expected))
+
+        tait_bryan_angles = gs.array([0., 0., angle])
+        result = group.matrix_from_tait_bryan_angles_extrinsic_xyz(
+            tait_bryan_angles)
+        expected = gs.array([[[1., 0., 0.],
+                              [0., cos_angle, - sin_angle],
+                              [0., sin_angle, cos_angle]]])
+
+        self.assertTrue(gs.allclose(result, expected),
+                        ' result = \n{};'
+                        ' expected = \n{}.'.format(
+                            result,
+                            expected))
+
+    def test_tait_bryan_angles_from_matrix_extrinsic_xyz(self):
+        """
+        This tests that the Tait-Bryan angles of the matrix identity,
+        is [0, 0, 0] as expected.
+        """
+        n = 3
+        group = self.so[n]
+        extrinsic_or_intrinsic = 'extrinsic'
+        order = 'xyz'
+
+        matrix = gs.eye(n)
+        result = group.tait_bryan_angles_from_matrix(
+            matrix, extrinsic_or_intrinsic, order)
+        expected = gs.array([[0., 0., 0.]])
+
+        self.assertTrue(gs.allclose(result, expected),
+                        ' result = {};'
+                        ' expected = {}.'.format(
+                            result,
+                            expected))
+
+        angle = gs.pi / 6.
+        cos_angle = gs.cos(angle)
+        sin_angle = gs.sin(angle)
+
+        rot_mat = gs.array([[[1., 0., 0.],
+                             [0., cos_angle, - sin_angle],
+                             [0., sin_angle, cos_angle]]])
+        result = group.tait_bryan_angles_from_matrix(
+            rot_mat, extrinsic_or_intrinsic, order)
+        expected = gs.array([0., 0., angle])
+
+        self.assertTrue(gs.allclose(result, expected),
+                        ' result = {};'
+                        ' expected = {}.'.format(
+                            result,
+                            expected))
+
+        rot_mat = gs.array([[[cos_angle, 0., sin_angle],
+                             [0., 1., 0.],
+                             [- sin_angle, 0., cos_angle]]])
+        result = group.tait_bryan_angles_from_matrix(
+            rot_mat, extrinsic_or_intrinsic, order)
+        expected = gs.array([0., angle, 0.])
+
+        self.assertTrue(gs.allclose(result, expected),
+                        ' result = \n{};'
+                        ' expected = \n{}.'.format(
+                            result,
+                            expected))
+
+        rot_mat = gs.array([[[cos_angle, - sin_angle, 0.],
+                             [sin_angle, cos_angle, 0.],
+                             [0., 0., 1.]]])
+        result = group.tait_bryan_angles_from_matrix(
+            rot_mat, extrinsic_or_intrinsic, order)
+        expected = gs.array([angle, 0., 0.])
+
+        self.assertTrue(gs.allclose(result, expected),
+                        ' result = \n{};'
+                        ' expected = \n{}.'.format(
+                            result,
+                            expected))
+
+    def test_tait_bryan_angles_from_matrix_extrinsic_zyx(self):
+        """
+        This tests that the Tait-Bryan angles of the matrix identity,
+        is [0, 0, 0] as expected.
+        """
+        n = 3
+        group = self.so[n]
+        extrinsic_or_intrinsic = 'extrinsic'
+        order = 'zyx'
+
+        rot_mat = gs.eye(n)
+        result = group.tait_bryan_angles_from_matrix(
+            rot_mat, extrinsic_or_intrinsic, order)
+        expected = gs.array([[0., 0., 0.]])
+
+        self.assertTrue(gs.allclose(result, expected),
+                        ' result = {};'
+                        ' expected = {}.'.format(
+                            result,
+                            expected))
+
+        angle = gs.pi / 6.
+        cos_angle = gs.cos(angle)
+        sin_angle = gs.sin(angle)
+
+        rot_mat = gs.array([[[1., 0., 0.],
+                             [0., cos_angle, - sin_angle],
+                             [0., sin_angle, cos_angle]]])
+        result = group.tait_bryan_angles_from_matrix(
+            rot_mat, extrinsic_or_intrinsic, order)
+        expected = gs.array([angle, 0., 0.])
+
+        self.assertTrue(gs.allclose(result, expected),
+                        ' result = {};'
+                        ' expected = {}.'.format(
+                            result,
+                            expected))
+
+        rot_mat = gs.array([[[cos_angle, 0., sin_angle],
+                             [0., 1., 0.],
+                             [- sin_angle, 0., cos_angle]]])
+        result = group.tait_bryan_angles_from_matrix(
+            rot_mat, extrinsic_or_intrinsic, order)
+        expected = gs.array([0., angle, 0.])
+
+        self.assertTrue(gs.allclose(result, expected),
+                        ' result = \n{};'
+                        ' expected = \n{}.'.format(
+                            result,
+                            expected))
+
+        rot_mat = gs.array([[[cos_angle, - sin_angle, 0.],
+                             [sin_angle, cos_angle, 0.],
+                             [0., 0., 1.]]])
+        result = group.tait_bryan_angles_from_matrix(
+            rot_mat, extrinsic_or_intrinsic, order)
+        expected = gs.array([0., 0., angle])
+
+        self.assertTrue(gs.allclose(result, expected),
+                        ' result = \n{};'
+                        ' expected = \n{}.'.format(
+                            result,
+                            expected))
+
+    def test_matrix_from_tait_bryan_angles_intrinsic_xyz(self):
+        """
+        This tests that the rotation matrix computed from the
+        Tait-Bryan angles [0, 0, 0] is the identiy as expected.
+        """
+        n = 3
+        group = self.so[n]
+
+        order = 'xyz'
+        extrinsic_or_intrinsic = 'intrinsic'
+
+        tait_bryan_angles = gs.array([0., 0., 0.])
+        result = group.matrix_from_tait_bryan_angles(
+            tait_bryan_angles,
+            extrinsic_or_intrinsic=extrinsic_or_intrinsic,
+            order=order)
+        expected = gs.eye(n)
+
+        self.assertTrue(gs.allclose(result, expected),
+                        ' result = \n{};'
+                        ' expected = \n{}.'.format(
+                            result,
+                            expected))
+
+    def test_matrix_from_tait_bryan_angles_intrinsic_zyx(self):
+        """
+        This tests that the matrix computed from the
+        Tait-Bryan angles[0, 0, 0] is [1, 0., 0., 0.] as expected.
+        """
+        n = 3
+        group = self.so[n]
+
+        order = 'zyx'
+        extrinsic_or_intrinsic = 'intrinsic'
+
+        tait_bryan_angles = gs.array([0., 0., 0.])
+        result = group.matrix_from_tait_bryan_angles(
+            tait_bryan_angles,
+            extrinsic_or_intrinsic=extrinsic_or_intrinsic,
+            order=order)
+        expected = gs.eye(n)
+
+        self.assertTrue(gs.allclose(result, expected),
+                        ' result = \n{};'
+                        ' expected = \n{}.'.format(
+                            result,
+                            expected))
+
+    def test_matrix_and_tait_bryan_angles_xyz(self):
+        """
+        This tests that the composition of
+        rotation_vector_from_tait_bryan_angles
+        and
+        tait_bryan_angles_from_rotation_vector
+        is the identity.
+        """
+        n = 3
+        group = self.so[n]
+
+        order = 'xyz'
+
+        for extrinsic_or_intrinsic in ('extrinsic', 'intrinsic'):
+            point = gs.pi / (6 * gs.sqrt(3)) * gs.array([1., 1., 1.])
+            matrix = group.matrix_from_rotation_vector(point)
+
+            tait_bryan_angles = group.tait_bryan_angles_from_matrix(
+                matrix,
+                extrinsic_or_intrinsic=extrinsic_or_intrinsic,
+                order=order)
+            result = group.matrix_from_tait_bryan_angles(
+                tait_bryan_angles,
+                extrinsic_or_intrinsic=extrinsic_or_intrinsic,
+                order=order)
+
+            expected = matrix
+            # TODO(nina): This test fails.
+            #  self.assertTrue(gs.allclose(result, expected),
+            #                  ' for {} Tait-Bryan angles with order {}\n'
+            #                  ' result = \n{};'
+            #                  ' expected = \n{}.'.format(
+            #                      extrinsic_or_intrinsic,
+            #                      order,
+            #                      result,
+            #                      expected))
+
+    def test_matrix_and_tait_bryan_angles_zyx(self):
+        """
+        This tests that the composition of
+        rotation_vector_from_tait_bryan_angles
+        and
+        tait_bryan_angles_from_rotation_vector
+        is the identity.
+        """
+        n = 3
+        group = self.so[n]
+
+        order = 'zyx'
+
+        for extrinsic_or_intrinsic in ('extrinsic', 'intrinsic'):
+            point = gs.pi / (6 * gs.sqrt(3)) * gs.array([1., 1., 1.])
+            matrix = group.matrix_from_rotation_vector(point)
+
+            tait_bryan_angles = group.tait_bryan_angles_from_matrix(
+                matrix,
+                extrinsic_or_intrinsic=extrinsic_or_intrinsic,
+                order=order)
+            result = group.matrix_from_tait_bryan_angles(
+                tait_bryan_angles,
+                extrinsic_or_intrinsic=extrinsic_or_intrinsic,
+                order=order)
+
+            expected = matrix
+            # TODO(nina): this test fails
+            # self.assertTrue(gs.allclose(result, expected),
+            #                 ' for {} Tait-Bryan angles with order {}\n'
+            #                 ' result = \n{};'
+            #                 ' expected = \n{}.'.format(
+            #                     extrinsic_or_intrinsic,
+            #                     order,
+            #                     result,
+            #                     expected))
+
+    def test_quaternion_from_tait_bryan_angles_intrinsic_xyz(self):
+        n = 3
+        group = self.so[n]
+
+        tait_bryan_angles = gs.array([0., 0., 0.])
+        result = group.quaternion_from_tait_bryan_angles_intrinsic_xyz(
+            tait_bryan_angles)
+        expected = gs.array([[1., 0., 0., 0.]])
+
+        self.assertTrue(gs.allclose(result, expected),
+                        ' result = {};'
+                        ' expected = {}.'.format(
+                            result,
+                            expected))
+        angle = gs.pi / 6.
+        cos_half_angle = gs.cos(angle / 2.)
+        sin_half_angle = gs.sin(angle / 2.)
+
+        tait_bryan_angles = gs.array([angle, 0., 0.])
+        result = group.quaternion_from_tait_bryan_angles_intrinsic_xyz(
+            tait_bryan_angles)
+        expected = gs.array([[cos_half_angle, sin_half_angle, 0., 0.]])
+
+        self.assertTrue(gs.allclose(result, expected),
+                        ' result = \n{};'
+                        ' expected = \n{}.'.format(
+                            result,
+                            expected))
+
+        tait_bryan_angles = gs.array([0., angle, 0.])
+        result = group.quaternion_from_tait_bryan_angles_intrinsic_xyz(
+            tait_bryan_angles)
+        expected = gs.array([[cos_half_angle, 0., sin_half_angle, 0.]])
+
+        self.assertTrue(gs.allclose(result, expected),
+                        ' result = \n{};'
+                        ' expected = \n{}.'.format(
+                            result,
+                            expected))
+
+        tait_bryan_angles = gs.array([0., 0., angle])
+        result = group.quaternion_from_tait_bryan_angles_intrinsic_xyz(
+            tait_bryan_angles)
+        expected = gs.array([[cos_half_angle, 0., 0., sin_half_angle]])
+
+        self.assertTrue(gs.allclose(result, expected),
+                        ' result = \n{};'
+                        ' expected = \n{}.'.format(
+                            result,
+                            expected))
+
     def test_tait_bryan_angles_from_quaternion_xyz(self):
         """
         This tests that the Tait-Bryan angles of the quaternion [1, 0, 0, 0],
@@ -784,325 +1143,6 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
                 #                     angle_type,
                 #                     result,
                 #                     expected))
-
-    def test_tait_bryan_angles_from_matrix_extrinsic_xyz(self):
-        """
-        This tests that the Tait-Bryan angles of the matrix identity,
-        is [0, 0, 0] as expected.
-        """
-        n = 3
-        group = self.so[n]
-        extrinsic_or_intrinsic = 'extrinsic'
-        order = 'xyz'
-
-        matrix = gs.eye(n)
-        result = group.tait_bryan_angles_from_matrix(
-            matrix, extrinsic_or_intrinsic, order)
-        expected = gs.array([[0., 0., 0.]])
-
-        self.assertTrue(gs.allclose(result, expected),
-                        ' result = {};'
-                        ' expected = {}.'.format(
-                            result,
-                            expected))
-
-        angle = gs.pi / 6.
-        cos_angle = gs.cos(angle)
-        sin_angle = gs.sin(angle)
-
-        rot_mat = gs.array([[[1., 0., 0.],
-                             [0., cos_angle, - sin_angle],
-                             [0., sin_angle, cos_angle]]])
-        result = group.tait_bryan_angles_from_matrix(
-            rot_mat, extrinsic_or_intrinsic, order)
-        expected = gs.array([0., 0., angle])
-
-        self.assertTrue(gs.allclose(result, expected),
-                        ' result = {};'
-                        ' expected = {}.'.format(
-                            result,
-                            expected))
-
-        rot_mat = gs.array([[[cos_angle, 0., sin_angle],
-                             [0., 1., 0.],
-                             [- sin_angle, 0., cos_angle]]])
-        result = group.tait_bryan_angles_from_matrix(
-            rot_mat, extrinsic_or_intrinsic, order)
-        expected = gs.array([0., angle, 0.])
-
-        self.assertTrue(gs.allclose(result, expected),
-                        ' result = \n{};'
-                        ' expected = \n{}.'.format(
-                            result,
-                            expected))
-
-        rot_mat = gs.array([[[cos_angle, - sin_angle, 0.],
-                             [sin_angle, cos_angle, 0.],
-                             [0., 0., 1.]]])
-        result = group.tait_bryan_angles_from_matrix(
-            rot_mat, extrinsic_or_intrinsic, order)
-        expected = gs.array([angle, 0., 0.])
-
-        self.assertTrue(gs.allclose(result, expected),
-                        ' result = \n{};'
-                        ' expected = \n{}.'.format(
-                            result,
-                            expected))
-
-    def test_tait_bryan_angles_from_matrix_extrinsic_zyx(self):
-        """
-        This tests that the Tait-Bryan angles of the matrix identity,
-        is [0, 0, 0] as expected.
-        """
-        n = 3
-        group = self.so[n]
-        extrinsic_or_intrinsic = 'extrinsic'
-        order = 'zyx'
-
-        rot_mat = gs.eye(n)
-        result = group.tait_bryan_angles_from_matrix(
-            rot_mat, extrinsic_or_intrinsic, order)
-        expected = gs.array([[0., 0., 0.]])
-
-        self.assertTrue(gs.allclose(result, expected),
-                        ' result = {};'
-                        ' expected = {}.'.format(
-                            result,
-                            expected))
-
-        angle = gs.pi / 6.
-        cos_angle = gs.cos(angle)
-        sin_angle = gs.sin(angle)
-
-        rot_mat = gs.array([[[1., 0., 0.],
-                             [0., cos_angle, - sin_angle],
-                             [0., sin_angle, cos_angle]]])
-        result = group.tait_bryan_angles_from_matrix(
-            rot_mat, extrinsic_or_intrinsic, order)
-        expected = gs.array([angle, 0., 0.])
-
-        self.assertTrue(gs.allclose(result, expected),
-                        ' result = {};'
-                        ' expected = {}.'.format(
-                            result,
-                            expected))
-
-        rot_mat = gs.array([[[cos_angle, 0., sin_angle],
-                             [0., 1., 0.],
-                             [- sin_angle, 0., cos_angle]]])
-        result = group.tait_bryan_angles_from_matrix(
-            rot_mat, extrinsic_or_intrinsic, order)
-        expected = gs.array([0., angle, 0.])
-
-        self.assertTrue(gs.allclose(result, expected),
-                        ' result = \n{};'
-                        ' expected = \n{}.'.format(
-                            result,
-                            expected))
-
-        rot_mat = gs.array([[[cos_angle, - sin_angle, 0.],
-                             [sin_angle, cos_angle, 0.],
-                             [0., 0., 1.]]])
-        result = group.tait_bryan_angles_from_matrix(
-            rot_mat, extrinsic_or_intrinsic, order)
-        expected = gs.array([0., 0., angle])
-
-        self.assertTrue(gs.allclose(result, expected),
-                        ' result = \n{};'
-                        ' expected = \n{}.'.format(
-                            result,
-                            expected))
-
-    def test_tait_bryan_angles_from_matrix_xyz(self):
-        """
-        This tests that the Tait-Bryan angles of the matrix identity,
-        is [0, 0, 0] as expected.
-        """
-        n = 3
-        group = self.so[n]
-
-        order = 'xyz'
-
-        for extrinsic_or_intrinsic in ('extrinsic', 'intrinsic'):
-            matrix = gs.eye(n)
-            result = group.tait_bryan_angles_from_matrix(
-                matrix, extrinsic_or_intrinsic='intrinsic', order='xyz')
-            expected = gs.array([[0., 0., 0.]])
-
-            self.assertTrue(gs.allclose(result, expected),
-                            ' for {} Tait-Bryan angles with order {}\n'
-                            ' result = {};'
-                            ' expected = {}.'.format(
-                                extrinsic_or_intrinsic,
-                                order,
-                                result,
-                                expected))
-
-    def test_matrix_from_tait_bryan_angles_xyz(self):
-        """
-        This tests that the rotation matrix computed from the
-        Tait-Bryan angles [0, 0, 0] is the identiy as expected.
-        """
-        n = 3
-        group = self.so[n]
-
-        order = 'xyz'
-
-        for extrinsic_or_intrinsic in ('extrinsic', 'intrinsic'):
-            tait_bryan_angles = gs.array([0., 0., 0.])
-            result = group.matrix_from_tait_bryan_angles(
-                tait_bryan_angles,
-                extrinsic_or_intrinsic=extrinsic_or_intrinsic,
-                order=order)
-            expected = gs.eye(n)
-
-            self.assertTrue(gs.allclose(result, expected),
-                            ' for {} Tait-Bryan angles with order {}\n'
-                            ' result = \n{};'
-                            ' expected = \n{}.'.format(
-                                extrinsic_or_intrinsic,
-                                order,
-                                result,
-                                expected))
-
-    def test_tait_bryan_angles_from_matrix_zyx(self):
-        """
-        This tests that the Tait-Bryan angles of the matrix [1, 0, 0, 0],
-        is [0, 0, 0] as expected.
-        """
-        n = 3
-        group = self.so[n]
-
-        order = 'zyx'
-
-        for extrinsic_or_intrinsic in ('extrinsic', 'intrinsic'):
-            matrix = gs.eye(n)
-            result = group.tait_bryan_angles_from_matrix(
-                matrix,
-                extrinsic_or_intrinsic=extrinsic_or_intrinsic,
-                order=order)
-            expected = gs.array([[0., 0., 0.]])
-
-            self.assertTrue(gs.allclose(result, expected),
-                            ' for {} Tait-Bryan angles with order {}\n'
-                            ' result = {};'
-                            ' expected = {}.'.format(
-                                extrinsic_or_intrinsic,
-                                order,
-                                result,
-                                expected))
-
-    def test_matrix_from_tait_bryan_angles_zyx(self):
-        """
-        This tests that the matrix computed from the
-        Tait-Bryan angles[0, 0, 0] is [1, 0., 0., 0.] as expected.
-        """
-        n = 3
-        group = self.so[n]
-
-        order = 'zyx'
-
-        for extrinsic_or_intrinsic in ('extrinsic', 'intrinsic'):
-            tait_bryan_angles = gs.array([0., 0., 0.])
-            result = group.matrix_from_tait_bryan_angles(
-                tait_bryan_angles,
-                extrinsic_or_intrinsic=extrinsic_or_intrinsic,
-                order=order)
-            expected = gs.eye(n)
-
-            self.assertTrue(gs.allclose(result, expected),
-                            ' for {} Tait-Bryan angles with order {}\n'
-                            ' result = \n{};'
-                            ' expected = \n{}.'.format(
-                                extrinsic_or_intrinsic,
-                                order,
-                                result,
-                                expected))
-
-    def test_matrix_and_tait_bryan_angles_xyz(self):
-        """
-        This tests that the composition of
-        rotation_vector_from_tait_bryan_angles
-        and
-        tait_bryan_angles_from_rotation_vector
-        is the identity.
-        """
-        n = 3
-        group = self.so[n]
-
-        order = 'xyz'
-
-        for extrinsic_or_intrinsic in ('extrinsic', 'intrinsic'):
-            for angle_type in self.elements[n]:
-                point = self.elements[n][angle_type]
-                if angle_type in self.angles_close_to_pi[n]:
-                    continue
-
-                matrix = group.matrix_from_rotation_vector(point)
-
-                tait_bryan_angles = group.tait_bryan_angles_from_matrix(
-                    matrix,
-                    extrinsic_or_intrinsic=extrinsic_or_intrinsic,
-                    order=order)
-                result = group.matrix_from_tait_bryan_angles(
-                    tait_bryan_angles,
-                    extrinsic_or_intrinsic=extrinsic_or_intrinsic,
-                    order=order)
-
-                expected = matrix
-                self.assertTrue(gs.allclose(result, expected),
-                                ' for {} Tait-Bryan angles with order {}\n'
-                                'for point {}:\n'
-                                ' result = \n{};'
-                                ' expected = \n{}.'.format(
-                                    extrinsic_or_intrinsic,
-                                    order,
-                                    angle_type,
-                                    result,
-                                    expected))
-
-    def test_matrix_and_tait_bryan_angles_zyx(self):
-        """
-        This tests that the composition of
-        rotation_vector_from_tait_bryan_angles
-        and
-        tait_bryan_angles_from_rotation_vector
-        is the identity.
-        """
-        n = 3
-        group = self.so[n]
-
-        order = 'zyx'
-
-        for extrinsic_or_intrinsic in ('extrinsic', 'intrinsic'):
-            for angle_type in self.elements[n]:
-                point = self.elements[n][angle_type]
-                if angle_type in self.angles_close_to_pi[n]:
-                    continue
-
-                matrix = group.matrix_from_rotation_vector(point)
-
-                tait_bryan_angles = group.tait_bryan_angles_from_matrix(
-                    matrix,
-                    extrinsic_or_intrinsic=extrinsic_or_intrinsic,
-                    order=order)
-                result = group.matrix_from_tait_bryan_angles(
-                    tait_bryan_angles,
-                    extrinsic_or_intrinsic=extrinsic_or_intrinsic,
-                    order=order)
-
-                expected = matrix
-
-                self.assertTrue(gs.allclose(result, expected),
-                                ' for {} Tait-Bryan angles with order {}\n'
-                                'for point {}:\n'
-                                ' result = \n{};'
-                                ' expected = \n{}.'.format(
-                                    extrinsic_or_intrinsic,
-                                    order,
-                                    angle_type,
-                                    result,
-                                    expected))
 
     def test_rotation_vector_and_rotation_matrix_vectorization(self):
         for n in self.n_seq:


### PR DESCRIPTION
This CR adds conversion functions for Euler angles with different conventions:
- Tait Bryan convention,
- extrinsic and intrinsic conventions,
- xyz order and zyx order conventions.

This CR also renames yaw pitch roll with Tait Bryan appelations.

Some unit tests fail and are commented.