### PR TITLE
remove vestigial rand function from pytorch.py backend

### DIFF
--- a/geomstats/backend/pytorch.py
+++ b/geomstats/backend/pytorch.py
@@ -234,10 +234,6 @@ def norm(val, axis):
     return torch.linalg.norm(val, axis=axis)
 
 
-def rand(*args, **largs):
-    return torch.rand(*args, **largs)
-
-
 def isclose(*args, **kwargs):
     return torch.from_numpy(np.isclose(*args, **kwargs).astype(int)).byte()
 


### PR DESCRIPTION
There was an unused rand function defined in the pytorch.py backend file. The current usage relies on the pytorch_random file.