### PR TITLE
ignore RuntimeWarning: More than 20 figures open

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -36,6 +36,7 @@ class TestExamples(geomstats.tests.TestCase):
     def setUp(self):
         warnings.simplefilter('ignore', category=ImportWarning)
         warnings.simplefilter('ignore', category=UserWarning)
+        plt.rcParams.update({'figure.max_open_warning': 0})
         plt.figure()
 
     @geomstats.tests.np_only


### PR DESCRIPTION
Continuing improvements to issue #380 

This PR ignores the RuntimeWarnings that are generated when more than 20 figures have been opened during the numpy nose2 tests