### PR TITLE
Enforce flake8 in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
     - pip install -q -r dev-requirements.txt
     - pip install -q -r requirements.txt --only-binary=numpy,scipy
 script:
-    - flake8 geomstats
+    - flake8 examples geomstats tests
     - nose2 --with-coverage --verbose tests
 env:
     - GEOMSTATS_BACKEND=numpy

--- a/tests/test_backend_numpy.py
+++ b/tests/test_backend_numpy.py
@@ -2,8 +2,6 @@
 Unit tests for numpy backend.
 """
 
-import os
-import unittest
 import warnings
 
 import geomstats.backend as gs

--- a/tests/test_backend_tensorflow.py
+++ b/tests/test_backend_tensorflow.py
@@ -2,8 +2,6 @@
 Unit tests for tensorflow backend.
 """
 
-import os
-
 import geomstats.backend as gs
 import geomstats.tests
 
@@ -28,4 +26,4 @@ class TestBackendTensorFlow(geomstats.tests.TestCase):
             tensor_1 = gs.ones((1, 1))
             tensor_2 = gs.ones((0, 1))
 
-            result = tensor_1 + tensor_2
+            tensor_1 + tensor_2

--- a/tests/test_grassmannian.py
+++ b/tests/test_grassmannian.py
@@ -31,6 +31,7 @@ r_z = gs.array([
     [0., 0., 0.]])
 pi_2 = gs.pi/2
 
+
 class TestGrassmannianMethods(geomstats.tests.TestCase):
     def setUp(self):
         gs.random.seed(1234)
@@ -39,17 +40,17 @@ class TestGrassmannianMethods(geomstats.tests.TestCase):
         self.k = 2
         self.space = Grassmannian(self.n, self.k)
         self.metric = GrassmannianCanonicalMetric(self.n, self.k)
-    
+
     @geomstats.tests.np_only
-    def test_exp_np(self): 
+    def test_exp_np(self):
         result = self.metric.exp(
-                pi_2 * r_y, 
+                pi_2 * r_y,
                 gs.array([p_xy, p_yz]))
         expected = gs.array([p_yz, p_xy])
         self.assertAllClose(result, expected)
-    
+
         result = self.metric.exp(
-            pi_2 * gs.array([r_y, r_z]), 
+            pi_2 * gs.array([r_y, r_z]),
             gs.array([p_xy, p_yz]))
         expected = gs.array([p_yz, p_xz])
         self.assertAllClose(result, expected)

--- a/tests/test_hyperbolic_space.py
+++ b/tests/test_hyperbolic_space.py
@@ -336,17 +336,15 @@ class TestHyperbolicSpaceMethods(geomstats.tests.TestCase):
         with self.session():
             self.assertAllClose(result, expected)
 
-
     def test_exp_poincare(self):
-
         result = 0
-        expected=0
+        expected = 0
         with self.session():
             self.assertAllClose(result, expected)
 
     def test_log_poincare(self):
         result = 0
-        expected=0
+        expected = 0
         with self.session():
             self.assertAllClose(result, expected)
 
@@ -442,16 +440,21 @@ class TestHyperbolicSpaceMethods(geomstats.tests.TestCase):
     @geomstats.tests.np_only
     def test_scaled_inner_product(self):
         base_point_intrinsic = gs.array([1, 1, 1])
-        base_point = self.space.intrinsic_to_extrinsic_coords(base_point_intrinsic)
+        base_point = self.space.intrinsic_to_extrinsic_coords(
+            base_point_intrinsic)
         tangent_vec_a = gs.array([1, 2, 3, 4])
         tangent_vec_b = gs.array([5, 6, 7, 8])
-        tangent_vec_a = self.space.projection_to_tangent_space(tangent_vec_a, base_point)
-        tangent_vec_b = self.space.projection_to_tangent_space(tangent_vec_b, base_point)
+        tangent_vec_a = self.space.projection_to_tangent_space(
+            tangent_vec_a, base_point)
+        tangent_vec_b = self.space.projection_to_tangent_space(
+            tangent_vec_b, base_point)
         scale = 2
         default_space = HyperbolicSpace(dimension=self.dimension)
         scaled_space = HyperbolicSpace(dimension=self.dimension, scale=2)
