### PR TITLE
Restrict backend tests

### DIFF
--- a/geomstats/__init__.py
+++ b/geomstats/__init__.py
@@ -10,4 +10,6 @@ import geomstats.geometry.minkowski_space
 import geomstats.geometry.spd_matrices_space
 import geomstats.geometry.special_euclidean_group
 import geomstats.geometry.special_orthogonal_group
+# XXX: Why does flake8 complain about this not being used but is fine with the
+#      other imports?
 import geomstats.geometry.riemannian_metric  # NOQA

--- a/geomstats/tests.py
+++ b/geomstats/tests.py
@@ -5,7 +5,6 @@ This class abstracts the backend type.
 """
 
 import os
-import tensorflow as tf
 import unittest
 
 import geomstats.backend as gs
@@ -70,6 +69,7 @@ class DummySession:
 
 _TestBaseClass = unittest.TestCase
 if tf_backend():
+    import tensorflow as tf
     _TestBaseClass = tf.test.TestCase
 
 

--- a/geomstats/tests.py
+++ b/geomstats/tests.py
@@ -23,36 +23,41 @@ def np_backend():
     return os.environ['GEOMSTATS_BACKEND'] == 'numpy'
 
 
-test_class = unittest.TestCase
-if tf_backend():
-    test_class = tf.test.TestCase
-
-
 def np_only(test_item):
     """Decorator to filter tests for numpy only."""
-    if not np_backend():
-        test_item.__unittest_skip__ = True
-        test_item.__unittest_skip_why__ = (
-            'Test for numpy backend only.')
-    return test_item
+    if np_backend():
+        return test_item
+    return unittest.skip('Test for numpy backend only.')(test_item)
+
+
+def pytorch_only(test_item):
+    """Decorator to filter tests for pytorch only."""
+    if pytorch_backend():
+        return test_item
+    return unittest.skip('Test for pytorch backend only.')(test_item)
+
+
+def tf_only(test_item):
+    """Decorator to filter tests for tensorflow only."""
+    if tf_backend():
+        return test_item
+    return unittest.skip('Test for tensorflow backend only.')(test_item)
 
 
 def np_and_tf_only(test_item):
     """Decorator to filter tests for numpy and tensorflow only."""
-    if not (np_backend() or tf_backend()):
-        test_item.__unittest_skip__ = True
-        test_item.__unittest_skip_why__ = (
-            'Test for numpy and tensorflow backends only.')
-    return test_item
+    if np_backend() or tf_backend():
+        return test_item
+    return unittest.skip('Test for numpy and tensorflow backends only.')(
+        test_item)
 
 
 def np_and_pytorch_only(test_item):
     """Decorator to filter tests for numpy and pytorch only."""
-    if not (np_backend() or pytorch_backend()):
-        test_item.__unittest_skip__ = True
-        test_item.__unittest_skip_why__ = (
-            'Test for numpy and pytorch backends only.')
-    return test_item
+    if np_backend() or pytorch_backend():
+        return test_item
+    return unittest.skip('Test for numpy and pytorch backends only.')(
+        test_item)
 
 
 class DummySession():
@@ -63,7 +68,13 @@ class DummySession():
         pass
 
 
-class TestCase(test_class):
+_TestBaseClass = unittest.TestCase
+if tf_backend():
+    _TestBaseClass = tf.test.TestCase
+
+
+class TestCase(_TestBaseClass):
+    _multiprocess_can_split = True
 
     def assertAllClose(self, a, b, rtol=1e-6, atol=1e-6):
         if tf_backend():

--- a/geomstats/tests.py
+++ b/geomstats/tests.py
@@ -60,7 +60,7 @@ def np_and_pytorch_only(test_item):
         test_item)
 
 
-class DummySession():
+class DummySession:
     def __enter__(self):
         pass
 

--- a/tests/test_backend_numpy.py
+++ b/tests/test_backend_numpy.py
@@ -13,8 +13,6 @@ from geomstats.geometry.special_orthogonal_group import SpecialOrthogonalGroup
 
 @geomstats.tests.np_only
 class TestBackendNumpy(geomstats.tests.TestCase):
-    _multiprocess_can_split_ = True
-
     def setUp(self):
         warnings.simplefilter('ignore', category=ImportWarning)
 

--- a/tests/test_backend_numpy.py
+++ b/tests/test_backend_numpy.py
@@ -6,13 +6,13 @@ import os
 import unittest
 import warnings
 
-from . import _test
+import geomstats.tests
 import geomstats.backend as gs
 from geomstats.geometry.special_orthogonal_group import SpecialOrthogonalGroup
 
 
-@_test.np_only
-class TestBackendNumpy(_test.TestCase):
+@geomstats.tests.np_only
+class TestBackendNumpy(geomstats.tests.TestCase):
     _multiprocess_can_split_ = True
 
     def setUp(self):

--- a/tests/test_backend_numpy.py
+++ b/tests/test_backend_numpy.py
@@ -7,11 +7,13 @@ import os
 import unittest
 import warnings
 
+from geomstats.tests import TestCase, np_only
 import geomstats.backend as gs
 from geomstats.geometry.special_orthogonal_group import SpecialOrthogonalGroup
 
 
-class TestBackendNumpy(unittest.TestCase):
+@np_only
+class TestBackendNumpy(TestCase):
     _multiprocess_can_split_ = True
 
     @classmethod
@@ -109,7 +111,3 @@ class TestBackendNumpy(unittest.TestCase):
         expected = point
 
         self.assertTrue(gs.allclose(result, expected))
-
-
-if __name__ == '__main__':
-        unittest.main()

--- a/tests/test_backend_numpy.py
+++ b/tests/test_backend_numpy.py
@@ -2,30 +2,18 @@
 Unit tests for numpy backend.
 """
 
