### PR TITLE
Uniformize logging

### DIFF
--- a/examples/empirical_frechet_mean_uncertainty_sn.py
+++ b/examples/empirical_frechet_mean_uncertainty_sn.py
@@ -8,6 +8,8 @@ for isotropic distributions on hyper-spheres of radius 0 < theta < Pi in
 the sphere S_dim (called here a bubble).
 """
 
+import logging
+
 import matplotlib.pyplot as plt
 
 import geomstats.backend as gs
@@ -136,7 +138,8 @@ def plot_modulation_factor(n_samples, dim, n_expectation=1000, n_theta=20):
             n_samples, theta_i, dim, n_expectation=n_expectation)
         measured_modulation_factor.append(var)
         error.append(std_var)
-        print(n_samples, theta_i, var, std_var, '\n')
+        logging.info(
+            '{} {} {} {}\n'.format(n_samples, theta_i, var, std_var))
         small_var_modulation_factor.append(
             1.0 + 2.0 / 3.0 * theta_i ** 2
             * (1.0 - 1.0 / dim) * (1.0 - 1.0 / n_samples))
@@ -197,7 +200,8 @@ def multi_plot_modulation_factor(dim, n_expectation=1000, n_theta=20):
             (var, std_var) = modulation_factor(
                 n_samples, theta_i, dim, n_expectation=n_expectation)
             measured_modulation_factor.append(var)
-            print(n_samples, theta_i, var, std_var, '\n')
+            logging.info(
+                '{} {} {} {}\n'.format(n_samples, theta_i, var, std_var))
         plt.plot(theta, measured_modulation_factor,
                  color=color[n_samples], label="N={0}".format(n_samples))
     plt.xlabel(r'Standard deviation $\theta$')
@@ -222,23 +226,23 @@ def main():
     """
     n_expectation = 10
 
-    print("Var of empirical mean for 1 sample, theta=0.1 in S2",
-          empirical_frechet_var_bubble(
-              1, 0.1, 2, n_expectation=n_expectation), "\n")
-    print("Var of empirical mean for 1 sample, theta=0.1 in S3",
-          empirical_frechet_var_bubble(
-              1, 0.1, 3, n_expectation=n_expectation), "\n")
+    logging.info('Var of empirical mean for 1 sample, theta=0.1 '
+                 'in S2 {} \n'.format(empirical_frechet_var_bubble(
+                     1, 0.1, 2, n_expectation=n_expectation)))
+    logging.info('Var of empirical mean for 1 sample, theta=0.1 '
+                 'in S3 {} \n'.format(empirical_frechet_var_bubble(
+                     1, 0.1, 3, n_expectation=n_expectation)))
 
-    print("Modulation factor for 1 sample theta=0.1 in S2 "
-          "(should be close to 1):",
-          modulation_factor(
-              1, 0.1, 2, n_expectation=n_expectation), "\n")
+    logging.info('Modulation factor for 1 sample theta=0.1 in S2 '
+                 '(should be close to 1): {} \n'.format(
+                     modulation_factor(
+                         1, 0.1, 2, n_expectation=n_expectation)))
 
-    print("Modulation factor for 500 sample theta close to Pi/2 in S5 "
-          "(should be around 25):",
-          modulation_factor(
-              500, gs.pi / 2 - 0.001, 5,
-              n_expectation=n_expectation), "\n")
+    logging.info('Modulation factor for 500 sample theta close to Pi/2 in S5 '
+                 '(should be around 25): {} \n'.format(
+                     modulation_factor(
+                         500, gs.pi / 2 - 0.001, 5,
+                         n_expectation=n_expectation)))
 
     plot_modulation_factor(2, 2, n_expectation=n_expectation)
     plot_modulation_factor(4, 2, n_expectation=n_expectation)