-        inner_product_default_metric = default_space.metric.inner_product(tangent_vec_a, tangent_vec_b, base_point)
-        inner_product_scaled_metric = scaled_space.metric.inner_product(tangent_vec_a, tangent_vec_b, base_point)
+        inner_product_default_metric = default_space.metric.inner_product(
+            tangent_vec_a, tangent_vec_b, base_point)
+        inner_product_scaled_metric = scaled_space.metric.inner_product(
+            tangent_vec_a, tangent_vec_b, base_point)
         result = inner_product_scaled_metric
         expected = scale ** 2 * inner_product_default_metric
         self.assertAllClose(result, expected)
@@ -459,14 +462,18 @@ class TestHyperbolicSpaceMethods(geomstats.tests.TestCase):
     @geomstats.tests.np_only
     def test_scaled_squared_norm(self):
         base_point_intrinsic = gs.array([1, 1, 1])
-        base_point = self.space.intrinsic_to_extrinsic_coords(base_point_intrinsic)
+        base_point = self.space.intrinsic_to_extrinsic_coords(
+            base_point_intrinsic)
         tangent_vec = gs.array([1, 2, 3, 4])
-        tangent_vec = self.space.projection_to_tangent_space(tangent_vec, base_point)
+        tangent_vec = self.space.projection_to_tangent_space(
+            tangent_vec, base_point)
         scale = 2
         default_space = HyperbolicSpace(dimension=self.dimension)
         scaled_space = HyperbolicSpace(dimension=self.dimension, scale=2)
-        squared_norm_default_metric = default_space.metric.squared_norm(tangent_vec, base_point)
-        squared_norm_scaled_metric = scaled_space.metric.squared_norm(tangent_vec, base_point)
+        squared_norm_default_metric = default_space.metric.squared_norm(
+            tangent_vec, base_point)
+        squared_norm_scaled_metric = scaled_space.metric.squared_norm(
+            tangent_vec, base_point)
         result = squared_norm_scaled_metric
         expected = scale ** 2 * squared_norm_default_metric
         self.assertAllClose(result, expected)

--- a/tests/test_hyperbolic_space_coordinates.py
+++ b/tests/test_hyperbolic_space_coordinates.py
@@ -35,27 +35,29 @@ class TestHyperbolicSpaceMethods(geomstats.tests.TestCase):
 
     def test_extrinsic_ball_extrinsic(self):
         x_in = gs.array([[0.5, 7]])
-        x = self.intrinsic_manifold.to_coordinates(x_in,
-                                                  to_point_type='extrinsic')
+        x = self.intrinsic_manifold.to_coordinates(
+            x_in, to_point_type='extrinsic')
         x_b = self.extrinsic_manifold.to_coordinates(x, to_point_type='ball')
         x2 = self.ball_manifold.to_coordinates(x_b, to_point_type='extrinsic')
         self.assertAllClose(x, x2, atol=1e-8)
 
     def test_extrinsic_half_plane_extrinsic(self):
         x_in = gs.array([[0.5, 7]])
-        x = self.intrinsic_manifold.to_coordinates(x_in,
-                                                   to_point_type='extrinsic')
-        x_up = self.extrinsic_manifold.to_coordinates(x, to_point_type='half-plane')
+        x = self.intrinsic_manifold.to_coordinates(
+            x_in, to_point_type='extrinsic')
+        x_up = self.extrinsic_manifold.to_coordinates(
+            x, to_point_type='half-plane')
 
-        x2 = self.half_plane_manifold.to_coordinates(x_up, to_point_type='extrinsic')
+        x2 = self.half_plane_manifold.to_coordinates(
+            x_up, to_point_type='extrinsic')
         self.assertAllClose(x, x2, atol=1e-8)
 
     def test_intrinsic_extrinsic_intrinsic(self):
         x_intr = gs.array([[0.5, 7]])
-        x_extr = self.intrinsic_manifold.to_coordinates(x_intr,
-                                                  to_point_type='extrinsic')
-        x_intr2 = self.extrinsic_manifold.to_coordinates(x_extr,
-                                                  to_point_type='intrinsic')
+        x_extr = self.intrinsic_manifold.to_coordinates(
+            x_intr, to_point_type='extrinsic')
+        x_intr2 = self.extrinsic_manifold.to_coordinates(
+            x_extr, to_point_type='intrinsic')
         self.assertAllClose(x_intr, x_intr2, atol=1e-8)
 
     def test_ball_extrinsic_ball(self):
@@ -72,10 +74,10 @@ class TestHyperbolicSpaceMethods(geomstats.tests.TestCase):
     def test_distance_ball_extrinsic_from_ball(self):
         x_ball = gs.array([[0.7, 0.2]])
         y_ball = gs.array([[0.2, 0.2]])
