### PR TITLE
Add simple example using geomstats in pymanopt

### DIFF
--- a/examples/geomstats_in_pymanopt.py
+++ b/examples/geomstats_in_pymanopt.py
@@ -68,9 +68,9 @@ def estimate_dominant_eigenvector(matrix):
     the Rayleigh quotient -x' * A * x / (x' * x).
     """
     num_rows, num_columns = gs.shape(matrix)
-    assert num_rows == num_columns, "matrix must be square"
+    assert num_rows == num_columns, 'matrix must be square'
     assert gs.allclose(gs.sum(matrix - gs.transpose(matrix)), 0.0), \
-        "matrix must be symmetric"
+        'matrix must be symmetric'
 
     def cost(vector):
         return -gs.dot(vector, gs.dot(matrix, vector))
@@ -84,10 +84,10 @@ def estimate_dominant_eigenvector(matrix):
     return solver.solve(problem)
 
 
-if __name__ == "__main__":
-    if os.environ.get("GEOMSTATS_BACKEND") != "numpy":
+if __name__ == '__main__':
+    if os.environ.get('GEOMSTATS_BACKEND') != 'numpy':
         raise SystemExit(
-            "This example currently only supports the numpy backend")
+            'This example currently only supports the numpy backend')
 
     ambient_dimension = 128
     matrix = gs.random.normal(size=(ambient_dimension, ambient_dimension))
@@ -101,11 +101,11 @@ if __name__ == "__main__":
             gs.sign(dominant_eigenvector_estimate[0])):
         dominant_eigenvector_estimate = -dominant_eigenvector_estimate
 
-    print("l2-norm of dominant eigenvector:",
+    print('l2-norm of dominant eigenvector:',
           gs.linalg.norm(dominant_eigenvector))
-    print("l2-norm of dominant eigenvector estimate:",
+    print('l2-norm of dominant eigenvector estimate:',
           gs.linalg.norm(dominant_eigenvector_estimate))
     error_norm = gs.linalg.norm(
         dominant_eigenvector - dominant_eigenvector_estimate)
-    print("l2-norm of difference vector:", error_norm)
-    print("solution found: %s" % gs.isclose(error_norm, 0.0, atol=1e-3))
+    print('l2-norm of difference vector:', error_norm)
+    print('solution found: %s' % gs.isclose(error_norm, 0.0, atol=1e-3))

--- a/examples/geomstats_in_pymanopt.py
+++ b/examples/geomstats_in_pymanopt.py
@@ -9,76 +9,79 @@ The example currently requires installing the pymanopt HEAD from git:
 
 import functools
 import os
-os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"  # NOQA
 
-import numpy as np
-from numpy import linalg as la, random as rnd
 from pymanopt import Problem
 from pymanopt.manifolds.manifold import Manifold
 from pymanopt.solvers import SteepestDescent
 
+import geomstats.backend as gs
 from geomstats.geometry.hypersphere import Hypersphere
 
 
-def squeeze_ndarray(f):
+def squeeze_output(function):
     """Decorator to remove singleton dimensions from a numpy.ndarray returned
     by the decorated function.
     """
-    @functools.wraps(f)
+    @functools.wraps(function)
     def inner(*args, **kwargs):
-        return np.squeeze(f(*args, **kwargs))
+        return gs.squeeze(function(*args, **kwargs))
     return inner
 
 
 class GeomstatsSphere(Manifold):
     """A simple adapter class which proxies calls by pymanopt's solvers to
