### PR TITLE
Forward-export numpy functions

### DIFF
--- a/geomstats/backend/numpy.py
+++ b/geomstats/backend/numpy.py
@@ -1,6 +1,81 @@
 """Numpy based computation backend."""
 
 import numpy as np
+from numpy import (  # NOQA
+    abs,
+    all,
+    allclose,
+    amax,
+    any,
+    arange,
+    arccos,
+    arccosh,
+    arcsin,
+    arctan2,
+    argmax,
+    argmin,
+    array,
+    asarray,
+    average,
+    clip,
+    concatenate,
+    cos,
+    cosh,
+    cov,
+    cross,
+    diagonal,
+    divide,
+    dot,
+    einsum,
+    empty_like,
+    equal,
+    exp,
+    expand_dims,
+    eye,
+    flip,
+    floor,
+    greater_equal,
+    greater,
+    hsplit,
+    hstack,
+    identity,
+    isclose,
+    ix_,
+    less,
+    less_equal,
+    linspace,
+    log,
+    matmul,
+    maximum,
+    mean,
+    mod,
+    nonzero,
+    ones,
+    ones_like,
+    outer,
+    prod,
+    real,
+    repeat,
+    reshape,
+    shape,
+    sign,
+    sin,
+    sinh,
+    sqrt,
+    squeeze,
+    stack,
+    sum,
+    tan,
+    tanh,
+    tile,
+    trace,
+    transpose,
+    triu_indices,
+    vstack,
+    where,
+    zeros,
+    zeros_like
+)
 
 
 int32 = np.int32
@@ -64,14 +139,6 @@ def cond(pred, true_fn, false_fn):
     return false_fn()
 
 
-def real(x):
-    return np.real(x)
-
-
-def reshape(*args, **kwargs):
-    return np.reshape(*args, **kwargs)
-
-
 def cast_to_complex(x):
     return np.vectorize(complex)(x)
 
@@ -80,140 +147,8 @@ def boolean_mask(x, mask):
     return x[mask]
 
 
-def flip(*args, **kwargs):
-    return np.flip(*args, **kwargs)
-
-
-def amax(*args, **kwargs):
-    return np.amax(*args, **kwargs)
-
-
-def arctan2(*args, **kwargs):
-    return np.arctan2(*args, **kwargs)
-
-
 def cast(x, dtype):
     return x.astype(dtype)
-
-
-def divide(*args, **kwargs):
-    return np.divide(*args, **kwargs)
-
-
-def repeat(*args, **kwargs):
-    return np.repeat(*args, **kwargs)
-
-
-def asarray(*args, **kwargs):
-    return np.asarray(*args, **kwargs)
-
-
-def concatenate(*args, **kwargs):
-    return np.concatenate(*args, **kwargs)
-
-
-def identity(val):
-    return np.identity(val)
-
-
-def hstack(val):
-    return np.hstack(val)
-
-
-def stack(*args, **kwargs):
-    return np.stack(*args, **kwargs)
-
-
-def vstack(val):
-    return np.vstack(val)
-
-
-def array(val):
-    return np.array(val)
-
-
-def abs(val):
-    return np.abs(val)
-
-
-def zeros(val):
-    return np.zeros(val)
-
-
-def ones(val):
-    return np.ones(val)
-
-
-def ones_like(*args, **kwargs):
-    return np.ones_like(*args, **kwargs)
-
-
-def empty_like(*args, **kwargs):
-    return np.empty_like(*args, **kwargs)
-
-
-def all(*args, **kwargs):
-    return np.all(*args, **kwargs)
-
-
-def allclose(a, b, **kwargs):
-    return np.allclose(a, b, **kwargs)
-
-
-def sin(val):
-    return np.sin(val)
-
-
-def cos(val):
-    return np.cos(val)
-
-
-def cosh(*args, **kwargs):
-    return np.cosh(*args, **kwargs)
-
-
-def sinh(*args, **kwargs):
-    return np.sinh(*args, **kwargs)
-
-
-def tanh(*args, **kwargs):
-    return np.tanh(*args, **kwargs)
-
-
-def arccosh(*args, **kwargs):
-    return np.arccosh(*args, **kwargs)
-
-
-def tan(val):
-    return np.tan(val)
-
-
-def arcsin(val):
-    return np.arcsin(val)
-
-
-def arccos(val):
-    return np.arccos(val)
-
-
-def shape(val):
-    return val.shape
-
-
-def dot(a, b):
-    return np.dot(a, b)
-
-
-def maximum(a, b):
-    return np.maximum(a, b)
-
-
-def greater(a, b):
-    return np.greater(a, b)
-
-
-def greater_equal(a, b):
-    return np.greater_equal(a, b)
 
 
 def to_ndarray(x, to_ndim, axis=0):
