### PR TITLE
Doc overview

### DIFF
--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -11,7 +11,7 @@ adapting usual optimisation algorithms to manifolds.
 ## Classes and Inheritance 
 
 The `geometry` module defines a collection of classes 
-representing some of the most usual manifolds.\\
+representing some of the most usual manifolds.
 Manifold objects are usually simply constructed by supplying 
 dimension arguments. For instance: 
 ```python
@@ -20,7 +20,7 @@ S3 = Hypersphere(3)
 instantiates a 3-sphere object. 
 
 Operations on manifolds are exposed as methods of these objects, 
-allowing to compute distances, geodesic paths, etc.\\
+allowing to compute distances, geodesic paths, etc.
 Those that do not depend explicitly on the dimension 
 should be implemented as class methods, 
 so that they may also be accessed directly 
@@ -63,23 +63,24 @@ Inheritance diagram:
     Aff(n-1) <----- GA(n) <--------- SE(n)                       
                                                             
 ```
-__Note__ :\\
+__Note:__\
 Other Lie groups such as `SL(n)` or `Sp(2n)` may also be implemented in the future.
 
 ### Matrices
 
-implements:
+__implements:__
 - elementary matrix operations: 
     + `equal : point -> bool`
     + `mul : (...points) -> point`
-    + `sum : (...points) -> point` (?)
-    + `span : (coefs, points) -> point` (?)
-- duality and related operations:
+- to be complemented with?
+    + `sum : (...points) -> point` 
+    + `span : (scalars, points) -> point`
+- scalar product and duality:
     + `transpose : point -> point`
     + `is_symmetric : point -> bool`
     + `to_symmetric : point -> point` 
 
-__Note__ :\\ 
+__Note:__\
 An `apply : (linear, vector) -> vector` method
 would also be convenient to couple matrix-classes and vector-classes, 
 e.g. have SO(n+1) act on the n-Sphere.
@@ -87,7 +88,7 @@ e.g. have SO(n+1) act on the n-Sphere.
 
 ### GeneralLinear 
 
-implements:
+__implements:__
 - elementary group operations:
     + `identity : () -> point`
     + `compose : (...points) -> point` alias of `mul`
@@ -100,29 +101,25 @@ implements:
 
 ### SpecialOrthogonal
 
-overrides: 
+__overrides:__ 
 + `inv`: call `transpose`
 
 ### SPDMatrices
 
-overrides:
+__overrides:__
 + `exp`: compute eigenvectors,  
 + `log`: same. 
 
-__Note__ :\\ 
+__Note:__\
 The symmetry check should be moved from the backend to the SPD group class. 
 
 ### Affine 
 
-__Note__ :\\
-Affine transformations are not yet implemented at the moment.  
+__Note:__ Affine transformations are not implemented at the moment.  
 
-The algebra of affine transformations on an n-dimensional space
-can be represented by square matrices of size n+1, 
-i.e. Aff(n) viewed as a subalgebra of Mat(n+1). 
-
-The affine transformation `x -> l(x) + v` is represented by the matrix: 
-```
+`Aff(n)` can be viewed as a subalgebra of `Mat(n+1)`,
+representing the affine transformation `x -> l(x) + v` by the matrix: 
+```python
 [[l_11, ..., l_1n, v_1],
  [l_21, ..., l_2n, v_2],
   ...
@@ -130,42 +127,61 @@ The affine transformation `x -> l(x) + v` is represented by the matrix:
  [   0, ...,    0,   1]]
 ```
 
-inherit:
-+ `mul`
-+ `equal`
+This view allows for inheritance of most matrix methods. 
 
-override:
+__override:__
 + `transpose`: restrict to the linear part,
 
-implement: 
+__implement:__
 + `to_linear : (affine) -> linear`
 + `to_vector : (affine) -> vector`
 + `apply : (affine, vector) -> vector`
 
 ### GeneralAffine
 
-inherit: 
-+ `exp`
-+ `log`: coincide with the linear matrix operations. 
+__inherit:__ `exp` and `log`. 
 
 ### SpecialEuclidian
 
-override:
-+ `inv`: transpose the linear part and invert the translation vector. 
+__override:__ `inv`, transpose the linear part and revert translation. 
+
 
 ## Vector Spaces and Embedded Manifolds
 
 ...more to come...
 
-+ riemannian structures:
-    - `exp`
-    - `log`
-    - `geodesic`
-    - `inner`
-+ embedding: 
-    - `is_tangent : vector -> bool`
-    - `to_tangent : vector -> vector`
+Here the inheritance diagram and the different class
+ names are somehow still unclear. 
+Overall, a first list of expected methods:
 
-__Note__ :\\
-`exp` and `log` may more generally derive from a connection. 
-In this case the `geodesic` is somewhat confusing 
++ (riemannian) connection:
+    - `exp : (vector, point1) -> point2`
+    - `log : (point2, point1) -> vector`
++ riemannian structure:
+    - `geodesic     : (point2, point1) -> (t -> point)` *
+    - `dist         : (point2, point 1) -> scalar` *
+    - `inner-matrix : point -> matrix` 
+    - `inner        : (vector1, vector2, point) -> scalar` * 
++ embedding: 
+    _ `belongs      : point -> bool`
+    - `is_tangent   : vector -> bool`
+    - `to_tangent   : vector -> vector`
+
+( * ): `geodesic`, `inner-prod` and `dist` should be generically defined 
+other methods such as `exp`, `log`, and `inner-matrix` 
+in the parent class for inheritance.
+
+In general, `exp` and `log` may derive from a connection. 
+In this case the `geodesic` terminology is somewhat confusing and could be aliased.
+
+__Notes:__ (discussed with @nguigs)
++ in the embedded case, the Levi-Civita connection can be numerically integrated
+by orthogonal projections onto the the tangent space, so that `exp` and 
+`log` would derive from `to_tangent` _in absence of closed-form._
+(the ODE solving code should kept separate by an import statement though)
++ the `EmbeddedManifold` interface should be shared by the previous Lie Groups, 
+which somewhat raises the issue of the 2D-shape signature of their tangent vectors, 
+the metric tensor being 4D.  
+(instead of recasting the metric to 2D and vectors to 1D, defining a
+`bilinear: (tensor, vector, vector) -> scalar` 
+in each of the two parent classes for instance may be more convenient)

--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -1,4 +1,4 @@
-# Package overview
+# Package Overview
 
 The geomstats package essentially consists of three layers: 
 + the [backend](geomstats/backend) module 
@@ -8,43 +8,50 @@ implementing a variety of geometric structures,
 + the [learning](geomstats/learning) module
 adapting usual optimisation algorithms to manifolds.
 
-# Classes and inheritance 
+## Classes and Inheritance 
 
 The `geometry` module defines a collection of classes 
-representing some of the most usual manifolds. 
+representing some of the most usual manifolds.\\
 Manifold objects are usually simply constructed by supplying 
 dimension arguments. For instance: 
-```
+```python
 S3 = Hypersphere(3)
 ```
 instantiates a 3-sphere object. 
 
