### PR TITLE
grassmannian logarithm

### DIFF
--- a/geomstats/geometry/grassmannian.py
+++ b/geomstats/geometry/grassmannian.py
@@ -6,8 +6,8 @@ where p <= n
 
 import geomstats.backend as gs
 from geomstats.geometry.embedded_manifold import EmbeddedManifold
-from geomstats.geometry.matrices_space import MatricesSpace
 from geomstats.geometry.matrices_space import MatricesMetric
+from geomstats.geometry.matrices_space import MatricesSpace
 from geomstats.geometry.riemannian_metric import RiemannianMetric
 
 TOLERANCE = 1e-5
@@ -40,8 +40,9 @@ class Grassmannian(EmbeddedManifold):
                 'The Grassmann `belongs` is not implemented.'
                 'It shall test whether p*=p, p^2 = p and rank(p) = k.')
 
-    def origin(self): 
+    def origin(self):
         return gs.diag(gs.repeat([1, 0], [self.k, self.n - self.k]))[0]
+
 
 class GrassmannianCanonicalMetric(RiemannianMetric):
     """
@@ -85,8 +86,8 @@ class GrassmannianCanonicalMetric(RiemannianMetric):
         return mul(mul(expm(vector), point), expm(-vector))
 
     def log(self, point, base_point):
-        """ 
-        Riemannian logarithm of a point from a base point. 
+        """
+        Riemannian logarithm of a point from a base point.
 
         Returns a skew-symmetric matrix in the image of [so(n), point].
 
@@ -104,10 +105,10 @@ class GrassmannianCanonicalMetric(RiemannianMetric):
         tr = MatricesSpace.transpose
         logm = gs.linalg.logm
 
-        def closest (rot): 
-            sign = lambda x : gs.where(x >= 0, 1., -1.)
+        def closest(rot):
             d_coefs = gs.diagonal(rot)
-            return mul(rot, gs.diag(sign(d_coefs))[0])
+            d_sign = gs.where(d_coefs >= 0, 1., -1.)
+            return mul(rot, gs.diag(d_sign)[0])
 
         rot2 = svd(point)[0]
         rot1 = svd(base_point)[0]

--- a/geomstats/geometry/matrices_space.py
+++ b/geomstats/geometry/matrices_space.py
@@ -63,6 +63,22 @@ class MatricesSpace(EuclideanSpace):
         return gs.matmul(a, b) - gs.matmul(b, a)
 
     @staticmethod
+    def transpose(mat):
+        """
+        Return the (vectorised) transpose of matrices. 
+
+        Parameters
+        ----------
+        a : array-like, shape=[n_samples, dim, dim]
+
+        Returns
+        -------
+        transpose : array-like, shape=[n_samples, dim, dim]
+        """
+        tr = gs.vectorize(gs.transpose, signature='(n,n)->(n,n)')
+        return tr(mat)
+
+    @staticmethod
     def vector_from_matrix(matrix):
         """
         Conversion function from (_, m, n) to (_, mn).

--- a/geomstats/geometry/matrices_space.py
+++ b/geomstats/geometry/matrices_space.py
@@ -65,18 +65,19 @@ class MatricesSpace(EuclideanSpace):
     @staticmethod
     def transpose(mat):
         """
-        Return the (vectorised) transpose of matrices. 
+        Return the transpose of matrices. 
 
         Parameters
         ----------
-        a : array-like, shape=[n_samples, dim, dim]
+        mat : array-like, shape=[n_samples, dim, dim]
 
         Returns
         -------
         transpose : array-like, shape=[n_samples, dim, dim]
         """
-        tr = gs.vectorize(gs.transpose, signature='(n,n)->(n,n)')
-        return tr(mat)
+        is_vec = (gs.ndim(gs.array(mat)) == 3)
+        axes = (0, 2, 1) if is_vec else (1, 0)
+        return gs.transpose(mat, axes)
 
     @staticmethod
     def vector_from_matrix(matrix):

--- a/tests/test_grassmannian.py
+++ b/tests/test_grassmannian.py
@@ -53,3 +53,12 @@ class TestGrassmannianMethods(geomstats.tests.TestCase):
             gs.array([p_xy, p_yz]))
         expected = gs.array([p_yz, p_xz])
         self.assertAllClose(result, expected)
+
+    @geomstats.tests.np_only
+    def test_log(self):
+        vector = (gs.pi/8) * r_y
+        base_point = p_xy
+        point = self.metric.exp(vector, base_point)
+        result = self.metric.log(point, base_point)
+        expected = vector
+        self.assertAllClose(result, expected)

--- a/tests/test_matrices_space.py
+++ b/tests/test_matrices_space.py
@@ -62,12 +62,11 @@ class TestMatricesSpaceMethods(geomstats.tests.TestCase):
     
     @geomstats.tests.np_only
     def test_transpose(self):
-        tr = self.space.transpose
         ar = gs.array
         a = gs.eye(3, 3, 1)
         b = gs.eye(3, 3, -1)
-        self.assertAllClose(tr(a), b)
-        self.assertAllClose(tr(ar([a, b])), ar([b, a]))
+        self.assertAllClose(self.space.transpose(a), b)
+        self.assertAllClose(self.space.transpose(ar([a, b])), ar([b, a]))
 
     @geomstats.tests.np_only
     def test_is_symmetric(self):


### PR DESCRIPTION
An implementation of the logarithm will stay on this branch.
tests: run on numpy 
issues: `logm` non-existent on torch, not properly vectorised on numpy

I honestly today don't have the courage to change the code into obfuscated one, just to prevent from assigning functions to local variable names. As mentioned, @johmathe, I don't see the point of this diktat, so I'll leave it like this for now, pull if you want else not, I'll work on different branches in the meantime. 

It seems to me there are more important topics, like having a consistent `expm` and `logm` methods in the backend, to be used accross all matrix classes. 