-import importlib
 import os
 import unittest
 import warnings
 
-import geomstats.tests
+from . import _test
 import geomstats.backend as gs
 from geomstats.geometry.special_orthogonal_group import SpecialOrthogonalGroup
 
 
-@geomstats.tests.np_only
-class TestBackendNumpy(geomstats.tests.TestCase):
+@_test.np_only
+class TestBackendNumpy(_test.TestCase):
     _multiprocess_can_split_ = True
-
-    @classmethod
-    def setUpClass(cls):
-        cls.initial_backend = os.environ['GEOMSTATS_BACKEND']
-        os.environ['GEOMSTATS_BACKEND'] = 'numpy'
-        importlib.reload(gs)
-
-    @classmethod
-    def tearDownClass(cls):
-        os.environ['GEOMSTATS_BACKEND'] = cls.initial_backend
-        importlib.reload(gs)
 
     def setUp(self):
         warnings.simplefilter('ignore', category=ImportWarning)

--- a/tests/test_backend_numpy.py
+++ b/tests/test_backend_numpy.py
@@ -6,8 +6,9 @@ import os
 import unittest
 import warnings
 
-import geomstats.tests
 import geomstats.backend as gs
+import geomstats.tests
+
 from geomstats.geometry.special_orthogonal_group import SpecialOrthogonalGroup
 
 

--- a/tests/test_backend_numpy.py
+++ b/tests/test_backend_numpy.py
@@ -7,13 +7,13 @@ import os
 import unittest
 import warnings
 
-from geomstats.tests import TestCase, np_only
+import geomstats.tests
 import geomstats.backend as gs
 from geomstats.geometry.special_orthogonal_group import SpecialOrthogonalGroup
 
 
-@np_only
-class TestBackendNumpy(TestCase):
+@geomstats.tests.np_only
+class TestBackendNumpy(geomstats.tests.TestCase):
     _multiprocess_can_split_ = True
 
     @classmethod

