### PR TITLE
Automatically deploy tags to pypi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,13 @@ env:
 
 after_success:
     - bash <(curl -s https://codecov.io/bash) -c -F $GEOMSTATS_BACKEND
+
+deploy:
+  - provider: pypi
+    username: $PYPI_USER
+    password: $PYPI_PASSWORD
+    on:
+      repo: geomstats/geomstats
+      tags: true
+    distributions: "sdist bdist_wheel"
+    skip_existing: true

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ And run unit tests from this folder:
 nose2 tests
 ```
 
-See our [contributing.rst](docs/contributing.rst) file!
+See our [contributing](https://github.com/geomstats/geomstats/blob/master/docs/contributing.rst) guidelines!
 
 ## Acknowledgements
 

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,9 @@ if __name__ == '__main__':
     }
     extras_require['all'] = list(chain(*extras_require.values()))
 
+    with open(os.path.join(base_dir, "README.md")) as f:
+        long_description = f.read()
+
     setup(
         name='geomstats',
         version=geomstats['__version__'],
@@ -44,6 +47,25 @@ if __name__ == '__main__':
         author='Nina Miolane',
         author_email='ninamio78@gmail.com',
         license='MIT',
+        classifiers=[
+            'Development Status :: 5 - Production/Stable',
+            'Intended Audience :: Science/Research',
+            'Topic :: Scientific/Engineering',
+            'Topic :: Scientific/Engineering :: Artificial Intelligence',
+            'Topic :: Scientific/Engineering :: Mathematics',
+            'License :: OSI Approved :: BSD License',
+            'Programming Language :: Python :: 3',
+            'Programming Language :: Python :: 3.5',
+            'Programming Language :: Python :: 3.6',
+            'Programming Language :: Python :: 3.7',
+            'Programming Language :: Python :: 3.8'
+        ],
+        long_description=long_description,
+        long_description_content_type='text/markdown',
         packages=find_packages(),
-        zip_safe=False
+        data_files=[
+            "LICENSE.md",
+            "README.md"
+        ],
+        zip_safe=False,
     )


### PR DESCRIPTION
This PR sets up travis to automatically deploy a new geomstats build to pypi when tags get pushed to the geomstats repository.