### PR TITLE
Temporarily remove tests with python 3.5, 3.6 and 3.8 to speed-up PRs…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,7 @@ dist: xenial
 cache: pip
 language: python
 python:
-  - "3.5"
-  - "3.6"
   - "3.7"
-  - "3.8"
 
 install:
   - pip install --upgrade pip setuptools wheel


### PR DESCRIPTION
… during the hackathon.