-Operations on manifolds are then exposed as methods of these objects, 
-allowing to compute distances, geodesic paths, etc. 
+Operations on manifolds are exposed as methods of these objects, 
+allowing to compute distances, geodesic paths, etc.\\
 Those that do not depend explicitly on the dimension 
 should be implemented as class methods, 
 so that they may also be accessed directly 
 from the class. 
-```
+```python
 Matrices.mul(a, b, c)
 ```
 returns the product of matrices `a`, `b`, and `c`.
+
 Most methods are vectorized 
-and accept arrays of elements, following (and sometimes correcting) 
-numpy's broadcasting behaviour.  
+and accept arrays of elements, following (and sometimes fixing)
+numpy's broadcasting behaviour.
 
-Depending on the shape of their elements, 
-geomstats manifolds may joined in two groups:
+Depending on the shape their elementary methods expect, 
+geomstats manifolds may still be joined into two groups:
 + _matrix_ spaces, whose methods act on 2D-arrays,
-+ _vector_ spaces, whose methods act on 1D-array.  
++ _vector_ spaces, whose methods act on 1D-arrays.  
+The first group for instance contains the space of 
+[SPD](geomstats/geometry/spd_matrices_space.py) matrices, 
+while the [hyperbolic space](geomstats/geometry/hyperbolic_space.py)
+belongs to the second. 
+
+In the following, we summarize the interface that should be shared by geomstat's 
+manifold classes. 
+Some of these common methods may then be relied upon by any abstract layer 
+of optimisation algorithms such as geomstat's learning module.
+
+### Matrix Spaces and Lie Groups
 
 
-## Matrices and classical Lie groups
 
-
-
-
-
-## Vectors and embedded riemannian manifolds
+### Vector Spaces and Embedded Manifolds
 
  

--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -63,7 +63,7 @@ of optimisation algorithms, such as geomstat's learning module.
     Aff(n-1) <----- GA(n-1) <------ SE(n-1)                       
                                                             
 ```
-__Note:__\
+__Note:__
 other Lie groups such as SL(n) or Sp(2n) may added to the picture.
 
 This allows for all matrix Lie groups to inherit most of their methods 

--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -68,7 +68,7 @@ Other Lie groups such as `SL(n)` or `Sp(2n)` may also be implemented in the futu
 
 ### Matrices
 
-__implements:__
+implements:
 - elementary matrix operations: 
     + `equal : point -> bool`
     + `mul : (...points) -> point`
@@ -88,7 +88,7 @@ e.g. have SO(n+1) act on the n-Sphere.
 
 ### GeneralLinear 
 
-__implements:__
+implements:
 - elementary group operations:
     + `identity : () -> point`
     + `compose : (...points) -> point` alias of `mul`
@@ -101,17 +101,15 @@ __implements:__
 
 ### SpecialOrthogonal
 
-__overrides:__ 
-+ `inv`: call `transpose`
+overrides: `inv`, call `transpose`.
 
 ### SPDMatrices
 
-__overrides:__
-+ `exp`: compute eigenvectors,  
-+ `log`: same. 
+overrides: `exp` and `log`, compute eigenvectors, and `compose`.
 
 __Note:__\
-The symmetry check should be moved from the backend to the SPD group class. 
+The actual symmetry check would and Yann `symexp`'s function would 
+be moved from the backend to the SPD group class. 
 
 ### Affine 
 
