### PR TITLE
Add point_type to ProductManifold + Start unit tests on ProductManifold

### DIFF
--- a/geomstats/geometry/product_manifold.py
+++ b/geomstats/geometry/product_manifold.py
@@ -12,48 +12,109 @@ from geomstats.geometry.manifold import Manifold
 class ProductManifold(Manifold):
     """Class for a product of manifolds M_1 x ... x M_n.
 
-    By default, a point is represented by an array of shape:
-        [n_samples, dim_1 + ... + dim_n_manifolds]
-    where n_manifolds is the number of manifolds in the product.
-
-    Alternatively, a point can be represented by an array of shape:
-        [n_samples, n_manifolds, dim]
-    if the n_manifolds have same dimension dim.
 
     In contrast to the class Landmarks or DiscretizedCruves,
     the manifolds M_1, ..., M_n need not be the same, nor of
     same dimension, but the list of manifolds needs to be provided.
     """
-    # TODO(nina): Introduce point_type to decide between the two
-    # representations (array shapes) of points in the product.
 
-    def __init__(self, manifolds):
+    def __init__(self, manifolds, default_point_type='vector'):
+        """Instantiate an object of the class ProductManifold.
+
+        By default, a point is represented by an array of shape:
+            [n_samples, dim_1 + ... + dim_n_manifolds]
+        where n_manifolds is the number of manifolds in the product.
+        This type of representation is called \'vector\'.
+
+        Alternatively, a point can be represented by an array of shape:
+            [n_samples, n_manifolds, dim]
+        if the n_manifolds have same dimension dim.
+        This type of representation is called \'matrix\'.
+
+        Parameters
+        ----------
+        manifolds : list of manifolds in the product
+        default_point_type : default representation of points
+        """
+        assert default_point_type in ['vector', 'matrix']
+        self.default_point_type = default_point_type
+
         self.manifolds = manifolds
         self.n_manifolds = len(manifolds)
+
         dimensions = [manifold.dimension for manifold in manifolds]
         super(ProductManifold, self).__init__(
             dimension=sum(dimensions))
 
-    def belongs(self, point):
-        """Check if the point belongs to the manifold."""
-        belong = [self.manifold[i].belongs(point[i])
-                  for i in range(self.n_manifolds)]
-        return gs.all(belong)
+    def belongs(self, point, point_type=None):
+        """Check if the point belongs to the manifold.
 
-    def regularize(self, point):
+        Parameters
+        ----------
+        point :
+        point_type :
+
+        Returns
+        -------
+        belongs: array-like, shape=[n_samples, 1]
+        """
+        if point_type is None:
+            point_type = self.default_point_type
+        assert point_type in ['vector', 'matrix']
+
+        if point_type == 'vector':
+            point = gs.to_ndarray(point, to_ndim=2)
+        else:
+            point = gs.to_ndarray(point, to_ndim=3)
+
+        n_manifolds = self.n_manifolds
+        belongs = gs.empty((point.shape[0], n_manifolds))
+        cum_dim = 0
+        # FIXME: this only works if the points are in
+        # intrinsic representation
+        for i in range(n_manifolds):
+            manifold_i = self.manifolds[i]
+            cum_dim_next = cum_dim + manifold_i.dimension
+            point_i = point[:, cum_dim:cum_dim_next]
+            belongs_i = manifold_i.belongs(point_i)
+            belongs[:, i] = belongs_i
+            cum_dim = cum_dim_next
+
+        belongs = gs.all(belongs, axis=1)
+        belongs = gs.to_ndarray(belongs, to_ndim=2)
+        return belongs
+
+    def regularize(self, point, point_type=None):
         """Regularizes the point's coordinates to the canonical representation
         chosen for this manifold.
         """
+        # TODO(nina): Vectorize.
+        if point_type is None:
+            point_type = self.default_point_type
+        assert point_type in ['vector', 'matrix']
+
         regularize_points = [self.manifold[i].regularize(point[i])
                              for i in range(self.n_manifolds)]