--- a/tests/test_backend_tensorflow.py
+++ b/tests/test_backend_tensorflow.py
@@ -2,7 +2,6 @@
 Unit tests for tensorflow backend.
 """
 
-import importlib
 import os
 
 import geomstats.tests
@@ -12,18 +11,6 @@ import geomstats.backend as gs
 @geomstats.tests.tf_only
 class TestBackendTensorFlow(geomstats.tests.TestCase):
     _multiprocess_can_split_ = True
-
-    @classmethod
-    def setUpClass(cls):
-        cls.initial_backend = os.environ['GEOMSTATS_BACKEND']
-        os.environ['GEOMSTATS_BACKEND'] = 'tensorflow'
-        os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
-        importlib.reload(gs)
-
-    @classmethod
-    def tearDownClass(cls):
-        os.environ['GEOMSTATS_BACKEND'] = cls.initial_backend
-        importlib.reload(gs)
 
     def test_vstack(self):
         import tensorflow as tf

--- a/tests/test_backend_tensorflow.py
+++ b/tests/test_backend_tensorflow.py
@@ -4,12 +4,13 @@ Unit tests for tensorflow backend.
 
 import importlib
 import os
-import tensorflow as tf
 
+from geomstats.tests import TestCase, tf_only
 import geomstats.backend as gs
 
 
-class TestBackendTensorFlow(tf.test.TestCase):
+@tf_only
+class TestBackendTensorFlow(TestCase):
     _multiprocess_can_split_ = True
 
     @classmethod
@@ -25,6 +26,7 @@ class TestBackendTensorFlow(tf.test.TestCase):
         importlib.reload(gs)
 
     def test_vstack(self):
+        import tensorflow as tf
         with self.test_session():
             tensor_1 = tf.convert_to_tensor([[1., 2., 3.], [4., 5., 6.]])
             tensor_2 = tf.convert_to_tensor([[7., 8., 9.]])
@@ -42,7 +44,3 @@ class TestBackendTensorFlow(tf.test.TestCase):
             tensor_2 = gs.ones((0, 1))
 
             result = tensor_1 + tensor_2
-
-
-if __name__ == '__main__':
-    tf.test.main()

--- a/tests/test_backend_tensorflow.py
+++ b/tests/test_backend_tensorflow.py
@@ -5,12 +5,12 @@ Unit tests for tensorflow backend.
 import importlib
 import os
 
-from geomstats.tests import TestCase, tf_only
+import geomstats.tests
 import geomstats.backend as gs
 
 
-@tf_only
-class TestBackendTensorFlow(TestCase):
+@geomstats.tests.tf_only
+class TestBackendTensorFlow(geomstats.tests.TestCase):
     _multiprocess_can_split_ = True
 
     @classmethod

--- a/tests/test_backend_tensorflow.py
+++ b/tests/test_backend_tensorflow.py
@@ -10,8 +10,6 @@ import geomstats.backend as gs
 
 @geomstats.tests.tf_only
 class TestBackendTensorFlow(geomstats.tests.TestCase):
-    _multiprocess_can_split_ = True
-
     def test_vstack(self):
         import tensorflow as tf
         with self.test_session():

--- a/tests/test_backend_tensorflow.py
+++ b/tests/test_backend_tensorflow.py
@@ -4,8 +4,8 @@ Unit tests for tensorflow backend.
 
 import os
 
-import geomstats.tests
 import geomstats.backend as gs
+import geomstats.tests
 
 
 @geomstats.tests.tf_only

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -52,7 +52,3 @@ class TestConnectionMethods(geomstats.tests.TestCase):
         expected = gs.zeros((1,) + (self.dimension, ) * 3)
 
         gs.testing.assert_allclose(result, expected)
-
-
-if __name__ == '__main__':
-        geomstats.tests.main()

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -10,8 +10,6 @@ from geomstats.geometry.euclidean_space import EuclideanMetric
 
 
 class TestConnectionMethods(geomstats.tests.TestCase):
-    _multiprocess_can_split_ = True
-
     def setUp(self):
         self.dimension = 4
         self.metric = EuclideanMetric(dimension=self.dimension)

--- a/tests/test_discretized_curves_space.py
+++ b/tests/test_discretized_curves_space.py
@@ -277,7 +277,3 @@ class TestDiscretizedCurvesSpaceMethods(geomstats.tests.TestCase):
         expected = self.srv_metric_r3.dist(self.curve_a, self.curve_b)
 
         self.assertAllClose(result, expected)
-
-
-if __name__ == '__main__':
-        geomstats.tests.main()

--- a/tests/test_discretized_curves_space.py
+++ b/tests/test_discretized_curves_space.py
@@ -11,8 +11,6 @@ from geomstats.geometry.hypersphere import Hypersphere
 
 
 class TestDiscretizedCurvesSpaceMethods(geomstats.tests.TestCase):
-    _multiprocess_can_split_ = True
-
     def setUp(self):
         s2 = Hypersphere(dimension=2)
         r3 = s2.embedding_manifold

--- a/tests/test_euclidean_space.py
+++ b/tests/test_euclidean_space.py
@@ -10,8 +10,6 @@ from geomstats.geometry.euclidean_space import EuclideanSpace
 
 
 class TestEuclideanSpaceMethods(geomstats.tests.TestCase):
-    _multiprocess_can_split_ = True
-
     def setUp(self):
         gs.random.seed(1234)
 

--- a/tests/test_euclidean_space.py
+++ b/tests/test_euclidean_space.py
@@ -360,7 +360,3 @@ class TestEuclideanSpaceMethods(geomstats.tests.TestCase):
         expected = helper.to_scalar(expected)
 
         self.assertAllClose(result, expected)
-
-
-if __name__ == '__main__':
-        geomstats.test.main()

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -97,7 +97,3 @@ class TestExamples(geomstats.tests.TestCase):
     @geomstats.tests.np_only
     def test_plot_quantization_s2(self):
         plot_quantization_s2.main()
-
-
-if __name__ == '__main__':
-        geomstats.tests.main()

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -28,8 +28,6 @@ import geomstats.tests
 
 
 class TestExamples(geomstats.tests.TestCase):
-    _multiprocess_can_split_ = True
-
     @classmethod
     def setUpClass(cls):
         sys.stdout = open(os.devnull, 'w')

--- a/tests/test_general_linear_group.py
+++ b/tests/test_general_linear_group.py
@@ -15,8 +15,6 @@ RTOL = 1e-5
 
 
 class TestGeneralLinearGroupMethods(geomstats.tests.TestCase):
-    _multiprocess_can_split_ = True
-
     def setUp(self):
         gs.random.seed(1234)
         self.n = 3

--- a/tests/test_general_linear_group.py
+++ b/tests/test_general_linear_group.py
@@ -164,7 +164,3 @@ class TestGeneralLinearGroupMethods(geomstats.tests.TestCase):
         expected = point
 
         self.assertAllClose(result, expected)
-
-
-if __name__ == '__main__':
-        geomstats.tests.main()

--- a/tests/test_grassmannian.py
+++ b/tests/test_grassmannian.py
@@ -9,8 +9,6 @@ from geomstats.geometry.grassmannian import Grassmannian
 
 
 class TestGrassmannianMethods(geomstats.tests.TestCase):
-    _multiprocess_can_split_ = True
-
     def setUp(self):
         gs.random.seed(1234)
 

--- a/tests/test_grassmannian.py
+++ b/tests/test_grassmannian.py
@@ -17,7 +17,3 @@ class TestGrassmannianMethods(geomstats.tests.TestCase):
         self.n = 4
         self.p = 2
         self.space = Grassmannian(self.n, self.p)
-
-
-if __name__ == '__main__':
-        geomstats.test.main()

--- a/tests/test_hyperbolic_space.py
+++ b/tests/test_hyperbolic_space.py
@@ -410,7 +410,3 @@ class TestHyperbolicSpaceMethods(geomstats.tests.TestCase):
         expected = gs.array([[True]])
 
         self.assertAllClose(result, expected)
-
-
-if __name__ == '__main__':
-    geomstats.tests.main()

--- a/tests/test_hyperbolic_space.py
+++ b/tests/test_hyperbolic_space.py
@@ -19,8 +19,6 @@ RTOL = 1e-6
 
 
 class TestHyperbolicSpaceMethods(geomstats.tests.TestCase):
-    _multiprocess_can_split_ = True
-
     def setUp(self):
         gs.random.seed(1234)
         self.dimension = 3

--- a/tests/test_hypersphere.py
+++ b/tests/test_hypersphere.py
@@ -543,7 +543,3 @@ class TestHypersphereMethods(geomstats.tests.TestCase):
             expected = 0.0
             self.assertAllClose(
                 result, expected, atol=OPTIMAL_QUANTIZATION_TOL)
-
-
-if __name__ == '__main__':
-        geomstats.tests.main()

--- a/tests/test_hypersphere.py
+++ b/tests/test_hypersphere.py
@@ -16,8 +16,6 @@ OPTIMAL_QUANTIZATION_TOL = 2e-2
 
 
 class TestHypersphereMethods(geomstats.tests.TestCase):
-    _multiprocess_can_split_ = True
-
     def setUp(self):
         gs.random.seed(1234)
 

--- a/tests/test_invariant_metric.py
+++ b/tests/test_invariant_metric.py
@@ -13,8 +13,6 @@ from geomstats.geometry.special_euclidean_group import SpecialEuclideanGroup
 
 
 class TestInvariantMetricMethods(geomstats.tests.TestCase):
-    _multiprocess_can_split_ = True
-
     def setUp(self):
         warnings.simplefilter('ignore', category=ImportWarning)
 

--- a/tests/test_invariant_metric.py
+++ b/tests/test_invariant_metric.py
@@ -456,7 +456,3 @@ class TestInvariantMetricMethods(geomstats.tests.TestCase):
                                              vector=log,
                                              base_point=self.point_1)
         self.assertAllClose(result, expected)
-
-
-if __name__ == '__main__':
-        geomstats.tests.main()

--- a/tests/test_landmarks_space.py
+++ b/tests/test_landmarks_space.py
@@ -184,7 +184,3 @@ class TestLandmarksSpaceMethods(geomstats.tests.TestCase):
         geod = self.l2_metric_s2.geodesic(
                 initial_landmarks=landmarks_ab,
                 end_landmarks=landmarks_bc)
-
-
-if __name__ == '__main__':
-        geomstats.tests.main()

--- a/tests/test_landmarks_space.py
+++ b/tests/test_landmarks_space.py
@@ -11,8 +11,6 @@ from geomstats.geometry.landmarks_space import LandmarksSpace
 
 
 class TestLandmarksSpaceMethods(geomstats.tests.TestCase):
-    _multiprocess_can_split_ = True
-
     def setUp(self):
         s2 = Hypersphere(dimension=2)
         r3 = s2.embedding_manifold

--- a/tests/test_lie_group.py
+++ b/tests/test_lie_group.py
@@ -18,7 +18,3 @@ class TestLieGroupMethods(geomstats.tests.TestCase):
         expected = self.dimension
 
         self.assertAllClose(result, expected)
-
-
-if __name__ == '__main__':
-        geomstats.tests.main()

--- a/tests/test_lie_group.py
+++ b/tests/test_lie_group.py
@@ -8,8 +8,6 @@ from geomstats.geometry.lie_group import LieGroup
 
 
 class TestLieGroupMethods(geomstats.tests.TestCase):
-    _multiprocess_can_split_ = True
-
     dimension = 4
     group = LieGroup(dimension=dimension)
 

--- a/tests/test_manifold.py
+++ b/tests/test_manifold.py
@@ -30,7 +30,3 @@ class TestManifoldMethods(geomstats.tests.TestCase):
         result = self.manifold.regularize(point)
         expected = point
         self.assertAllClose(result, expected)
-
-
-if __name__ == '__main__':
-    geomstats.test.main()

--- a/tests/test_manifold.py
+++ b/tests/test_manifold.py
@@ -9,8 +9,6 @@ from geomstats.geometry.manifold import Manifold
 
 
 class TestManifoldMethods(geomstats.tests.TestCase):
-    _multiprocess_can_split_ = True
-
     def setUp(self):
         self.dimension = 4
         self.manifold = Manifold(self.dimension)

--- a/tests/test_matrices_space.py
+++ b/tests/test_matrices_space.py
@@ -23,7 +23,7 @@ class TestMatricesSpaceMethods(geomstats.tests.TestCase):
     @geomstats.tests.np_only
     def test_mul(self):
         a = gs.eye(3, 3, 1)
-        b = gs.eye(3, 3, -1) 
+        b = gs.eye(3, 3, -1)
         c = gs.array([
             [1., 0., 0.],
             [0., 1., 0.],
@@ -157,7 +157,3 @@ class TestMatricesSpaceMethods(geomstats.tests.TestCase):
         expected = helper.to_scalar(expected)
 
         self.assertAllClose(result, expected)
-
-
-if __name__ == '__main__':
-        geomstats.tests.main()

--- a/tests/test_matrices_space.py
+++ b/tests/test_matrices_space.py
@@ -10,8 +10,6 @@ from geomstats.geometry.matrices_space import MatricesSpace
 
 
 class TestMatricesSpaceMethods(geomstats.tests.TestCase):
-    _multiprocess_can_split_ = True
-
     def setUp(self):
         gs.random.seed(1234)
 

--- a/tests/test_minkowski_space.py
+++ b/tests/test_minkowski_space.py
@@ -254,7 +254,3 @@ class TestMinkowskiSpaceMethods(geomstats.tests.TestCase):
         # we expect the average of the points' Minkowski sq norms.
         expected = helper.to_scalar(gs.array([True]))
         self.assertAllClose(result, expected)
-
-
-if __name__ == '__main__':
-        geomstats.tests.main()

--- a/tests/test_minkowski_space.py
+++ b/tests/test_minkowski_space.py
@@ -12,8 +12,6 @@ from geomstats.geometry.minkowski_space import MinkowskiSpace
 
 
 class TestMinkowskiSpaceMethods(geomstats.tests.TestCase):
-    _multiprocess_can_split_ = True
-
     def setUp(self):
         gs.random.seed(1234)
 

--- a/tests/test_poincare_polydisk.py
+++ b/tests/test_poincare_polydisk.py
@@ -10,8 +10,6 @@ from geomstats.geometry.poincare_polydisk import PoincarePolydisk
 
 
 class TestPoincarePolydiskMethods(geomstats.tests.TestCase):
-    _multiprocess_can_split_ = True
-
     def setUp(self):
         gs.random.seed(1234)
         self.n_disks = 5

--- a/tests/test_quantization.py
+++ b/tests/test_quantization.py
@@ -7,8 +7,6 @@ from geomstats.learning.quantization import Quantization
 
 
 class TestQuantizationMethods(geomstats.tests.TestCase):
-    _multiprocess_can_split_ = True
-
     def setUp(self):
         gs.random.seed(1234)
 

--- a/tests/test_quantization.py
+++ b/tests/test_quantization.py
@@ -42,7 +42,3 @@ class TestQuantizationMethods(geomstats.tests.TestCase):
         result = prediction
         expected = clustering.labels_[0]
         self.assertAllClose(expected, result)
-
-
-if __name__ == '__main__':
-    geomstats.tests.main()

--- a/tests/test_spd_matrices_space.py
+++ b/tests/test_spd_matrices_space.py
@@ -289,7 +289,3 @@ class TestSPDMatricesSpaceMethods(geomstats.tests.TestCase):
         result = self.metric.squared_dist(point_1, point_2)
 
         self.assertAllClose(gs.shape(result), (1, 1))
-
-
-if __name__ == '__main__':
-    geomstats.tests.main()

--- a/tests/test_spd_matrices_space.py
+++ b/tests/test_spd_matrices_space.py
@@ -12,8 +12,6 @@ from geomstats.geometry.spd_matrices_space import SPDMatricesSpace, SPDMetricPro
 
 
 class TestSPDMatricesSpaceMethods(geomstats.tests.TestCase):
-    _multiprocess_can_split_ = True
-
     def setUp(self):
         warnings.simplefilter('ignore', category=ImportWarning)
 

--- a/tests/test_special_euclidean_group.py
+++ b/tests/test_special_euclidean_group.py
@@ -590,10 +590,9 @@ class TestSpecialEuclideanGroupMethods(geomstats.tests.TestCase):
                 axis=1)
             inv_expected = helper.to_vector(inv_expected)
 
-            with self.session():
-                self.assertTrue(
-                    gs.eval(gs.allclose(result, expected, atol=1e-4))
-                    or gs.eval(gs.allclose(result, inv_expected, atol=1e-4)))
+            self.assertTrue(
+                gs.allclose(result, expected, atol=1e-4)
+                or gs.allclose(result, inv_expected, atol=1e-4))
 
             if geomstats.tests.tf_backend():
                 break
@@ -790,10 +789,9 @@ class TestSpecialEuclideanGroupMethods(geomstats.tests.TestCase):
                     axis=1)
                 inv_expected = helper.to_vector(inv_expected)
 
-                with self.session():
-                    self.assertTrue(
-                        gs.eval(gs.allclose(result, expected))
-                        or gs.eval(gs.allclose(result, inv_expected)))
+                self.assertTrue(
+                    gs.allclose(result, expected)
+                    or gs.allclose(result, inv_expected))
 
                 if geomstats.tests.tf_backend():
                     break
@@ -852,15 +850,9 @@ class TestSpecialEuclideanGroupMethods(geomstats.tests.TestCase):
                     axis=1)
                 inv_expected = helper.to_vector(inv_expected)
 
-                with self.session():
-                    self.assertTrue(
-                        gs.eval(gs.allclose(
-                            result, expected, atol=1e-5))
-                        or gs.eval(gs.allclose(
-                            result, inv_expected, atol=1e-5)))
-
-                if geomstats.tests.tf_backend():
-                    break
+                self.assertTrue(
+                    gs.allclose(result, expected, atol=1e-5)
+                    or gs.allclose(result, inv_expected, atol=1e-5))
 
     @geomstats.tests.np_only
     def test_exp_left(self):
@@ -972,10 +964,9 @@ class TestSpecialEuclideanGroupMethods(geomstats.tests.TestCase):
                         axis=1)
                     inv_expected = helper.to_vector(inv_expected)
 
-                    with self.session():
-                        self.assertTrue(
-                            gs.eval(gs.allclose(result, expected))
-                            or gs.eval(gs.allclose(result, inv_expected)))
+                    self.assertTrue(
+                        gs.allclose(result, expected)
+                        or gs.allclose(result, inv_expected))
 
                     if geomstats.tests.tf_backend():
                         break
@@ -1043,11 +1034,9 @@ class TestSpecialEuclideanGroupMethods(geomstats.tests.TestCase):
                         axis=1)
                     inv_expected = helper.to_vector(inv_expected)
 
-                    with self.session():
-                        self.assertTrue(
-                            gs.eval(gs.allclose(result, expected, atol=1e-3))
-                            or gs.eval(gs.allclose(
-                                result, inv_expected, atol=1e-3)))
+                    self.assertTrue(
+                        gs.allclose(result, expected, atol=1e-3)
+                        or gs.allclose(result, inv_expected, atol=1e-3))
 
                     if geomstats.tests.tf_backend():
                         break
@@ -1114,10 +1103,9 @@ class TestSpecialEuclideanGroupMethods(geomstats.tests.TestCase):
                     if norm != 0:
                         atol = RTOL * norm
 
-                    with self.session():
-                        self.assertTrue(
-                            gs.eval(gs.allclose(result, expected))
-                            or gs.eval(gs.allclose(result, inv_expected)))
+                    self.assertTrue(
+                        gs.allclose(result, expected)
+                        or gs.allclose(result, inv_expected))
 
                     if geomstats.tests.tf_backend():
                         break

--- a/tests/test_special_euclidean_group.py
+++ b/tests/test_special_euclidean_group.py
@@ -1417,7 +1417,3 @@ class TestSpecialEuclideanGroupMethods(geomstats.tests.TestCase):
             result = point_step
             expected = helper.to_vector(points[i])
             self.assertAllClose(result, expected)
-
-
-if __name__ == '__main__':
-        geomstats.tests.main()

--- a/tests/test_special_euclidean_group.py
+++ b/tests/test_special_euclidean_group.py
@@ -25,8 +25,6 @@ RTOL = 1e-5
 
 
 class TestSpecialEuclideanGroupMethods(geomstats.tests.TestCase):
-    _multiprocess_can_split_ = True
-
     def setUp(self):
         warnings.simplefilter('ignore', category=ImportWarning)
         gs.random.seed(1234)

--- a/tests/test_special_orthogonal_group.py
+++ b/tests/test_special_orthogonal_group.py
@@ -2514,10 +2514,9 @@ class TestSpecialOrthogonalGroupMethods(geomstats.tests.TestCase):
             expected = group.regularize(point)
             inv_expected = - expected
 
-            with self.session():
-                self.assertTrue(
-                    gs.eval(gs.allclose(result, expected))
-                    or gs.eval(gs.allclose(result, inv_expected)))
+            self.assertTrue(
+                gs.allclose(result, expected)
+                or gs.allclose(result, inv_expected))
 
     @geomstats.tests.np_only
     def test_quaternion_and_rotation_vector(self):
@@ -2665,10 +2664,9 @@ class TestSpecialOrthogonalGroupMethods(geomstats.tests.TestCase):
             expected = matrix
             inv_expected = gs.linalg.inv(matrix)
 
-            with self.session():
-                self.assertTrue(
-                    gs.eval(gs.allclose(result, expected))
-                    or gs.eval(gs.allclose(result, inv_expected)))
+            self.assertTrue(
+                gs.eval(gs.allclose(result, expected))
+                or gs.eval(gs.allclose(result, inv_expected)))
 
     @geomstats.tests.np_only
     def test_quaternion_and_rotation_vector_and_matrix_vectorization(self):
@@ -2704,10 +2702,9 @@ class TestSpecialOrthogonalGroupMethods(geomstats.tests.TestCase):
 
                     else:
                         inv_expected = - expected
-                        with self.session():
-                            self.assertTrue(
-                                gs.eval(gs.allclose(result, expected))
-                                or gs.eval(gs.allclose(result, inv_expected)))
+                        self.assertTrue(
+                            gs.eval(gs.allclose(result, expected))
+                            or gs.eval(gs.allclose(result, inv_expected)))
 
                     # Composition by identity, on the left
                     # Expect the original transformation
@@ -2718,10 +2715,9 @@ class TestSpecialOrthogonalGroupMethods(geomstats.tests.TestCase):
                         self.assertAllClose(result, expected)
                     else:
                         inv_expected = - expected
-                        with self.session():
-                            self.assertTrue(
-                                gs.eval(gs.allclose(result, expected))
-                                or gs.eval(gs.allclose(result, inv_expected)))
+                        self.assertTrue(
+                            gs.eval(gs.allclose(result, expected))
+                            or gs.eval(gs.allclose(result, inv_expected)))
 
             else:
                 angle = 0.986
@@ -3080,10 +3076,9 @@ class TestSpecialOrthogonalGroupMethods(geomstats.tests.TestCase):
                                                 tangent_vec=tangent_vec,
                                                 metric=metric)
                 inv_expected = - expected
-                with self.session():
-                    self.assertTrue(
-                        gs.eval(gs.allclose(result, expected))
-                        or gs.eval(gs.allclose(result, inv_expected)))
+                self.assertTrue(
+                    gs.eval(gs.allclose(result, expected))
+                    or gs.eval(gs.allclose(result, inv_expected)))
 
     @geomstats.tests.np_only
     def test_log_then_exp_from_identity(self):
@@ -3129,10 +3124,9 @@ class TestSpecialOrthogonalGroupMethods(geomstats.tests.TestCase):
                 expected = group.regularize(point)
                 inv_expected = - expected
 
-                with self.session():
-                    self.assertTrue(
-                        gs.eval(gs.allclose(result, expected))
-                        or gs.eval(gs.allclose(result, inv_expected)))
+                self.assertTrue(
+                    gs.eval(gs.allclose(result, expected))
+                    or gs.eval(gs.allclose(result, inv_expected)))
 
     @geomstats.tests.np_only
     def test_exp_then_log(self):
@@ -3194,12 +3188,11 @@ class TestSpecialOrthogonalGroupMethods(geomstats.tests.TestCase):
                     expected = reg_tangent_vec
                     inv_expected = - expected
 
-                    with self.session():
-                        self.assertTrue(
-                            gs.eval(gs.allclose(
-                                result, expected, atol=1e-5))
-                            or gs.eval(gs.allclose(
-                                result, inv_expected, atol=1e-5)))
+                    self.assertTrue(
+                        gs.eval(gs.allclose(
+                            result, expected, atol=1e-5))
+                        or gs.eval(gs.allclose(
+                            result, inv_expected, atol=1e-5)))
 
     @geomstats.tests.np_only
     def test_log_then_exp(self):
@@ -3229,10 +3222,9 @@ class TestSpecialOrthogonalGroupMethods(geomstats.tests.TestCase):
                     expected = group.regularize(point)
                     inv_expected = - expected
 
-                    with self.session():
-                        self.assertTrue(
-                            gs.eval(gs.allclose(result, expected))
-                            or gs.eval(gs.allclose(result, inv_expected)))
+                    self.assertTrue(
+                        gs.eval(gs.allclose(result, expected))
+                        or gs.eval(gs.allclose(result, inv_expected)))
 
     @geomstats.tests.np_only
     def test_log_then_exp_with_angles_close_to_pi(self):
@@ -3258,11 +3250,10 @@ class TestSpecialOrthogonalGroupMethods(geomstats.tests.TestCase):
                     expected = group.regularize(point)
                     inv_expected = - expected
 
-                    with self.session():
-                        self.assertTrue(
-                            gs.eval(gs.allclose(result, expected, atol=1e-5))
-                            or gs.eval(gs.allclose(
-                                result, inv_expected, atol=1e-5)))
+                    self.assertTrue(
+                        gs.eval(gs.allclose(result, expected, atol=1e-5))
+                        or gs.eval(gs.allclose(
+                            result, inv_expected, atol=1e-5)))
 
     def test_group_exp_from_identity_vectorization(self):
         n = 3
@@ -3490,11 +3481,9 @@ class TestSpecialOrthogonalGroupMethods(geomstats.tests.TestCase):
                 expected = reg_tangent_vec
                 inv_expected = - expected
 
-                with self.session():
-                    self.assertTrue(
-                        gs.eval(gs.allclose(result, expected, atol=1e-5))
-                        or gs.eval(gs.allclose(
-                            result, inv_expected, atol=1e-5)))
+                self.assertTrue(
+                    gs.eval(gs.allclose(result, expected, atol=1e-5))
+                    or gs.eval(gs.allclose(result, inv_expected, atol=1e-5)))
 
     @geomstats.tests.np_only
     def test_group_log_then_exp(self):
@@ -3545,11 +3534,9 @@ class TestSpecialOrthogonalGroupMethods(geomstats.tests.TestCase):
                 expected = group.regularize(point)
                 inv_expected = - expected
 
-                with self.session():
-                    self.assertTrue(
-                        gs.eval(gs.allclose(result, expected, atol=1e-5))
-                        or gs.eval(gs.allclose(
-                            result, inv_expected, atol=1e-5)))
+                self.assertTrue(
+                    gs.allclose(result, expected, atol=1e-5)
+                    or gs.allclose(result, inv_expected, atol=1e-5))
 
     @geomstats.tests.np_only
     def test_group_exponential_barycenter(self):

--- a/tests/test_special_orthogonal_group.py
+++ b/tests/test_special_orthogonal_group.py
@@ -3807,7 +3807,3 @@ class TestSpecialOrthogonalGroupMethods(geomstats.tests.TestCase):
             gs.array([[[0., 0., 0.], [0., 0., -1.], [0., 1., 0.]]]))
 
         self.assertAllClose(result, expected)
-
-
-if __name__ == '__main__':
-    geomstats.tests.main()

--- a/tests/test_special_orthogonal_group.py
+++ b/tests/test_special_orthogonal_group.py
@@ -20,8 +20,6 @@ ATOL = 1e-5
 
 
 class TestSpecialOrthogonalGroupMethods(geomstats.tests.TestCase):
-    _multiprocess_can_split_ = True
-
     def setUp(self):
         warnings.simplefilter('ignore', category=ImportWarning)
 

--- a/tests/test_stiefel.py
+++ b/tests/test_stiefel.py
@@ -268,7 +268,3 @@ class TestStiefelMethods(geomstats.tests.TestCase):
             tangent_vector_2,
             base_point=base_point)
         self.assertAllClose(gs.shape(result), (1, 1))
-
-
-if __name__ == '__main__':
-        geomstats.tests.main()

--- a/tests/test_stiefel.py
+++ b/tests/test_stiefel.py
@@ -14,8 +14,6 @@ ATOL = 1e-6
 
 
 class TestStiefelMethods(geomstats.tests.TestCase):
-    _multiprocess_can_split_ = True
-
     def setUp(self):
         """
         Tangent vectors constructed following:

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -62,7 +62,3 @@ class TestVisualizationMethods(geomstats.tests.TestCase):
     def test_plot_points_h2_klein_disk(self):
         points = self.H2.random_uniform(self.n_samples)
         visualization.plot(points, space='H2_klein_disk')
-
-
-if __name__ == '__main__':
-        geomstats.tests.main()

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -16,8 +16,6 @@ from geomstats.geometry.special_orthogonal_group import SpecialOrthogonalGroup
 
 
 class TestVisualizationMethods(geomstats.tests.TestCase):
-    _multiprocess_can_split_ = True
-
     def setUp(self):
         self.n_samples = 10
         self.SO3_GROUP = SpecialOrthogonalGroup(n=3)


### PR DESCRIPTION
This change makes sure that we don't switch the backend unnecessarily when testing a specific backend. This effectively suppresses curious messages like "Using numpy backend" when running tests for tensorflow. Similiarly, running the test suite on the numpy backend now no longer produces tensorflow deprecation warnings as we don't import tensorflow in the first place.