### PR TITLE
Simplify pytorch version check in backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
     - pip install -q -r requirements.txt --only-binary=numpy,scipy
 script:
     - flake8 geomstats
-    - nose2 --with-coverage --verbose
+    - nose2 --with-coverage --verbose tests
 env:
     - GEOMSTATS_BACKEND=numpy
     - GEOMSTATS_BACKEND=pytorch

--- a/geomstats/backend/pytorch/__init__.py
+++ b/geomstats/backend/pytorch/__init__.py
@@ -15,14 +15,6 @@ int32 = 'torch.LongTensor'
 int8 = 'torch.ByteTensor'
 
 
-def version_maj():
-    return int(torch.__version__.split(".")[0])
-
-
-def version_min():
-    return int(torch.__version__.split(".")[1])
-
-
 def while_loop(cond, body, loop_vars, maximum_iterations):
     iteration = 0
     while cond(*loop_vars):
@@ -70,14 +62,13 @@ def divide(*args, **kwargs):
 
 
 def repeat(x, repeat_time, axis=None):
-    if(version_maj() >= 1 and version_min() >= 1):
+    if torch.__version__ >= "1.1":
         return torch.repeat_interleave(x, repeat_time, axis)
-    else:
-        if(axis is None):
-            axis = 0
-        shape = list(x.shape)
-        shape[axis] = shape[axis] * repeat_time
-        return x.repeat(*shape)
+    if(axis is None):
+        axis = 0
+    shape = list(x.shape)
+    shape[axis] = shape[axis] * repeat_time
+    return x.repeat(*shape)
 
 
 def asarray(x):


### PR DESCRIPTION
This PR also explicitly specifies to nose2 to do test discovery only in the tests directory, which likely would have fixed the issues encountered in the CI tests of https://github.com/geomstats/geomstats/pull/264.