### PR TITLE
add grassmannian logarithm

### DIFF
--- a/geomstats/geometry/grassmannian.py
+++ b/geomstats/geometry/grassmannian.py
@@ -31,7 +31,6 @@ class Grassmannian(EmbeddedManifold):
             dimension=dimension,
             embedding_manifold=Matrices(n, n))
 
-
     def belongs(self, point, tolerance=TOLERANCE):
         """Check if the point belongs to the manifold.
 

--- a/geomstats/geometry/grassmannian.py
+++ b/geomstats/geometry/grassmannian.py
@@ -88,7 +88,7 @@ class GrassmannianCanonicalMetric(RiemannianMetric):
         return mul(expm(tangent_vec), base_point, expm(-tangent_vec))
 
     def log(self, point, base_point):
-        r"""Compute the riemannian logarithm of point w.r.t. base_point.
+        r"""Compute the Riemannian logarithm of point w.r.t. base_point.
 
         Given :math:`P, P'` in Gr(n, k) the logarithm from :math:`P`
         to :math:`P` is given by the infinitesimal rotation [Batzies2015]_:

--- a/geomstats/geometry/grassmannian.py
+++ b/geomstats/geometry/grassmannian.py
@@ -3,6 +3,7 @@
 import geomstats.backend as gs
 from geomstats.geometry.embedded_manifold import EmbeddedManifold
 from geomstats.geometry.euclidean import EuclideanMetric
+from geomstats.geometry.general_linear import GeneralLinear
 from geomstats.geometry.matrices import Matrices
 from geomstats.geometry.riemannian_metric import RiemannianMetric
 
@@ -23,11 +24,13 @@ class Grassmannian(EmbeddedManifold):
 
         self.n = n
         self.k = k
+        self.metric = GrassmannianCanonicalMetric(3, 2)
 
         dimension = int(k * (n - k))
         super(Grassmannian, self).__init__(
             dimension=dimension,
             embedding_manifold=Matrices(n, n))
+
 
     def belongs(self, point, tolerance=TOLERANCE):
         """Check if the point belongs to the manifold.
@@ -67,7 +70,7 @@ class GrassmannianCanonicalMetric(RiemannianMetric):
             signature=(dimension, 0, 0))
         self.embedding_metric = EuclideanMetric(n * p)
 
-    def exp(self, vector, point):
+    def exp(self, tangent_vec, base_point):
         """Exponentiate the invariant vector field v from base point p.
 
         Parameters
@@ -83,4 +86,39 @@ class GrassmannianCanonicalMetric(RiemannianMetric):
         """
         expm = gs.linalg.expm
         mul = Matrices.mul
-        return mul(expm(vector), point, expm(-vector))
+        return mul(expm(tangent_vec), base_point, expm(-tangent_vec))
+
+    def log(self, point, base_point):
+        r"""Compute the riemannian logarithm of point w.r.t. base_point.
+
+        Given :math:`P, P'` in Gr(n, k) the logarithm from :math:`P`
+        to :math:`P` is given by the infinitesimal rotation [Batzies2015]_:
+
+        .. math::
+
+            \omega = \frac 1 2 \log \big((2 P' - 1)(2 P - 1)\big)
+
+        Parameters
+        ----------
+        point : array-like, shape=[n_samples, n, n]
+            Point in the Grassmannian.
+        base_point : array-like, shape=[n_samples, n, n]
+            Point in the Grassmannian.
+
+        Returns
+        -------
+        tangent_vec : array-like, shape=[n_samples, n, n]
+            Tangent vector at `base_point`.
+
+        References
+        ----------
+        .. [Batzies2015] Batzies, Hüper, Machado, Leite.
+            "Geometric Mean and Geodesic Regression on Grassmannians"
+            Linear Algebra and its Applications, 466, 83-101, 2015.
+        """
+        GLn = GeneralLinear(self.n)
+        id_n = GLn.identity()
+        sym2 = 2 * point - id_n
+        sym1 = 2 * base_point - id_n
+        rot = GLn.mul(sym2, sym1)
+        return GLn.log(rot) / 2

--- a/tests/test_grassmannian.py
+++ b/tests/test_grassmannian.py
@@ -29,6 +29,7 @@ r_z = gs.array([
     [1., 0., 0.],
     [0., 0., 0.]])
 pi_2 = gs.pi / 2
+pi_4 = gs.pi / 4
 
 
 class TestGrassmannianMethods(geomstats.tests.TestCase):
@@ -52,4 +53,21 @@ class TestGrassmannianMethods(geomstats.tests.TestCase):
             pi_2 * gs.array([r_y, r_z]),
             gs.array([p_xy, p_yz]))
         expected = gs.array([p_yz, p_xz])
+        self.assertAllClose(result, expected)
+
+    @geomstats.tests.np_only
+    def test_log(self):
+        result = self.metric.log(
+            self.metric.exp(pi_4 * r_y, p_xy),
+            p_xy)
+        expected = pi_4 * r_y
+        self.assertAllClose(result, expected)
+    
+    @geomstats.tests.np_only
+    def test_log_vectorized(self):
+        tangent_vecs = pi_4 * gs.array([r_y, r_z])
+        base_points = gs.array([p_xy, p_xz])
+        points = self.metric.exp(tangent_vecs, base_points)
+        result = self.metric.log(points, base_points)
+        expected = tangent_vecs
         self.assertAllClose(result, expected)

--- a/tests/test_grassmannian.py
+++ b/tests/test_grassmannian.py
@@ -62,7 +62,7 @@ class TestGrassmannianMethods(geomstats.tests.TestCase):
             p_xy)
         expected = pi_4 * r_y
         self.assertAllClose(result, expected)
-    
+
     @geomstats.tests.np_only
     def test_log_vectorized(self):
         tangent_vecs = pi_4 * gs.array([r_y, r_z])


### PR DESCRIPTION
Given two projectors `p1` and `p2`, a rotation from `p1` to `p2` is given by the square root of their composed symmetries (see Batzies et al in docstring) 
```
U = (2. p2 - 1) . (2. p1 - 1)
```
And the log can be computed as `Gr.metric.log(p2, p1) = (1/2) logm(U)`

Tests pass on numpy but we still lack a matrix logarithm on pytorch, would it be ok to use `scipy.linalg.logm` as a workaround @ninamiolane ? (on a separate backend PR!)