### PR TITLE
Hot fix following pip upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
     - "3.8"
 
 install:
-    - pip install --upgrade pip setuptools wheel
+    - pip install --upgrade "pip<20.0" setuptools wheel
     - pip install -q -r dev-requirements.txt
     - pip install -q -r requirements.txt --only-binary=numpy,scipy
 script:


### PR DESCRIPTION
Recent pip upgrade breaks geomstats' travis. This is a hot fix, thanks to @nkoep .

https://github.com/pypa/pip/issues/7620