-        x_extr = self.ball_manifold.to_coordinates(x_ball,
-                                                  to_point_type='extrinsic')
-        y_extr = self.ball_manifold.to_coordinates(y_ball,
-                                                  to_point_type='extrinsic')
+        x_extr = self.ball_manifold.to_coordinates(
+            x_ball, to_point_type='extrinsic')
+        y_extr = self.ball_manifold.to_coordinates(
+            y_ball, to_point_type='extrinsic')
         dst_ball = self.ball_metric.dist(x_ball, y_ball)
         dst_extr = self.extrinsic_metric.dist(x_extr, y_extr)
         self.assertAllClose(dst_ball, dst_extr)
@@ -83,14 +85,14 @@ class TestHyperbolicSpaceMethods(geomstats.tests.TestCase):
     def test_distance_ball_extrinsic_from_extr(self):
         x_int = gs.array([[10, 0.2]])
         y_int = gs.array([[1, 6.]])
-        x_extr = self.intrinsic_manifold.to_coordinates(x_int,
-                                                       to_point_type='extrinsic')
-        y_extr = self.intrinsic_manifold.to_coordinates(y_int,
-                                                       to_point_type='extrinsic')
-        x_ball = self.extrinsic_manifold.to_coordinates(x_extr,
-                                                       to_point_type='ball')
-        y_ball = self.extrinsic_manifold.to_coordinates(y_extr,
-                                                       to_point_type='ball')
+        x_extr = self.intrinsic_manifold.to_coordinates(
+            x_int, to_point_type='extrinsic')
+        y_extr = self.intrinsic_manifold.to_coordinates(
+            y_int, to_point_type='extrinsic')
+        x_ball = self.extrinsic_manifold.to_coordinates(
+            x_extr, to_point_type='ball')
+        y_ball = self.extrinsic_manifold.to_coordinates(
+            y_extr, to_point_type='ball')
         dst_ball = self.ball_metric.dist(x_ball, y_ball)
         dst_extr = self.extrinsic_metric.dist(x_extr, y_extr)
         self.assertAllClose(dst_ball, dst_extr)
@@ -101,14 +103,14 @@ class TestHyperbolicSpaceMethods(geomstats.tests.TestCase):
         extrinsic_manifold = HyperbolicSpace(4, point_type='extrinsic')
         ball_metric = HyperbolicMetric(4, point_type='ball')
         extrinsic_metric = HyperbolicMetric(4, point_type='extrinsic')
-        x_extr = extrinsic_manifold.from_coordinates(x_int,
-                                                     from_point_type='intrinsic')
-        y_extr = extrinsic_manifold.from_coordinates(y_int,
-                                                     from_point_type='intrinsic')
-        x_ball = extrinsic_manifold.to_coordinates(x_extr,
-                                                   to_point_type='ball')
-        y_ball = extrinsic_manifold.to_coordinates(y_extr,
-                                                   to_point_type='ball')
+        x_extr = extrinsic_manifold.from_coordinates(
+            x_int, from_point_type='intrinsic')
+        y_extr = extrinsic_manifold.from_coordinates(
+            y_int, from_point_type='intrinsic')
+        x_ball = extrinsic_manifold.to_coordinates(
+            x_extr, to_point_type='ball')
+        y_ball = extrinsic_manifold.to_coordinates(
+            y_extr, to_point_type='ball')
         dst_ball = ball_metric.dist(x_ball, y_ball)
         dst_extr = extrinsic_metric.dist(x_extr, y_extr)
         self.assertAllClose(dst_ball, dst_extr)

--- a/tests/test_invariant_metric.py
+++ b/tests/test_invariant_metric.py
@@ -293,7 +293,7 @@ class TestInvariantMetricMethods(geomstats.tests.TestCase):
         result = helper.exp_then_log_from_identity(self.right_metric,
                                                    self.point_1)
         expected = self.point_1
-        # self.assertAllClose(result, expected)
+        self.assertAllClose(result, expected)
 
         result = helper.exp_then_log_from_identity(self.right_metric,
                                                    self.point_small)
@@ -305,12 +305,12 @@ class TestInvariantMetricMethods(geomstats.tests.TestCase):
         result = helper.log_then_exp_from_identity(self.right_metric,
                                                    self.point_1)
         expected = self.point_1