-    manifolds to the underlying geomstats Hypersphere class.
+    `Manifold` subclasses to the underlying geomstats `Hypersphere` class.
     """
 
-    def __init__(self, n):
-        self._sphere = Hypersphere(n-1)
+    def __init__(self, ambient_dimension):
+        self._sphere = Hypersphere(ambient_dimension-1)
 
-    def norm(self, x, g):
-        return self._sphere.metric.norm(g, base_point=x)
+    def norm(self, base_vector, tangent_vector):
+        return self._sphere.metric.norm(tangent_vector, base_point=base_vector)
 
-    @squeeze_ndarray
-    def proj(self, x, g):
-        return self._sphere.projection_to_tangent_space(g, base_point=x)
+    def inner(self, base_vector, tangent_vector_a, tangent_vector_b):
+        return self._sphere.metric.inner_product(
+            tangent_vector_a, tangent_vector_b, base_point=base_vector)
 
-    @squeeze_ndarray
-    def retr(self, x, g):
-        # geomstats's hypersphere implementation doesn't provide a retraction
-        # so use the exponential map instead.
-        return self._sphere.metric.exp(g, base_point=x)
+    @squeeze_output
+    def proj(self, base_vector, tangent_vector):
+        return self._sphere.projection_to_tangent_space(
+            tangent_vector, base_point=base_vector)
 
-    def inner(self, x, u, v):
-        return self._sphere.metric.inner_product(u, v, base_point=x)
+    @squeeze_output
+    def retr(self, base_vector, tangent_vector):
+        """The retraction operator, which maps a tangent vector in the tangent
+        space at a specific point back to the manifold by approximating moving
+        along a geodesic. Since geomstats's `Hypersphere` class doesn't provide
+        a retraction we use the exponential map instead (see also
+        https://hal.archives-ouvertes.fr/hal-00651608/document).
+        """
+        return self._sphere.metric.exp(tangent_vector, base_point=base_vector)
 
-    @squeeze_ndarray
+    @squeeze_output
     def rand(self):
         return self._sphere.random_uniform()
 
 
-@squeeze_ndarray
-def dominant_eigenvector(A):
+def estimate_dominant_eigenvector(matrix):
     """Returns the dominant eigenvector of the symmetric matrix A by minimizing
     the Rayleigh quotient -x' * A * x / (x' * x).
     """
-    m, n = A.shape
-    assert m == n, "matrix must be square"
-    assert np.allclose(np.sum(A - A.T), 0), "matrix must be symmetric"
+    num_rows, num_columns = gs.shape(matrix)
+    assert num_rows == num_columns, "matrix must be square"
+    assert gs.allclose(gs.sum(matrix - gs.transpose(matrix)), 0.0), \
+        "matrix must be symmetric"
 
-    def cost(x):
-        return -np.inner(x, A @ x)
+    def cost(vector):
+        return -gs.dot(vector, gs.dot(matrix, vector))
 
-    def egrad(x):
-        return -2 * A @ x
+    def egrad(vector):
+        return -2 * gs.dot(matrix, vector)
 
-    sphere = GeomstatsSphere(n)
+    sphere = GeomstatsSphere(num_columns)
     problem = Problem(manifold=sphere, cost=cost, egrad=egrad)
     solver = SteepestDescent()
-    xopt = solver.solve(problem)
-    return xopt
+    return solver.solve(problem)
 
 
 if __name__ == "__main__":
@@ -86,28 +89,23 @@ if __name__ == "__main__":
         raise SystemExit(
             "This example currently only supports the numpy backend")
 
-    # Generate random problem data.
-    n = 128
-    A = rnd.randn(n, n)
-    A = 0.5 * (A + A.T)
+    ambient_dimension = 128
+    matrix = gs.random.normal(size=(ambient_dimension, ambient_dimension))
+    matrix = 0.5 * (matrix + matrix.T)
 
-    # Calculate the actual solution by a conventional eigenvalue decomposition.
-    w, v = la.eig(A)
-    x = v[:, np.argmax(w)]
+    eigenvalues, eigenvectors = gs.linalg.eig(matrix)
+    dominant_eigenvector = eigenvectors[:, gs.argmax(eigenvalues)]
 
-    # Solve the problem again with the wrapped geomstats manifold
-    # implementation.
-    xopt = dominant_eigenvector(A)
+    dominant_eigenvector_estimate = estimate_dominant_eigenvector(matrix)
+    if (gs.sign(dominant_eigenvector[0]) !=
+            gs.sign(dominant_eigenvector_estimate[0])):
+        dominant_eigenvector_estimate = -dominant_eigenvector_estimate
 
-    # Make sure both vectors have the same direction. Both are valid
-    # eigenvectors, of course, but for comparison we need to get rid of the
-    # ambiguity.
-    if np.sign(x[0]) != np.sign(xopt[0]):
-        xopt = -xopt
-
-    # Print information about the solution.
-    print("l2-norm of x:", la.norm(x))
-    print("l2-norm of xopt:", la.norm(xopt))
-    error_norm = la.norm(x - xopt)
-    print("l2-error:", error_norm)
-    print("solution found: %s" % np.isclose(error_norm, 0.0, atol=1e-3))
+    print("l2-norm of dominant eigenvector:",
+          gs.linalg.norm(dominant_eigenvector))
+    print("l2-norm of dominant eigenvector estimate:",
+          gs.linalg.norm(dominant_eigenvector_estimate))
+    error_norm = gs.linalg.norm(
+        dominant_eigenvector - dominant_eigenvector_estimate)
+    print("l2-norm of difference vector:", error_norm)
+    print("solution found: %s" % gs.isclose(error_norm, 0.0, atol=1e-3))

--- a/examples/geomstats_in_pymanopt.py
+++ b/examples/geomstats_in_pymanopt.py
@@ -1,0 +1,113 @@
+"""This very simple example demonstrates how geometries from geomstats can be
+used in pymanopt to perform optimization on manifolds. It uses the Riemannian
+steepest descent solver.
+
+The example currently requires installing the pymanopt HEAD from git:
+
+    pip install git+ssh://git@github.com/pymanopt/pymanopt.git
+"""
+
+import functools
+import os
+os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"  # NOQA
+
+import numpy as np
+from numpy import linalg as la, random as rnd
+from pymanopt import Problem
+from pymanopt.manifolds.manifold import Manifold
+from pymanopt.solvers import SteepestDescent
+
+from geomstats.geometry.hypersphere import Hypersphere
+
+
+def squeeze_ndarray(f):
+    """Decorator to remove singleton dimensions from a numpy.ndarray returned
+    by the decorated function.
+    """
+    @functools.wraps(f)
+    def inner(*args, **kwargs):
+        return np.squeeze(f(*args, **kwargs))
+    return inner
+
+
+class GeomstatsSphere(Manifold):
+    """A simple adapter class which proxies calls by pymanopt's solvers to
+    manifolds to the underlying geomstats Hypersphere class.
+    """
+
+    def __init__(self, n):
+        self._sphere = Hypersphere(n-1)
+
+    def norm(self, x, g):
+        return self._sphere.metric.norm(g, base_point=x)
+
+    @squeeze_ndarray
+    def proj(self, x, g):
+        return self._sphere.projection_to_tangent_space(g, base_point=x)
+
+    @squeeze_ndarray
+    def retr(self, x, g):
+        # geomstats's hypersphere implementation doesn't provide a retraction
+        # so use the exponential map instead.
+        return self._sphere.metric.exp(g, base_point=x)
+
+    def inner(self, x, u, v):
+        return self._sphere.metric.inner_product(u, v, base_point=x)
+
+    @squeeze_ndarray
+    def rand(self):
+        return self._sphere.random_uniform()
+
+
+@squeeze_ndarray
+def dominant_eigenvector(A):
+    """Returns the dominant eigenvector of the symmetric matrix A by minimizing
+    the Rayleigh quotient -x' * A * x / (x' * x).
+    """
+    m, n = A.shape
+    assert m == n, "matrix must be square"
+    assert np.allclose(np.sum(A - A.T), 0), "matrix must be symmetric"
+
+    def cost(x):
+        return -np.inner(x, A @ x)
+
+    def egrad(x):
+        return -2 * A @ x
+
+    sphere = GeomstatsSphere(n)
+    problem = Problem(manifold=sphere, cost=cost, egrad=egrad)
+    solver = SteepestDescent()
+    xopt = solver.solve(problem)
+    return xopt
+
+
+if __name__ == "__main__":
+    if os.environ.get("GEOMSTATS_BACKEND") != "numpy":
+        raise SystemExit(
+            "This example currently only supports the numpy backend")
+
+    # Generate random problem data.
+    n = 128
+    A = rnd.randn(n, n)
+    A = 0.5 * (A + A.T)
+
+    # Calculate the actual solution by a conventional eigenvalue decomposition.
+    w, v = la.eig(A)
+    x = v[:, np.argmax(w)]
+
+    # Solve the problem again with the wrapped geomstats manifold
+    # implementation.
+    xopt = dominant_eigenvector(A)
+
+    # Make sure both vectors have the same direction. Both are valid
+    # eigenvectors, of course, but for comparison we need to get rid of the
+    # ambiguity.
+    if np.sign(x[0]) != np.sign(xopt[0]):
+        xopt = -xopt
+
+    # Print information about the solution.
+    print("l2-norm of x:", la.norm(x))
+    print("l2-norm of xopt:", la.norm(xopt))
+    error_norm = la.norm(x - xopt)
+    print("l2-error:", error_norm)
+    print("solution found: %s" % np.isclose(error_norm, 0.0, atol=1e-3))


### PR DESCRIPTION
This implements a simple toy example from pymanopt on top of geomstats. I've intentionally not included the example in `tests/test_examples.py`, as the example obviously requires pymanopt to run, which we probably shouldn't add as a (hard) dev dependency. The example merely demonstrates how to adapt geomstats to pymanopt's manifold interface.