### PR TITLE
 ENH: Support optional dependencies, geomstats.__version__ 

### DIFF
--- a/geomstats/__about__.py
+++ b/geomstats/__about__.py
@@ -1,0 +1,15 @@
+__version__ = '1.11-dev'  # Remove -dev before releasing
+
+install_requires = [
+    'autograd',
+    'numpy>=1.14.1',
+    'scipy',
+    'matplotlib',
+    ]
+
+extras_require = {
+    'test': ['nose2', 'coverage', 'codecov'],
+    'tf': ['tensorflow>=1.8'],
+    'torch': ['torch==0.4.0'],
+    }
+extras_require['all'] = sum(extras_require.values(), [])

--- a/geomstats/__about__.py
+++ b/geomstats/__about__.py
@@ -1,15 +1,18 @@
-__version__ = '1.11-dev'  # Remove -dev before releasing
+# Remove -dev before releasing
+__version__ = '1.11-dev'
+
+from itertools import chain
 
 install_requires = [
     'autograd',
+    'matplotlib',
     'numpy>=1.14.1',
     'scipy',
-    'matplotlib',
     ]
 
 extras_require = {
-    'test': ['nose2', 'coverage', 'codecov'],
+    'test': ['codecov', 'coverage', 'nose2'],
     'tf': ['tensorflow>=1.8'],
     'torch': ['torch==0.4.0'],
     }
-extras_require['all'] = sum(extras_require.values(), [])
+extras_require['all'] = list(chain(*extras_require.values()))

--- a/geomstats/__init__.py
+++ b/geomstats/__init__.py
@@ -1,3 +1,5 @@
+from .__about__ import __version__
+
 import geomstats.manifold
 import geomstats.euclidean_space
 import geomstats.hyperbolic_space

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,14 @@
+import os
+import runpy
 from setuptools import setup, find_packages
-from geomstats.__about__ import __version__, install_requires, extras_require
+
+base_dir = os.path.dirname(os.path.abspath(__file__))
+about = runpy.run_path(os.path.join(base_dir, 'geomstats', '__about__.py'))
 
 setup(name='geomstats',
-      version=__version__,
-      install_requires=install_requires,
-      extras_require=extras_require,
+      version=about['__version__'],
+      install_requires=about['install_requires'],
+      extras_require=about['extras_require'],
       description='Geometric statistics on manifolds',
       url='http://github.com/geomstats/geomstats',
       author='Nina Miolane',

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,10 @@
 from setuptools import setup, find_packages
-
-with open('requirements.txt') as fp:
-        install_requires = fp.read()
+from geomstats.__about__ import __version__, install_requires, extras_require
 
 setup(name='geomstats',
-      version='1.11',
+      version=__version__,
       install_requires=install_requires,
+      extras_require=extras_require,
       description='Geometric statistics on manifolds',
       url='http://github.com/geomstats/geomstats',
       author='Nina Miolane',


### PR DESCRIPTION
This PR adds "extra" installs, which allow optional functionality to be installed only if requested. It also adds a `geomstats.__version__` string, which is generally a good practice.

I use the `<package>/__about__.py` convention to store this metadata, so it's available both within the package and without.

Happy to rework if this doesn't fit with your development workflow.

Closes #136.