-        # self.assertAllClose(result, expected)
+        self.assertAllClose(result, expected)
 
         result = helper.log_then_exp_from_identity(self.right_metric,
                                                    self.point_small)
         expected = self.point_small
-        # self.assertAllClose(result, expected)
+        self.assertAllClose(result, expected)
 
     @geomstats.tests.np_and_tf_only
     def test_exp_and_log_left_diag_metrics(self):

--- a/tests/test_invariant_metric.py
+++ b/tests/test_invariant_metric.py
@@ -326,12 +326,14 @@ class TestInvariantMetricMethods(geomstats.tests.TestCase):
         result = helper.log_then_exp(self.left_diag_metric,
                                      base_point, self.point_1)
         expected = self.group.regularize(self.point_1)
+        # FIXME:
         # self.assertAllClose(result, expected)
 
         # Edge case, small angle
         result = helper.log_then_exp(self.left_diag_metric,
                                      base_point, self.point_small)
         expected = self.group.regularize(self.point_small)
+        # FIXME:
         # self.assertAllClose(result, expected)
 
     @geomstats.tests.np_and_tf_only
@@ -348,11 +350,13 @@ class TestInvariantMetricMethods(geomstats.tests.TestCase):
         result = helper.log_then_exp(self.left_metric,
                                      base_point, self.point_1)
         expected = self.point_1
+        # FIXME
         # self.assertAllClose(result, expected)
 
         result = helper.log_then_exp(self.left_metric,
                                      base_point, self.point_small)
         expected = self.point_small
+        # FIXME
         # self.assertAllClose(result, expected)
 
     @geomstats.tests.np_and_tf_only
@@ -368,11 +372,13 @@ class TestInvariantMetricMethods(geomstats.tests.TestCase):
         result = helper.log_then_exp(self.right_diag_metric,
                                      base_point, self.point_1)
         expected = self.group.regularize(self.point_1)
+        # FIXME
         # self.assertAllClose(result, expected)
 
         result = helper.log_then_exp(self.right_diag_metric,
                                      base_point, self.point_small)
         expected = self.group.regularize(self.point_small)
+        # FIXME
         # self.assertAllClose(result, expected)
 
     @geomstats.tests.np_and_tf_only
@@ -388,11 +394,13 @@ class TestInvariantMetricMethods(geomstats.tests.TestCase):
         result = helper.log_then_exp(self.right_metric,
                                      base_point, self.point_1)
         expected = self.point_1
+        # FIXME
         # self.assertAllClose(result, expected)
 
         result = helper.log_then_exp(self.right_metric,
                                      base_point, self.point_small)
         expected = self.point_small
+        # FIXME
         # self.assertAllClose(result, expected)
 
     @geomstats.tests.np_and_tf_only

--- a/tests/test_landmarks_space.py
+++ b/tests/test_landmarks_space.py
@@ -20,12 +20,15 @@ class TestLandmarksSpaceMethods(geomstats.tests.TestCase):
         initial_tangent_vec_b = [0., 1., 0.]
         initial_tangent_vec_c = [-1., 0., 0.]
 
-        landmarks_a = s2.metric.geodesic(initial_point=initial_point,
-                                     initial_tangent_vec=initial_tangent_vec_a)
-        landmarks_b = s2.metric.geodesic(initial_point=initial_point,
-                                     initial_tangent_vec=initial_tangent_vec_b)
-        landmarks_c = s2.metric.geodesic(initial_point=initial_point,
-                                     initial_tangent_vec=initial_tangent_vec_c)
+        landmarks_a = s2.metric.geodesic(
+            initial_point=initial_point,
+            initial_tangent_vec=initial_tangent_vec_a)
+        landmarks_b = s2.metric.geodesic(
+            initial_point=initial_point,
+            initial_tangent_vec=initial_tangent_vec_b)
+        landmarks_c = s2.metric.geodesic(
+            initial_point=initial_point,
+            initial_tangent_vec=initial_tangent_vec_c)
 
         self.n_sampling_points = 10
         sampling_times = gs.linspace(0., 1., self.n_sampling_points)
@@ -63,7 +66,8 @@ class TestLandmarksSpaceMethods(geomstats.tests.TestCase):
         log_ab = tangent_vec
         result = self.l2_metric_s2.squared_norm(
                 vector=log_ab, base_point=self.landmarks_a)
-        expected = self.l2_metric_s2.dist(self.landmarks_a, self.landmarks_b) ** 2
+        expected = self.l2_metric_s2.dist(
+            self.landmarks_a, self.landmarks_b) ** 2
         expected = helper.to_scalar(expected)
 
         self.assertAllClose(result, expected)

