### PR TITLE
tf backend fixes 3

### DIFF
--- a/geomstats/backend/tensorflow.py
+++ b/geomstats/backend/tensorflow.py
@@ -259,3 +259,7 @@ def cross(a, b):
 
 def stack(*args, **kwargs):
     return tf.stack(*args, **kwargs)
+
+
+def arctan2(*args, **kwargs):
+    return tf.atan2(*args, **kwargs)

--- a/geomstats/backend/tensorflow_linalg.py
+++ b/geomstats/backend/tensorflow_linalg.py
@@ -16,8 +16,8 @@ def eig(x):
 
 
 def svd(x):
-    s, u, v = tf.linalg.svd(x)
-    return u, s, v
+    s, u, v_t = tf.svd(x, full_matrices=True)
+    return u, s, tf.transpose(v_t, perm=(0, 2, 1))
 
 
 def norm(x, axis=None):

--- a/geomstats/invariant_metric.py
+++ b/geomstats/invariant_metric.py
@@ -57,9 +57,16 @@ class InvariantMetric(RiemannianMetric):
             tangent_vec_a = gs.to_ndarray(tangent_vec_a, to_ndim=2)
             tangent_vec_b = gs.to_ndarray(tangent_vec_b, to_ndim=2)
 
+            n_vecs_a = tangent_vec_a.shape[0]
+            n_vecs_b = tangent_vec_b.shape[0]
+            assert n_vecs_a == n_vecs_b
+
+            inner_product_mat_at_identity = gs.array(
+                [self.inner_product_mat_at_identity[0]] * n_vecs_a)
+
             inner_prod = gs.einsum('ij,ijk,ik->i',
                                    tangent_vec_a,
-                                   self.inner_product_mat_at_identity,
+                                   inner_product_mat_at_identity,
                                    tangent_vec_b)
 
             inner_prod = gs.to_ndarray(inner_prod, to_ndim=2, axis=1)
@@ -121,9 +128,9 @@ class InvariantMetric(RiemannianMetric):
         inv_jacobian = gs.linalg.inv(jacobian)
         inv_jacobian_transposed = gs.transpose(inv_jacobian, axes=(0, 2, 1))
 
-        inner_product_mat_at_id = self.inner_product_mat_at_identity
-        inner_product_mat_at_id = gs.to_ndarray(
-            inner_product_mat_at_id, to_ndim=3)
+        n_base_points = base_point.shape[0]
+        inner_product_mat_at_id = gs.array(
+            [self.inner_product_mat_at_identity[0]] * n_base_points)
 
         metric_mat = gs.matmul(inv_jacobian_transposed,
                                inner_product_mat_at_id)

--- a/geomstats/invariant_metric.py
+++ b/geomstats/invariant_metric.py
@@ -60,7 +60,7 @@ class InvariantMetric(RiemannianMetric):
             n_tangent_vec_a = tangent_vec_a.shape[0]
             n_tangent_vec_b = tangent_vec_b.shape[0]
 
