### PR TITLE
Merge matrices.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
     - "3.8"
 
 install:
-    - pip install --upgrade pip setuptools wheel
+    - pip install --upgrade "pip<20.0" setuptools wheel
     - pip install -q -r dev-requirements.txt
     - pip install -q -r requirements.txt --only-binary=numpy,scipy
 script:

--- a/README.md
+++ b/README.md
@@ -55,4 +55,5 @@ See our [CONTRIBUTING.md](CONTRIBUTING.md) file!
 
 This work is partially supported by:
 - the National Science Foundation (grant NSF DMS RTG 1501767),
-- the Inria-Stanford associated team GeomStats.
+- the Inria-Stanford associated team [GeomStats](http://www-sop.inria.fr/asclepios/projects/GeomStats/).
+- the European Research Council (ERC) under the European Union's Horizon 2020 research and innovation program (grant agreement [G-Statistics](https://team.inria.fr/epione/en/research/erc-g-statistics/) No. 786854)

--- a/geomstats/geometry/general_linear.py
+++ b/geomstats/geometry/general_linear.py
@@ -1,8 +1,4 @@
-"""
-This module exposes the `GeneralLinearGroup` class. 
-
-Note: This class is temporarily kept for compatibility purposes
-but will soon be renamed `GeneralLinear`.
+"""Module exposing the GeneralLinear group class.
 """
 
 import geomstats.backend as gs

--- a/geomstats/geometry/general_linear.py
+++ b/geomstats/geometry/general_linear.py
@@ -1,4 +1,9 @@
-"""The General Linear Group, i.e. the matrix group GL(n)."""
+"""
+This module exposes the `GeneralLinearGroup` class. 
+
+Note: This class is temporarily kept for compatibility purposes
+but will soon be renamed `GeneralLinear`.
+"""
 
 import geomstats.backend as gs
 from geomstats.geometry.lie_group import LieGroup

--- a/geomstats/geometry/grassmannian.py
+++ b/geomstats/geometry/grassmannian.py
@@ -1,8 +1,4 @@
-"""Grassmannian manifold Gr(n, p).
-
-The Grassmannian manifold is the set of all p-dimensional
-subspaces in n-dimensional space, where p <= n.
-"""
+"""This module exposes the `Grassmannian` and `GrassmannianMetric` class."""
 
 import geomstats.backend as gs
 from geomstats.geometry.embedded_manifold import EmbeddedManifold
@@ -87,4 +83,4 @@ class GrassmannianCanonicalMetric(RiemannianMetric):
         """
         expm = gs.linalg.expm
         mul = Matrices.mul
-        return mul(mul(expm(vector), point), expm(-vector))
+        return mul(expm(vector), point, expm(-vector))

--- a/geomstats/geometry/matrices.py
+++ b/geomstats/geometry/matrices.py
@@ -1,7 +1,8 @@
-"""This module exposes the `Matrices` and `MatricesMetric` class."""
+"""Module exposing the `Matrices` and `MatricesMetric` class."""
+
+from functools import reduce
 
 import geomstats.backend as gs
-from functools import reduce
 from geomstats.geometry.euclidean_space import EuclideanSpace
 from geomstats.geometry.riemannian_metric import RiemannianMetric
 
@@ -25,7 +26,7 @@ class Matrices(Euclidean):
         point = gs.to_ndarray(point, to_ndim=3)
         _, mat_dim_1, mat_dim_2 = point.shape
         return mat_dim_1 == self.m & mat_dim_2 == self.n
-    
+
     @staticmethod
     def equal(a, b, atol=TOLERANCE):
         """
@@ -40,8 +41,8 @@ class Matrices(Euclidean):
         -------
         eq : array-like boolean, shape=[n_samples]
         """
-        is_vectorized = (gs.ndim(gs.array(a)) == 3)\
-                or (gs.ndim(gs.array(b)) == 3)
+        is_vectorized = \
+            (gs.ndim(gs.array(a)) == 3) or (gs.ndim(gs.array(b)) == 3)
         axes = (1, 2) if is_vectorized else (0, 1)
         return gs.all(gs.isclose(a, b, atol=atol), axes)
 

--- a/geomstats/geometry/matrices.py
+++ b/geomstats/geometry/matrices.py
@@ -67,8 +67,7 @@ class Matrices(Euclidean):
     @classmethod
     def bracket(cls, mat_a, mat_b):
         """
-        Return the commutator of a and b,
-        i.e. `[a, b] = ab - ba`.
+        Return the commutator of a and b, i.e. `[a, b] = ab - ba`.
 
         Parameters
         ----------
@@ -101,7 +100,7 @@ class Matrices(Euclidean):
     def is_symmetric(cls, mat, atol=TOLERANCE):
         """
         Check if a matrix is symmetric.
-        
+
         Parameters
         ----------
         mat : array-like, shape=[n_samples, n, n]
@@ -121,7 +120,7 @@ class Matrices(Euclidean):
         Parameters
         ----------
         mat : array-like, shape=[n_samples, n, n]
-        
+
         Returns
         -------
         sym : array-like, shape=[n_samples, n, n]

--- a/geomstats/geometry/matrices.py
+++ b/geomstats/geometry/matrices.py
@@ -1,7 +1,8 @@
-"""The space of matrices (m, n), which is the Euclidean space R^{mn}."""
+"""This module exposes the `Matrices` and `MatricesMetric` class."""
 
 import geomstats.backend as gs
-from geomstats.geometry.euclidean import Euclidean
+from functools import reduce
+from geomstats.geometry.euclidean_space import EuclideanSpace
 from geomstats.geometry.riemannian_metric import RiemannianMetric
 
 
@@ -24,10 +25,11 @@ class Matrices(Euclidean):
         point = gs.to_ndarray(point, to_ndim=3)
         _, mat_dim_1, mat_dim_2 = point.shape
         return mat_dim_1 == self.m & mat_dim_2 == self.n
-
+    
     @staticmethod
-    def mul(a, b):
-        """Return the product of matrices a and b.
+    def equal(a, b, atol=TOLERANCE):
+        """
+        Test if matrices a and b are close.
 
         Parameters
         ----------
@@ -36,13 +38,36 @@ class Matrices(Euclidean):
 
         Returns
         -------
-        c : array-like, shape=[n_samples, dim1, dim3]
+        eq : array-like boolean, shape=[n_samples]
         """
-        return gs.matmul(a, b)
+        is_vectorized = (gs.ndim(gs.array(a)) == 3)\
+                or (gs.ndim(gs.array(b)) == 3)
+        axes = (1, 2) if is_vectorized else (0, 1)
+        return gs.all(gs.isclose(a, b, atol=atol), axes)
 
     @staticmethod
-    def commutator(a, b):
-        """Return the commutator of a and b, i.e. :math: `[a, b] = ab - ba`.
+    def mul(*args):
+        """
+        Return the product of matrices a1, ..., an.
+
+        Parameters
+        ----------
+        a1 : array-like, shape=[n_samples, dim_1, dim_2]
+        a2 : array-like, shape=[n_samples, dim_2, dim_3]
+        ...
+        an : array-like, shape=[n_samples, dim_n-1, dim_n]
+
+        Returns
+        -------
+        mul : array-like, shape=[n_samples, dim_1, dim_n]
+        """
+        return reduce(gs.matmul, args)
+
+    @classmethod
+    def commutator(cls, a, b):
+        """
+        Return the commutator of a and b,
+        i.e. `[a, b] = ab - ba`.
 
         Parameters
         ----------
@@ -53,7 +78,7 @@ class Matrices(Euclidean):
         -------
         c : array-like, shape=[n_samples, dim, dim]
         """
-        return gs.matmul(a, b) - gs.matmul(b, a)
+        return cls.mul(a, b) - cls.mul(b, a)
 
     @staticmethod
     def transpose(mat):
@@ -67,40 +92,49 @@ class Matrices(Euclidean):
         -------
         transpose : array-like, shape=[n_samples, dim, dim]
         """
-        is_vec = (gs.ndim(gs.array(mat)) == 3)
-        axes = (0, 2, 1) if is_vec else (1, 0)
+        is_vectorized = (gs.ndim(gs.array(mat)) == 3)
+        axes = (0, 2, 1) if is_vectorized else (1, 0)
         return gs.transpose(mat, axes)
+
+    @classmethod
+    def is_symmetric(cls, mat, atol=TOLERANCE):
+        """
+        Check if a matrix is symmetric.
+        
+        Parameters
+        ----------
+        mat : array-like, shape=[n_samples, n, n]
+        atol : float, absolute tolerance. defaults to TOLERANCE
+
+        Returns
+        -------
+        is_sym : array-like boolean, shape=[n_samples]
+        """
+        return cls.equal(mat, cls.transpose(mat), atol)
+
+    @classmethod
+    def make_symmetric(cls, mat):
+        """
+        Make a matrix symmetric, by averaging with its transpose.
+
+        Parameters
+        ----------
+        mat : array-like, shape=[n_samples, n, n]
+        
+        Returns
+        -------
+        sym : array-like, shape=[n_samples, n, n]
+        """
+        return 1/2 * (mat + cls.transpose(mat))
 
     @staticmethod
     def vector_from_matrix(matrix):
-        """Conversion function from (_, m, n) to (_, mn)."""
+        """
+        Conversion function from (_, m, n) to (_, mn).
+        """
         matrix = gs.to_ndarray(matrix, to_ndim=3)
         n_mats, m, n = matrix.shape
         return gs.reshape(matrix, (n_mats, m*n))
-
-    @staticmethod
-    def is_symmetric(matrix, tolerance=TOLERANCE):
-        """Check if a matrix is symmetric."""
-        matrix = gs.to_ndarray(matrix, to_ndim=3)
-        n_mats, m, n = matrix.shape
-        assert m == n
-        matrix_transpose = gs.transpose(matrix, axes=(0, 2, 1))
-
-        mask = gs.isclose(matrix, matrix_transpose, atol=tolerance)
-        mask = gs.all(mask, axis=(1, 2))
-
-        mask = gs.to_ndarray(mask, to_ndim=1)
-        mask = gs.to_ndarray(mask, to_ndim=2, axis=1)
-        return mask
-
-    @staticmethod
-    def make_symmetric(matrix):
-        """Make a matrix fully symmetric to avoid numerical issues."""
-        matrix = gs.to_ndarray(matrix, to_ndim=3)
-        n_mats, m, n = matrix.shape
-        assert m == n
-        matrix = gs.to_ndarray(matrix, to_ndim=3)
-        return (matrix + gs.transpose(matrix, axes=(0, 2, 1))) / 2
 
     def random_uniform(self, n_samples=1):
         """Generate n samples from a uniform distribution."""

--- a/geomstats/geometry/matrices.py
+++ b/geomstats/geometry/matrices.py
@@ -128,15 +128,6 @@ class Matrices(Euclidean):
         """
         return 1/2 * (mat + cls.transpose(mat))
 
-    @staticmethod
-    def vector_from_matrix(matrix):
-        """
-        Conversion function from (_, m, n) to (_, mn).
-        """
-        matrix = gs.to_ndarray(matrix, to_ndim=3)
-        n_mats, m, n = matrix.shape
-        return gs.reshape(matrix, (n_mats, m*n))
-
     def random_uniform(self, n_samples=1):
         """Generate n samples from a uniform distribution."""
         point = gs.random.rand(n_samples, self.m, self.n)

--- a/geomstats/geometry/matrices.py
+++ b/geomstats/geometry/matrices.py
@@ -3,7 +3,7 @@
 from functools import reduce
 
 import geomstats.backend as gs
-from geomstats.geometry.euclidean_space import EuclideanSpace
+from geomstats.geometry.euclidean import Euclidean
 from geomstats.geometry.riemannian_metric import RiemannianMetric
 
 

--- a/geomstats/geometry/matrices.py
+++ b/geomstats/geometry/matrices.py
@@ -28,23 +28,23 @@ class Matrices(Euclidean):
         return mat_dim_1 == self.m & mat_dim_2 == self.n
 
     @staticmethod
-    def equal(a, b, atol=TOLERANCE):
+    def equal(mat_a, mat_b, atol=TOLERANCE):
         """
         Test if matrices a and b are close.
 
         Parameters
         ----------
-        a : array-like, shape=[n_samples, dim1, dim2]
-        b : array-like, shape=[n_samples, dim2, dim3]
+        mat_a : array-like, shape=[n_samples, dim1, dim2]
+        mat_b : array-like, shape=[n_samples, dim2, dim3]
 
         Returns
         -------
         eq : array-like boolean, shape=[n_samples]
         """
         is_vectorized = \
-            (gs.ndim(gs.array(a)) == 3) or (gs.ndim(gs.array(b)) == 3)
+            (gs.ndim(gs.array(mat_a)) == 3) or (gs.ndim(gs.array(mat_b)) == 3)
         axes = (1, 2) if is_vectorized else (0, 1)
-        return gs.all(gs.isclose(a, b, atol=atol), axes)
+        return gs.all(gs.isclose(mat_a, mat_b, atol=atol), axes)
 
     @staticmethod
     def mul(*args):

--- a/geomstats/geometry/matrices.py
+++ b/geomstats/geometry/matrices.py
@@ -65,21 +65,21 @@ class Matrices(Euclidean):
         return reduce(gs.matmul, args)
 
     @classmethod
-    def commutator(cls, a, b):
+    def bracket(cls, mat_a, mat_b):
         """
         Return the commutator of a and b,
         i.e. `[a, b] = ab - ba`.
 
         Parameters
         ----------
-        a : array-like, shape=[n_samples, dim, dim]
-        b : array-like, shape=[n_samples, dim, dim]
+        mat_a : array-like, shape=[n_samples, dim, dim]
+        mat_b : array-like, shape=[n_samples, dim, dim]
 
         Returns
         -------
-        c : array-like, shape=[n_samples, dim, dim]
+        mat_c : array-like, shape=[n_samples, dim, dim]
         """
-        return cls.mul(a, b) - cls.mul(b, a)
+        return cls.mul(mat_a, mat_b) - cls.mul(mat_b, mat_a)
 
     @staticmethod
     def transpose(mat):

--- a/geomstats/geometry/spd_matrices.py
+++ b/geomstats/geometry/spd_matrices.py
@@ -3,6 +3,7 @@
 import math
 
 import geomstats.backend as gs
+from geomstats.geometry.matrices import Matrices
 from geomstats.geometry.embedded_manifold import EmbeddedManifold
 from geomstats.geometry.general_linear import GeneralLinear
 from geomstats.geometry.riemannian_metric import RiemannianMetric
@@ -21,19 +22,12 @@ class SPDMatrices(EmbeddedManifold):
             embedding_manifold=GeneralLinear(n=n))
         self.n = n
 