@@ -127,23 +125,22 @@ representing the affine transformation `x -> l(x) + v` by the matrix:
  [   0, ...,    0,   1]]
 ```
 
-This view allows for inheritance of most matrix methods. 
+This view will allow for inheritance of most matrix methods. 
 
-__override:__
-+ `transpose`: restrict to the linear part,
+override: `transpose`, restrict to the linear part.
 
-__implement:__
+implement:
 + `to_linear : (affine) -> linear`
 + `to_vector : (affine) -> vector`
 + `apply : (affine, vector) -> vector`
 
 ### GeneralAffine
 
-__inherit:__ `exp` and `log`. 
+inherit: `exp` and `log`. 
 
 ### SpecialEuclidian
 
-__override:__ `inv`, transpose the linear part and revert translation. 
+override: `inv`, transpose the linear part and revert translation. 
 
 
 ## Vector Spaces and Embedded Manifolds
@@ -163,7 +160,7 @@ Overall, a first list of expected methods:
     - `inner-matrix : point -> matrix` 
     - `inner        : (vector1, vector2, point) -> scalar` * 
 + embedding: 
-    _ `belongs      : point -> bool`
+    - `belongs      : point -> bool`
     - `is_tangent   : vector -> bool`
     - `to_tangent   : vector -> vector`
 
@@ -178,7 +175,7 @@ __Notes:__ (discussed with @nguigs)
 + in the embedded case, the Levi-Civita connection can be numerically integrated
 by orthogonal projections onto the the tangent space, so that `exp` and 
 `log` would derive from `to_tangent` _in absence of closed-form._
-(the ODE solving code should kept separate by an import statement though)
+(the ODE solving code should be kept separate by an import statement though)
 + the `EmbeddedManifold` interface should be shared by the previous Lie Groups, 
 which somewhat raises the issue of the 2D-shape signature of their tangent vectors, 
 the metric tensor being 4D.  

--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -51,7 +51,7 @@ of optimisation algorithms, such as geomstat's learning module.
 
 ## Matrix Spaces and Lie Groups
 
-Inheritance diagram:
+### Inheritance Diagram:
 
 ```python
                                .--- SPD(n)                  
@@ -60,12 +60,24 @@ Inheritance diagram:
        ^                                                  
        |                                                  
                                                            
-    Aff(n-1) <----- GA(n) <--------- SE(n)                       
+    Aff(n-1) <----- GA(n-1) <------ SE(n-1)                       
                                                             
 ```
 __Note:__\
-Other Lie groups such as `SL(n)` or `Sp(2n)` may also be implemented in the future.
+other Lie groups such as `SL(n)` or `Sp(2n)` may added to the picture.
 
+This allows for all matrix Lie groups to inherit most of their methods 
+such as `exp`, `log`, `transpose`, etc. 
+either from GL(n) or Mat(n,n). 
+
+A class-specific implementation should hence only be provided if the class
+allows for a more performant way to compute the same return value, e.g. 
+the inverse of an orthogonal matrix is the transposed matrix.
+
+As embedded manifolds (see [below](#vector-spaces-and-embedded-manifolds)) 
+they should also provide with a specific 'belongs' map, projection to tangent space,
+etc. 
+ 
 ### Matrices
 
 implements:
@@ -94,7 +106,7 @@ implements:
 ```python
 # elementary group operations:
     identity: () -> point
-    compose : (...points) -> point          (alias of mul)
+    compose : (...points) -> point              #(alias of mul)
     inv     : point -> point
 # Lie group operations: 
     exp     : (vector, point1) -> point2
@@ -103,19 +115,17 @@ implements:
     orbit    : (point2, point1) -> (t -> point)
 ```
 
-### SpecialOrthogonal
-
+__SpecialOrthogonal__:\
 overrides: `inv`, call `transpose`.
 
-### SPDMatrices
-
+__SPDMatrices__:\
 overrides: `exp` and `log`, compute eigenvectors, and `compose`.
 
 __Note:__\
 The actual symmetry check and Yann `symexp`'s function would 
 be moved from the backend to the SPD group class. 
 
-### Affine 
+### AffineMatrices 
 
 __Note:__ Affine transformations are not implemented at the moment.  
 
@@ -131,8 +141,6 @@ representing the affine transformation `x -> l(x) + v` by:
 
 This view will allow for inheritance of most matrix methods. 
 
-override: `transpose`, restrict to the linear part.
-
 implement:
 ```python
     to_linear   : (affine) -> linear
@@ -140,13 +148,15 @@ implement:
     apply       : (affine, vector) -> vector
 ```
 
-### GeneralAffine
+override: `transpose`, restrict to the linear part and revert translation
 
-inherit: `exp` and `log`. 
+__GeneralAffine:__\
+inherit: `exp`, `log`, `inv`... from GL(n)
 
-### SpecialEuclidian
+__SpecialEuclidian:__\
+override: `inv`, call transpose 
 
-override: `inv`, transpose the linear part and revert translation. 
+---
 
 
 ## Vector Spaces and Embedded Manifolds
@@ -161,7 +171,7 @@ ease future maintainability and
 facilitate user access to the library's logic :electric_plug: :computer: 
 
 We brainstormed about this on friday with Nina, 
-Here is my attempt to lay down the brainstorm we had on friday with Nina, 
+here is my attempt to lay it down
 hoping this first draft will lead us to a more precise specification soon!
 
 ### Methods
@@ -236,12 +246,12 @@ Here the inheritance diagram with the different class
 names is somehow still unclear. A picture attempt:
 ```python
     Connection <---- LeviCivita                             
-                                                            
-                         :                                  
+                         .                                  
+                         .                                  
                                                            
                        Metric                    Vector                
