### PR TITLE
Remove unit tests in python 3.5 and 3.5-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ dist: trusty
 cache: pip
 language: python
 python:
-    - "3.5"
-    - "3.5-dev"
     - "3.6"
     - "3.6-dev"
 


### PR DESCRIPTION
Temporarily remove some CI to speed-up the hackathon