-    def belongs(self, mat, tolerance=TOLERANCE):
-        """Check if a matrix belongs to the manifold of SPD matrices."""
-        mat = gs.to_ndarray(mat, to_ndim=3)
-        n_mats, mat_dim, _ = mat.shape
-
-        mask_is_symmetric = self.embedding_manifold.is_symmetric(
-                mat, tolerance=tolerance)
-        mask_is_invertible = self.embedding_manifold.belongs(mat)
-
-        belongs = mask_is_symmetric & mask_is_invertible
-        belongs = gs.to_ndarray(belongs, to_ndim=1)
-        belongs = gs.to_ndarray(belongs, to_ndim=2, axis=1)
-        return belongs
+    def belongs(self, mat, atol=TOLERANCE):
+        """
+        Check if a matrix belongs to the manifold of
+        symmetric positive definite matrices.
+        """
+        return Matrices.is_symmetric(mat)
 
     def vector_from_symmetric_matrix(self, mat):
         """Convert the symmetric part of a symmetric matrix into a vector."""

--- a/geomstats/geometry/spd_matrices.py
+++ b/geomstats/geometry/spd_matrices.py
@@ -3,9 +3,9 @@
 import math
 
 import geomstats.backend as gs
-from geomstats.geometry.matrices import Matrices
 from geomstats.geometry.embedded_manifold import EmbeddedManifold
 from geomstats.geometry.general_linear import GeneralLinear
