### PR TITLE
Remove TF from travis backends

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ script:
 env:
     - GEOMSTATS_BACKEND=numpy
     - GEOMSTATS_BACKEND=pytorch
-    - GEOMSTATS_BACKEND=tensorflow
 
 after_success:
     - bash <(curl -s https://codecov.io/bash) -c -F $GEOMSTATS_BACKEND


### PR DESCRIPTION
Remove unit tests in tensorflow to temporarily speed-up travis continuous integration