+
+        # TODO(nina): Put this in a decorator
+        if point_type == 'vector':
+            regularize_points = gs.hstack(regularize_points)
+        elif point_type == 'matrix':
+            regularize_points = gs.vstack(regularize_points)
+        return gs.all(regularize_points)
+
         return regularize_points
 
     def geodesic(self, initial_point,
                  end_point=None, initial_tangent_vec=None,
-                 point_type='vector'):
+                 point_type=None):
         """Geodesic curve for a product metric seen as the product of the geodesic
         on each space.
         """
+        if point_type is None:
+            point_type = self.default_point_type
+        assert point_type in ['vector', 'matrix']
+
         geodesics = gs.asarray([[self.manifold[i].metric.geodesic(
             initial_point,
             end_point=end_point,

--- a/geomstats/geometry/product_manifold.py
+++ b/geomstats/geometry/product_manifold.py
@@ -10,7 +10,22 @@ from geomstats.geometry.manifold import Manifold
 
 
 class ProductManifold(Manifold):
-    """Class for a product of manifolds."""
+    """Class for a product of manifolds M_1 x ... x M_n.
+
+    By default, a point is represented by an array of shape:
+        [n_samples, dim_1 + ... + dim_n_manifolds]
+    where n_manifolds is the number of manifolds in the product.
+
+    Alternatively, a point can be represented by an array of shape:
+        [n_samples, n_manifolds, dim]
+    if the n_manifolds have same dimension dim.
+
+    In contrast to the class Landmarks or DiscretizedCruves,
+    the manifolds M_1, ..., M_n need not be the same, nor of
+    same dimension, but the list of manifolds needs to be provided.
+    """
+    # TODO(nina): Introduce point_type to decide between the two
+    # representations (array shapes) of points in the product.
 
     def __init__(self, manifolds):
         self.manifolds = manifolds
@@ -26,8 +41,7 @@ class ProductManifold(Manifold):
         return gs.all(belong)
 
     def regularize(self, point):
-        """
-        Regularizes the point's coordinates to the canonical representation
+        """Regularizes the point's coordinates to the canonical representation
         chosen for this manifold.
         """
         regularize_points = [self.manifold[i].regularize(point[i])
@@ -37,8 +51,7 @@ class ProductManifold(Manifold):
     def geodesic(self, initial_point,
                  end_point=None, initial_tangent_vec=None,
                  point_type='vector'):
-        """
-        Geodesic curve for a product metric seen as the product of the geodesic
+        """Geodesic curve for a product metric seen as the product of the geodesic
         on each space.
         """
         geodesics = gs.asarray([[self.manifold[i].metric.geodesic(

--- a/tests/test_product_manifold.py
+++ b/tests/test_product_manifold.py
@@ -1,0 +1,26 @@
+"""
+Unit tests for ProductManifold.
+"""
+
+
+import geomstats.backend as gs
+import geomstats.tests
+from geomstats.geometry.hyperbolic import Hyperbolic
+from geomstats.geometry.hypersphere import Hypersphere
+from geomstats.geometry.product_manifold import ProductManifold
+
+
+class TestProductManifoldMethods(geomstats.tests.TestCase):
+    def setUp(self):
+        gs.random.seed(1234)
+
+        self.sphere = Hypersphere(dimension=2)
+        self.hyperbolic = Hyperbolic(dimension=5)
+
+        self.space = ProductManifold(
+            manifolds=[self.sphere, self.hyperbolic])
+
+    def test_dimension(self):
+        expected = 7
+        result = self.space.dimension
+        self.assertAllClose(result, expected)


### PR DESCRIPTION
Start to address #377 :
- Add `point_type` to `ProductManifold` constructor to distinguish between the two possible representations.
- Start unit tests that were non-existing for `product_manifold`.