+from geomstats.geometry.matrices import Matrices
 from geomstats.geometry.riemannian_metric import RiemannianMetric
 
 EPSILON = 1e-6

--- a/tests/test_matrices.py
+++ b/tests/test_matrices.py
@@ -74,14 +74,14 @@ class TestMatricesMethods(geomstats.tests.TestCase):
         sym_mat = gs.array([[1., 2.],
                             [2., 1.]])
         result = self.space.is_symmetric(sym_mat)
-        expected = gs.array([[True]])
+        expected = gs.array(True)
         self.assertAllClose(result, expected)
 
         not_a_sym_mat = gs.array([[1., 0.6, -3.],
                                   [6., -7., 0.],
                                   [0., 7., 8.]])
         result = self.space.is_symmetric(not_a_sym_mat)
-        expected = gs.array([[False]])
+        expected = gs.array(False)
         self.assertAllClose(result, expected)
 
     @geomstats.tests.np_and_tf_only

--- a/tests/test_matrices.py
+++ b/tests/test_matrices.py
@@ -39,7 +39,7 @@ class TestMatricesMethods(geomstats.tests.TestCase):
         self.assertAllClose(result, expected)
 
     @geomstats.tests.np_only
-    def test_commutator(self):
+    def test_bracket(self):
         x = gs.array([
             [0., 0., 0.],
             [0., 0., -1.],
@@ -52,11 +52,11 @@ class TestMatricesMethods(geomstats.tests.TestCase):
             [0., -1., 0.],
             [1., 0., 0.],
             [0., 0., 0.]])
