### PR TITLE
Add options for code coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,18 +1,12 @@
 # Team Yaml
 coverage:
-  round: down
-  precision: 5
+  round: up
+  precision: 2
 
 # Repository Yaml
 coverage:
   round: up
-  range: 0..10
-
-# Used in Codecov after updating
-coverage:
-  round: up
-  range: 0..10
-  precision: 5
+  range: 50..100
 
 # Files to ignore
 ignore:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,20 @@
+# Team Yaml
+coverage:
+  round: down
+  precision: 5
+
+# Repository Yaml
+coverage:
+  round: up
+  range: 0..10
+
+# Used in Codecov after updating
+coverage:
+  round: up
+  range: 0..10
+  precision: 5
+
+# Files to ignore
+ignore:
+  - "examples/data"
+  - "examples/imgs"

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ env:
   - GEOMSTATS_BACKEND=tensorflow
 
 after_success:
-  - bash <(curl -s https://codecov.io/bash) -c -F $GEOMSTATS_BACKEND -y .
+  - bash <(curl -s https://codecov.io/bash) -c -F $GEOMSTATS_BACKEND
   - >
     PYTHONPATH=. sphinx-build
     -b html

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ env:
   - GEOMSTATS_BACKEND=tensorflow
 
 after_success:
-  - bash <(curl -s https://codecov.io/bash) -c -F $GEOMSTATS_BACKEND -y .codecov.yml
+  - bash <(curl -s https://codecov.io/bash) -c -F $GEOMSTATS_BACKEND -y .
   - >
     PYTHONPATH=. sphinx-build
     -b html

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ env:
   - GEOMSTATS_BACKEND=tensorflow
 
 after_success:
-  - bash <(curl --data-binary @codecov.yml -s https://codecov.io/bash) -c -F $GEOMSTATS_BACKEND
+  - bash <(curl -s https://codecov.io/bash) -c -F $GEOMSTATS_BACKEND -y .codecov.yml
   - >
     PYTHONPATH=. sphinx-build
     -b html

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ env:
   - GEOMSTATS_BACKEND=tensorflow
 
 after_success:
-  - bash <(curl -s https://codecov.io/bash) -c -F $GEOMSTATS_BACKEND
+  - bash <(curl --data-binary @codecov.yml -s https://codecov.io/bash) -c -F $GEOMSTATS_BACKEND
   - >
     PYTHONPATH=. sphinx-build
     -b html


### PR DESCRIPTION
This commit adds a .codecov.yml that allows to set options relative to
code coverage with codecov. Specifically, the option to ignore data/ and
imgs/ folder from the examples/ is added.