--- a/examples/geomstats_in_pymanopt.py
+++ b/examples/geomstats_in_pymanopt.py
@@ -8,6 +8,7 @@ The example currently requires installing the pymanopt HEAD from git:
 """
 
 import functools
+import logging
 import os
 
 from pymanopt import Problem
@@ -101,11 +102,11 @@ if __name__ == '__main__':
             gs.sign(dominant_eigenvector_estimate[0])):
         dominant_eigenvector_estimate = -dominant_eigenvector_estimate
 
-    print('l2-norm of dominant eigenvector:',
-          gs.linalg.norm(dominant_eigenvector))
-    print('l2-norm of dominant eigenvector estimate:',
-          gs.linalg.norm(dominant_eigenvector_estimate))
+    logging.info('l2-norm of dominant eigenvector: {}'.format(
+        gs.linalg.norm(dominant_eigenvector)))
+    logging.info('l2-norm of dominant eigenvector estimate: {}'.format(
+        gs.linalg.norm(dominant_eigenvector_estimate)))
     error_norm = gs.linalg.norm(
         dominant_eigenvector - dominant_eigenvector_estimate)
-    print('l2-norm of difference vector:', error_norm)
-    print('solution found: %s' % gs.isclose(error_norm, 0.0, atol=1e-3))
+    logging.info('l2-norm of difference vector: {}'.format(error_norm))
+    logging.info('solution found: %s' % gs.isclose(error_norm, 0.0, atol=1e-3))

--- a/examples/gradient_descent_s2.py
+++ b/examples/gradient_descent_s2.py
@@ -11,6 +11,8 @@ on the sphere. We solve this in 3 dimension on the 2-sphere
 manifold so that we can visualize and render the path as a video.
 """
 
+import logging
+
 import matplotlib
 matplotlib.use("Agg")  # NOQA
 import matplotlib.animation as animation