-        result = self.space.commutator([x, y], [y, z])
+        result = self.space.bracket([x, y], [y, z])
         expected = gs.array([z, x])
         self.assertAllClose(result, expected)
 
-        result = self.space.commutator(x, [x, y, z])
+        result = self.space.bracket(x, [x, y, z])
         expected = gs.array([gs.zeros((3, 3)), z, -y])
         self.assertAllClose(result, expected)
 

--- a/tests/test_matrices.py
+++ b/tests/test_matrices.py
@@ -95,35 +95,18 @@ class TestMatricesMethods(geomstats.tests.TestCase):
         expected = True
         self.assertAllClose(result, expected)
 
-<<<<<<< HEAD
     @geomstats.tests.np_and_pytorch_only
-=======
->>>>>>> rename and track "test_matrices.py"
     def test_make_symmetric(self):
         sym_mat = gs.array([[1., 2.],
                             [2., 1.]])
         result = self.space.make_symmetric(sym_mat)
-<<<<<<< HEAD
-        expected = helper.to_matrix(sym_mat)
-=======
         expected = sym_mat
->>>>>>> rename and track "test_matrices.py"
         self.assertAllClose(result, expected)
 
         mat = gs.array([[1., 2., 3.],
                         [0., 0., 0.],
                         [3., 1., 1.]])
         result = self.space.make_symmetric(mat)
