### PR TITLE
Add python 3.8 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,8 @@ install:
     - pip install -q -r requirements.txt --only-binary=numpy,scipy
 script:
     - flake8 examples geomstats tests
-    - if [[ $TRAVIS_PYTHON_VERSION != 3.8 || $GEOMSTATS_BACKEND != tensorflow ]]; then nose2 --with-coverage --verbose tests; fi
+    - if [[ $TRAVIS_PYTHON_VERSION != 3.8 ]]; then nose2 --with-coverage --verbose tests; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == 3.8 && $GEOMSTATS_BACKEND == numpy ]]; then nose2 --with-coverage --verbose tests; fi
 env:
     - GEOMSTATS_BACKEND=numpy
     - GEOMSTATS_BACKEND=pytorch

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
     - "3.5"
     - "3.6"
     - "3.7"
+    - "3.8"
 
 install:
     - pip install --upgrade pip setuptools wheel
@@ -13,7 +14,7 @@ install:
     - pip install -q -r requirements.txt --only-binary=numpy,scipy
 script:
     - flake8 examples geomstats tests
-    - nose2 --with-coverage --verbose tests
+    - if [[ $TRAVIS_PYTHON_VERSION != 3.8 || $GEOMSTATS_BACKEND != tensorflow ]]; then nose2 --with-coverage --verbose tests; fi
 env:
     - GEOMSTATS_BACKEND=numpy
     - GEOMSTATS_BACKEND=pytorch

--- a/examples/loss_and_gradient_se3.py
+++ b/examples/loss_and_gradient_se3.py
@@ -2,10 +2,6 @@
 Predict on SE3: losses.
 """
 
-import os
-
-import tensorflow as tf
-
 import geomstats.backend as gs
 import geomstats.geometry.lie_group as lie_group
 from geomstats.geometry.special_euclidean_group import SpecialEuclideanGroup
@@ -102,15 +98,12 @@ def main():
 
     loss_rot_vec = loss(y_pred, y_true)
     grad_rot_vec = grad(y_pred, y_true)
-    if os.environ['GEOMSTATS_BACKEND'] == 'tensorflow':
-        with tf.Session() as sess:
-            loss_rot_vec = sess.run(loss_rot_vec)
-            grad_rot_vec = sess.run(grad_rot_vec)
+
     print('The loss between the poses using rotation vectors is: {}'.format(
         loss_rot_vec[0, 0]))
     print('The riemannian gradient is: {}'.format(grad_rot_vec))
 
-    angle = gs.pi / 6
+    angle = gs.array(gs.pi / 6)
     cos = gs.cos(angle / 2)
     sin = gs.sin(angle / 2)
     u = gs.array([1., 2., 3.])
@@ -120,7 +113,7 @@ def main():
     translation = gs.array([5., 6., 7.])
     y_pred_quaternion = gs.concatenate([[scalar], vec, translation], axis=0)
 
-    angle = gs.pi / 7
+    angle = gs.array(gs.pi / 7)
     cos = gs.cos(angle / 2)
     sin = gs.sin(angle / 2)
     u = gs.array([1., 2., 3.])
@@ -134,10 +127,6 @@ def main():
                            representation='quaternion')
     grad_quaternion = grad(y_pred_quaternion, y_true_quaternion,
                            representation='quaternion')
-    if os.environ['GEOMSTATS_BACKEND'] == 'tensorflow':
-        with tf.Session() as sess:
-            loss_quaternion = sess.run(loss_quaternion)
-            grad_quaternion = sess.run(grad_quaternion)
     print('The loss between the poses using quaternions is: {}'.format(
         loss_quaternion[0, 0]))
     print('The riemannian gradient is: {}'.format(

--- a/examples/loss_and_gradient_so3.py
+++ b/examples/loss_and_gradient_so3.py
@@ -2,10 +2,6 @@
 Predict on manifolds: losses.
 """
 
-import os
-
-import tensorflow as tf
-
 import geomstats.backend as gs
 import geomstats.geometry.lie_group as lie_group
 from geomstats.geometry.special_orthogonal_group import SpecialOrthogonalGroup
@@ -76,16 +72,13 @@ def main():
 
     loss_rot_vec = loss(y_pred, y_true)
     grad_rot_vec = grad(y_pred, y_true)
-    if os.environ['GEOMSTATS_BACKEND'] == 'tensorflow':
-        with tf.Session() as sess:
-            loss_rot_vec = sess.run(loss_rot_vec)
-            grad_rot_vec = sess.run(grad_rot_vec)
+
     print('The loss between the rotation vectors is: {}'.format(
         loss_rot_vec[0, 0]))
     print('The riemannian gradient is: {}'.format(
         grad_rot_vec))
 