@@ -222,106 +157,6 @@ def to_ndarray(x, to_ndim, axis=0):
         x = np.expand_dims(x, axis=axis)
     assert x.ndim >= to_ndim
     return x
-
-
-def sqrt(val):
-    return np.sqrt(val)
-
-
-def norm(val, axis):
-    return np.linalg.norm(val, axis=axis)
-
-
-def rand(*args, **largs):
-    return np.random.rand(*args, **largs)
-
-
-def randint(*args, **kwargs):
-    return np.random.randint(*args, **kwargs)
-
-
-def isclose(*args, **kwargs):
-    return np.isclose(*args, **kwargs)
-
-
-def less_equal(a, b):
-    return np.less_equal(a, b)
-
-
-def less(a, b):
-    return np.less(a, b)
-
-
-def eye(*args, **kwargs):
-    return np.eye(*args, **kwargs)
-
-
-def average(*args, **kwargs):
-    return np.average(*args, **kwargs)
-
-
-def matmul(*args, **kwargs):
-    return np.matmul(*args, **kwargs)
-
-
-def sum(*args, **kwargs):
-    return np.sum(*args, **kwargs)
-
-
-def einsum(*args, **kwargs):
-    return np.einsum(*args, **kwargs)
-
-
-def transpose(*args, **kwargs):
-    return np.transpose(*args, **kwargs)
-
-
-def squeeze(*args, **kwargs):
-    return np.squeeze(*args, **kwargs)
-
-
-def zeros_like(*args, **kwargs):
-    return np.zeros_like(*args, **kwargs)
-
-
-def trace(*args, **kwargs):
-    return np.trace(*args, **kwargs)
-
-
-def mod(*args, **kwargs):
-    return np.mod(*args, **kwargs)
-
-
-def linspace(*args, **kwargs):
-    return np.linspace(*args, **kwargs)
-
-
-def equal(*args, **kwargs):
-    return np.equal(*args, **kwargs)
-
-
-def floor(*args, **kwargs):
-    return np.floor(*args, **kwargs)
-
-
-def cross(*args, **kwargs):
-    return np.cross(*args, **kwargs)
-
-
-def triu_indices(*args, **kwargs):
-    return np.triu_indices(*args, **kwargs)
-
-
-def where(*args, **kwargs):
-    return np.where(*args, **kwargs)
-
-
-def tile(*args, **kwargs):
-    return np.tile(*args, **kwargs)
-
-
-def clip(*args, **kwargs):
-    return np.clip(*args, **kwargs)
 
 
 def diag(x):
@@ -338,46 +173,6 @@ def diag(x):
     return result
 
 
-def any(*args, **kwargs):
-    return np.any(*args, **kwargs)
-
-
-def expand_dims(*args, **kwargs):
-    return np.expand_dims(*args, **kwargs)
-
-
-def outer(*args, **kwargs):
-    return np.outer(*args, **kwargs)
-
-
-def hsplit(*args, **kwargs):
-    return np.hsplit(*args, **kwargs)
-
-
-def argmax(*args, **kwargs):
-    return np.argmax(*args, **kwargs)
-
-
-def argmin(*args, **kwargs):
-    return np.argmin(*args, **kwargs)
-
-
-def diagonal(*args, **kwargs):
-    return np.diagonal(*args, **kwargs)
-
-
-def exp(*args, **kwargs):
-    return np.exp(*args, **kwargs)
-
-
-def log(*args, **kwargs):
-    return np.log(*args, **kwargs)
-
-
-def cov(*args, **kwargs):
-    return np.cov(*args, **kwargs)
-
-
 def eval(x):
     return x
 
@@ -386,36 +181,7 @@ def ndim(x):
     return x.ndim
 
 
