### PR TITLE
Remove redundant code of tangent pca in the RiemannianMetric class

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,3 +2,4 @@
 application_import_names = geomstats
 import_order_style = smarkets
 docstring-convention = numpy
+exclude = examples/*.ipynb

--- a/examples/tangent_pca_h2.py
+++ b/examples/tangent_pca_h2.py
@@ -1,7 +1,4 @@
-"""
-Compute the mean of a data set on the hyperbolic_plane.
-Performs tangent PCA at the mean.
-"""
+"""Perform tangent PCA at the mean."""
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -12,6 +9,7 @@ from geomstats.learning.pca import TangentPCA
 
 
 def main():
+    """Perform tangent PCA at the mean."""
     fig = plt.figure(figsize=(15, 5))
 
     hyperbolic_plane = Hyperbolic(dimension=2)
@@ -20,7 +18,7 @@ def main():
     mean = hyperbolic_plane.metric.mean(data)
 
     tpca = TangentPCA(metric=hyperbolic_plane.metric, n_components=2)
-    tpca = tpca.fit(data, base_point=mean)
+    tpca = tpca.fit(data)
     tangent_projected_data = tpca.transform(data)
 
     geodesic_0 = hyperbolic_plane.metric.geodesic(

--- a/examples/tangent_pca_h2.py
+++ b/examples/tangent_pca_h2.py
@@ -18,7 +18,7 @@ def main():
     mean = hyperbolic_plane.metric.mean(data)
 
     tpca = TangentPCA(metric=hyperbolic_plane.metric, n_components=2)
-    tpca = tpca.fit(data)
+    tpca = tpca.fit(data, base_point=mean)
     tangent_projected_data = tpca.transform(data)
 
     geodesic_0 = hyperbolic_plane.metric.geodesic(

--- a/examples/tangent_pca_s2.ipynb
+++ b/examples/tangent_pca_s2.ipynb
@@ -855,7 +855,7 @@
     "mean = sphere.metric.mean(data)\n",
     "\n",
     "tpca = TangentPCA(metric=sphere.metric, n_components=2)\n",
-    "tpca = tpca.fit(data, base_point=mean)\n",
+    "tpca = tpca.fit(data)\n",
     "tangent_projected_data = tpca.transform(data)"
    ]
   },
@@ -1699,9 +1699,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "env_geom",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "env_geom"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1713,7 +1713,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.2"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,

--- a/examples/tangent_pca_s2.ipynb
+++ b/examples/tangent_pca_s2.ipynb
@@ -855,7 +855,7 @@
     "mean = sphere.metric.mean(data)\n",
     "\n",
     "tpca = TangentPCA(metric=sphere.metric, n_components=2)\n",
-    "tpca = tpca.fit(data)\n",
+    "tpca = tpca.fit(data, base_point=mean)\n",
     "tangent_projected_data = tpca.transform(data)"
    ]
   },

--- a/examples/tangent_pca_s2.py
+++ b/examples/tangent_pca_s2.py
@@ -1,7 +1,4 @@
-"""
-Compute the mean of a data set on the sphere.
-Performs tangent PCA at the mean.
-"""
+"""Perform tangent PCA at the mean."""
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -12,6 +9,7 @@ from geomstats.learning.pca import TangentPCA
 
 
 def main():
+    """Perform tangent PCA at the mean."""
     fig = plt.figure(figsize=(15, 5))
 
     sphere = Hypersphere(dimension=2)
@@ -20,7 +18,7 @@ def main():
     mean = sphere.metric.mean(data)
 
     tpca = TangentPCA(metric=sphere.metric, n_components=2)
-    tpca = tpca.fit(data, base_point=mean)
+    tpca = tpca.fit(data)
     tangent_projected_data = tpca.transform(data)
 
     geodesic_0 = sphere.metric.geodesic(

--- a/examples/tangent_pca_s2.py
+++ b/examples/tangent_pca_s2.py
@@ -18,7 +18,7 @@ def main():
     mean = sphere.metric.mean(data)
 
     tpca = TangentPCA(metric=sphere.metric, n_components=2)
-    tpca = tpca.fit(data)
+    tpca = tpca.fit(data, base_point=mean)
     tangent_projected_data = tpca.transform(data)
 
     geodesic_0 = sphere.metric.geodesic(

--- a/examples/tangent_pca_so3.py
+++ b/examples/tangent_pca_so3.py
@@ -1,7 +1,4 @@
-"""
-Compute the mean of a data set of 3D rotations.
-Performs tangent PCA at the mean.
-"""
+"""Perform tangent PCA at the mean."""
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -18,13 +15,14 @@ N_COMPONENTS = 2
 
 
 def main():
+    """Perform tangent PCA at the mean."""
     fig = plt.figure(figsize=(15, 5))
 
     data = SO3_GROUP.random_uniform(n_samples=N_SAMPLES)
     mean = METRIC.mean(data)
 
     tpca = TangentPCA(metric=METRIC, n_components=N_COMPONENTS)
-    tpca = tpca.fit(data, base_point=mean)
+    tpca = tpca.fit(data)
     tangent_projected_data = tpca.transform(data)
     print(
         'Coordinates of the Log of the first 5 data points at the mean, '

--- a/examples/tangent_pca_so3.py
+++ b/examples/tangent_pca_so3.py
@@ -22,7 +22,7 @@ def main():
     mean = METRIC.mean(data)
 
     tpca = TangentPCA(metric=METRIC, n_components=N_COMPONENTS)
-    tpca = tpca.fit(data)
+    tpca = tpca.fit(data, base_point=mean)
     tangent_projected_data = tpca.transform(data)
     print(
         'Coordinates of the Log of the first 5 data points at the mean, '

--- a/geomstats/geometry/riemannian_metric.py
+++ b/geomstats/geometry/riemannian_metric.py
@@ -594,29 +594,6 @@ class RiemannianMetric(Connection):
 
         return gs.to_ndarray(current_mean, to_ndim=2)
 
-    def tangent_pca(self, points, base_point=None, point_type='vector'):
-        """Tangent PCA of points on the tangent space wrt a base point.
-
-        Tangent Principal Component Analysis (tPCA) of points
-        on the tangent space at a base point.
-        """
-        if point_type == 'matrix':
-            raise NotImplementedError(
-                'This is currently only implemented for vectors.')
-        if base_point is None:
-            base_point = self.mean(points)
-
-        tangent_vecs = self.log(points, base_point=base_point)
-
-        covariance_mat = gs.cov(tangent_vecs.transpose())
-        eigenvalues, tangent_eigenvecs = gs.linalg.eig(covariance_mat)
-
-        idx = eigenvalues.argsort()[::-1]
-        eigenvalues = eigenvalues[idx]
-        tangent_eigenvecs = tangent_eigenvecs[idx]
-
-        return eigenvalues, tangent_eigenvecs
-
     def diameter(self, points):
         """Give the distance between two farthest points.
 

--- a/geomstats/learning/pca.py
+++ b/geomstats/learning/pca.py
@@ -1,5 +1,4 @@
-""" Principal Component Analysis on Manifolds
-"""
+"""Principal Component Analysis on Manifolds."""
 
 import numbers
 from math import log
@@ -15,7 +14,7 @@ import geomstats.backend as gs
 
 
 def _assess_dimension_(spectrum, rank, n_samples, n_features):
-    """Compute the likelihood of a rank ``rank`` dataset
+    """Compute the likelihood of a rank ``rank`` dataset.
 
     The dataset is assumed to be embedded in gaussian noise of shape(n,
     dimf) having spectrum ``spectrum``.
@@ -77,7 +76,7 @@ def _assess_dimension_(spectrum, rank, n_samples, n_features):
 
 
 def _infer_dimension_(spectrum, n_samples, n_features):
-    """Infers the dimension of a dataset of shape (n_samples, n_features)
+    """Infers the dimension of a dataset of shape (n_samples, n_features).
 
     The dataset is described by its spectrum `spectrum`.
     """
@@ -89,12 +88,12 @@ def _infer_dimension_(spectrum, n_samples, n_features):
 
 
 class TangentPCA(_BasePCA):
-    """Tangent Principal component analysis (tPCA)
+    """Tangent Principal component analysis (tPCA).
 
     Linear dimensionality reduction using
     Singular Value Decomposition of the
     Riemannian Log of the data at the tangent space
-    of the mean.
+    of the Frechet mean.
     """
 
     def __init__(self, metric, n_components=None, copy=True,
@@ -108,8 +107,7 @@ class TangentPCA(_BasePCA):
         self.iterated_power = iterated_power
         self.random_state = random_state
 
-    def fit(self, X,
-            base_point=None, point_type='vector', y=None):
+    def fit(self, X, point_type='vector', y=None):
         """Fit the model with X.
 
         Parameters
@@ -117,6 +115,7 @@ class TangentPCA(_BasePCA):
         X : array-like, shape (n_samples, n_features)
             Training data, where n_samples is the number of samples
             and n_features is the number of features.
+        point_type :
 
         y : Ignored
 
@@ -125,12 +124,10 @@ class TangentPCA(_BasePCA):
         self : object
             Returns the instance itself.
         """
-        self._fit(X, base_point, point_type)
+        self._fit(X, point_type)
         return self
 
-    def fit_transform(self, X,
-                      base_point=None, point_type='vector',
-                      y=None):
+    def fit_transform(self, X, point_type='vector', y=None):
         """Fit the model with X and apply the dimensionality reduction on X.
 
         Parameters
@@ -138,6 +135,7 @@ class TangentPCA(_BasePCA):
         X : array-like, shape (n_samples, n_features)
             Training data, where n_samples is the number of samples
             and n_features is the number of features.
+        point_type :
 
         y : Ignored
 
@@ -146,20 +144,19 @@ class TangentPCA(_BasePCA):
         X_new : array-like, shape (n_samples, n_components)
 
         """
-        U, S, V = self._fit(X, base_point, point_type)
+        U, S, V = self._fit(X, point_type)
         U = U[:, :self.n_components_]
 
         U *= S[:self.n_components_]
 
         return U
 
-    def _fit(self, X, base_point=None, point_type='vector'):
-        """Fit the model by computing full SVD on X"""
+    def _fit(self, X, point_type='vector'):
+        """Fit the model by computing full SVD on X."""
         if point_type == 'matrix':
             raise NotImplementedError(
                 'This is currently only implemented for vectors.')
-        if base_point is None:
-            base_point = self.metric.mean(X)
+        base_point = self.metric.mean(X)
 
         tangent_vecs = self.metric.log(X, base_point=base_point)
 
@@ -169,7 +166,6 @@ class TangentPCA(_BasePCA):
         X = check_array(X, dtype=[gs.float64, gs.float32], ensure_2d=True,
                         copy=self.copy)
 
-        # Handle n_components==None
         if self.n_components is None:
             n_components = min(X.shape)
         else:
@@ -192,7 +188,7 @@ class TangentPCA(_BasePCA):
                                  "was of type=%r"
                                  % (n_components, type(n_components)))
 
-        # Center data
+        # Center data - the mean should be 0
         self.mean_ = gs.mean(X, axis=0)
         X -= self.mean_
 


### PR DESCRIPTION
Tangent PCA algorithm was present twice: 
- as a method of the class RiemannianMetric
- as an algorithm in the folder geomstats/learning

This PR removes the first one and cleans docstrings.