### PR TITLE
Minor corrections

### DIFF
--- a/geomstats/matrices_spaces.py
+++ b/geomstats/matrices_spaces.py
@@ -12,7 +12,7 @@ class MatrixSpace(EuclideanSpace):
 
     def __init__(self, m, n):
         assert isinstance(m, int) and isinstance(n, int) and m > 0 and n > 0
-        super().init(dimension=m*n)
+        super().__init__(dimension=m*n)
         self.m = m
         self.n = n
 

--- a/geomstats/spd_matrices_space.py
+++ b/geomstats/spd_matrices_space.py
@@ -195,7 +195,9 @@ class SPDMatricesSpace(EmbeddedManifold):
 class SPDMetric(RiemannianMetric):
 
     def __init__(self, n):
-        super(SPDMetric, self).__init__(dimension=int(n * (n + 1) / 2))
+        super(SPDMetric, self).__init__(
+                dimension=int(n * (n + 1) / 2),
+                signature=(int(n * (n + 1) / 2), 0, 0))
 
     def inner_product(self, tangent_vec_a, tangent_vec_b, base_point):
         """


### PR DESCRIPTION
Hi ! I just noticed that there was a typo in matrices_spaces.py and that the ```signature``` attribute was missing for ```SPDMetric```, which prevents one from using the ```dist``` method (although there is no problem for ```squared_dist```).