@@ -45,9 +47,9 @@ def gradient_descent(start,
         x = manifold.metric.exp(base_point=x, tangent_vec=tangent_vec)[0]
         if (gs.abs(loss(x, use_gs=True) - loss(x_prev, use_gs=True))
                 <= precision):
-            print('x: %s' % x)
-            print('reached precision %s' % precision)
-            print('iterations: %d' % i)
+            logging.info('x: %s' % x)
+            logging.info('reached precision %s' % precision)
+            logging.info('iterations: %d' % i)
             break
         yield x, loss(x)
 

--- a/examples/loss_and_gradient_se3.py
+++ b/examples/loss_and_gradient_se3.py
@@ -2,6 +2,8 @@
 Predict on SE3: losses.
 """
 
+import logging
+
 import geomstats.backend as gs
 import geomstats.geometry.lie_group as lie_group
 from geomstats.geometry.special_euclidean import SpecialEuclidean
@@ -99,9 +101,9 @@ def main():
     loss_rot_vec = loss(y_pred, y_true)
     grad_rot_vec = grad(y_pred, y_true)
 
-    print('The loss between the poses using rotation vectors is: {}'.format(
-        loss_rot_vec[0, 0]))
-    print('The riemannian gradient is: {}'.format(grad_rot_vec))
+    logging.info('The loss between the poses using rotation '
+                 'vectors is: {}'.format(loss_rot_vec[0, 0]))
+    logging.info('The riemannian gradient is: {}'.format(grad_rot_vec))
 
     angle = gs.array(gs.pi / 6)
     cos = gs.cos(angle / 2)
@@ -127,9 +129,9 @@ def main():
                            representation='quaternion')
     grad_quaternion = grad(y_pred_quaternion, y_true_quaternion,
                            representation='quaternion')
-    print('The loss between the poses using quaternions is: {}'.format(
+    logging.info('The loss between the poses using quaternions is: {}'.format(
         loss_quaternion[0, 0]))
-    print('The riemannian gradient is: {}'.format(
+    logging.info('The riemannian gradient is: {}'.format(
         grad_quaternion))
 
 

--- a/examples/loss_and_gradient_so3.py
+++ b/examples/loss_and_gradient_so3.py
@@ -2,6 +2,8 @@
 Predict on manifolds: losses.
 """
 
+import logging
+
 import geomstats.backend as gs
 import geomstats.geometry.lie_group as lie_group
 from geomstats.geometry.special_orthogonal import SpecialOrthogonal
@@ -73,9 +75,9 @@ def main():
     loss_rot_vec = loss(y_pred, y_true)
     grad_rot_vec = grad(y_pred, y_true)
 
-    print('The loss between the rotation vectors is: {}'.format(
+    logging.info('The loss between the rotation vectors is: {}'.format(
         loss_rot_vec[0, 0]))
-    print('The riemannian gradient is: {}'.format(
+    logging.info('The riemannian gradient is: {}'.format(
         grad_rot_vec))
 
     angle = gs.array(gs.pi / 6)
@@ -101,9 +103,9 @@ def main():
     grad_quaternion = grad(y_pred_quaternion, y_true_quaternion,
                            representation='quaternion')
 
-    print('The loss between the quaternions is: {}'.format(
+    logging.info('The loss between the quaternions is: {}'.format(
         loss_quaternion[0, 0]))
-    print('The riemannian gradient is: {}'.format(
+    logging.info('The riemannian gradient is: {}'.format(
         grad_quaternion))
 
 

--- a/examples/plot_geodesics_h2.py
+++ b/examples/plot_geodesics_h2.py
@@ -4,6 +4,7 @@ Plot a geodesic on the Hyperbolic space H2.
 With Poincare Disk visualization.
 """
 
+import logging
 import os
 
 import matplotlib.pyplot as plt
@@ -63,9 +64,9 @@ def main():
 
 if __name__ == "__main__":
     if os.environ['GEOMSTATS_BACKEND'] == 'tensorflow':
-        print('Examples with visualizations are only implemented '
-              'with numpy backend.\n'
-              'To change backend, write: '
-              'export GEOMSTATS_BACKEND = \'numpy\'.')
+        logging.info('Examples with visualizations are only implemented '
+                     'with numpy backend.\n'
+                     'To change backend, write: '
+                     'export GEOMSTATS_BACKEND = \'numpy\'.')
     else:
         main()

--- a/examples/plot_geodesics_s2.py
+++ b/examples/plot_geodesics_s2.py
@@ -2,6 +2,7 @@
 Plot a geodesic on the sphere S2
 """
 
+import logging
 import os
 
 import matplotlib.pyplot as plt
@@ -32,9 +33,9 @@ def main():
 
 if __name__ == "__main__":
     if os.environ['GEOMSTATS_BACKEND'] == 'tensorflow':
-        print('Examples with visualizations are only implemented '
-              'with numpy backend.\n'
-              'To change backend, write: '
-              'export GEOMSTATS_BACKEND = \'numpy\'.')
+        logging.info('Examples with visualizations are only implemented '
+                     'with numpy backend.\n'
+                     'To change backend, write: '
+                     'export GEOMSTATS_BACKEND = \'numpy\'.')
     else:
         main()

--- a/examples/plot_geodesics_se3.py
+++ b/examples/plot_geodesics_se3.py
@@ -3,6 +3,7 @@ Plot a geodesic of SE(3) equipped
 with its left-invariant canonical METRIC.
 """
 
+import logging
 import os
 
 import matplotlib.pyplot as plt
@@ -32,9 +33,9 @@ def main():
 
 if __name__ == "__main__":
     if os.environ['GEOMSTATS_BACKEND'] == 'tensorflow':
-        print('Examples with visualizations are only implemented '
-              'with numpy backend.\n'
-              'To change backend, write: '
-              'export GEOMSTATS_BACKEND = \'numpy\'.')
+        logging.info('Examples with visualizations are only implemented '
+                     'with numpy backend.\n'
+                     'To change backend, write: '
+                     'export GEOMSTATS_BACKEND = \'numpy\'.')
     else:
         main()

--- a/examples/plot_geodesics_so3.py
+++ b/examples/plot_geodesics_so3.py
@@ -3,6 +3,7 @@ Plot a geodesic of SO(3) equipped
 with its left-invariant canonical METRIC.
 """
 
+import logging
 import os
 
 import matplotlib.pyplot as plt
@@ -31,9 +32,9 @@ def main():
 
 if __name__ == "__main__":
     if os.environ['GEOMSTATS_BACKEND'] == 'tensorflow':
-        print('Examples with visualizations are only implemented '
-              'with numpy backend.\n'
-              'To change backend, write: '
-              'export GEOMSTATS_BACKEND = \'numpy\'.')
+        logging.info('Examples with visualizations are only implemented '
+                     'with numpy backend.\n'
+                     'To change backend, write: '
+                     'export GEOMSTATS_BACKEND = \'numpy\'.')
     else:
         main()

--- a/examples/plot_grid_h2.py
+++ b/examples/plot_grid_h2.py
@@ -3,6 +3,7 @@ Plot a grid on H2
 with Poincare Disk visualization.
 """
 
+import logging
 import os
 
 import matplotlib.pyplot as plt
@@ -45,9 +46,9 @@ def main(left=-128,
 
 if __name__ == "__main__":
     if os.environ['GEOMSTATS_BACKEND'] == 'tensorflow':
-        print('Examples with visualizations are only implemented '
-              'with numpy backend.\n'
-              'To change backend, write: '
-              'export GEOMSTATS_BACKEND = \'numpy\'.')
+        logging.info('Examples with visualizations are only implemented '
+                     'with numpy backend.\n'
+                     'To change backend, write: '
+                     'export GEOMSTATS_BACKEND = \'numpy\'.')
     else:
         main()

--- a/examples/plot_kmeans_manifolds.py
+++ b/examples/plot_kmeans_manifolds.py
@@ -7,6 +7,8 @@ algorithm and plot the points labels as two distinct colors. For the moment
 the example works on the Poincaré Ball and the Hypersphere.
 Computed means are marked as green stars.
 """
+
+import logging
 import os
 
 import matplotlib.pyplot as plt
@@ -136,9 +138,9 @@ def main():
 
 if __name__ == "__main__":
     if os.environ['GEOMSTATS_BACKEND'] != 'numpy':
-        print('Examples with visualizations are only implemented '
-              'with numpy backend.\n'
-              'To change backend, write: '
-              'export GEOMSTATS_BACKEND = \'numpy\'.')
+        logging.info('Examples with visualizations are only implemented '
+                     'with numpy backend.\n'
+                     'To change backend, write: '
+                     'export GEOMSTATS_BACKEND = \'numpy\'.')
     else:
         main()

--- a/examples/plot_online_kmeans_s1.py
+++ b/examples/plot_online_kmeans_s1.py
@@ -3,6 +3,7 @@ Plot the result of optimal quantization of the uniform distribution
 on the circle, using online k-means clustering of a sample.
 """
 
+import logging
 import os
 
 import matplotlib.pyplot as plt
@@ -43,9 +44,9 @@ def main():
 
 if __name__ == "__main__":
     if os.environ['GEOMSTATS_BACKEND'] == 'tensorflow':
-        print('Examples with visualizations are only implemented '
-              'with numpy backend.\n'
-              'To change backend, write: '
-              'export GEOMSTATS_BACKEND = \'numpy\'.')
+        logging.info('Examples with visualizations are only implemented '
+                     'with numpy backend.\n'
+                     'To change backend, write: '
+                     'export GEOMSTATS_BACKEND = \'numpy\'.')
     else:
         main()

--- a/examples/plot_online_kmeans_s2.py
+++ b/examples/plot_online_kmeans_s2.py
@@ -3,6 +3,7 @@ Plot the result of optimal quantization of the von Mises Fisher distribution
 on the sphere using online k-means clustering of a sample.
 """
 
+import logging
 import os
 
 import matplotlib.pyplot as plt
@@ -39,9 +40,9 @@ def main():
 
 if __name__ == "__main__":
     if os.environ['GEOMSTATS_BACKEND'] == 'tensorflow':
-        print('Examples with visualizations are only implemented '
-              'with numpy backend.\n'
-              'To change backend, write: '
-              'export GEOMSTATS_BACKEND = \'numpy\'.')
+        logging.info('Examples with visualizations are only implemented '
+                     'with numpy backend.\n'
+                     'To change backend, write: '
+                     'export GEOMSTATS_BACKEND = \'numpy\'.')
     else:
         main()

--- a/examples/plot_square_h2_klein_disk.py
+++ b/examples/plot_square_h2_klein_disk.py
@@ -2,6 +2,7 @@
 Plot a square on H2 with Poincare Disk visualization.
 """
 
+import logging
 import os
 
 import matplotlib.pyplot as plt
@@ -44,9 +45,9 @@ def main():
 
 if __name__ == "__main__":
     if os.environ['GEOMSTATS_BACKEND'] == 'tensorflow':
-        print('Examples with visualizations are only implemented '
-              'with numpy backend.\n'
-              'To change backend, write: '
-              'export GEOMSTATS_BACKEND = \'numpy\'.')
+        logging.info('Examples with visualizations are only implemented '
+                     'with numpy backend.\n'
+                     'To change backend, write: '
+                     'export GEOMSTATS_BACKEND = \'numpy\'.')
     else:
         main()

--- a/examples/plot_square_h2_poincare_disk.py
+++ b/examples/plot_square_h2_poincare_disk.py
@@ -1,5 +1,6 @@
 """Plot a square on H2 with Poincare Disk visualization."""
 
+import logging
 import os
 
 import matplotlib.pyplot as plt
@@ -44,9 +45,9 @@ def main():
 
 if __name__ == "__main__":
     if os.environ['GEOMSTATS_BACKEND'] == 'tensorflow':
-        print('Examples with visualizations are only implemented '
-              'with numpy backend.\n'
-              'To change backend, write: '
-              'export GEOMSTATS_BACKEND = \'numpy\'.')
+        logging.info('Examples with visualizations are only implemented '
+                     'with numpy backend.\n'
+                     'To change backend, write: '
+                     'export GEOMSTATS_BACKEND = \'numpy\'.')
     else:
         main()

--- a/examples/plot_square_h2_poincare_half_plane.py
+++ b/examples/plot_square_h2_poincare_half_plane.py
@@ -1,5 +1,6 @@
 """Plot a square on H2 with Poincare half-plane visualization."""
 
+import logging
 import os
 
 import matplotlib.pyplot as plt
@@ -44,9 +45,9 @@ def main():
 
 if __name__ == "__main__":
     if os.environ['GEOMSTATS_BACKEND'] == 'tensorflow':
-        print('Examples with visualizations are only implemented '
-              'with numpy backend.\n'
-              'To change backend, write: '
-              'export GEOMSTATS_BACKEND = \'numpy\'.')
+        logging.info('Examples with visualizations are only implemented '
+                     'with numpy backend.\n'
+                     'To change backend, write: '
+                     'export GEOMSTATS_BACKEND = \'numpy\'.')
     else:
         main()

--- a/examples/tangent_pca_h2.py
+++ b/examples/tangent_pca_h2.py
@@ -1,5 +1,7 @@
 """Perform tangent PCA at the mean."""
 
+import logging
+
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -38,10 +40,10 @@ def main():
     geodesic_points_0 = geodesic_0(t)
     geodesic_points_1 = geodesic_1(t)
 
-    print(
+    logging.info(
         'Coordinates of the Log of the first 5 data points at the mean, '
         'projected on the principal components:')
-    print(tangent_projected_data[:5])
+    logging.info('\n{}'.format(tangent_projected_data[:5]))
 
     ax_var = fig.add_subplot(121)
     xticks = np.arange(1, 2 + 1, 1)

--- a/examples/tangent_pca_s2.py
+++ b/examples/tangent_pca_s2.py
@@ -1,5 +1,7 @@
 """Perform tangent PCA at the mean."""
 
+import logging
+
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -38,10 +40,10 @@ def main():
     geodesic_points_0 = geodesic_0(t)
     geodesic_points_1 = geodesic_1(t)
 
-    print(
+    logging.info(
         'Coordinates of the Log of the first 5 data points at the mean, '
         'projected on the principal components:')
-    print(tangent_projected_data[:5])
+    logging.info('\n{}'.format(tangent_projected_data[:5]))
 
     ax_var = fig.add_subplot(121)
     xticks = np.arange(1, 2 + 1, 1)

--- a/examples/tangent_pca_so3.py
+++ b/examples/tangent_pca_so3.py
@@ -1,5 +1,7 @@
 """Perform tangent PCA at the mean."""
 
+import logging
+
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -29,10 +31,10 @@ def main():
     tpca = TangentPCA(metric=METRIC, n_components=N_COMPONENTS)
     tpca = tpca.fit(data, base_point=mean_estimate)
     tangent_projected_data = tpca.transform(data)
-    print(
+    logging.info(
         'Coordinates of the Log of the first 5 data points at the mean, '
         'projected on the principal components:')
-    print(tangent_projected_data[:5])
+    logging.info('\n{}'.format(tangent_projected_data[:5]))
 
     ax_var = fig.add_subplot(121)
     xticks = np.arange(1, N_COMPONENTS + 1, 1)

--- a/geomstats/backend/__init__.py
+++ b/geomstats/backend/__init__.py
@@ -3,7 +3,7 @@ import os
 
 from numpy import pi  # NOQA
 
-logging.basicConfig()
+logging.basicConfig(format= '%(levelname)s: %(message)s')
 logging.getLogger().setLevel(logging.INFO)
 
 

--- a/geomstats/backend/__init__.py
+++ b/geomstats/backend/__init__.py
@@ -3,7 +3,7 @@ import os
 
 from numpy import pi  # NOQA
 
-logging.basicConfig(format= '%(levelname)s: %(message)s')
+logging.basicConfig(format='%(levelname)s: %(message)s')
 logging.getLogger().setLevel(logging.INFO)
 
 
@@ -20,3 +20,7 @@ elif _BACKEND == 'tensorflow':
 else:
     raise RuntimeError('Unknown backend \'{:s}\''.format(_BACKEND))
 logging.info('Using {:s} backend'.format(_BACKEND))
+
+loggers = [logging.getLogger(name) for name in logging.root.manager.loggerDict]
+if loggers:
+    logging.getLogger().setLevel(logging.WARNING)

--- a/geomstats/backend/__init__.py
+++ b/geomstats/backend/__init__.py
@@ -22,5 +22,5 @@ else:
 logging.info('Using {:s} backend'.format(_BACKEND))
 
 loggers = [logging.getLogger(name) for name in logging.root.manager.loggerDict]
-if loggers:
+if loggers and loggers[0].name.startswith('nose2'):
     logging.getLogger().setLevel(logging.WARNING)

--- a/geomstats/backend/__init__.py
+++ b/geomstats/backend/__init__.py
@@ -1,7 +1,10 @@
+import logging
 import os
-import sys
 
 from numpy import pi  # NOQA
+
+logging.basicConfig()
+logging.getLogger().setLevel(logging.INFO)
 
 
 _BACKEND = os.environ.get('GEOMSTATS_BACKEND')
@@ -16,4 +19,4 @@ elif _BACKEND == 'tensorflow':
     from geomstats.backend.tensorflow import *  # NOQA
 else:
     raise RuntimeError('Unknown backend \'{:s}\''.format(_BACKEND))
-print('Using {:s} backend'.format(_BACKEND), file=sys.stderr)
+logging.info('Using {:s} backend'.format(_BACKEND))

--- a/geomstats/learning/frechet_mean.py
+++ b/geomstats/learning/frechet_mean.py
@@ -1,7 +1,7 @@
 """Frechet mean."""
 
+import logging
 import math
-import warnings
 
 from sklearn.base import BaseEstimator
 
@@ -159,11 +159,12 @@ def _default_gradient_descent(points, metric, weights,
         maximum_iterations=n_max_iterations)
 
     if last_iteration == n_max_iterations:
-        print('Maximum number of iterations {} reached.'
-              'The mean may be inaccurate'.format(n_max_iterations))
+        logging.warning(
+            'Maximum number of iterations {} reached.'
+            'The mean may be inaccurate'.format(n_max_iterations))
 
     if verbose:
-        print('n_iter: {}, final variance: {}, final dist: {}'.format(
+        logging.info('n_iter: {}, final variance: {}, final dist: {}'.format(
             last_iteration, var, sq_dist))
 
     mean = gs.to_ndarray(mean, to_ndim=2)
@@ -194,7 +195,7 @@ def _ball_gradient_descent(points, metric, weights, n_max_iterations,
         barycenter = cc_barycenter
 
     if iteration == n_max_iterations:
-        warnings.warn(
+        logging.warning(
             'Maximum number of iterations {} reached. The '
             'mean may be inaccurate'.format(n_max_iterations))
 
@@ -291,7 +292,7 @@ def _adaptive_gradient_descent(points,
             tau = tau * 0.8
 
     if iteration == n_max_iterations:
-        warnings.warn(
+        logging.warning(
             'Maximum number of iterations {} reached.'
             'The mean may be inaccurate'.format(n_max_iterations))
 

--- a/geomstats/learning/kmeans.py
+++ b/geomstats/learning/kmeans.py
@@ -1,4 +1,6 @@
 """K-means clustering."""
+
+import logging
 from random import randint
 
 from sklearn.base import BaseEstimator, ClusterMixin
@@ -105,13 +107,14 @@ class RiemannianKMeans(TransformerMixin, ClusterMixin, BaseEstimator):
 
             if gs.mean(centroids_distances) < self.tol:
                 if self.verbose > 0:
-                    print("Convergence Reached after ", index, " iterations")
+                    logging.info('Convergence Reached after {} '
+                                 'iterations'.format(index))
 
                 return gs.copy(self.centroids)
 
         if index == max_iter:
-            print('K-means maximum number of iterations {} reached.'
-                  'The mean may be inaccurate'.format(max_iter))
+            logging.info('K-means maximum number of iterations {} reached.'
+                         'The mean may be inaccurate'.format(max_iter))
 
         return gs.copy(self.centroids)
 

--- a/geomstats/learning/kmeans.py
+++ b/geomstats/learning/kmeans.py
@@ -113,8 +113,8 @@ class RiemannianKMeans(TransformerMixin, ClusterMixin, BaseEstimator):
                 return gs.copy(self.centroids)
 
         if index == max_iter:
-            logging.info('K-means maximum number of iterations {} reached.'
-                         'The mean may be inaccurate'.format(max_iter))
+            logging.warning('K-means maximum number of iterations {} reached.'
+                            'The mean may be inaccurate'.format(max_iter))
 
         return gs.copy(self.centroids)
 

--- a/geomstats/learning/online_kmeans.py
+++ b/geomstats/learning/online_kmeans.py
@@ -1,5 +1,7 @@
 """Online kmeans algorithm on Manifolds."""
 
+import logging
+
 from sklearn.base import BaseEstimator, ClusterMixin
 
 import geomstats.backend as gs
@@ -89,8 +91,9 @@ def online_kmeans(X, metric, n_clusters, n_repetitions=20,
             break
 
     if iteration == n_max_iterations - 1:
-        print('Maximum number of iterations {} reached. The'
-              'clustering may be inaccurate'.format(n_max_iterations))
+        logging.warning(
+            'Maximum number of iterations {} reached. The'
+            'clustering may be inaccurate'.format(n_max_iterations))
 
     labels = gs.zeros(n_samples)
     for i in range(n_samples):


### PR DESCRIPTION
Fixes part of issue #429 

This PR addresses the uniform handling of print / logging / warnings. Work is in progress as some warning statements still need to be changed.

**Note:**
Because nose2 introduces its own logging configuration, the logging **format** will not be displayed as implemented in `geomstats/backend/__init__py` during testing. I tried to find a way around this problem but everything I tried just introduced more issues. 
Nevertheless, the correct logging format will be displayed when running examples or other task that do not involve nose2 testing.