-<<<<<<< HEAD
-        expected = gs.array([[[1., 1., 3.],
-                              [1., 0., 0.5],
-                              [3., 0.5, 1.]]])
-        self.assertAllClose(result, expected)
-
-        mat = gs.array([[[1e100, 1e-100, 1e100],
-                         [1e100, 1e-100, 1e100],
-                         [1e-100, 1e-100, 1e100]]])
-=======
         expected = gs.array([[1., 1., 3.],
                               [1., 0., 0.5],
                               [3., 0.5, 1.]])
@@ -132,20 +115,13 @@ class TestMatricesMethods(geomstats.tests.TestCase):
         mat = gs.array([[1e100, 1e-100, 1e100],
                         [1e100, 1e-100, 1e100],
                         [1e-100, 1e-100, 1e100]])
->>>>>>> rename and track "test_matrices.py"
         result = self.space.make_symmetric(mat)
 
         res = 0.5 * (1e100 + 1e-100)
 
-<<<<<<< HEAD
-        expected = gs.array([[[1e100, res, res],
-                              [res, 1e-100, res],
-                              [res, res, 1e100]]])
-=======
         expected = gs.array([[1e100, res, res],
                              [res, 1e-100, res],
                              [res, res, 1e100]])
->>>>>>> rename and track "test_matrices.py"
         self.assertAllClose(result, expected)
 
     @geomstats.tests.np_and_tf_only