-def nonzero(x):
-    return np.nonzero(x)
-
-
-def ix_(*args):
-    return np.ix_(*args)
-
-
-def arange(*args, **kwargs):
-    return np.arange(*args, **kwargs)
-
-
-def prod(x, axis=None):
-    return np.prod(x, axis=axis)
-
-
-def sign(*args, **kwargs):
-    return np.sign(*args, **kwargs)
-
-
-def mean(x, axis=None):
-    return np.mean(x, axis)
-
-
-def normal(*args, **kwargs):
-    return np.random.normal(*args, **kwargs)
-
-
 def cumprod(x, axis=0):
     if axis is None:
         raise NotImplementedError('cumprod is not defined where axis is None')
-    else:
-        return np.cumprod(x, axis=axis)
+    return np.cumprod(x, axis=axis)

--- a/geomstats/backend/numpy_linalg.py
+++ b/geomstats/backend/numpy_linalg.py
@@ -2,6 +2,16 @@
 
 import numpy as np
 import scipy.linalg
+from numpy.linalg import (  # NOQA
+    det,
+    eig,
+    eigh,
+    eigvalsh,
+    inv,
+    norm,
+    matrix_rank,
+    svd
+)
 
 from geomstats.backend.numpy import to_ndarray
 
@@ -32,8 +42,7 @@ def expm(x):
 
     if ndim == 2:
         return result[0]
-    else:
-        return result
+    return result
 
 
 def logm(x):
@@ -56,8 +65,7 @@ def logm(x):
 
     if ndim == 2:
         return result[0]
-    else:
-        return result
+    return result
 
 
 def powerm(x, power):
@@ -86,45 +94,12 @@ def powerm(x, power):
 
     if ndim == 2:
         return result[0]
-    else:
-        return result
+    return result
 
 
 def sqrtm(x):
     return np.vectorize(
         scipy.linalg.sqrtm, signature='(n,m)->(n,m)')(x)
-
-
-def det(*args, **kwargs):
-    return np.linalg.det(*args, **kwargs)
-
-
-def norm(*args, **kwargs):
-    return np.linalg.norm(*args, **kwargs)
-
-
-def inv(*args, **kwargs):
-    return np.linalg.inv(*args, **kwargs)
-
-
-def matrix_rank(*args, **kwargs):
-    return np.linalg.matrix_rank(*args, **kwargs)
-
-
-def eigvalsh(*args, **kwargs):
-    return np.linalg.eigvalsh(*args, **kwargs)
-
-
-def svd(*args, **kwargs):
-    return np.linalg.svd(*args, **kwargs)
-
-
-def eigh(*args, **kwargs):
-    return np.linalg.eigh(*args, **kwargs)
-
-
-def eig(*args, **kwargs):
-    return np.linalg.eig(*args, **kwargs)
 
 
 def exp(*args, **kwargs):

--- a/geomstats/backend/numpy_random.py
+++ b/geomstats/backend/numpy_random.py
@@ -1,19 +1,9 @@
 """Numpy based random backend."""
 
-import numpy as np
-
-
-def rand(*args, **kwargs):
-    return np.random.rand(*args, **kwargs)
-
-
-def randint(*args, **kwargs):
-    return np.random.randint(*args, **kwargs)
-
-
-def seed(*args, **kwargs):
-    return np.random.seed(*args, **kwargs)
-
-
-def normal(*args, **kwargs):
-    return np.random.normal(*args, **kwargs)
+from numpy.random import (  # NOQA
+    normal,
+    rand,
+    randint,
+    randn,
+    seed
+)

--- a/geomstats/backend/pytorch.py
+++ b/geomstats/backend/pytorch.py
@@ -238,10 +238,6 @@ def sqrt(val):
     return torch.sqrt(torch.tensor(val).float())
 
 
-def norm(val, axis):
-    return torch.linalg.norm(val, axis=axis)
-
-
 def isclose(*args, **kwargs):
     if version_maj() >= 1 and version_min() > 1:
         return torch.from_numpy(np.isclose(*args, **kwargs))


### PR DESCRIPTION
The majority of functions defined in the numpy backend were straightforward forward-calls to the bare numpy functions. This change simply forward-exports these functions rather than adding wrapper functions which simply pass along their `*args, **kwargs` arguments.