### PR TITLE
Add quantization as method of RiemannianMetric

### DIFF
--- a/examples/quantization_s1.py
+++ b/examples/quantization_s1.py
@@ -20,7 +20,7 @@ TOLERANCE = 1e-6
 def main():
     points = CIRCLE.random_uniform(n_samples=N_POINTS, bound=None)
 
-    centers, weights, clusters, n_iterations = METRIC.riemannian_quantization(
+    centers, weights, clusters, n_iterations = METRIC.optimal_quantization(
                 points=points, n_centers=N_CENTERS,
                 n_repetitions=N_REPETITIONS, tolerance=TOLERANCE
                 )

--- a/examples/quantization_s1.py
+++ b/examples/quantization_s1.py
@@ -1,0 +1,39 @@
+"""
+Plot the result of optimal quantization of the uniform distribution
+on the circle.
+"""
+
+import matplotlib.pyplot as plt
+
+import geomstats.visualization as visualization
+
+from geomstats.hypersphere import Hypersphere
+
+CIRCLE = Hypersphere(dimension=1)
+METRIC = CIRCLE.metric
+N_POINTS = 1000
+N_CENTERS = 5
+N_REPETITIONS = 20
+TOLERANCE = 1e-6
+
+
+def main():
+    points = CIRCLE.random_uniform(n_samples=N_POINTS, bound=None)
+
+    centers, weights, clusters, n_iterations = METRIC.riemannian_quantization(
+                points=points, n_centers=N_CENTERS,
+                n_repetitions=N_REPETITIONS, tolerance=TOLERANCE
+                )
+
+    plt.figure(0)
+    visualization.plot(points=centers, space='S1', color='red')
+
+    plt.figure(1)
+    circle = visualization.Circle()
+    circle.draw()
+    for i in range(N_CENTERS):
+        circle.draw_points(points=clusters[i])
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/quantization_s2.py
+++ b/examples/quantization_s2.py
@@ -20,7 +20,7 @@ KAPPA = 10
 def main():
     points = SPHERE2.random_von_mises_fisher(kappa=KAPPA, n_samples=N_POINTS)
 
-    centers, weights, clusters, n_steps = METRIC.riemannian_quantization(
+    centers, weights, clusters, n_steps = METRIC.optimal_quantization(
                 points=points, n_centers=N_CENTERS,
                 n_repetitions=N_REPETITIONS
                 )

--- a/examples/quantization_s2.py
+++ b/examples/quantization_s2.py
@@ -1,0 +1,42 @@
+"""
+Plot the result of optimal quantization of the von Mises Fisher distribution
+on the sphere
+"""
+
+import matplotlib.pyplot as plt
+
+import geomstats.visualization as visualization
+
+from geomstats.hypersphere import Hypersphere
+
+SPHERE2 = Hypersphere(dimension=2)
+METRIC = SPHERE2.metric
+N_POINTS = 1000
+N_CENTERS = 4
+N_REPETITIONS = 20
+KAPPA = 10
+
+
+def main():
+    points = SPHERE2.random_von_mises_fisher(kappa=KAPPA, n_samples=N_POINTS)
+
+    centers, weights, clusters, n_steps = METRIC.riemannian_quantization(
+                points=points, n_centers=N_CENTERS,
+                n_repetitions=N_REPETITIONS
+                )
+
+    plt.figure(0)
+    ax = plt.subplot(111, projection="3d", aspect="equal")
+    visualization.plot(points=centers, ax=ax, space='S2', c='r')
+    plt.show()
+
+    plt.figure(1)
+    ax = plt.subplot(111, projection="3d", aspect="equal")
+    sphere = visualization.Sphere()
+    sphere.draw(ax=ax)
+    for i in range(N_CENTERS):
+        sphere.draw_points(ax=ax, points=clusters[i])
+
+
+if __name__ == "__main__":
+    main()

--- a/geomstats/riemannian_metric.py
+++ b/geomstats/riemannian_metric.py
@@ -343,7 +343,7 @@ class RiemannianMetric(object):
 
         return closest_neighbor_index
 
-    def riemannian_quantization(self, points, n_centers=N_CENTERS,
+    def optimal_quantization(self, points, n_centers=N_CENTERS,
                                 n_repetitions=N_REPETITIONS,
                                 tolerance=TOLERANCE,
                                 n_max_iterations=N_MAX_ITERATIONS):

--- a/tests/test_hypersphere.py
+++ b/tests/test_hypersphere.py
@@ -12,6 +12,7 @@ from geomstats.hypersphere import Hypersphere
 
 MEAN_ESTIMATION_TOL = 1e-6
 KAPPA_ESTIMATION_TOL = 1e-3
+OPTIMAL_QUANTIZATION_TOL = 5e-3
 
 # TODO(nina): Casting tensors to type tf.float32 at
 # the beginning of each function
@@ -475,6 +476,28 @@ class TestHypersphereMethods(unittest.TestCase):
         self.assertTrue(
                 gs.allclose(result, expected, atol=KAPPA_ESTIMATION_TOL)
                 )
+
+    def test_riemannian_quantization(self):
+            """
+            Check that optimal quantization yields the same result as
+            the karcher flow algorithm when we look for one center.
+            """
+            dim = 2
+            n_points = 1000
+            n_centers = 1
+            sphere = Hypersphere(dim)
+            points = sphere.random_von_mises_fisher(
+                    kappa=10, n_samples=n_points
+                    )
+            mean = sphere.metric.mean(points)
+            centers, weights, clusters, n_iterations = sphere.metric.\
+                riemannian_quantization(points=points, n_centers=n_centers)
+            error = sphere.metric.dist(mean, centers)
+            diameter = sphere.metric.diameter(points)
+            result = error / diameter
+            expected = 0.0
+            self.assertTrue(gs.allclose(result, expected,
+                                        atol=OPTIMAL_QUANTIZATION_TOL))
 
 
 if __name__ == '__main__':

--- a/tests/test_hypersphere.py
+++ b/tests/test_hypersphere.py
@@ -477,7 +477,7 @@ class TestHypersphereMethods(unittest.TestCase):
                 gs.allclose(result, expected, atol=KAPPA_ESTIMATION_TOL)
                 )
 
-    def test_riemannian_quantization(self):
+    def test_optimal_quantization(self):
             """
             Check that optimal quantization yields the same result as
             the karcher flow algorithm when we look for one center.
@@ -491,7 +491,7 @@ class TestHypersphereMethods(unittest.TestCase):
                     )
             mean = sphere.metric.mean(points)
             centers, weights, clusters, n_iterations = sphere.metric.\
-                riemannian_quantization(points=points, n_centers=n_centers)
+                optimal_quantization(points=points, n_centers=n_centers)
             error = sphere.metric.dist(mean, centers)
             diameter = sphere.metric.diameter(points)
             result = error / diameter


### PR DESCRIPTION
I have changed the name ```optimal_quantization``` to ```riemannian_quantization``` and added it as a method of the ```RiemannianMetric``` class as we previously discussed. The test is in ```test_hypersphere.py``` and I moved the examples to https://github.com/geomstats/geomstats/tree/master/examples. 

If this is to be merged eventually, it would mean deleting the quantization folder in https://github.com/geomstats/examples.