### PR TITLE
Fix nose2 warnings

### DIFF
--- a/geomstats/geometry/riemannian_metric.py
+++ b/geomstats/geometry/riemannian_metric.py
@@ -461,8 +461,8 @@ class RiemannianMetric(object):
             maximum_iterations=n_max_iterations)
 
         if last_iteration == n_max_iterations:
-            warnings.warn('Maximum number of iterations {} reached.'
-                  'The mean may be inaccurate'.format(n_max_iterations))
+            warnings.warn('Maximum number of iterations {} reached. The '
+                          'mean may be inaccurate'.format(n_max_iterations))
 
         if verbose:
             print('n_iter: {}, final variance: {}, final dist: {}'.format(

--- a/geomstats/geometry/riemannian_metric.py
+++ b/geomstats/geometry/riemannian_metric.py
@@ -1,6 +1,7 @@
 """Riemannian and pseudo-Riemannian metrics."""
 
 import math
+import warnings
 
 import geomstats.backend as gs
 
@@ -460,7 +461,7 @@ class RiemannianMetric(object):
             maximum_iterations=n_max_iterations)
 
         if last_iteration == n_max_iterations:
-            print('Maximum number of iterations {} reached.'
+            warnings.warn('Maximum number of iterations {} reached.'
                   'The mean may be inaccurate'.format(n_max_iterations))
 
         if verbose:

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -13,14 +13,14 @@ from geomstats.geometry.hypersphere import Hypersphere
 
 class TestConnectionMethods(geomstats.tests.TestCase):
     def setUp(self):
+        warnings.simplefilter('ignore', category=UserWarning)
+
         self.dimension = 4
         self.euc_metric = EuclideanMetric(dimension=self.dimension)
         self.lc_connection = LeviCivitaConnection(self.euc_metric)
 
         self.connection = Connection(dimension=2)
         self.hypersphere = Hypersphere(dimension=2)
-
-        warnings.simplefilter("ignore", category=UserWarning)
 
     def test_metric_matrix(self):
         base_point = gs.array([0., 1., 0., 0.])

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -2,6 +2,8 @@
 Unit tests for the affine connections.
 """
 
+import warnings
+
 import geomstats.backend as gs
 import geomstats.tests
 from geomstats.geometry.connection import Connection, LeviCivitaConnection
@@ -17,6 +19,8 @@ class TestConnectionMethods(geomstats.tests.TestCase):
 
         self.connection = Connection(dimension=2)
         self.hypersphere = Hypersphere(dimension=2)
+
+        warnings.simplefilter("ignore", category=UserWarning)
 
     def test_metric_matrix(self):
         base_point = gs.array([0., 1., 0., 0.])

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -35,6 +35,7 @@ class TestExamples(geomstats.tests.TestCase):
 
     def setUp(self):
         warnings.simplefilter('ignore', category=ImportWarning)
+        warnings.simplefilter("ignore", category=UserWarning)
         plt.figure()
 
     @geomstats.tests.np_only

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -35,7 +35,7 @@ class TestExamples(geomstats.tests.TestCase):
 
     def setUp(self):
         warnings.simplefilter('ignore', category=ImportWarning)
-        warnings.simplefilter("ignore", category=UserWarning)
+        warnings.simplefilter('ignore', category=UserWarning)
         plt.figure()
 
     @geomstats.tests.np_only

--- a/tests/test_special_orthogonal.py
+++ b/tests/test_special_orthogonal.py
@@ -22,6 +22,7 @@ ATOL = 1e-5
 class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
     def setUp(self):
         warnings.simplefilter('ignore', category=ImportWarning)
+        warnings.simplefilter('ignore', category=UserWarning)
 
         gs.random.seed(1234)
 


### PR DESCRIPTION
fixes issue #380 

ignores UserWarnings on Numpy and PyTorch backends when running the command `nose2 tests`. Only Sklearn deprecated FutureWarning is left in (can be ignored upon request).

Unfortunately I'm unable to see the results using the Tensorflow backend due to the following issue and my computer being a bit older:
[github.com/tensorflow/tensorflow/issues/17411](https://github.com/tensorflow/tensorflow/issues/17411)