--- a/tests/test_matrices_space.py
+++ b/tests/test_matrices_space.py
@@ -57,9 +57,9 @@ class TestMatricesSpaceMethods(geomstats.tests.TestCase):
         self.assertAllClose(result, expected)
 
         result = self.space.commutator(x, [x, y, z])
-        expected = gs.array([gs.zeros((3,3)), z, -y])
+        expected = gs.array([gs.zeros((3, 3)), z, -y])
         self.assertAllClose(result, expected)
-    
+
     @geomstats.tests.np_only
     def test_transpose(self):
         tr = self.space.transpose

--- a/tests/test_spd_matrices_space.py
+++ b/tests/test_spd_matrices_space.py
@@ -8,7 +8,9 @@ import geomstats.backend as gs
 import geomstats.tests
 import tests.helper as helper
 
-from geomstats.geometry.spd_matrices_space import SPDMatricesSpace, SPDMetricAffine, SPDMetricProcrustes, SPDMetricEuclidean
+from geomstats.geometry.spd_matrices_space import (
+    SPDMatricesSpace, SPDMetricAffine, SPDMetricProcrustes, SPDMetricEuclidean
+)
 
 
 class TestSPDMatricesSpaceMethods(geomstats.tests.TestCase):

--- a/tests/test_special_euclidean_group.py
+++ b/tests/test_special_euclidean_group.py
@@ -121,6 +121,7 @@ class TestSpecialEuclideanGroupMethods(geomstats.tests.TestCase):
             'right_canonical': group.right_canonical_metric,
             'left_diag': left_diag_metric,
             'right_diag': right_diag_metric}
+        # FIXME:
         # 'left': left_metric,
         # 'right': right_metric}
         metrics = metrics_all
@@ -997,7 +998,7 @@ class TestSpecialEuclideanGroupMethods(geomstats.tests.TestCase):
                     atol = RTOL
                     if norm != 0:
                         atol = RTOL * norm
-                    self.assertAllClose(result, expected, atol=1e-5)
+                    self.assertAllClose(result, expected, atol=atol)
 
                     if geomstats.tests.tf_backend():
                         break
@@ -1064,7 +1065,7 @@ class TestSpecialEuclideanGroupMethods(geomstats.tests.TestCase):
                     atol = RTOL
                     if norm != 0:
                         atol = RTOL * norm
-                    self.assertAllClose(result, expected, atol=1e-5)
+                    self.assertAllClose(result, expected, atol=atol)
 
                     if geomstats.tests.tf_backend():
                         break
@@ -1102,8 +1103,8 @@ class TestSpecialEuclideanGroupMethods(geomstats.tests.TestCase):
                         atol = RTOL * norm
 
                     self.assertTrue(
-                        gs.allclose(result, expected)
-                        or gs.allclose(result, inv_expected))
+                        gs.allclose(result, expected, atol=atol)
+                        or gs.allclose(result, inv_expected, atol=atol))
 
                     if geomstats.tests.tf_backend():
                         break

--- a/tests/test_special_orthogonal_group.py
+++ b/tests/test_special_orthogonal_group.py
@@ -3727,7 +3727,7 @@ class TestSpecialOrthogonalGroupMethods(geomstats.tests.TestCase):
         for i in range(n_steps+1):
             point_step = metric.exp(tangent_vec=i * tangent_vec_step,
                                     base_point=initial_point)
-            #self.assertTrue(gs.allclose(point_step, points[i]))
+            # self.assertTrue(gs.allclose(point_step, points[i]))
 
     def test_lie_bracket_at_identity(self):
         dim = 3

--- a/tests/test_special_orthogonal_group.py
+++ b/tests/test_special_orthogonal_group.py
@@ -3727,6 +3727,7 @@ class TestSpecialOrthogonalGroupMethods(geomstats.tests.TestCase):
         for i in range(n_steps+1):
             point_step = metric.exp(tangent_vec=i * tangent_vec_step,
                                     base_point=initial_point)
+            # FIXME
             # self.assertTrue(gs.allclose(point_step, points[i]))
 
     def test_lie_bracket_at_identity(self):


### PR DESCRIPTION
This is a partial PR to enforce flake8 compliance in the examples and tests as well. Some of the tests are currently broken and therefore comment out assert calls, resulting in flake8 warnings about unused variables. These tests should be fixed first before this gets merged.