### PR TITLE
Debug pytorch tests hypersphere

### DIFF
--- a/geomstats/backend/numpy.py
+++ b/geomstats/backend/numpy.py
@@ -9,6 +9,18 @@ float32 = np.float32
 float64 = np.float64
 
 
+def indexing(x):
+    return x
+
+
+def float_to_double(x):
+    return x
+
+
+def byte_to_float(x):
+    return x
+
+
 def while_loop(cond, body, loop_vars, maximum_iterations):
     iteration = 0
     while cond(*loop_vars):

--- a/geomstats/backend/pytorch.py
+++ b/geomstats/backend/pytorch.py
@@ -11,6 +11,33 @@ int32 = 'torch.LongTensor'
 int8 = 'torch.ByteTensor'
 
 
+def indexing(x):
+    return x.type(torch.LongTensor)
+
+
+def float_to_double(x):
+    return x.double()
+
+
+def byte_to_float(x):
+    return x.type(torch.FloatTensor)
+
+
+def while_loop(cond, body, loop_vars, maximum_iterations):
+    iteration = 0
+    while cond(*loop_vars):
+        loop_vars = body(*loop_vars)
+        iteration += 1
+        if iteration >= maximum_iterations:
+            break
+    return loop_vars
+
+
+def logical_or(x, y):
+    bool_result = x or y
+    return bool_result
+
+
 def cond(pred, true_fn, false_fn):
     if pred:
         return true_fn()
@@ -115,7 +142,7 @@ def empty_like(*args, **kwargs):
 def all(x, axis=None):
     if axis is None:
         return x.byte().all()
-    return torch.from_numpy(np.all(x, axis=axis).astype(int))
+    return torch.from_numpy(np.all(np.array(x), axis=axis).astype(int))
 
 
 def allclose(a, b, **kwargs):
@@ -296,11 +323,11 @@ def equal(a, b, **kwargs):
         a = cast(a, torch.uint8).float()
     if b.dtype == torch.ByteTensor:
         b = cast(b, torch.uint8).float()
-    return torch.equal(a, b, **kwargs)
+    return torch.eq(a, b, **kwargs)
 
 
 def floor(*args, **kwargs):
-    return torch.floor(*args, **kwargs)
+    return np.floor(*args, **kwargs)
 
 
 def cross(x, y):
@@ -352,8 +379,8 @@ def diagonal(*args, **kwargs):
     return torch.diagonal(*args, **kwargs)
 
 
-def exp(*args, **kwargs):
-    return torch.exp(*args, **kwargs)
+def exp(input):
+    return torch.exp(torch.tensor(input))
 
 
 def log(*args, **kwargs):
@@ -401,3 +428,7 @@ def mean(x, axis=None):
         return torch.mean(x)
     else:
         return np.mean(x, axis)
+
+
+def argmin(*args, **kwargs):
+    return torch.argmin(*args, **kwargs)

--- a/geomstats/backend/pytorch.py
+++ b/geomstats/backend/pytorch.py
@@ -11,17 +11,6 @@ int32 = 'torch.LongTensor'
 int8 = 'torch.ByteTensor'
 
 
-def indexing(x):
-    return x.type(torch.LongTensor)
-
-
-def float_to_double(x):
-    return x.double()
-
-
-def byte_to_float(x):
-    return x.type(torch.FloatTensor)
-
 
 def while_loop(cond, body, loop_vars, maximum_iterations):
     iteration = 0
@@ -327,7 +316,7 @@ def equal(a, b, **kwargs):
 
 
 def floor(*args, **kwargs):
-    return np.floor(*args, **kwargs)
+    return torch.floor(*args, **kwargs)
 
 
 def cross(x, y):
@@ -380,7 +369,7 @@ def diagonal(*args, **kwargs):
 
 
 def exp(input):
-    return torch.exp(torch.tensor(input))
+    return torch.exp(input)
 
 
 def log(*args, **kwargs):

--- a/geomstats/hypersphere.py
+++ b/geomstats/hypersphere.py
@@ -162,8 +162,8 @@ class Hypersphere(EmbeddedManifold):
         unit_vector = gs.hstack((gs.cos(angle), gs.sin(angle)))
         scalar = gs.random.rand(n_samples)
 
-        coord_z = 1. + 1. / kappa * gs.log(
-                      scalar + (1. - scalar) * gs.exp(-2. * kappa))
+        coord_z = 1. + 1. / kappa * gs.log(scalar + (1. - scalar) *
+                gs.exp(gs.array(-2. * kappa)))
         coord_z = gs.to_ndarray(coord_z, to_ndim=2, axis=1)
 
         coord_xy = gs.sqrt(1. - coord_z**2) * unit_vector

--- a/geomstats/riemannian_metric.py
+++ b/geomstats/riemannian_metric.py
@@ -393,7 +393,7 @@ class RiemannianMetric(object):
 
         random_indices = gs.random.randint(low=0, high=n_points,
                                            size=(n_centers,))
-        centers = points[gs.ix_(random_indices, gs.arange(dimension))]
+        centers = points[gs.indexing(random_indices), :]
 
         gap = 1.0
         iteration = 0
@@ -403,7 +403,7 @@ class RiemannianMetric(object):
             step_size = gs.floor(iteration / n_repetitions) + 1
 
             random_index = gs.random.randint(low=0, high=n_points, size=(1,))
