### PR TITLE
Improve SO(n) inverse

### DIFF
--- a/geomstats/geometry/special_orthogonal_group.py
+++ b/geomstats/geometry/special_orthogonal_group.py
@@ -1153,12 +1153,12 @@ class SpecialOrthogonalGroup(LieGroup, EmbeddedManifold):
 
         if point_type == 'vector':
             if self.n == 3:
-                inv_point = -self.regularize(point, point_type=point_type)
-                return inv_point
+                return -self.regularize(point, point_type=point_type)
             else:
                 point = self.matrix_from_rotation_vector(point)
 
-        inv_point = gs.linalg.inv(point)
+        transpose_order = (0, 2, 1) if point.ndim == 3 else (1, 0)
+        inv_point = gs.transpose(point, transpose_order)
 
         if point_type == 'vector':
             inv_point = self.rotation_vector_from_matrix(inv_point)


### PR DESCRIPTION
In SO(n) the inverse of a matrix can be easily caclulated by transposing the matrix. Depending on the input of points (vectorized or not) we have to keep the first index fixed (or not).