-                                                   ^     
-                         :                         '       
+                         .                         ^     
+                         .                         '       
                                         .--- EmbeddedManifold
                      RiemannianMfd <---(                        
                                         `--- ProductRiemannianMfd

--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -49,72 +49,73 @@ manifold classes.
 These common methods may then be relied upon by any abstract layer 
 of optimisation algorithms, such as geomstat's learning module.
 
-### Matrix Spaces and Lie Groups
+## Matrix Spaces and Lie Groups
 
 Inheritance diagram:
 
-```
+```python
                                .--- SPD(n)                  
     Mat(n,n) <----- GL(n) <---(                             
                                `--- SO(n)                   
-       ^                                                   
-       '                                                  
-       '                                                    
-
+       ^                                                  
+       |                                                  
+                                                           
     Aff(n-1) <----- GA(n) <--------- SE(n)                       
                                                             
 ```
-__Note__ : 
+__Note__ :\\
 Other Lie groups such as `SL(n)` or `Sp(2n)` may also be implemented in the future.
 
-#### Matrices
+### Matrices
 
 implements:
--  elementary matrix operations: 
+- elementary matrix operations: 
     + `equal : point -> bool`
     + `mul : (...points) -> point`
+    + `sum : (...points) -> point` (?)
+    + `span : (coefs, points) -> point` (?)
+- duality and related operations:
     + `transpose : point -> point`
-- convenience methods:
     + `is_symmetric : point -> bool`
     + `to_symmetric : point -> point` 
 
-__Note__ : 
-an `apply : (linear, vector) -> vector` method
+__Note__ :\\ 
+An `apply : (linear, vector) -> vector` method
 would also be convenient to couple matrix-classes and vector-classes, 
 e.g. have SO(n+1) act on the n-Sphere.
 
 
-#### GeneralLinear 
+### GeneralLinear 
 
 implements:
 - elementary group operations:
     + `identity : () -> point`
     + `compose : (...points) -> point` alias of `mul`
     + `inv : point -> point`
-- the Lie group operations: 
+- Lie group operations: 
     + `exp : (vector, point1) -> point2`
     + `log : (point2, point1) -> vector`
-- the interpolating one-parameter orbit:
+- interpolating one-parameter orbit:
     + `orbit : (point2, point1) -> (t -> point)`
 
-#### SpecialOrthogonal
+### SpecialOrthogonal
 
 overrides: 
 + `inv`: call `transpose`
 
-#### SPD 
+### SPDMatrices
 
 overrides:
-+ `exp`  
-+ `log`: solve the eigenvalue problem. 
++ `exp`: compute eigenvectors,  
++ `log`: same. 
 
-__Note__ : 
-the symmetry check should be moved from the backend to the SPD group class. 
+__Note__ :\\ 
+The symmetry check should be moved from the backend to the SPD group class. 
 
 ### Affine 
 
-__Note__ : 
-affine transformations are not yet implemented at the moment.  
+__Note__ :\\
+Affine transformations are not yet implemented at the moment.  
 
 The algebra of affine transformations on an n-dimensional space
 can be represented by square matrices of size n+1, 
@@ -132,8 +133,10 @@ The affine transformation `x -> l(x) + v` is represented by the matrix:
 inherit:
 + `mul`
 + `equal`
+
 override:
 + `transpose`: restrict to the linear part,
+
 implement: 
 + `to_linear : (affine) -> linear`
 + `to_vector : (affine) -> vector`
@@ -150,9 +153,9 @@ inherit:
 override:
 + `inv`: transpose the linear part and invert the translation vector. 
 
-### Vector Spaces and Embedded Manifolds
+## Vector Spaces and Embedded Manifolds
 
-...to come...
+...more to come...
 
 + riemannian structures:
     - `exp`
@@ -163,6 +166,6 @@ override:
     - `is_tangent : vector -> bool`
     - `to_tangent : vector -> vector`
 
-__Note__ :
+__Note__ :\\
 `exp` and `log` may more generally derive from a connection. 
 In this case the `geodesic` is somewhat confusing 

--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -36,8 +36,8 @@ numpy's broadcasting behaviour.
 
 Depending on the array shape their elementary methods expect, 
 geomstats manifolds may be joined in two groups:
-+ 2D-arrays for _matrix-embedded spaces_,
-+ 1D-arrays for _vector-embedded spaces_.
++ 2D-arrays for _matrix-embedded_ spaces,
++ 1D-arrays for _vector-embedded_ spaces.
 
 The first group for instance contains the space of 
 [SPD](geomstats/geometry/spd_matrices_space.py) matrices, 
@@ -46,13 +46,123 @@ belongs to the second.
 
 In the following, we summarize the interface that should be shared by geomstat's 
 manifold classes. 
-Some of these common methods may then be relied upon by any abstract layer 
+These common methods may then be relied upon by any abstract layer 
 of optimisation algorithms, such as geomstat's learning module.
 
 ### Matrix Spaces and Lie Groups
 
+Inheritance diagram:
 
+```
+                               .--- SPD(n)                  
+    Mat(n,n) <----- GL(n) <---(                             
+                               `--- SO(n)                   
+       ^                                                   
+       '                                                  
+       '                                                    
+
+    Aff(n-1) <----- GA(n) <--------- SE(n)                       
+                                                            
+```
+__Note__ : 
+Other Lie groups such as `SL(n)` or `Sp(2n)` may also be implemented in the future.
+
+#### Matrices
+
+implements:
+-  elementary matrix operations: 
+    + `equal : point -> bool`
+    + `mul : (...points) -> point`
+    + `transpose : point -> point`
+- convenience methods:
+    + `is_symmetric : point -> bool`
+    + `to_symmetric : point -> point` 
+
+__Note__ : 
+an `apply : (linear, vector) -> vector` method
+would also be convenient to couple matrix-classes and vector-classes, 
+e.g. have SO(n+1) act on the n-Sphere.
+
+
+#### GeneralLinear 
+
+implements:
+- elementary group operations:
+    + `identity : () -> point`
+    + `compose : (...points) -> point` alias of `mul`
+    + `inv : point -> point`
+- the Lie group operations: 
+    + `exp : (vector, point1) -> point2`
+    + `log : (point2, point1) -> vector`
+- the interpolating one-parameter orbit:
+    + `orbit : (point2, point1) -> (t -> point)`
+
+#### SpecialOrthogonal
+
+overrides: 
++ `inv`: call `transpose`
+
+#### SPD 
+
+overrides:
++ `exp`  
++ `log`: solve the eigenvalue problem. 
+
+__Note__ : 
+the symmetry check should be moved from the backend to the SPD group class. 
+
+### Affine 
+
+__Note__ : 
+affine transformations are not yet implemented at the moment.  
+
+The algebra of affine transformations on an n-dimensional space
+can be represented by square matrices of size n+1, 
+i.e. Aff(n) viewed as a subalgebra of Mat(n+1). 
+
+The affine transformation `x -> l(x) + v` is represented by the matrix: 
+```
+[[l_11, ..., l_1n, v_1],
+ [l_21, ..., l_2n, v_2],
+  ...
+ [l_n1, ..., l_nn, v_n],
+ [   0, ...,    0,   1]]
+```
+
+inherit:
++ `mul`
++ `equal`
+override:
++ `transpose`: restrict to the linear part,
+implement: 
++ `to_linear : (affine) -> linear`
++ `to_vector : (affine) -> vector`
++ `apply : (affine, vector) -> vector`
+
+### GeneralAffine
+
+inherit: 
++ `exp`
++ `log`: coincide with the linear matrix operations. 
+
+### SpecialEuclidian
+
+override:
++ `inv`: transpose the linear part and invert the translation vector. 
 
 ### Vector Spaces and Embedded Manifolds
 
- 
+...to come...
+
++ riemannian structures:
+    - `exp`
+    - `log`
+    - `geodesic`
+    - `inner`
++ embedding: 
+    - `is_tangent : vector -> bool`
+    - `to_tangent : vector -> vector`
+
+__Note__ :
+`exp` and `log` may more generally derive from a connection. 
+In this case the `geodesic` is somewhat confusing 

--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -94,7 +94,7 @@ implements:
 ```python
 # elementary group operations:
     identity: () -> point
-    compose : (...points) -> point alias of mul
+    compose : (...points) -> point          (alias of mul)
     inv     : point -> point
 # Lie group operations: 
     exp     : (vector, point1) -> point2
@@ -151,38 +151,22 @@ override: `inv`, transpose the linear part and revert translation.
 
 ## Vector Spaces and Embedded Manifolds
 
-Here the inheritance diagram with the different class
-names is somehow still unclear. A picture attempt:
-```python
-                                                            
-    Connection <---- LeviCivita                             
-                                                            
-                         '                                  
-                                                           
-                       Metric                                     
-                                                 Vector      
-                         '                         ^     
-                         '                         '       
-                                        .--- EmbeddedManifold
-                     RiemannianMfd <---(                        
-                                        `--- ProductRiemannianMfd
-                                                   :        
-                                                   v         
-                                                Product            
-```         
+Under this category falls most of the `geomstats/geometry` package. 
 
-I think the picture might get simpler 
-if metrics, connections, etc. were thought of as
-auxiliary objects serving to provide a manifold 
-with 'riemannian' methods. Something like:
-```python
-manifold.use_metric(metric)   
-```
-That way the methods a manifold exposes would depend on the structures 
-it is equipped with. 
+Lots of code and different objects thanks to the hackathon :octocat: :sunny:!
 
-Overall, a first list of expected methods:
+It would be great to figure out a common shared interface
+to make the best use of this week's work, 
+ease future maintainability and 
+facilitate user access to the library's logic :electric_plug: :computer: 
 
+We brainstormed about this on friday with Nina, 
+Here is my attempt to lay down the brainstorm we had on friday with Nina, 
+hoping this first draft will lead us to a more precise specification soon!
+
+### Methods
+
+A first list attempt of expected methods:
 ```python
 # (riemannian) connection:
     exp : (vector, point1) -> point2
@@ -192,20 +176,20 @@ Overall, a first list of expected methods:
   * dist         : (point2, point 1) -> scalar 
     inner_matrix : point -> matrix 
   * inner        : (vector1, vector2, point) -> scalar  
-# embedding: 
-    belongs      : point -> bool
-    is_tangent   : vector -> bool
-    to_tangent   : vector -> vector
+# embedding:                                #-- renaming ? --
+    is_point     : point -> bool            #-> belongs
+    to_point     : point -> point           #-> regularize 
+    is_tangent   : vector -> bool           #-> is_tangent_vector
+    to_tangent   : vector -> vector         #-> project_to_tangent_space
 ```
-
-( * ): `geodesic`, `inner-prod` and `dist` should be generically defined 
-from other methods such as `exp`, `log`, and `inner-matrix` 
+( * ): `geodesic`, `dist` and `inner` should be generically defined 
+from other methods such as `exp`, `log` and `inner_matrix` 
 in the parent class for inheritance.
 
 In general, `exp` and `log` may derive from a connection. 
 In this case the `geodesic` terminology is somewhat confusing and could be aliased.
 
-__Notes:__ (came up discussing with @nguigs)
+__Notes:__ (came up discussing with @nguigs) 
 + the `EmbeddedManifold` interface should be shared by the previous Lie Groups, 
 which somewhat raises the issue of the 2D-shape signature of their tangent vectors
 and the metric tensor being 4D, 
@@ -227,7 +211,7 @@ _if not overriden by closed formulas_.
     manifolds defined as level surfaces `{ f = cst }` 
     of smooth functions and their intersections, using autograd :scream:.  
 
-    I suggest most of the ODE solving code be kept separate in a separate 
+    ODE solving code should be kept separate in some
     `integrators.py` file by an import statement though.
     Hence the `EmbeddedManifold` class file would only define its objects interfaces
     (of which already defined manifolds would only inherit the metric tensor), 
@@ -242,6 +226,38 @@ and @nguigs's landmarks spaces: __product spaces__.
     be inherited by a `ProductManifold` child class. 
     I think this is also related to the first point 
     (matrices being 2D and vectorization) 
-    products yield new object shapes and may not always 
+    as products yield new object shapes and may not always 
     be represented by rectangular arrays, 
     thus raising the concern for a common interface reference. 
+
+### Classes
+
+Here the inheritance diagram with the different class
+names is somehow still unclear. A picture attempt:
+```python
+    Connection <---- LeviCivita                             
+                                                            
+                         :                                  
+                                                           
+                       Metric                    Vector                
+                                                   ^     
+                         :                         '       
+                                        .--- EmbeddedManifold
+                     RiemannianMfd <---(                        
+                                        `--- ProductRiemannianMfd
+                                                   :        
+                                                   v         
+                                                Product            
+```         
+
+I think the picture might get simpler 
+if metrics, connections, etc. were thought of as
+auxiliary objects serving to provide/override a manifold's 
+'riemannian' methods. Something like:
+```python
+manifold.use_metric(metric)   
+```
+That way the methods a manifold exposes would depend on the structures 
+it is equipped with. 
+To compare different metric-induced maps, the user would instantiate 
+two distinct manifold objects.  

--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -64,7 +64,7 @@ of optimisation algorithms, such as geomstat's learning module.
                                                             
 ```
 __Note:__\
-other Lie groups such as `SL(n)` or `Sp(2n)` may added to the picture.
+other Lie groups such as SL(n) or Sp(2n) may added to the picture.
 
 This allows for all matrix Lie groups to inherit most of their methods 
 such as `exp`, `log`, `transpose`, etc. 
@@ -75,7 +75,7 @@ allows for a more performant way to compute the same return value, e.g.
 the inverse of an orthogonal matrix is the transposed matrix.
 
 As embedded manifolds (see [below](#vector-spaces-and-embedded-manifolds)) 
-they should also provide with a specific 'belongs' map, projection to tangent space,
+they should also provide with a specific 'belongs', projection to tangent space,
 etc. 
  
 ### Matrices
@@ -115,11 +115,11 @@ implements:
     orbit    : (point2, point1) -> (t -> point)
 ```
 
-SO(n) overrides: `inv`, call `transpose`.
+SO(n): overrides `inv`, calling `transpose`.
 
-SPD(n) overrides `exp` and `log`, computing eigenvectors, and `compose`.
+SPD(n): overrides `exp` and `log`, computing eigenvectors, and `compose`.
 
-__Note:__\
+__Note:__
 the actual symmetry check and Yann `symexp`'s function would 
 be moved from the backend to the SPD group class. 
 
@@ -146,11 +146,9 @@ implement:
 
 override `transpose`, restrict to the linear part and revert translation
 
-GA(n) inherits `exp`, `log`, `inv`... from GL(n+1)
+GA(n): inherits `exp`, `log`, `inv`... from GL(n+1)
 
-SE(n) overrides `inv`, calling `transpose` 
-
----
+SE(n): overrides `inv`, calling `transpose` 
 
 
 ## Vector Spaces and Embedded Manifolds

--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -69,16 +69,18 @@ Other Lie groups such as `SL(n)` or `Sp(2n)` may also be implemented in the futu
 ### Matrices
 
 implements:
-- elementary matrix operations: 
-    + `equal : point -> bool`
-    + `mul : (...points) -> point`
-- to be complemented with?
-    + `sum : (...points) -> point` 
-    + `span : (scalars, points) -> point`
-- scalar product and duality:
-    + `transpose : point -> point`
-    + `is_symmetric : point -> bool`
-    + `to_symmetric : point -> point` 
+```python
+# elementary matrix operations: 
+    equal   : point -> bool
+    mul     : (...points) -> point
+# to be complemented with?
+    sum     : (...points) -> point 
+    span    : (scalars, points) -> point
+# scalar product and duality:
+    transpose       : point -> point
+    is_symmetric    : point -> bool
+    to_symmetric    : point -> point 
+```
 
 __Note:__\
 An `apply : (linear, vector) -> vector` method
@@ -89,15 +91,17 @@ e.g. have SO(n+1) act on the n-Sphere.
 ### GeneralLinear 
 
 implements:
-- elementary group operations:
-    + `identity : () -> point`
-    + `compose : (...points) -> point` alias of `mul`
-    + `inv : point -> point`
-- Lie group operations: 
-    + `exp : (vector, point1) -> point2`
-    + `log : (point2, point1) -> vector`
-- interpolating one-parameter orbit:
-    + `orbit : (point2, point1) -> (t -> point)`
+```python
+# elementary group operations:
+    identity: () -> point
+    compose : (...points) -> point alias of mul
+    inv     : point -> point
+# Lie group operations: 
+    exp     : (vector, point1) -> point2
+    log     : (point2, point1) -> vector
+# interpolating one-parameter orbit:
+    orbit    : (point2, point1) -> (t -> point)
+```
 
 ### SpecialOrthogonal
 
@@ -108,7 +112,7 @@ overrides: `inv`, call `transpose`.
 overrides: `exp` and `log`, compute eigenvectors, and `compose`.
 
 __Note:__\
-The actual symmetry check would and Yann `symexp`'s function would 
+The actual symmetry check and Yann `symexp`'s function would 
 be moved from the backend to the SPD group class. 
 
 ### Affine 
@@ -116,13 +120,13 @@ be moved from the backend to the SPD group class.
 __Note:__ Affine transformations are not implemented at the moment.  
 
 `Aff(n)` can be viewed as a subalgebra of `Mat(n+1)`,
-representing the affine transformation `x -> l(x) + v` by the matrix: 
+representing the affine transformation `x -> l(x) + v` by: 
 ```python
-[[l_11, ..., l_1n, v_1],
- [l_21, ..., l_2n, v_2],
-  ...
- [l_n1, ..., l_nn, v_n],
- [   0, ...,    0,   1]]
+(l, v) = [[l_11, ..., l_1n, v_1],
+          [l_21, ..., l_2n, v_2],
+           ...
+          [l_n1, ..., l_nn, v_n],
+          [   0, ...,    0,   1]]
 ```
 
 This view will allow for inheritance of most matrix methods. 
@@ -130,9 +134,11 @@ This view will allow for inheritance of most matrix methods.
 override: `transpose`, restrict to the linear part.
 
 implement:
-+ `to_linear : (affine) -> linear`
-+ `to_vector : (affine) -> vector`
-+ `apply : (affine, vector) -> vector`
+```python
+    to_linear   : (affine) -> linear
+    to_vector   : (affine) -> vector
+    apply       : (affine, vector) -> vector
+```
 
 ### GeneralAffine
 
@@ -151,18 +157,20 @@ Here the inheritance diagram and the different class
  names are somehow still unclear. 
 Overall, a first list of expected methods:
 
-+ (riemannian) connection:
-    - `exp : (vector, point1) -> point2`
-    - `log : (point2, point1) -> vector`
-+ riemannian structure:
-    - `geodesic     : (point2, point1) -> (t -> point)` *
-    - `dist         : (point2, point 1) -> scalar` *
-    - `inner-matrix : point -> matrix` 
-    - `inner        : (vector1, vector2, point) -> scalar` * 
-+ embedding: 
-    - `belongs      : point -> bool`
-    - `is_tangent   : vector -> bool`
-    - `to_tangent   : vector -> vector`
+```python
+# (riemannian) connection:
+    exp : (vector, point1) -> point2
+    log : (point2, point1) -> vector
+# riemannian structure:
+    geodesic     : (point2, point1) -> (t -> point) *
+    dist         : (point2, point 1) -> scalar *
+    inner-matrix : point -> matrix 
+    inner        : (vector1, vector2, point) -> scalar * 
+# embedding: 
+    belongs      : point -> bool
+    is_tangent   : vector -> bool
+    to_tangent   : vector -> vector
+```
 
 ( * ): `geodesic`, `inner-prod` and `dist` should be generically defined 
 other methods such as `exp`, `log`, and `inner-matrix` 
@@ -171,7 +179,7 @@ in the parent class for inheritance.
 In general, `exp` and `log` may derive from a connection. 
 In this case the `geodesic` terminology is somewhat confusing and could be aliased.
 
-__Notes:__ (discussed with @nguigs)
+__Notes:__ (came up with @nguigs)
 + in the embedded case, the Levi-Civita connection can be numerically integrated
 by orthogonal projections onto the the tangent space, so that `exp` and 
 `log` would derive from `to_tangent` _in absence of closed-form._
@@ -179,6 +187,6 @@ by orthogonal projections onto the the tangent space, so that `exp` and
 + the `EmbeddedManifold` interface should be shared by the previous Lie Groups, 
 which somewhat raises the issue of the 2D-shape signature of their tangent vectors, 
 the metric tensor being 4D.  
-(instead of recasting the metric to 2D and vectors to 1D, defining a
-`bilinear: (tensor, vector, vector) -> scalar` 
-in each of the two parent classes for instance may be more convenient)
++ in the matrix case, instead of recasting tangent vectors to 1D by default, 
+interfacing with overriden methods such as `bilinear: (tensor, vector, vector) -> scalar`, 
+`add` and `span` defined in each of the two parent classes could be more convenient.

--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -1,0 +1,50 @@
+# Package overview
+
+The geomstats package essentially consists of three layers: 
++ the [backend](geomstats/backend) module 
+providing an agnostic interface to numpy, pytorch and tensorflow,
++ the [geometry](geomstats/geometry) module 
+implementing a variety of geometric structures, 
++ the [learning](geomstats/learning) module
+adapting usual optimisation algorithms to manifolds.
+
+# Classes and inheritance 
+
+The `geometry` module defines a collection of classes 
+representing some of the most usual manifolds. 
+Manifold objects are usually simply constructed by supplying 
+dimension arguments. For instance: 
+```
+S3 = Hypersphere(3)
+```
+instantiates a 3-sphere object. 
+
+Operations on manifolds are then exposed as methods of these objects, 
+allowing to compute distances, geodesic paths, etc. 
+Those that do not depend explicitly on the dimension 
+should be implemented as class methods, 
+so that they may also be accessed directly 
+from the class. 
+```
+Matrices.mul(a, b, c)
+```
+returns the product of matrices `a`, `b`, and `c`.
+Most methods are vectorized 
+and accept arrays of elements, following (and sometimes correcting) 
+numpy's broadcasting behaviour.  
+
+Depending on the shape of their elements, 
+geomstats manifolds may joined in two groups:
++ _matrix_ spaces, whose methods act on 2D-arrays,
++ _vector_ spaces, whose methods act on 1D-array.  
+
+
+## Matrices and classical Lie groups
+
+
+
+
+
+## Vectors and embedded riemannian manifolds
+
+ 

--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -6,7 +6,7 @@ providing an agnostic interface to numpy, pytorch and tensorflow,
 + the [geometry](geomstats/geometry) module 
 implementing a variety of geometric structures, 
 + the [learning](geomstats/learning) module
-adapting usual optimisation algorithms to manifolds.
+adapting usual learning algorithms to manifolds.
 
 ## Classes and Inheritance 
 
@@ -54,9 +54,9 @@ of optimisation algorithms, such as geomstat's learning module.
 ### Inheritance Diagram:
 
 ```python
-                               .--- SPD(n)                  
-    Mat(n,n) <----- GL(n) <---(                             
-                               `--- SO(n)                   
+                 .--- SPD(n)                  
+    Mat(n,n) <--(                             
+                 `--- GL(n) <----- SO(n)                  
        ^                                                  
        |                                                  
                                                            

--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -85,7 +85,7 @@ implements:
 # elementary matrix operations: 
     equal   : point -> bool
     mul     : (...points) -> point
-# to be complemented with?
+# ?
     sum     : (...points) -> point 
     span    : (scalars, points) -> point
 # scalar product and duality:
@@ -115,19 +115,15 @@ implements:
     orbit    : (point2, point1) -> (t -> point)
 ```
 
-__SpecialOrthogonal__:\
-overrides: `inv`, call `transpose`.
+SO(n) overrides: `inv`, call `transpose`.
 
-__SPDMatrices__:\
-overrides: `exp` and `log`, compute eigenvectors, and `compose`.
+SPD(n) overrides `exp` and `log`, computing eigenvectors, and `compose`.
 
 __Note:__\
-The actual symmetry check and Yann `symexp`'s function would 
+the actual symmetry check and Yann `symexp`'s function would 
 be moved from the backend to the SPD group class. 
 
 ### AffineMatrices 
-
-__Note:__ Affine transformations are not implemented at the moment.  
 
 `Aff(n)` can be viewed as a subalgebra of `Mat(n+1)`,
 representing the affine transformation `x -> l(x) + v` by: 
@@ -148,13 +144,11 @@ implement:
     apply       : (affine, vector) -> vector
 ```
 
-override: `transpose`, restrict to the linear part and revert translation
+override `transpose`, restrict to the linear part and revert translation
 
-__GeneralAffine:__\
-inherit: `exp`, `log`, `inv`... from GL(n)
+GA(n) inherits `exp`, `log`, `inv`... from GL(n+1)
 
-__SpecialEuclidian:__\
-override: `inv`, call transpose 
+SE(n) overrides `inv`, calling `transpose` 
 
 ---
 

--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -31,13 +31,14 @@ Matrices.mul(a, b, c)
 returns the product of matrices `a`, `b`, and `c`.
 
 Most methods are vectorized 
-and accept arrays of elements, following (and sometimes fixing)
+and accept arrays of elements, following --sometimes fixing--
 numpy's broadcasting behaviour.
 
-Depending on the shape their elementary methods expect, 
-geomstats manifolds may still be joined into two groups:
-+ _matrix_ spaces, whose methods act on 2D-arrays,
-+ _vector_ spaces, whose methods act on 1D-arrays.  
+Depending on the array shape their elementary methods expect, 
+geomstats manifolds may be joined in two groups:
++ 2D-arrays for _matrix-embedded spaces_,
++ 1D-arrays for _vector-embedded spaces_.
+
 The first group for instance contains the space of 
 [SPD](geomstats/geometry/spd_matrices_space.py) matrices, 
 while the [hyperbolic space](geomstats/geometry/hyperbolic_space.py)
@@ -46,7 +47,7 @@ belongs to the second.
 In the following, we summarize the interface that should be shared by geomstat's 
 manifold classes. 
 Some of these common methods may then be relied upon by any abstract layer 
-of optimisation algorithms such as geomstat's learning module.
+of optimisation algorithms, such as geomstat's learning module.
 
 ### Matrix Spaces and Lie Groups
 


### PR DESCRIPTION
Opening this PR to provide the package with an 'overview.md' file, following the discussion we had with Nina on classes and inheritance friday afternoon! ([read here](https://github.com/opeltre/geomstats/blob/doc-overview/OVERVIEW.md))

This may or may not be the right place to put it... Most of it could for instance be moved to the `geomstats/geometry/README.md` and referenced from the index readme, should also be configured available to the website... I'm sure @cshewmake2 will have some ideas about this :) 

I think it would be good for us to have some kind of common reference, for us to work on, available somewhere as soon as possible!

In the meantime we can discuss here :)

PS: I also have a Mat(n,p) PR ready to open but I have to go! I'll submit those stepwise, i.e. 'merge-matrices', 'merge-general-linear', 'merge-special-orthogonal' branches 
... 