### PR TITLE
Replace np.less_equal with torch.le

### DIFF
--- a/geomstats/backend/pytorch/__init__.py
+++ b/geomstats/backend/pytorch/__init__.py
@@ -260,7 +260,7 @@ def less(a, b):
 
 
 def less_equal(a, b):
-    return _np.less_equal(a, b)
+    return torch.le(a, b)
 
 
 def eye(*args, **kwargs):


### PR DESCRIPTION
Fixes part of issue #380 

This PR replaces the numpy version of less_equal( ) with the equivalent PyTorch version torch.le( )