-            point = points[gs.ix_(random_index, gs.arange(dimension))]
+            point = points[gs.indexing(random_index), :]
 
             index_to_update = self.closest_neighbor_index(point, centers)
             center_to_update = centers[index_to_update, :]
@@ -415,12 +415,12 @@ class RiemannianMetric(object):
                     tangent_vec=tangent_vec_update, base_point=center_to_update
                     )
             gap = self.dist(center_to_update, new_center)
-            gap = (gap != 0) * gap + (gap == 0)
+            gap = gs.byte_to_float(gap != 0) * gap + gs.byte_to_float(gap == 0)
 
             centers[index_to_update, :] = new_center
 
             if gs.isclose(gap, 0, atol=tolerance):
-                    break
+                break
 
         if iteration == n_max_iterations-1:
             print('Maximum number of iterations {} reached. The'
@@ -432,6 +432,7 @@ class RiemannianMetric(object):
 
         for point in points:
             index = self.closest_neighbor_index(point, centers)
+            index = index.item()
             if index not in index_list:
                 clusters[index] = list()
                 index_list.append(index)

--- a/geomstats/riemannian_metric.py
+++ b/geomstats/riemannian_metric.py
@@ -393,7 +393,7 @@ class RiemannianMetric(object):
 
         random_indices = gs.random.randint(low=0, high=n_points,
                                            size=(n_centers,))
-        centers = points[gs.indexing(random_indices), :]
+        centers = points[gs.cast(random_indices, gs.int32), :]
 
         gap = 1.0
         iteration = 0
@@ -415,7 +415,7 @@ class RiemannianMetric(object):
                     tangent_vec=tangent_vec_update, base_point=center_to_update
                     )
             gap = self.dist(center_to_update, new_center)
-            gap = gs.byte_to_float(gap != 0) * gap + gs.byte_to_float(gap == 0)
+            gap = gs.cast(gap != 0, gs.float32) * gap + gs.cast(gap == 0, gs.float32)
 
             centers[index_to_update, :] = new_center
 

--- a/tests/test_hypersphere.py
+++ b/tests/test_hypersphere.py
@@ -301,7 +301,6 @@ class TestHypersphereMethods(geomstats.tests.TestCase):
         result = self.metric.squared_dist(n_points_a, n_points_b)
         self.assertAllClose(gs.shape(result), (n_samples, 1))
 
-    #@geomstats.tests.np_and_tf_only
     def test_norm_and_dist(self):
         """
         Test that the distance between two points is
@@ -417,6 +416,7 @@ class TestHypersphereMethods(geomstats.tests.TestCase):
 
         self.assertAllClose(expected, result)
 
+    @geomstats.tests.np_and_pytorch_only
     def test_variance(self):
         point = gs.array([0., 0., 0., 0., 1.])
         points = gs.zeros((2, point.shape[0]))
@@ -427,6 +427,7 @@ class TestHypersphereMethods(geomstats.tests.TestCase):
 
         self.assertAllClose(expected, result)
 
+    @geomstats.tests.np_and_pytorch_only
     def test_mean(self):
         point = gs.array([0., 0., 0., 0., 1.])
         points = gs.zeros((2, point.shape[0]))
@@ -437,6 +438,7 @@ class TestHypersphereMethods(geomstats.tests.TestCase):
 
         self.assertAllClose(expected, result)
 
+    @geomstats.tests.np_and_pytorch_only
     def test_mean_and_belongs(self):
         point_a = gs.array([1., 0., 0., 0., 0.])
         point_b = gs.array([0., 1., 0., 0., 0.])
@@ -504,7 +506,7 @@ class TestHypersphereMethods(geomstats.tests.TestCase):
         mean_norm = gs.linalg.norm(sum_points) / n_points
         kappa_estimate = (mean_norm * (dim + 1. - mean_norm**2)
                           / (1. - mean_norm**2))
-        kappa_estimate = gs.float_to_double(kappa_estimate)
+        kappa_estimate = gs.cast(kappa_estimate, gs.float64)
         p = dim + 1
         n_steps = 100
         for i in range(n_steps):
@@ -512,7 +514,7 @@ class TestHypersphereMethods(geomstats.tests.TestCase):
             bessel_func_2 = scipy.special.iv(p/2.-1., kappa_estimate)
             ratio = bessel_func_1 / bessel_func_2
             denominator = 1. - ratio**2 - (p-1.)*ratio/kappa_estimate
-            mean_norm = gs.float_to_double(mean_norm)
+            mean_norm = gs.cast(mean_norm, gs.float64)
             kappa_estimate = kappa_estimate - (ratio-mean_norm)/denominator
         expected = kappa
         result = kappa_estimate


### PR DESCRIPTION
Debug of pytorch unit tests of hypersphere. The general precision of the results in the unit tests is usually a little worse in pytorch than in numpy, and so I have increases the tolerances.

Still the last one ```test_optimat_quantization.py``` is not working well, because the ```gap``` variable in the ```optimal_quantization``` method of ```riemannian_metric.py```, computed as the distance between ```center_to_update``` and ```new_center```, is sometimes zero with pytorch whereas it is non zero (but close) with numpy. I have traced this to the ```inner_product``` method of the embedding Euclidean metric, which seems to be less precise in pytorch than in numpy, but I don't understand why.