-            assert (tangent_vec_a.shape == tangent_vec_a.shape
+            assert (tangent_vec_a.shape == tangent_vec_b.shape
                     or n_tangent_vec_a == 1
                     or n_tangent_vec_b == 1)
 

--- a/geomstats/invariant_metric.py
+++ b/geomstats/invariant_metric.py
@@ -57,12 +57,22 @@ class InvariantMetric(RiemannianMetric):
             tangent_vec_a = gs.to_ndarray(tangent_vec_a, to_ndim=2)
             tangent_vec_b = gs.to_ndarray(tangent_vec_b, to_ndim=2)
 
-            n_vecs_a = tangent_vec_a.shape[0]
-            n_vecs_b = tangent_vec_b.shape[0]
-            assert n_vecs_a == n_vecs_b
+            n_tangent_vec_a = tangent_vec_a.shape[0]
+            n_tangent_vec_b = tangent_vec_b.shape[0]
+
+            assert (tangent_vec_a.shape == tangent_vec_a.shape
+                    or n_tangent_vec_a == 1
+                    or n_tangent_vec_b == 1)
+
+            if n_tangent_vec_a == 1:
+                tangent_vec_a = gs.array([tangent_vec_a[0]] * n_tangent_vec_b)
+
+            if n_tangent_vec_b == 1:
+                tangent_vec_b = gs.array([tangent_vec_b[0]] * n_tangent_vec_a)
 
             inner_product_mat_at_identity = gs.array(
-                [self.inner_product_mat_at_identity[0]] * n_vecs_a)
+                [self.inner_product_mat_at_identity[0]] * \
+                max(n_tangent_vec_a, n_tangent_vec_b))
 
             inner_prod = gs.einsum('ij,ijk,ik->i',
                                    tangent_vec_a,

--- a/geomstats/lie_group.py
+++ b/geomstats/lie_group.py
@@ -146,7 +146,6 @@ class LieGroup(Manifold):
             point_type = self.default_point_type
 
         identity = self.get_identity(point_type=point_type)
-        #identity = self.regularize(identity, point_type=point_type)
         if base_point is None:
             base_point = identity
 

--- a/geomstats/lie_group.py
+++ b/geomstats/lie_group.py
@@ -146,10 +146,26 @@ class LieGroup(Manifold):
             point_type = self.default_point_type
 
         identity = self.get_identity(point_type=point_type)
-        identity = self.regularize(identity, point_type=point_type)
+        #identity = self.regularize(identity, point_type=point_type)
         if base_point is None:
             base_point = identity
+
+        point = self.regularize(point, point_type=point_type)
         base_point = self.regularize(base_point, point_type=point_type)
+
+        n_points = point.shape[0]
+        n_base_points = base_point.shape[0]
+
+        assert (point.shape == base_point.shape
+                or n_points == 1
+                or n_base_points == 1)
+
+        if n_points == 1:
+            point = gs.array([point[0]] * n_base_points)
+
+        if n_base_points == 1:
+            base_point = gs.array([base_point[0]] * n_points)
+
         if gs.allclose(base_point, identity):
             return self.group_log_from_identity(point, point_type=point_type)
 

--- a/geomstats/riemannian_metric.py
+++ b/geomstats/riemannian_metric.py
@@ -31,7 +31,10 @@ def grad(y_pred, y_true, metric):
 
     inner_prod_mat = metric.inner_product_matrix(base_point=y_pred)
 
-    grad = gs.dot(grad_vec, gs.transpose(inner_prod_mat, axes=(0, 2, 1)))
+    grad = gs.einsum('ni,nij->ni',
+                     grad_vec,
+                     gs.transpose(inner_prod_mat, axes=(0, 2, 1)))
+
     return grad
 
 

--- a/geomstats/special_euclidean_group.py
+++ b/geomstats/special_euclidean_group.py
@@ -323,7 +323,7 @@ class SpecialEuclideanGroup(LieGroup):
             jacobian = gs.concatenate(
                 [jacobian_block_line_1, jacobian_block_line_2], axis=1)
 
-            assert jacobian.ndim == 3
+            assert gs.ndim(jacobian) == 3
 
         elif point_type == 'matrix':
             raise NotImplementedError()

--- a/geomstats/special_orthogonal_group.py
+++ b/geomstats/special_orthogonal_group.py
@@ -686,15 +686,17 @@ class SpecialOrthogonalGroup(LieGroup, EmbeddedManifold):
         half_angle = gs.to_ndarray(half_angle, to_ndim=2, axis=1)
         assert half_angle.shape == (n_quaternions, 1)
 
-        rot_vec = gs.zeros_like(quaternion[:, 1:])
-
         mask_0 = gs.isclose(half_angle, 0.)
         mask_0 = gs.squeeze(mask_0, axis=1)
         mask_not_0 = ~mask_0
-        rotation_axis = (quaternion[mask_not_0, 1:]
-                         / gs.sin(half_angle[mask_not_0]))
-        rot_vec[mask_not_0] = (2 * half_angle[mask_not_0]
-                               * rotation_axis)
+
+        rotation_axis = gs.divide(quaternion[:, 1:],
+                                  gs.sin(half_angle) *
+                                  gs.cast(mask_0, gs.float32) +
+                                  gs.cast(mask_not_0, gs.float32))
+        rot_vec = gs.array(2 * half_angle *
+                           rotation_axis *
+                           gs.cast(mask_not_0, gs.float32))
 
         rot_vec = self.regularize(rot_vec, point_type='vector')
         return rot_vec

--- a/geomstats/special_orthogonal_group.py
+++ b/geomstats/special_orthogonal_group.py
@@ -232,11 +232,14 @@ class SpecialOrthogonalGroup(LieGroup, EmbeddedManifold):
                 if metric is None:
                     metric = self.left_canonical_metric
                 base_point = self.regularize(base_point, point_type)
+                # TODO: what is the output of this function with N base_points?
+                n_vecs = tangent_vec.shape[0]
 
                 jacobian = self.jacobian_translation(
                               point=base_point,
                               left_or_right=metric.left_or_right,
                               point_type=point_type)
+                jacobian = gs.array([jacobian[0]] * n_vecs)
                 inv_jacobian = gs.linalg.inv(jacobian)
                 tangent_vec_at_id = gs.einsum(
                         'ni,nij->nj',
@@ -1133,6 +1136,19 @@ class SpecialOrthogonalGroup(LieGroup, EmbeddedManifold):
         if point_type == 'vector':
             point_1 = self.matrix_from_rotation_vector(point_1)
             point_2 = self.matrix_from_rotation_vector(point_2)
+
+        n_points_1 = point_1.shape[0]
+        n_points_2 = point_2.shape[0]
+
+        assert (point_1.shape == point_2.shape
+                or n_points_1 == 1
+                or n_points_2 == 1)
+
+        if n_points_1 == 1:
+            point_1 = gs.stack([point_1[0]] * n_points_2)
+
+        if n_points_2 == 1:
+            point_2 = gs.stack([point_2[0]] * n_points_1)
 
         point_prod = gs.einsum('ijk,ikl->ijl', point_1, point_2)
 

--- a/tests/test_special_orthogonal_group.py
+++ b/tests/test_special_orthogonal_group.py
@@ -3584,24 +3584,21 @@ class TestSpecialOrthogonalGroupMethods(unittest.TestCase):
         base_point = group.random_uniform(n_samples=1)
         results = group.group_log(points, base_point)
 
-        self.assertTrue(gs.allclose(results.shape,
-                                    (n_samples, group.dimension)))
+        self.assertTrue(results.shape == (n_samples, group.dimension))
 
         # Test with the same number of base points and points
         points = group.random_uniform(n_samples=n_samples)
         base_points = group.random_uniform(n_samples=n_samples)
         results = group.group_log(points, base_points)
 
-        self.assertTrue(gs.allclose(results.shape,
-                                    (n_samples, group.dimension)))
+        self.assertTrue(results.shape == (n_samples, group.dimension))
 
         # Test with the several base points, and 1 point
         point = group.random_uniform(n_samples=1)
         base_points = group.random_uniform(n_samples=n_samples)
         results = group.group_log(point, base_points)
 
-        self.assertTrue(gs.allclose(results.shape,
-                                    (n_samples, group.dimension)))
+        self.assertTrue(results.shape == (n_samples, group.dimension))
 
     def test_group_exp_then_log_from_identity(self):
         """


### PR DESCRIPTION
- geomstats/invariant_metric.py:
	inner_product_at_identity():
		- ensures that tangent_vec_a and tangent_vec_b have the same cardinality
		- stack self.inner_product_mat_at_identity N times w.r.t. tangent_vec
	inner_product_matrix():
		- stack self.inner_product_mat_at_identity N times w.r.t. base_point

- geomstats/lie_group.py:
	group_log():
		- ensure point and base_point cardinality match for tf.einsum()

- geomstats/special_euclidean_group.py:
	jacobian_translation():
		- fix assert gs.ndim(jacobian) == 3

- geomstats/special_orthogonal_group.py:
	regularize_tangent_vec():
		- ensure jacobian has the same cardinality as tangent_vec
		- N.B. TODO: check, this fix assumes there will always be one base_point to many tangent_vec
	compose():
		- ensures that point_1 and point_2 have the same cardinality
		- stack point_1 and point_2 N times for tf.einsum() fix

- geomstats/backend/tensorflow_linalg.py
	svd(x)
		- np.linalg.svd() returns U, S, V
		- tf.svd() returns S, U, V_transposed

tests/test_special_orthogonal_group.py
	test_group_log_vectorization()
		- gs.allclose() is not required in tuple formation