--- a/tests/test_matrices.py
+++ b/tests/test_matrices.py
@@ -108,8 +108,8 @@ class TestMatricesMethods(geomstats.tests.TestCase):
                         [3., 1., 1.]])
         result = self.space.make_symmetric(mat)
         expected = gs.array([[1., 1., 3.],
-                              [1., 0., 0.5],
-                              [3., 0.5, 1.]])
+                             [1., 0., 0.5],
+                             [3., 0.5, 1.]])
         self.assertAllClose(result, expected)
 
         mat = gs.array([[1e100, 1e-100, 1e100],

--- a/tests/test_matrices.py
+++ b/tests/test_matrices.py
@@ -95,18 +95,26 @@ class TestMatricesMethods(geomstats.tests.TestCase):
         expected = True
         self.assertAllClose(result, expected)
 
+<<<<<<< HEAD
     @geomstats.tests.np_and_pytorch_only
+=======
+>>>>>>> rename and track "test_matrices.py"
     def test_make_symmetric(self):
         sym_mat = gs.array([[1., 2.],
                             [2., 1.]])
         result = self.space.make_symmetric(sym_mat)
+<<<<<<< HEAD
         expected = helper.to_matrix(sym_mat)
+=======
+        expected = sym_mat
+>>>>>>> rename and track "test_matrices.py"
         self.assertAllClose(result, expected)
 
         mat = gs.array([[1., 2., 3.],
                         [0., 0., 0.],
                         [3., 1., 1.]])
         result = self.space.make_symmetric(mat)
+<<<<<<< HEAD
         expected = gs.array([[[1., 1., 3.],
                               [1., 0., 0.5],
                               [3., 0.5, 1.]]])
@@ -115,13 +123,29 @@ class TestMatricesMethods(geomstats.tests.TestCase):
         mat = gs.array([[[1e100, 1e-100, 1e100],
                          [1e100, 1e-100, 1e100],
                          [1e-100, 1e-100, 1e100]]])
+=======
+        expected = gs.array([[1., 1., 3.],
+                              [1., 0., 0.5],
+                              [3., 0.5, 1.]])
+        self.assertAllClose(result, expected)
+
+        mat = gs.array([[1e100, 1e-100, 1e100],
+                        [1e100, 1e-100, 1e100],
+                        [1e-100, 1e-100, 1e100]])
+>>>>>>> rename and track "test_matrices.py"
         result = self.space.make_symmetric(mat)
 
         res = 0.5 * (1e100 + 1e-100)
 
+<<<<<<< HEAD
         expected = gs.array([[[1e100, res, res],
                               [res, 1e-100, res],
                               [res, res, 1e100]]])
+=======
+        expected = gs.array([[1e100, res, res],
+                             [res, 1e-100, res],
+                             [res, res, 1e100]])
+>>>>>>> rename and track "test_matrices.py"
         self.assertAllClose(result, expected)
 
     @geomstats.tests.np_and_tf_only

--- a/tests/test_spd_matrices.py
+++ b/tests/test_spd_matrices.py
@@ -38,9 +38,6 @@ class TestSPDMatricesMethods(geomstats.tests.TestCase):
 
     @geomstats.tests.np_and_tf_only
     def test_random_uniform_and_belongs_vectorization(self):
-        """
-        same: fix belongs.
-        """
         n_samples = self.n_samples
         points = self.space.random_uniform(n_samples=n_samples)
         result = self.space.belongs(points)

--- a/tests/test_spd_matrices.py
+++ b/tests/test_spd_matrices.py
@@ -29,14 +29,14 @@ class TestSPDMatricesMethods(geomstats.tests.TestCase):
         self.metric_logeuclidean = SPDMetricLogEuclidean(n=self.n)
         self.n_samples = 4
 
-    @geomstats.tests.np_and_tf_only
+    @geomstats.tests.np_only
     def test_random_uniform_and_belongs(self):
         point = self.space.random_uniform()
         result = self.space.belongs(point)
         expected = gs.array(True)
         self.assertAllClose(result, expected)
 
-    @geomstats.tests.np_and_tf_only
+    @geomstats.tests.np_only
     def test_random_uniform_and_belongs_vectorization(self):
         n_samples = self.n_samples
         points = self.space.random_uniform(n_samples=n_samples)

--- a/tests/test_spd_matrices.py
+++ b/tests/test_spd_matrices.py
@@ -33,19 +33,18 @@ class TestSPDMatricesMethods(geomstats.tests.TestCase):
     def test_random_uniform_and_belongs(self):
         point = self.space.random_uniform()
         result = self.space.belongs(point)
-        expected = gs.array([[True]])
+        expected = gs.array(True)
         self.assertAllClose(result, expected)
 
     @geomstats.tests.np_and_tf_only
     def test_random_uniform_and_belongs_vectorization(self):
         """
-        Test that the random uniform method samples
-        on the hypersphere space.
+        same: fix belongs.
         """
         n_samples = self.n_samples
         points = self.space.random_uniform(n_samples=n_samples)
         result = self.space.belongs(points)
-        self.assertAllClose(gs.shape(result), (n_samples, 1))
+        self.assertAllClose(gs.shape(result), n_samples)
 
     @geomstats.tests.np_and_tf_only
     def vector_from_symmetric_matrix_and_symmetric_matrix_from_vector(self):
@@ -310,7 +309,7 @@ class TestSPDMatricesMethods(geomstats.tests.TestCase):
         metric = self.metric_affine
         exps = metric.exp(tangent_vec, base_point)
         result = self.space.belongs(exps)
-        expected = gs.array([[True]] * n_samples)
+        expected = gs.array([True] * n_samples)
 
         self.assertAllClose(result, expected)
 
@@ -383,7 +382,7 @@ class TestSPDMatricesMethods(geomstats.tests.TestCase):
         t = gs.linspace(start=0., stop=1., num=n_points)
         points = geodesic(t)
         result = self.space.belongs(points)
-        expected = gs.array([[True]] * n_points)
+        expected = gs.array([True] * n_points)
 
         self.assertAllClose(result, expected)
 


### PR DESCRIPTION
This merge updates the `Matrices` class to provide with convenience methods discussed: equal, transpose, is_symmetric etc. 

I spent some time recabling the tests as well, while doing so I noticed many of them had really inconsistent shape signatures and this fixes them. 

This merge is an important step towards unifying vectorization behaviour across matrices-related files. Inline implementations are bug-prone and sometimes really hard to find.

I should also mention the convoluted way SPD(n) resorted to symmetry checks: 
```python
SPD.__init__:
     SPDn.embedding_manifold = GLn
SPD.belongs:
     #gs.to_ndarray cooking
     return self.embedding_manifold.is_symmetric(...)

GL.is_symmetric: 
      # inherited from MatricesSpace
``` 