### PR TITLE
Add prod function to pytorch backend

### DIFF
--- a/geomstats/backend/pytorch.py
+++ b/geomstats/backend/pytorch.py
@@ -400,13 +400,13 @@ def nonzero(*args, **kwargs):
 def seed(x):
     torch.manual_seed(x)
 
-    
-def prod(x, axis = None):
+
+def prod(x, axis=None):
     if axis is None:
         return torch.prod(x)
     else:
-        return torch.prod(x, dim = axis)
-    
+        return torch.prod(x, dim=axis)
+
 
 def sign(*args, **kwargs):
     return torch.sign(*args, **kwargs)

--- a/geomstats/backend/pytorch.py
+++ b/geomstats/backend/pytorch.py
@@ -404,6 +404,13 @@ def nonzero(*args, **kwargs):
 def seed(x):
     torch.manual_seed(x)
 
+    
+def prod(x, axis = None):
+    if axis is None:
+        return torch.prod(x)
+    else:
+        return torch.prod(x, dim = axis)
+    
 
 def sign(*args, **kwargs):
     return torch.sign(*args, **kwargs)


### PR DESCRIPTION
The pytorch backend was missing the prod function despite its presence in the numpy backend. nose2 tests run before and after the change show no new errors. The pytorch prod function produces equivalent results as the numpy prod function.