### PR TITLE
matrix transpose

### DIFF
--- a/geomstats/geometry/matrices_space.py
+++ b/geomstats/geometry/matrices_space.py
@@ -65,7 +65,7 @@ class MatricesSpace(EuclideanSpace):
     @staticmethod
     def transpose(mat):
         """
-        Return the transpose of matrices. 
+        Return the transpose of matrices.
 
         Parameters
         ----------

--- a/geomstats/geometry/matrices_space.py
+++ b/geomstats/geometry/matrices_space.py
@@ -63,6 +63,23 @@ class MatricesSpace(EuclideanSpace):
         return gs.matmul(a, b) - gs.matmul(b, a)
 
     @staticmethod
+    def transpose(mat):
+        """
+        Return the transpose of matrices. 
+
+        Parameters
+        ----------
+        mat : array-like, shape=[n_samples, dim, dim]
+
+        Returns
+        -------
+        transpose : array-like, shape=[n_samples, dim, dim]
+        """
+        is_vec = (gs.ndim(gs.array(mat)) == 3)
+        axes = (0, 2, 1) if is_vec else (1, 0)
+        return gs.transpose(mat, axes)
+
+    @staticmethod
     def vector_from_matrix(matrix):
         """
         Conversion function from (_, m, n) to (_, mn).

--- a/tests/test_matrices_space.py
+++ b/tests/test_matrices_space.py
@@ -60,6 +60,7 @@ class TestMatricesSpaceMethods(geomstats.tests.TestCase):
         expected = gs.array([gs.zeros((3,3)), z, -y])
         self.assertAllClose(result, expected)
     
+    @geomstats.test.np_only
     def test_transpose(self):
         tr = self.space.transpose
         ar = gs.array

--- a/tests/test_matrices_space.py
+++ b/tests/test_matrices_space.py
@@ -60,7 +60,7 @@ class TestMatricesSpaceMethods(geomstats.tests.TestCase):
         expected = gs.array([gs.zeros((3,3)), z, -y])
         self.assertAllClose(result, expected)
     
-    @geomstats.test.np_only
+    @geomstats.tests.np_only
     def test_transpose(self):
         tr = self.space.transpose
         ar = gs.array

--- a/tests/test_matrices_space.py
+++ b/tests/test_matrices_space.py
@@ -59,6 +59,14 @@ class TestMatricesSpaceMethods(geomstats.tests.TestCase):
         result = self.space.commutator(x, [x, y, z])
         expected = gs.array([gs.zeros((3,3)), z, -y])
         self.assertAllClose(result, expected)
+    
+    def test_transpose(self):
+        tr = self.space.transpose
+        ar = gs.array
+        a = gs.eye(3, 3, 1)
+        b = gs.eye(3, 3, -1)
+        self.assertAllClose(tr(a), b)
+        self.assertAllClose(tr(ar([a, b])), ar([b, a]))
 
     @geomstats.tests.np_only
     def test_is_symmetric(self):


### PR DESCRIPTION
add vectorised matrix transpose. 

N.B:  this is only a first push to expose a vectorized transpose map with **correct shape signature**. 
Many other methods resort to matrix transposition usually via an inline implementation and resorting to `gs.to_ndim` for vectorisation. They might have inconsistent vectorization behaviour, next step is to check this, point to `Mat.transpose` while checking `spd_matrices` stays ok. 

For instance: 
+ `is_symmetric`
+ `make_symmetric`
+ `inverse` on orthogonal matrices!
+ ... 

Look at the implementation to see how array shapes should be checked, and pass the correct `axes` argument to `gs.transpose`. 

```
tr = MatricesSpace.transpose
a = gs.array([
    [1, 0],
    [0, 1]])
b = tr(a) 

tr([a, b]) 
>>> [b, a]
```