-    angle = gs.pi / 6
+    angle = gs.array(gs.pi / 6)
     cos = gs.cos(angle / 2)
     sin = gs.sin(angle / 2)
     u = gs.array([1., 2., 3.])
@@ -94,7 +87,7 @@ def main():
     vec = sin * u
     y_pred_quaternion = gs.concatenate([scalar, vec], axis=0)
 
-    angle = gs.pi / 7
+    angle = gs.array(gs.pi / 7)
     cos = gs.cos(angle / 2)
     sin = gs.sin(angle / 2)
     u = gs.array([1., 2., 3.])
@@ -108,10 +101,6 @@ def main():
     grad_quaternion = grad(y_pred_quaternion, y_true_quaternion,
                            representation='quaternion')
 
-    if os.environ['GEOMSTATS_BACKEND'] == 'tensorflow':
-        with tf.Session() as sess:
-            loss_quaternion = sess.run(loss_quaternion)
-            grad_quaternion = sess.run(grad_quaternion)
     print('The loss between the quaternions is: {}'.format(
         loss_quaternion[0, 0]))
     print('The riemannian gradient is: {}'.format(

--- a/geomstats/backend/pytorch/__init__.py
+++ b/geomstats/backend/pytorch/__init__.py
@@ -48,7 +48,7 @@ def boolean_mask(x, mask):
 
 
 def arctan2(*args, **kwargs):
-    return torch.arctan2(*args, **kwargs)
+    return torch.atan2(*args, **kwargs)
 
 
 def cast(x, dtype):
@@ -75,7 +75,7 @@ def asarray(x):
 
 
 def concatenate(seq, axis=0, out=None):
-    seq = [t.float() for t in seq]
+    seq = [cast(t, float32) for t in seq]
     return torch.cat(seq, dim=axis, out=out)
 
 
@@ -463,8 +463,8 @@ def gather(x, indices, axis=0):
 
 
 def get_mask_i_float(i, n):
-    range_n = arange(n)
-    i_float = cast(array([i]), int32)[0]
+    range_n = arange(cast(array(n), int32)[0])
+    i_float = cast(array(i), int32)
     mask_i = equal(range_n, i_float)
     mask_i_float = cast(mask_i, float32)
     return mask_i_float

--- a/geomstats/backend/pytorch/linalg.py
+++ b/geomstats/backend/pytorch/linalg.py
@@ -5,6 +5,12 @@ import scipy.linalg
 import torch
 
 
+def sqrtm(x):
+    np_sqrtm = np.vectorize(
+        scipy.linalg.sqrtm, signature='(n,m)->(n,m)')(x)
+    return torch.from_numpy(np_sqrtm)
+
+
 def expm(x):
     np_expm = np.vectorize(
         scipy.linalg.expm, signature='(n,m)->(n,m)')(x)

--- a/geomstats/geometry/invariant_metric.py
+++ b/geomstats/geometry/invariant_metric.py
@@ -73,7 +73,11 @@ class InvariantMetric(RiemannianMetric):
                 [self.inner_product_mat_at_identity[0]] *
                 max(n_tangent_vec_a, n_tangent_vec_b))
 
-            inner_prod = gs.einsum('ij,ijk,ik->i',
+            tangent_vec_a = gs.to_ndarray(tangent_vec_a, to_ndim=2)
+            tangent_vec_b = gs.to_ndarray(tangent_vec_b, to_ndim=2)
+            inner_product_mat_at_identity = gs.to_ndarray(
+                inner_product_mat_at_identity, to_ndim=3)
+            inner_prod = gs.einsum('nj,njk,nk->n',
                                    tangent_vec_a,
                                    inner_product_mat_at_identity,
                                    tangent_vec_b)

--- a/geomstats/geometry/special_orthogonal_group.py
+++ b/geomstats/geometry/special_orthogonal_group.py
@@ -228,6 +228,7 @@ class SpecialOrthogonalGroup(LieGroup, EmbeddedManifold):
                               point_type=point_type)
                 jacobian = gs.array([jacobian[0]] * n_vecs)
                 inv_jacobian = gs.linalg.inv(jacobian)
+                inv_jacobian = gs.to_ndarray(inv_jacobian, to_ndim=3)
                 tangent_vec_at_id = gs.einsum(
                         'ni,nij->nj',
                         tangent_vec,
@@ -238,6 +239,7 @@ class SpecialOrthogonalGroup(LieGroup, EmbeddedManifold):
                                               metric,
                                               point_type)
 
+                jacobian = gs.to_ndarray(jacobian, to_ndim=3)
                 regularized_tangent_vec = gs.einsum(
                         'ni,nij->nj',
                         tangent_vec_at_id,

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ matplotlib
 numpy>=1.18.1
 scikit-learn>=0.22.1
 scipy>=1.4.1
-tensorflow==2.0; python_version < ‘3.8’
+tensorflow==2.0; python_version < '3.8'
 torch==1.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ matplotlib
 numpy>=1.18.1
 scikit-learn>=0.22.1
 scipy>=1.4.1
-tensorflow==2.0
+tensorflow==2.0; python_version < ‘3.8’
 torch==1.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ numpy>=1.18.1
 scikit-learn>=0.22.1
 scipy>=1.4.1
 tensorflow==2.0; python_version < '3.8'
-torch==1.3.1
+torch==1.3.1; python_version < '3.8'

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -7,6 +7,8 @@ import sys
 import warnings
 
 import examples.gradient_descent_s2 as gradient_descent_s2
+import examples.loss_and_gradient_se3 as loss_and_gradient_se3
+import examples.loss_and_gradient_so3 as loss_and_gradient_so3
 import examples.plot_geodesics_h2 as plot_geodesics_h2
 import examples.plot_geodesics_s2 as plot_geodesics_s2
 import examples.plot_geodesics_se3 as plot_geodesics_se3
@@ -19,9 +21,6 @@ import examples.plot_square_h2_poincare_disk as plot_square_h2_poincare_disk
 import examples.plot_square_h2_poincare_half_plane as plot_square_h2_poincare_half_plane  # NOQA
 import examples.tangent_pca_s2 as tangent_pca_s2
 import examples.tangent_pca_so3 as tangent_pca_so3
-if os.environ['GEOMSTATS_BACKEND'] == 'tensorflow':  # NOQA
-    import examples.loss_and_gradient_se3 as loss_and_gradient_se3
-    import examples.loss_and_gradient_so3 as loss_and_gradient_so3
 import matplotlib
 matplotlib.use('Agg')  # NOQA
 import matplotlib.pyplot as plt
@@ -42,11 +41,9 @@ class TestExamples(geomstats.tests.TestCase):
     def test_gradient_descent_s2(self):
         gradient_descent_s2.main(max_iter=32, output_file=None)
 
-    @geomstats.tests.tf_only
     def test_loss_and_gradient_so3(self):
         loss_and_gradient_so3.main()
 
-    @geomstats.tests.tf_only
     def test_loss_and_gradient_se3(self):
         loss_and_gradient_se3.main()
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -42,11 +42,11 @@ class TestExamples(geomstats.tests.TestCase):
     def test_gradient_descent_s2(self):
         gradient_descent_s2.main(max_iter=32, output_file=None)
 
-    @geomstats.tests.np_only
+    @geomstats.tests.tf_only
     def test_loss_and_gradient_so3(self):
         loss_and_gradient_so3.main()
 
-    @geomstats.tests.np_only
+    @geomstats.tests.tf_only
     def test_loss_and_gradient_se3(self):
         loss_and_gradient_se3.main()
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -7,8 +7,6 @@ import sys
 import warnings
 
 import examples.gradient_descent_s2 as gradient_descent_s2
-import examples.loss_and_gradient_se3 as loss_and_gradient_se3
-import examples.loss_and_gradient_so3 as loss_and_gradient_so3
 import examples.plot_geodesics_h2 as plot_geodesics_h2
 import examples.plot_geodesics_s2 as plot_geodesics_s2
 import examples.plot_geodesics_se3 as plot_geodesics_se3
@@ -21,6 +19,9 @@ import examples.plot_square_h2_poincare_disk as plot_square_h2_poincare_disk
 import examples.plot_square_h2_poincare_half_plane as plot_square_h2_poincare_half_plane  # NOQA
 import examples.tangent_pca_s2 as tangent_pca_s2
 import examples.tangent_pca_so3 as tangent_pca_so3
+if os.environ['GEOMSTATS_BACKEND'] == 'tensorflow':  # NOQA
+    import examples.loss_and_gradient_se3 as loss_and_gradient_se3
+    import examples.loss_and_gradient_so3 as loss_and_gradient_so3
 import matplotlib
 matplotlib.use('Agg')  # NOQA
 import matplotlib.pyplot as plt


### PR DESCRIPTION
Since tensorflow 2.0 does not support python 3.8, we avoid testing in tf 2.0 in the 3.8 version.