### PR TITLE
Add pre-commit config

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,6 @@
 [flake8]
 application_import_names = geomstats
-import_order_style = smarkets
 docstring-convention = numpy
 exclude = examples/*.ipynb
+ignore = W503,W504
+import_order_style = smarkets

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.5.0
+    hooks:
+      - id: check-byte-order-marker
+      - id: check-case-conflict
+      - id: check-merge-conflict
+      - id: check-yaml
+      - id: flake8
+        exclude: examples/.*ipynb$
+      - id: mixed-line-ending
+        args:
+          - --fix=no
+      - id: no-commit-to-branch
+        args:
+          - --branch=master
+      - id: trailing-whitespace

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ install:
 script:
     - >
       flake8 $(git diff --name-only master HEAD geomstats examples tests)
-      --ignore=D,W503,W504
-    - flake8 geomstats/geometry --ignore=W503,W504
+      --ignore=D
+    - flake8 geomstats/geometry
     - |
       if [[ $TRAVIS_PYTHON_VERSION != 3.8 ||
             ($TRAVIS_PYTHON_VERSION == 3.8 &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+os: linux
 dist: xenial
 cache: pip
 language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,16 @@ install:
     - pip install -q -r dev-requirements.txt
     - pip install -q -r requirements.txt --only-binary=numpy,scipy
 script:
-    - flake8 $(git diff --name-only master HEAD geomstats examples tests) --ignore=D,W503,W504
+    - >
+      flake8 $(git diff --name-only master HEAD geomstats examples tests)
+      --ignore=D,W503,W504
     - flake8 geomstats/geometry --ignore=W503,W504
-    - if [[ $TRAVIS_PYTHON_VERSION != 3.8 ]]; then nose2 --with-coverage --verbose tests; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == 3.8 && $GEOMSTATS_BACKEND != tensorflow ]]; then nose2 --with-coverage --verbose tests; fi
+    - |
+      if [[ $TRAVIS_PYTHON_VERSION != 3.8 ||
+            ($TRAVIS_PYTHON_VERSION == 3.8 &&
+             $GEOMSTATS_BACKEND != tensorflow) ]]; then
+        nose2 --with-coverage --verbose tests
+      fi
 env:
     - GEOMSTATS_BACKEND=numpy
     - GEOMSTATS_BACKEND=pytorch

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ python:
 install:
     - pip install --upgrade pip setuptools wheel
     - pip install -q -r dev-requirements.txt
-    - pip install -q -r requirements.txt --only-binary=numpy,scipy
+    - pip install -q -r requirements.txt
 script:
     - >
       flake8 $(git diff --name-only master HEAD geomstats examples tests)

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
     - "3.8"
 
 install:
-    - pip install --upgrade "pip<20.0" setuptools wheel
+    - pip install --upgrade pip setuptools wheel
     - pip install -q -r dev-requirements.txt
     - pip install -q -r requirements.txt --only-binary=numpy,scipy
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ python:
 
 install:
     - pip install --upgrade pip setuptools wheel
+    - pip install -q -r ci-requirements.txt
     - pip install -q -r dev-requirements.txt
     - pip install -q -r requirements.txt
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,10 @@ python:
 
 install:
     - pip install --upgrade pip setuptools wheel
-    - pip install -q -r ci-requirements.txt
-    - pip install -q -r dev-requirements.txt
-    - pip install -q -r requirements.txt
+    - |
+      for req in ci-requirements.txt dev-requirements.txt requirements.txt; do
+        pip install -q -r $req
+      done
 script:
     - >
       flake8 $(git diff --name-only master HEAD geomstats examples tests)

--- a/ci-requirements.txt
+++ b/ci-requirements.txt
@@ -1,0 +1,2 @@
+codecov
+coverage

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,4 @@
-codecov
-coverage
 flake8
-flake8-import-order
 flake8-docstrings
+flake8-import-order
 nose2

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,3 +2,4 @@ flake8
 flake8-docstrings
 flake8-import-order
 nose2
+pre-commit

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -165,9 +165,9 @@ It is often helpful to keep your local feature branch synchronized with the
 latest changes of the main geomstats repository::
 
     $ git fetch upstream
-    $ git merge upstream/master
+    $ git rebase upstream/master
 
-Subsequently, you might need to solve the conflicts. You can refer to the
+Subsequently, you might need to solve potential conflicts. Refer to the
 `Git documentation related to resolving merge conflict using the command
 line
 <https://help.github.com/articles/resolving-a-merge-conflict-using-the-command-line/>`_.
@@ -220,17 +220,24 @@ complies with the following rules. The **bolded** ones are especially important:
 
 5. **Make sure that your PR follows Python international style guidelines**,
    `PEP8 <https://www.python.org/dev/peps/pep-0008>`_, which you should read.
-   The software `flake8` automatically looks for style violations when you submit
-   your PR. We recommend installing flake8 with its plugins on your machine
+   The `flake8` package automatically checks for style violations when you
+   submit your PR. We recommend installing flake8 with its plugins on your
+   machine by running
 
-   `pip3 install flake8 flake8-docstrings flake8-import-order`
+   `pip3 install -r dev-requirements.txt`
 
    Then you can run
 
    `flake8 geomstats tests examples`
-   
-   Please avoid reformatting parts of the file that your pull request doesn't change, as it distracts
-   from code review.
+
+   To prevent adding commits which fail to adhere to the PEP8 guidelines, we
+   include a `pre-commit <https://pre-commit.com/>` config, which immediately
+   invokes flake8 on all files staged for commit when running `git commit`. To
+   enable the hook, simply run `pre-commit install` after installing
+   `pre-commit` either manually via `pip` or as part of `dev-requirements.txt`.
+
+   Please avoid reformatting parts of the file that your pull request doesn't
+   change, as it distracts during code reviews.
 
 6. **Make sure that your PR follows geomstats coding style and API**,
    see our `coding-guidelines`_ below. Ensuring style consistency throughout
@@ -432,7 +439,7 @@ In general, have the following in mind:
        "See also" in docstrings should be one line per reference,
        with a colon and an explanation.
 
-When editing reStructuredText (``.rst``) files, try to keep line length under 
+When editing reStructuredText (``.rst``) files, try to keep line length under
 80 characters (exceptions include links and tables).
 
 .. _coding-guidelines:

--- a/geomstats/tests.py
+++ b/geomstats/tests.py
@@ -83,8 +83,6 @@ if tf_backend():
 
 
 class TestCase(_TestBaseClass):
-    _multiprocess_can_split_ = True
-
     def assertAllClose(self, a, b, rtol=1e-6, atol=1e-6):
         if tf_backend():
             return super().assertAllClose(a, b, rtol=rtol, atol=atol)


### PR DESCRIPTION
Apart from general clean-up of the travis config, this PR adds a [pre-commit](https://pre-commit.com/) config to the source tree. This is an opt-in feature, which adds a git pre-commit hook if enabled that currently

1. checks for byte-order markers
2. checks for filename case conflicts (macos and windows file systems are case-insensitive by default)
3. checks for left-over merge conflict markers
4. runs flake8
5. checks for mixed line-endings
6. prevents direct commits to master
7. cleans up trailing whitespace

If the `pre-commit` package is installed, the hook can be enabled by running `pre-commit install` in the repository root. The hook only checks files staged for commit. Most importantly, this means that it only checks for flake8 violations in modified and staged files rather than the entire repo.
