### PR TITLE
Fix Link to Contribution.Md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ The following outlines how ``geomstats`` developers think about these tools.
 A general guideline: if you find yourself tempted to write a great big issue that
 is difficult to describe as one unit of work, please consider splitting it into two or more issues.
 
-* Issues are assigned [labels](#issue-labels) which explain how they relate to the overall project's
+* Issues are assigned [labels](#submit-a-pull-request) which explain how they relate to the overall project's
 goals and immediate next steps.
 
 
@@ -71,7 +71,7 @@ Changes here will not effect anyone else's work, so it is a safe space to explor
 
 Make sure to [keep your fork up to date][link_updateupstreamwiki] with the master repository.
 
-**3. Make the changes you have discussed, following the [geomstats coding style guide](#geomstats-coding-style-guide).**
+**3. Make the changes you have discussed, following the [geomstats coding style guide](#ensure-geomstats-coding-style-guide).**
 
 - Create your feature branch (`git checkout -b feature/fooBar`)
 - Commit your changes (`git commit -am 'Add some fooBar'`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ The following outlines how ``geomstats`` developers think about these tools.
 A general guideline: if you find yourself tempted to write a great big issue that
 is difficult to describe as one unit of work, please consider splitting it into two or more issues.
 
-* Issues are assigned [labels](#submit-a-pull-request) which explain how they relate to the overall project's
+* Issues are assigned labels which explain how they relate to the overall project's
 goals and immediate next steps.
 
 
@@ -71,7 +71,7 @@ Changes here will not effect anyone else's work, so it is a safe space to explor
 
 Make sure to [keep your fork up to date][link_updateupstreamwiki] with the master repository.
 
-**3. Make the changes you have discussed, following the [geomstats coding style guide](#ensure-geomstats-coding-style-guide).**
+**3. Make the changes you have discussed, following the geomstats coding style guide.**
 
 - Create your feature branch (`git checkout -b feature/fooBar`)
 - Commit your changes (`git commit -am 'Add some fooBar'`)

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ python3 examples/plot_grid_h2.py
 
 ## Contributing
 
-See our [CONTRIBUTING.md](CONTRIBUTION.md) file!
+See our [CONTRIBUTING.md](CONTRIBUTING.md) file!
 
 ## Authors & Contributors
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ python3 examples/plot_grid_h2.py
 
 ## Contributing
 
-See our [CONTRIBUTING.md][link_contributing] file!
+See our [CONTRIBUTING.md](CONTRIBUTION.md) file!
 
 ## Authors & Contributors
 
@@ -59,5 +59,3 @@ See our [CONTRIBUTING.md][link_contributing] file!
 ## Acknowledgements
 
 This work is partially supported by the National Science Foundation, grant NSF DMS RTG 1501767.
-
-[link_contributing]: https://github.com/geomstats/geomstats/CONTRIBUTING.md


### PR DESCRIPTION
Fixes #345 

I removed the links from CONTRIBUTION.MD, because you can not link to 3rd level headers in markdown.