### PR TITLE
Update decorator that performs automatic vectorization of functions/methods

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,0 +1,8 @@
+version = 1
+
+[[analyzers]]
+name = "python"
+enabled = true
+
+  [analyzers.meta]
+  runtime_version = "3.x.x"

--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,6 +1,0 @@
-version = 1
-
-[[analyzers]]
-name = "python"
-enabled = true
-runtime_version = "3.x.x"

--- a/0.22.1
+++ b/0.22.1
@@ -1,0 +1,3 @@
+Requirement already satisfied: scikit-learn in d:\apps\anaconda3\lib\site-packages (0.20.3)
+Requirement already satisfied: numpy>=1.8.2 in d:\apps\anaconda3\lib\site-packages (from scikit-learn) (1.16.2)
+Requirement already satisfied: scipy>=0.13.3 in d:\apps\anaconda3\lib\site-packages (from scikit-learn) (1.2.1)

--- a/0.22.1
+++ b/0.22.1
@@ -1,3 +1,0 @@
-Requirement already satisfied: scikit-learn in d:\apps\anaconda3\lib\site-packages (0.20.3)
-Requirement already satisfied: numpy>=1.8.2 in d:\apps\anaconda3\lib\site-packages (from scikit-learn) (1.16.2)
-Requirement already satisfied: scipy>=0.13.3 in d:\apps\anaconda3\lib\site-packages (from scikit-learn) (1.2.1)

--- a/1.18.1
+++ b/1.18.1
@@ -1,0 +1,1 @@
+Requirement already satisfied: numpy in d:\apps\anaconda3\lib\site-packages (1.16.2)

--- a/1.18.1
+++ b/1.18.1
@@ -1,1 +1,0 @@
-Requirement already satisfied: numpy in d:\apps\anaconda3\lib\site-packages (1.16.2)

--- a/examples/plot_bch_so3.py
+++ b/examples/plot_bch_so3.py
@@ -1,4 +1,5 @@
-"""
+"""Visualizes convergenve of the BCH formula approximation on so(n).
+
 Visualize the first, second and third order approximation of the Baker Campbell
 Hausdorf formula on so(n). To this end, sample 2 random elements a,b of so(n)
 and compute both the BCH approximations of different orders as well as

--- a/examples/plot_bch_so3.py
+++ b/examples/plot_bch_so3.py
@@ -1,4 +1,4 @@
-"""Visualizes convergenve of the BCH formula approximation on so(n).
+"""Visualize convergenve of the BCH formula approximation on so(n).
 
 Visualize the first, second and third order approximation of the Baker Campbell
 Hausdorf formula on so(n). To this end, sample 2 random elements a,b of so(n)

--- a/examples/plot_bch_so3.py
+++ b/examples/plot_bch_so3.py
@@ -32,15 +32,19 @@ ALGEBRA = SkewSymmetricMatrices(n=N)
 
 
 def main():
-    norm_rv_1 = gs.normal(size=DIM)
+    # norm_rv_1 = gs.normal(size=DIM)
+    norm_rv_1 = gs.random.normal(size=DIM)
     tan_rv_1 = ALGEBRA.matrix_representation(
-        norm_rv_1 / gs.norm(norm_rv_1, axis=0) / 2
+        # norm_rv_1 / gs.norm(norm_rv_1, axis=0) / 2
+        norm_rv_1 / gs.linalg.norm(norm_rv_1, axis=0) * 2
     )
     exp_1 = gs.linalg.expm(tan_rv_1)
 
-    norm_rv_2 = gs.normal(size=DIM)
+    # norm_rv_2 = gs.normal(size=DIM)
+    norm_rv_2 = gs.random.normal(size=DIM)
     tan_rv_2 = ALGEBRA.matrix_representation(
-        norm_rv_2 / gs.norm(norm_rv_2, axis=0) / 2
+        # norm_rv_2 / gs.norm(norm_rv_2, axis=0) / 2
+        norm_rv_2 / gs.linalg.norm(norm_rv_2, axis=0) * 2
     )
     exp_2 = gs.linalg.expm(tan_rv_2)
 
@@ -86,7 +90,7 @@ def main():
     plt.grid()
 
     plt.show()
-    plt.close()
+    # plt.close()
 
 
 if __name__ == '__main__':

--- a/examples/plot_bch_so3.py
+++ b/examples/plot_bch_so3.py
@@ -86,7 +86,6 @@ def main():
     plt.grid()
 
     plt.show()
-    # plt.close()
 
 
 if __name__ == '__main__':

--- a/examples/plot_bch_so3.py
+++ b/examples/plot_bch_so3.py
@@ -32,19 +32,15 @@ ALGEBRA = SkewSymmetricMatrices(n=N)
 
 
 def main():
-    # norm_rv_1 = gs.normal(size=DIM)
     norm_rv_1 = gs.random.normal(size=DIM)
     tan_rv_1 = ALGEBRA.matrix_representation(
-        # norm_rv_1 / gs.norm(norm_rv_1, axis=0) / 2
-        norm_rv_1 / gs.linalg.norm(norm_rv_1, axis=0) * 2
+        norm_rv_1 / gs.linalg.norm(norm_rv_1, axis=0) / 2
     )
     exp_1 = gs.linalg.expm(tan_rv_1)
 
-    # norm_rv_2 = gs.normal(size=DIM)
     norm_rv_2 = gs.random.normal(size=DIM)
     tan_rv_2 = ALGEBRA.matrix_representation(
-        # norm_rv_2 / gs.norm(norm_rv_2, axis=0) / 2
-        norm_rv_2 / gs.linalg.norm(norm_rv_2, axis=0) * 2
+        norm_rv_2 / gs.linalg.norm(norm_rv_2, axis=0) / 2
     )
     exp_2 = gs.linalg.expm(tan_rv_2)
 

--- a/examples/plot_knn_s2.py
+++ b/examples/plot_knn_s2.py
@@ -27,8 +27,8 @@ def main():
         kappa=10,
         n_samples=n_samples_per_dataset)
     training_dataset = gs.concatenate((dataset_1, dataset_2), axis=0)
-    labels_dataset_1 = gs.zeros([n_samples_per_dataset], dtype=int)
-    labels_dataset_2 = gs.ones([n_samples_per_dataset], dtype=int)
+    labels_dataset_1 = gs.zeros([n_samples_per_dataset], dtype=gs.int64)
+    labels_dataset_2 = gs.ones([n_samples_per_dataset], dtype=gs.int64)
     labels = gs.concatenate((labels_dataset_1, labels_dataset_2))
     target = sphere.random_uniform(n_samples=n_targets)
 

--- a/examples/plot_knn_s2.py
+++ b/examples/plot_knn_s2.py
@@ -32,13 +32,14 @@ def main():
     labels = gs.concatenate((labels_dataset_1, labels_dataset_2))
     target = sphere.random_uniform(n_samples=n_targets)
 
-    neigh = KNearestNeighborsClassifier(n_neighbors=2,
-                                        metric=sphere_distance)
+    neigh = KNearestNeighborsClassifier(
+        n_neighbors=2,
+        metric=sphere_distance)
     neigh.fit(training_dataset, labels)
     target_labels = neigh.predict(target)
 
     plt.figure(0)
-    ax = plt.subplot(111, projection="3d")
+    ax = plt.subplot(111, projection='3d')
     plt.title('Training set')
     sphere_plot = visualization.Sphere()
     sphere_plot.draw(ax=ax)
@@ -47,7 +48,7 @@ def main():
         sphere_plot.draw_points(ax=ax, points=points_label_i)
 
     plt.figure(1)
-    ax = plt.subplot(111, projection="3d")
+    ax = plt.subplot(111, projection='3d')
     plt.title('Classification')
     sphere_plot = visualization.Sphere()
     sphere_plot.draw(ax=ax)

--- a/examples/plot_knn_s2.py
+++ b/examples/plot_knn_s2.py
@@ -1,0 +1,68 @@
+"""Plot the result of a KNN classification on the sphere."""
+
+import logging
+import os
+
+import matplotlib.pyplot as plt
+
+import geomstats.backend as gs
+import geomstats.visualization as visualization
+from geomstats.geometry.hypersphere import Hypersphere
+from geomstats.learning.knn import KNearestNeighborsClassifier
+
+
+def main():
+    """Plot the result of a KNN classification on the sphere."""
+    sphere = Hypersphere(dimension=2)
+    sphere_distance = sphere.metric.dist
+
+    n_labels = 2
+    n_samples_per_dataset = 10
+    n_targets = 200
+
+    dataset_1 = sphere.random_von_mises_fisher(
+        kappa=10,
+        n_samples=n_samples_per_dataset)
+    dataset_2 = - sphere.random_von_mises_fisher(
+        kappa=10,
+        n_samples=n_samples_per_dataset)
+    training_dataset = gs.concatenate((dataset_1, dataset_2), axis=0)
+    labels_dataset_1 = gs.zeros([n_samples_per_dataset], dtype=int)
+    labels_dataset_2 = gs.ones([n_samples_per_dataset], dtype=int)
+    labels = gs.concatenate((labels_dataset_1, labels_dataset_2))
+    target = sphere.random_uniform(n_samples=n_targets)
+
+    neigh = KNearestNeighborsClassifier(n_neighbors=2,
+                                        metric=sphere_distance)
+    neigh.fit(training_dataset, labels)
+    target_labels = neigh.predict(target)
+
+    plt.figure(0)
+    ax = plt.subplot(111, projection="3d")
+    plt.title('Training set')
+    sphere_plot = visualization.Sphere()
+    sphere_plot.draw(ax=ax)
+    for i_label in range(n_labels):
+        points_label_i = training_dataset[labels == i_label, ...]
+        sphere_plot.draw_points(ax=ax, points=points_label_i)
+
+    plt.figure(1)
+    ax = plt.subplot(111, projection="3d")
+    plt.title('Classification')
+    sphere_plot = visualization.Sphere()
+    sphere_plot.draw(ax=ax)
+    for i_label in range(n_labels):
+        target_points_label_i = target[target_labels == i_label, ...]
+        sphere_plot.draw_points(ax=ax, points=target_points_label_i)
+
+    plt.show()
+
+
+if __name__ == "__main__":
+    if os.environ['GEOMSTATS_BACKEND'] == 'tensorflow':
+        logging.info('Examples with visualizations are only implemented '
+                     'with numpy backend.\n'
+                     'To change backend, write: '
+                     'export GEOMSTATS_BACKEND = \'numpy\'.')
+    else:
+        main()

--- a/geomstats/__init__.py
+++ b/geomstats/__init__.py
@@ -1,5 +1,6 @@
 __version__ = '1.17'
 
+import geomstats._logging
 import geomstats.geometry.discretized_curves
 import geomstats.geometry.euclidean
 import geomstats.geometry.hyperbolic

--- a/geomstats/_logging.py
+++ b/geomstats/_logging.py
@@ -1,0 +1,8 @@
+import logging
+
+
+logging.basicConfig(format='%(levelname)s: %(message)s')
+logging.getLogger().setLevel(logging.INFO)
+loggers = [logging.getLogger(name) for name in logging.root.manager.loggerDict]
+if loggers and loggers[0].name.startswith('nose2'):
+    logging.getLogger().setLevel(logging.WARNING)

--- a/geomstats/backend/__init__.py
+++ b/geomstats/backend/__init__.py
@@ -3,9 +3,6 @@ import os
 
 from numpy import pi  # NOQA
 
-logging.basicConfig(format='%(levelname)s: %(message)s')
-logging.getLogger().setLevel(logging.INFO)
-
 
 _BACKEND = os.environ.get('GEOMSTATS_BACKEND')
 if _BACKEND is None:
@@ -20,7 +17,3 @@ elif _BACKEND == 'tensorflow':
 else:
     raise RuntimeError('Unknown backend \'{:s}\''.format(_BACKEND))
 logging.info('Using {:s} backend'.format(_BACKEND))
-
-loggers = [logging.getLogger(name) for name in logging.root.manager.loggerDict]
-if loggers and loggers[0].name.startswith('nose2'):
-    logging.getLogger().setLevel(logging.WARNING)

--- a/geomstats/backend/pytorch/__init__.py
+++ b/geomstats/backend/pytorch/__init__.py
@@ -142,7 +142,8 @@ def empty_like(*args, **kwargs):
 def all(x, axis=None):
     if axis is None:
         return x.byte().all()
-    return torch.from_numpy(_np.array(_np.all(_np.array(x), axis=axis).astype(int)))
+    numpy_result = _np.array(_np.all(_np.array(x), axis=axis).astype(int))
+    return torch.from_numpy(numpy_result)
 
 
 def allclose(a, b, **kwargs):

--- a/geomstats/backend/pytorch/__init__.py
+++ b/geomstats/backend/pytorch/__init__.py
@@ -142,7 +142,7 @@ def empty_like(*args, **kwargs):
 def all(x, axis=None):
     if axis is None:
         return x.byte().all()
-    return torch.from_numpy(_np.all(_np.array(x), axis=axis).astype(int))
+    return torch.from_numpy(_np.array(_np.all(_np.array(x), axis=axis).astype(int)))
 
 
 def allclose(a, b, **kwargs):

--- a/geomstats/backend/tensorflow/linalg.py
+++ b/geomstats/backend/tensorflow/linalg.py
@@ -2,25 +2,15 @@
 
 import tensorflow as tf
 
-from .common import to_ndarray
-
-
-def sqrtm(sym_mat):
-    sym_mat = to_ndarray(sym_mat, to_ndim=3)
-
-    [eigenvalues, vectors] = tf.linalg.eigh(sym_mat)
-
-    sqrt_eigenvalues = tf.sqrt(eigenvalues)
-
-    aux = tf.einsum('ijk,ik->ijk', vectors, sqrt_eigenvalues)
-    sqrt_mat = tf.einsum('ijk,ilk->ijl', aux, vectors)
-
-    sqrt_mat = to_ndarray(sqrt_mat, to_ndim=3)
-    return sqrt_mat
-
-
-def expm(x):
-    return tf.linalg.expm(x)
+# "Forward-import" primitives. Due to the way the 'linalg' module is exported
+# in TF, this does not work with 'from tensorflow.linalg import ...'.
+det = tf.linalg.det
+eigh = tf.linalg.eigh
+eigvalsh = tf.linalg.eigvalsh
+expm = tf.linalg.expm
+inv = tf.linalg.inv
+norm = tf.linalg.norm
+sqrtm = tf.linalg.sqrtm
 
 
 def logm(x):
@@ -30,37 +20,13 @@ def logm(x):
     return logm
 
 
-def det(x):
-    return tf.linalg.det(x)
-
-
-def eigh(x):
-    return tf.linalg.eigh(x)
-
-
-def eig(x):
-    return tf.linalg.eig(x)
-
-
 def svd(x):
     s, u, v_t = tf.linalg.svd(x, full_matrices=True)
     return u, s, tf.transpose(v_t, perm=(0, 2, 1))
 
 
-def norm(x, axis=None):
-    return tf.linalg.norm(x, axis=axis)
-
-
-def inv(x):
-    return tf.linalg.inv(x)
-
-
 def matrix_rank(x):
     return tf.rank(x)
-
-
-def eigvalsh(x):
-    return tf.linalg.eigvalsh(x)
 
 
 def qr(*args, mode='reduced'):

--- a/geomstats/geometry/general_linear.py
+++ b/geomstats/geometry/general_linear.py
@@ -31,27 +31,27 @@ class GeneralLinear(Matrices):
         return gs.linalg.inv(point)
 
     @classmethod
-    def exp(cls, tangent_vec, base_point=None):
+    def exp(cls, algebra_mat, base_point=None):
         """
         Exponentiate a left-invariant vector field from a base point.
 
         Parameters
         ----------
-        tangent_vec :   array-like, shape=[..., n, n]
+        algebra_mat :   array-like, shape=[..., n, n]
         base_point :    array-like, shape=[..., n, n]
             Defaults to identity.
 
         Returns
         -------
         point :         array-like, shape=[..., n, n]
-            The left multiplication of `exp(tangent_vec)` with
+            The left multiplication of `exp(algebra_mat)` with
             `base_point`.
         """
         expm = gs.linalg.expm
         if base_point is None:
-            return expm(tangent_vec)
+            return expm(algebra_mat)
         else:
-            return cls.mul(expm(tangent_vec), base_point)
+            return cls.mul(base_point, expm(algebra_mat))
 
     @classmethod
     def log(cls, point, base_point=None):
@@ -66,14 +66,14 @@ class GeneralLinear(Matrices):
 
         Returns
         -------
-        tangent_vec :   array-like, shape=[..., n, n]
-            A matrix such that `exp(tangent_vec, base_point) = point`.
+        algebra_mat :   array-like, shape=[..., n, n]
+            A matrix such that `exp(algebra_mat, base_point) = point`.
         """
         logm = gs.linalg.logm
         if base_point is None:
             return logm(point)
         else:
-            return logm(cls.mul(point, cls.inv(base_point)))
+            return logm(cls.mul(cls.inv(base_point), point))
 
     @classmethod
     def orbit(cls, point, base_point=None):
@@ -114,9 +114,9 @@ class GeneralLinear(Matrices):
 
         Will work when expm gets properly 4-D vectorized.
         """
-        tangent_vec = cls.log(point, base_point)
+        algebra_mat = cls.log(point, base_point)
 
         def path(time):
-            vecs = gs.einsum('t,...ij->...tij', time, tangent_vec)
+            vecs = gs.einsum('t,...ij->...tij', time, algebra_mat)
             return cls.exp(vecs, base_point)
         return path

--- a/geomstats/geometry/general_linear.py
+++ b/geomstats/geometry/general_linear.py
@@ -31,13 +31,25 @@ class GeneralLinear(Matrices):
         return gs.linalg.inv(point)
 
     @classmethod
-    def exp(cls, algebra_mat, base_point=None):
-        """
+    def exp(cls, tangent_vec, base_point=None):
+        r"""
         Exponentiate a left-invariant vector field from a base point.
+
+        The vector input is not an element of the Lie algebra, but of the
+        tangent space at base_point: if :math:`g` denotes `base_point`,
+        :math:`v` the tangent vector, and :math:'V = g^{-1} v' the associated
+        Lie algebra vector, then
+
+        .. math::
+
+            \exp(v, g) = mul(g, \exp(V))
+
+        Therefore, the Lie exponential is obtained when base_point is None, or
+        the identity.
 
         Parameters
         ----------
-        algebra_mat :   array-like, shape=[..., n, n]
+        tangent_vec :   array-like, shape=[..., n, n]
         base_point :    array-like, shape=[..., n, n]
             Defaults to identity.
 
@@ -49,14 +61,18 @@ class GeneralLinear(Matrices):
         """
         expm = gs.linalg.expm
         if base_point is None:
-            return expm(algebra_mat)
+            return expm(tangent_vec)
         else:
-            return cls.mul(base_point, expm(algebra_mat))
+            lie_algebra_vec = cls.mul(cls.inv(base_point), tangent_vec)
+            return cls.mul(base_point, cls.exp(lie_algebra_vec))
 
     @classmethod
     def log(cls, point, base_point=None):
-        """
+        r"""
         Calculate a left-invariant vector field bringing base_point to point.
+
+        The output is a vector of the tangent space at base_point, so not a Lie
+        algebra element if it is not the identity.
 
         Parameters
         ----------
@@ -66,14 +82,24 @@ class GeneralLinear(Matrices):
 
         Returns
         -------
-        algebra_mat :   array-like, shape=[..., n, n]
-            A matrix such that `exp(algebra_mat, base_point) = point`.
+        tangent_vec :   array-like, shape=[..., n, n]
+            A matrix such that `exp(tangent_vec, base_point) = point`.
+
+        Notes
+        -----
+        Denoting `point` by :math:`g` and `base_point` by :math:`h`,
+        the output satisfies:
+
+        .. math::
+
+            g = \exp(\log(g, h), h)
         """
         logm = gs.linalg.logm
         if base_point is None:
             return logm(point)
         else:
-            return logm(cls.mul(cls.inv(base_point), point))
+            lie_algebra_vec = logm(cls.mul(cls.inv(base_point), point))
+            return cls.mul(base_point, lie_algebra_vec)
 
     @classmethod
     def orbit(cls, point, base_point=None):
@@ -114,9 +140,9 @@ class GeneralLinear(Matrices):
 
         # TODO(nina): Will work when expm gets properly 4-D vectorized.
         """
-        algebra_mat = cls.log(point, base_point)
+        tangent_vec = cls.log(point, base_point)
 
         def path(time):
-            vecs = gs.einsum('t,...ij->...tij', time, algebra_mat)
+            vecs = gs.einsum('t,...ij->...tij', time, tangent_vec)
             return cls.exp(vecs, base_point)
         return path

--- a/geomstats/geometry/general_linear.py
+++ b/geomstats/geometry/general_linear.py
@@ -112,7 +112,7 @@ class GeneralLinear(Matrices):
         Return a collection of trajectories (4-D array)
         from a collection of input matrices (3-D array).
 
-        Will work when expm gets properly 4-D vectorized.
+        # TODO(nina): Will work when expm gets properly 4-D vectorized.
         """
         algebra_mat = cls.log(point, base_point)
 

--- a/geomstats/geometry/invariant_metric.py
+++ b/geomstats/geometry/invariant_metric.py
@@ -28,6 +28,8 @@ class InvariantMetric(RiemannianMetric):
     def __init__(self, group,
                  inner_product_mat_at_identity=None,
                  left_or_right='left'):
+
+        self.group = group
         if inner_product_mat_at_identity is None:
             inner_product_mat_at_identity = gs.eye(self.group.dimension)
         inner_product_mat_at_identity = gs.to_ndarray(
@@ -43,10 +45,6 @@ class InvariantMetric(RiemannianMetric):
         n_neg_eigval = gs.sum(gs.cast(mask_neg_eigval, gs.int32))
         mask_null_eigval = gs.isclose(eigenvalues, 0.)
         n_null_eigval = gs.sum(gs.cast(mask_null_eigval, gs.int32))
-
-        self.group = group
-        if inner_product_mat_at_identity is None:
-            inner_product_mat_at_identity = gs.eye(self.group.dimension)
 
         self.inner_product_mat_at_identity = inner_product_mat_at_identity
         self.left_or_right = left_or_right

--- a/geomstats/geometry/spd_matrices.py
+++ b/geomstats/geometry/spd_matrices.py
@@ -111,7 +111,7 @@ class SPDMatrices(EmbeddedManifold):
 
         Parameters
         ----------
-        power : int
+        power : float
         tangent_vec : array_like, shape=[n_samples, n, n]
             Tangent vectors.
         base_point : array_like, shape=[n_samples, n, n]

--- a/geomstats/geometry/spd_matrices.py
+++ b/geomstats/geometry/spd_matrices.py
@@ -112,6 +112,7 @@ class SPDMatrices(EmbeddedManifold):
         Parameters
         ----------
         power : float
+            Power function to differentiate.
         tangent_vec : array_like, shape=[n_samples, n, n]
             Tangent vectors.
         base_point : array_like, shape=[n_samples, n, n]

--- a/geomstats/geometry/symmetric_matrices.py
+++ b/geomstats/geometry/symmetric_matrices.py
@@ -1,0 +1,20 @@
+"""The vector space of symmetric matrices."""
+
+from geomstats.geometry.embedded_manifold import EmbeddedManifold
+from geomstats.geometry.matrices import Matrices
+
+EPSILON = 1e-6
+TOLERANCE = 1e-12
+
+class SymmetricMatrices(EmbeddedManifold):
+    """Class for the vector space of symmetric matrices of size n."""
+
+    def __init__(self, n):
+        assert isinstance(n, int) and n > 0
+        super(SymmetricMatrices, self).__init__(
+            dimension=int(n * (n + 1) / 2),
+            embedding_manifold=Matrices(n, n))
+        self.n = n
+
+    def belongs(self, mat, atol=TOLERANCE):
+        return Matrices(self.n, self.n).is_symmetric(mat=mat, atol=atol)

--- a/geomstats/geometry/symmetric_matrices.py
+++ b/geomstats/geometry/symmetric_matrices.py
@@ -6,6 +6,7 @@ from geomstats.geometry.matrices import Matrices
 EPSILON = 1e-6
 TOLERANCE = 1e-12
 
+
 class SymmetricMatrices(EmbeddedManifold):
     """Class for the vector space of symmetric matrices of size n."""
 
@@ -17,4 +18,5 @@ class SymmetricMatrices(EmbeddedManifold):
         self.n = n
 
     def belongs(self, mat, atol=TOLERANCE):
+        """Check if mat belongs to the manifold of symmetric matrices."""
         return Matrices(self.n, self.n).is_symmetric(mat=mat, atol=atol)

--- a/geomstats/geometry/symmetric_matrices.py
+++ b/geomstats/geometry/symmetric_matrices.py
@@ -18,5 +18,5 @@ class SymmetricMatrices(EmbeddedManifold):
         self.n = n
 
     def belongs(self, mat, atol=TOLERANCE):
-        """Check if mat belongs to the manifold of symmetric matrices."""
+        """Check if mat belongs to the vector space of symmetric matrices."""
         return Matrices(self.n, self.n).is_symmetric(mat=mat, atol=atol)

--- a/geomstats/learning/frechet_mean.py
+++ b/geomstats/learning/frechet_mean.py
@@ -161,7 +161,7 @@ def _default_gradient_descent(points, metric, weights,
 
     if last_iteration == n_max_iterations:
         logging.warning(
-            'Maximum number of iterations {} reached.'
+            'Maximum number of iterations {} reached. '
             'The mean may be inaccurate'.format(n_max_iterations))
 
     if verbose:
@@ -294,7 +294,7 @@ def _adaptive_gradient_descent(points,
 
     if iteration == n_max_iterations:
         logging.warning(
-            'Maximum number of iterations {} reached.'
+            'Maximum number of iterations {} reached. '
             'The mean may be inaccurate'.format(n_max_iterations))
 
     return gs.to_ndarray(current_mean, to_ndim=2)

--- a/geomstats/learning/knn.py
+++ b/geomstats/learning/knn.py
@@ -2,11 +2,6 @@
 
 from sklearn.neighbors import KNeighborsClassifier
 
-from geomstats.geometry.euclidean import Euclidean
-
-EUCLIDEAN = Euclidean(dimension=1)
-EUCLIDEAN_METRIC = EUCLIDEAN.metric
-
 
 class KNearestNeighborsClassifier(KNeighborsClassifier):
     """Classifier implementing the k-nearest neighbors vote on manifolds.
@@ -25,23 +20,21 @@ class KNearestNeighborsClassifier(KNeighborsClassifier):
         - [callable] : a user-defined function which accepts an
           array of distances, and returns an array of the same shape
           containing the weights.
-    metric : callable or string, default is Euclidean metric in dimension 1.
-        The distance metric to use.
-        The 'minkowski' string metric with p=2 is equivalent to the standard
-        Euclidean metric.
-        See the documentation of the DistanceMetric class in the scikit-learn
-        library for a list of available metrics.
-        If metric is "precomputed", X is assumed to be a distance matrix and
-        must be square during fit.
-    dimension : int, optional (default = 1)
-        Dimension of the manifold used if the metric parameter is callable.
-    metric_params : dict, optional (default = None)
-        Additional keyword arguments for the metric function.
     p : integer, optional (default = 2)
         Power parameter for the 'minkowski' string metric.
         When p = 1, this is equivalent to using manhattan_distance (l1),
         and euclidean_distance (l2) for p = 2.
         For arbitrary p, minkowski_distance (l_p) is used.
+    metric : string or callable, default 'minkowski'
+        The distance metric to use.
+        The default metric is minkowski, and with p=2 is equivalent to the
+        standard Euclidean metric.
+        See the documentation of the DistanceMetric class in the scikit-learn
+        library for a list of available metrics.
+        If metric is "precomputed", X is assumed to be a distance matrix and
+        must be square during fit.
+    metric_params : dict, optional (default = None)
+        Additional keyword arguments for the metric function.
     n_jobs : int or None, optional (default=None)
         The number of parallel jobs to run for neighbors search.
         ``None`` means 1; ``-1`` means using all processors.
@@ -72,9 +65,9 @@ class KNearestNeighborsClassifier(KNeighborsClassifier):
 
     def __init__(self, n_neighbors=5,
                  weights='uniform',
-                 metric=EUCLIDEAN_METRIC,
-                 metric_params=None,
                  p=2,
+                 metric='minkowski',
+                 metric_params=None,
                  n_jobs=None,
                  **kwargs):
 
@@ -82,8 +75,8 @@ class KNearestNeighborsClassifier(KNeighborsClassifier):
             n_neighbors=n_neighbors,
             weights=weights,
             algorithm='brute',
-            metric=metric.dist,
-            metric_params=metric_params,
             p=p,
+            metric=metric,
+            metric_params=metric_params,
             n_jobs=n_jobs,
             **kwargs)

--- a/geomstats/learning/knn.py
+++ b/geomstats/learning/knn.py
@@ -1,0 +1,93 @@
+"""The KNN classifier on manifolds."""
+
+from sklearn.neighbors import KNeighborsClassifier
+
+from geomstats.geometry.euclidean import EuclideanMetric
+
+
+class KNearestNeighborsClassifier(KNeighborsClassifier):
+    """Classifier implementing the k-nearest neighbors vote on manifolds..
+
+    Parameters
+    ----------
+    n_neighbors : int, optional (default = 5)
+        Number of neighbors to use by default.
+    weights : str or callable, optional (default = 'uniform')
+        weight function used in prediction.  Possible values:
+        - 'uniform' : uniform weights.  All points in each neighborhood
+          are weighted equally.
+        - 'distance' : weight points by the inverse of their distance.
+          in this case, closer neighbors of a query point will have a
+          greater influence than neighbors which are further away.
+        - [callable] : a user-defined function which accepts an
+          array of distances, and returns an array of the same shape
+          containing the weights.
+    metric : callable or string, default EuclideanMetric
+        the distance metric to use.
+        The 'minkowski' string metric with p=2 is equivalent to the standard
+        Euclidean metric.
+        See the documentation of the DistanceMetric class in the scikit-learn
+        library for a list of available metrics.
+        If metric is "precomputed", X is assumed to be a distance matrix and
+        must be square during fit.
+    dimension : int, optional (default = 1)
+        Dimension of the manifold used if the metric parameter is callable.
+    metric_params : dict, optional (default = None)
+        Additional keyword arguments for the metric function.
+    p : integer, optional (default = 2)
+        Power parameter for the 'minkowski' string metric.
+        When p = 1, this is equivalent to using manhattan_distance (l1),
+        and euclidean_distance (l2) for p = 2.
+        For arbitrary p, minkowski_distance (l_p) is used.
+    n_jobs : int or None, optional (default=None)
+        The number of parallel jobs to run for neighbors search.
+        ``None`` means 1; ``-1`` means using all processors.
+
+    Attributes
+    ----------
+    classes_ : array of shape (n_classes,)
+        Class labels known to the classifier
+    effective_metric_ : callable or string
+        The distance metric used. It will be same as the `metric` parameter
+        or a synonym of it, e.g. 'euclidean' if the `metric` parameter set to
+        'minkowski' and `p` parameter set to 2.
+    effective_metric_params_ : dict
+        Additional keyword arguments for the metric function. For most metrics
+        will be same with `metric_params` parameter, but may also contain the
+        `p` parameter value if the `effective_metric_` attribute is set to
+        'minkowski'.
+    outputs_2d_ : bool
+        False when `y`'s shape is (n_samples, ) or (n_samples, 1) during fit
+        otherwise True.
+
+    References
+    ----------
+    This algorithm uses the scikit-learn library:
+    https://github.com/scikit-learn/scikit-learn/blob/95d4f0841/sklearn/
+    neighbors/_classification.py#L25
+    """
+
+    def __init__(self, n_neighbors=5,
+                 weights='uniform',
+                 metric=EuclideanMetric,
+                 dimension=1,
+                 metric_params=None,
+                 p=2,
+                 n_jobs=None,
+                 **kwargs):
+
+        if isinstance(metric, str):
+            distance = metric
+        else:
+            manifold_metric = metric(dimension=dimension)
+            distance = manifold_metric.dist
+
+        super().__init__(
+            n_neighbors=n_neighbors,
+            weights=weights,
+            algorithm='brute',
+            metric=distance,
+            metric_params=metric_params,
+            p=p,
+            n_jobs=n_jobs,
+            **kwargs)

--- a/geomstats/learning/knn.py
+++ b/geomstats/learning/knn.py
@@ -5,7 +5,7 @@ from sklearn.neighbors import KNeighborsClassifier
 from geomstats.geometry.euclidean import Euclidean
 
 EUCLIDEAN = Euclidean(dimension=1)
-EUCLIDEAN_DISTANCE = EUCLIDEAN.metric.dist
+EUCLIDEAN_METRIC = EUCLIDEAN.metric
 
 
 class KNearestNeighborsClassifier(KNeighborsClassifier):
@@ -25,7 +25,7 @@ class KNearestNeighborsClassifier(KNeighborsClassifier):
         - [callable] : a user-defined function which accepts an
           array of distances, and returns an array of the same shape
           containing the weights.
-    metric : callable or string, default EuclideanMetric
+    metric : callable or string, default is Euclidean metric in dimension 1.
         The distance metric to use.
         The 'minkowski' string metric with p=2 is equivalent to the standard
         Euclidean metric.
@@ -72,7 +72,7 @@ class KNearestNeighborsClassifier(KNeighborsClassifier):
 
     def __init__(self, n_neighbors=5,
                  weights='uniform',
-                 metric=EUCLIDEAN_DISTANCE,
+                 metric=EUCLIDEAN_METRIC,
                  metric_params=None,
                  p=2,
                  n_jobs=None,
@@ -82,7 +82,7 @@ class KNearestNeighborsClassifier(KNeighborsClassifier):
             n_neighbors=n_neighbors,
             weights=weights,
             algorithm='brute',
-            metric=metric,
+            metric=metric.dist,
             metric_params=metric_params,
             p=p,
             n_jobs=n_jobs,

--- a/geomstats/learning/knn.py
+++ b/geomstats/learning/knn.py
@@ -2,18 +2,21 @@
 
 from sklearn.neighbors import KNeighborsClassifier
 
-from geomstats.geometry.euclidean import EuclideanMetric
+from geomstats.geometry.euclidean import Euclidean
+
+EUCLIDEAN = Euclidean(dimension=1)
+EUCLIDEAN_DISTANCE = EUCLIDEAN.metric.dist
 
 
 class KNearestNeighborsClassifier(KNeighborsClassifier):
-    """Classifier implementing the k-nearest neighbors vote on manifolds..
+    """Classifier implementing the k-nearest neighbors vote on manifolds.
 
     Parameters
     ----------
     n_neighbors : int, optional (default = 5)
         Number of neighbors to use by default.
     weights : str or callable, optional (default = 'uniform')
-        weight function used in prediction.  Possible values:
+        Weight function used in prediction.  Possible values:
         - 'uniform' : uniform weights.  All points in each neighborhood
           are weighted equally.
         - 'distance' : weight points by the inverse of their distance.
@@ -23,7 +26,7 @@ class KNearestNeighborsClassifier(KNeighborsClassifier):
           array of distances, and returns an array of the same shape
           containing the weights.
     metric : callable or string, default EuclideanMetric
-        the distance metric to use.
+        The distance metric to use.
         The 'minkowski' string metric with p=2 is equivalent to the standard
         Euclidean metric.
         See the documentation of the DistanceMetric class in the scikit-learn
@@ -45,7 +48,7 @@ class KNearestNeighborsClassifier(KNeighborsClassifier):
 
     Attributes
     ----------
-    classes_ : array of shape (n_classes,)
+    classes_ : array, shape=[n_classes,]
         Class labels known to the classifier
     effective_metric_ : callable or string
         The distance metric used. It will be same as the `metric` parameter
@@ -69,24 +72,17 @@ class KNearestNeighborsClassifier(KNeighborsClassifier):
 
     def __init__(self, n_neighbors=5,
                  weights='uniform',
-                 metric=EuclideanMetric,
-                 dimension=1,
+                 metric=EUCLIDEAN_DISTANCE,
                  metric_params=None,
                  p=2,
                  n_jobs=None,
                  **kwargs):
 
-        if isinstance(metric, str):
-            distance = metric
-        else:
-            manifold_metric = metric(dimension=dimension)
-            distance = manifold_metric.dist
-
         super().__init__(
             n_neighbors=n_neighbors,
             weights=weights,
             algorithm='brute',
-            metric=distance,
+            metric=metric,
             metric_params=metric_params,
             p=p,
             n_jobs=n_jobs,

--- a/geomstats/learning/knn.py
+++ b/geomstats/learning/knn.py
@@ -10,8 +10,8 @@ class KNearestNeighborsClassifier(KNeighborsClassifier):
     ----------
     n_neighbors : int, optional (default = 5)
         Number of neighbors to use by default.
-    weights : str or callable, optional (default = 'uniform')
-        Weight function used in prediction.  Possible values:
+    weights : string or callable, optional (default = 'uniform')
+        Weight function used in prediction. Possible values:
         - 'uniform' : uniform weights.  All points in each neighborhood
           are weighted equally.
         - 'distance' : weight points by the inverse of their distance.
@@ -25,7 +25,7 @@ class KNearestNeighborsClassifier(KNeighborsClassifier):
         When p = 1, this is equivalent to using manhattan_distance (l1),
         and euclidean_distance (l2) for p = 2.
         For arbitrary p, minkowski_distance (l_p) is used.
-    metric : string or callable, default 'minkowski'
+    metric : string or callable, optional (default = 'minkowski')
         The distance metric to use.
         The default metric is minkowski, and with p=2 is equivalent to the
         standard Euclidean metric.
@@ -35,7 +35,7 @@ class KNearestNeighborsClassifier(KNeighborsClassifier):
         must be square during fit.
     metric_params : dict, optional (default = None)
         Additional keyword arguments for the metric function.
-    n_jobs : int or None, optional (default=None)
+    n_jobs : int or None, optional (default = None)
         The number of parallel jobs to run for neighbors search.
         ``None`` means 1; ``-1`` means using all processors.
 
@@ -43,7 +43,7 @@ class KNearestNeighborsClassifier(KNeighborsClassifier):
     ----------
     classes_ : array, shape=[n_classes,]
         Class labels known to the classifier
-    effective_metric_ : callable or string
+    effective_metric_ : string or callable
         The distance metric used. It will be same as the `metric` parameter
         or a synonym of it, e.g. 'euclidean' if the `metric` parameter set to
         'minkowski' and `p` parameter set to 2.

--- a/geomstats/tests.py
+++ b/geomstats/tests.py
@@ -64,18 +64,6 @@ def np_and_pytorch_only(test_item):
         test_item)
 
 
-class DummySession:
-    """Class for dummy sessions."""
-
-    def __enter__(self):
-        """Enter."""
-        pass
-
-    def __exit__(self, a, b, c):
-        """Exit."""
-        pass
-
-
 _TestBaseClass = unittest.TestCase
 if tf_backend():
     import tensorflow as tf
@@ -97,11 +85,6 @@ class TestCase(_TestBaseClass):
         else:
             are_same = np.all(a == np_a)
         return are_same_shape and are_same
-
-    def session(self):
-        if tf_backend():
-            return super().test_session()
-        return DummySession()
 
     def assertShapeEqual(self, a, b):
         if tf_backend():

--- a/geomstats/vectorization.py
+++ b/geomstats/vectorization.py
@@ -13,7 +13,7 @@ POINT_TYPES_TO_NDIMS = {
 
 
 def squeeze_output_dim_0(initial_ndims, point_types):
-    """Determine if the output needs to squeeze a singular dimension 0.
+    """Determine if the output needs to be squeezed on dim 0.
 
     The dimension 0 is squeezed iff all input parameters:
     - contain one sample,

--- a/geomstats/vectorization.py
+++ b/geomstats/vectorization.py
@@ -52,11 +52,11 @@ def is_scalar(vect_array):
 
 
 def squeeze_output_dim_1(result, initial_shapes, point_types):
-    """Determine if the output needs to squeeze a singular dimension 1.
+    """Determine if the output needs to be squeezed on dim 1.
 
     This happens if the user represents scalars as array of shapes:
     [n_samples,] instead of [n_samples, 1]
-    Dimension 1 is squeezed by default if the return point type is a scalar.
+    Dimension 1 is squeezed by default if point_type is 'scalar'.
     Dimension 1 is not squeezed if the user inputs at least one scalar with
     a singleton in dimension 1.
 
@@ -97,7 +97,7 @@ def decorator(point_types):
     where "fully-vectorized" means that:
     - one scalar has shape [1, 1],
     - n scalars have shape [n, 1],
-    - on d-D vector has shape [1, d],
+    - one d-D vector has shape [1, d],
     - n d-D vectors have shape [n, d],
     etc.
 

--- a/geomstats/vectorization.py
+++ b/geomstats/vectorization.py
@@ -1,5 +1,4 @@
-"""
-Decorator to handle vectorization.
+"""Decorator to handle vectorization.
 
 This abstracts the backend type.
 This assumes that functions are implemented to return vectorized outputs.
@@ -21,19 +20,35 @@ def squeeze_output_dim_0(initial_ndims, point_types):
     - have the corresponding dimension 0 squeezed,
     i.e. if all input parameters have ndim strictly less than the ndim
     corresponding to their vectorized shape.
+
+    Parameters
+    ----------
+    initial_ndims : list
+        Initial ndims of input parameters, as entered by the user.
+    point_types : list
+        Associated list of point_type of input parameters.
+
+    Returns
+    -------
+    squeeze : bool
+        Boolean deciding whether to squeeze dim 0 of the output.
     """
     for ndim, point_type in zip(initial_ndims, point_types):
-        vect_ndim = POINT_TYPES_TO_NDIMS[point_type]
-        assert ndim <= vect_ndim
-        if ndim == vect_ndim:
-            return False
+        if point_type != 'else' and ndim is not None:
+            vect_ndim = POINT_TYPES_TO_NDIMS[point_type]
+            assert ndim <= vect_ndim
+            if ndim == vect_ndim:
+                return False
     return True
 
 
 def is_scalar(vect_array):
+    """Test if an array represents a scalar."""
     has_ndim_2 = vect_array.ndim == 2
+    if not has_ndim_2:
+        return False
     has_singleton_dim_1 = vect_array.shape[1] == 1
-    return has_ndim_2 and has_singleton_dim_1
+    return has_singleton_dim_1
 
 
 def squeeze_output_dim_1(result, initial_shapes, point_types):
@@ -41,58 +56,100 @@ def squeeze_output_dim_1(result, initial_shapes, point_types):
 
     This happens if the user represents scalars as array of shapes:
     [n_samples,] instead of [n_samples, 1]
-
     Dimension 1 is squeezed by default if the return point type is a scalar.
     Dimension 1 is not squeezed if the user inputs at least one scalar with
     a singleton in dimension 1.
+
+    Parameters
+    ----------
+    result: array-like
+        Result output by the function, before reshaping.
+    initial_shapes : list
+        Initial shapes of input parameters, as entered by the user.
+    point_types : list
+        Associated list of point_type of input parameters.
+
+    Returns
+    -------
+    squeeze : bool
+        Boolean deciding whether to squeeze dim 1 of the output.
     """
     if not is_scalar(result):
         return False
 
     for shape, point_type in zip(initial_shapes, point_types):
-        ndim = len(shape)
-        if point_type == 'scalar':
-            assert ndim <= 2
-            if ndim == 2:
-                return False
+        if point_type != 'else' and shape is not None:
+            ndim = len(shape)
+            if point_type == 'scalar':
+                assert ndim <= 2
+                if ndim == 2:
+                    return False
     return True
 
 
-def decorator(param_names, point_types):
-    """Decorator vectorizing geomstats functions.
+def decorator(point_types):
+    """Vectorize geomstats functions.
+
+    This decorator assumes that its function:
+    - works with fully-vectorized inputs,
+    - returns fully-vectorized outputs,
+
+    where "fully-vectorized" means that:
+    - one scalar has shape [1, 1],
+    - n scalars have shape [n, 1],
+    - on d-D vector has shape [1, d],
+    - n d-D vectors have shape [n, d],
+    etc.
+
+    The decorator:
+    - converts the inputs into fully-vectorized inputs,
+    - calls the function,
+    - adapts the output shapes to match the users' expectations.
 
     Parameters
     ----------
-    param_names: list
-        parameters names to be vectorized
-    point_types: list
-        associated list of ndims after vectorization
+    point_types : list
+        List of inputs' point_types, including for optional inputs.
     """
     def aux_decorator(function):
         def wrapper(*args, **kwargs):
             vect_args = []
             initial_shapes = []
             initial_ndims = []
-            for param, point_type in zip(args, point_types):
-                if point_type == 'scalar':
-                    param = gs.array(param)
-                initial_shapes.append(param.shape)
-                initial_ndims.append(gs.ndim(param))
+
+            for i_arg, arg in enumerate(args):
+                # Enumerate args that have been input (not default args)
+                point_type = point_types[i_arg]
 
                 if point_type == 'scalar':
-                    vect_param = gs.to_ndarray(param, to_ndim=1)
-                    vect_param = gs.to_ndarray(vect_param, to_ndim=2, axis=1)
+                    arg = gs.array(arg)
+
+                if point_type == 'else' or arg is None:
+                    initial_shapes.append(None)
+                    initial_ndims.append(None)
                 else:
-                    vect_param = gs.to_ndarray(
-                        param, POINT_TYPES_TO_NDIMS[point_type])
-                vect_args.append(vect_param)
+                    initial_shapes.append(arg.shape)
+                    initial_ndims.append(gs.ndim(arg))
+
+                if point_type == 'else' or arg is None:
+                    vect_arg = arg
+                elif point_type == 'scalar':
+                    vect_arg = gs.to_ndarray(arg, to_ndim=1)
+                    vect_arg = gs.to_ndarray(vect_arg, to_ndim=2, axis=1)
+                elif point_type in ['vector', 'matrix']:
+                    print('hello')
+                    vect_arg = gs.to_ndarray(
+                        arg, to_ndim=POINT_TYPES_TO_NDIMS[point_type])
+                vect_args.append(vect_arg)
             result = function(*vect_args, **kwargs)
 
             if squeeze_output_dim_1(result, initial_shapes, point_types):
-                result = gs.squeeze(result, axis=1)
+                if result.shape[1] == 1:
+                    result = gs.squeeze(result, axis=1)
 
             if squeeze_output_dim_0(initial_ndims, point_types):
-                result = gs.squeeze(result, axis=0)
+                if result.shape[0] == 1:
+                    result = gs.squeeze(result, axis=0)
             return result
         return wrapper
     return aux_decorator

--- a/geomstats/vectorization.py
+++ b/geomstats/vectorization.py
@@ -110,6 +110,8 @@ def decorator(point_types):
     ----------
     point_types : list
         List of inputs' point_types, including for optional inputs.
+        The `point_type`s of optional inputs will not be read
+        by the decorator if the corresponding input is not given.
     """
     def aux_decorator(function):
         def wrapper(*args, **kwargs):
@@ -118,7 +120,6 @@ def decorator(point_types):
             initial_ndims = []
 
             for i_arg, arg in enumerate(args):
-                # Enumerate args that have been input (not default args)
                 point_type = point_types[i_arg]
 
                 if point_type == 'scalar':
@@ -137,7 +138,6 @@ def decorator(point_types):
                     vect_arg = gs.to_ndarray(arg, to_ndim=1)
                     vect_arg = gs.to_ndarray(vect_arg, to_ndim=2, axis=1)
                 elif point_type in ['vector', 'matrix']:
-                    print('hello')
                     vect_arg = gs.to_ndarray(
                         arg, to_ndim=POINT_TYPES_TO_NDIMS[point_type])
                 vect_args.append(vect_arg)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 autograd
+joblib==0.14.1
 matplotlib
 numpy>=1.18.1
 scikit-learn>=0.22.1

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -45,7 +45,7 @@ def exp_then_log_from_identity(metric, tangent_vec):
     return result
 
 
-def log_then_exp(metric, point, base_point):
+def log_then_exp(metric, point, base_point=None):
     aux = metric.log(point=point,
                      base_point=base_point)
     result = metric.exp(tangent_vec=aux,
@@ -53,7 +53,7 @@ def log_then_exp(metric, point, base_point):
     return result
 
 
-def exp_then_log(metric, tangent_vec, base_point):
+def exp_then_log(metric, tangent_vec, base_point=None):
     aux = metric.exp(tangent_vec=tangent_vec,
                      base_point=base_point)
     result = metric.log(point=aux,

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -209,24 +209,22 @@ class TestBackends(geomstats.tests.TestCase):
     @geomstats.tests.tf_only
     def test_vstack(self):
         import tensorflow as tf
-        with self.test_session():
-            tensor_1 = tf.convert_to_tensor([[1., 2., 3.], [4., 5., 6.]])
-            tensor_2 = tf.convert_to_tensor([[7., 8., 9.]])
+        tensor_1 = tf.convert_to_tensor([[1., 2., 3.], [4., 5., 6.]])
+        tensor_2 = tf.convert_to_tensor([[7., 8., 9.]])
 
-            result = gs.vstack([tensor_1, tensor_2])
-            expected = tf.convert_to_tensor([
-                [1., 2., 3.],
-                [4., 5., 6.],
-                [7., 8., 9.]])
-            self.assertAllClose(result, expected)
+        result = gs.vstack([tensor_1, tensor_2])
+        expected = tf.convert_to_tensor([
+            [1., 2., 3.],
+            [4., 5., 6.],
+            [7., 8., 9.]])
+        self.assertAllClose(result, expected)
 
     @geomstats.tests.tf_only
     def test_tensor_addition(self):
-        with self.test_session():
-            tensor_1 = gs.ones((1, 1))
-            tensor_2 = gs.ones((0, 1))
+        tensor_1 = gs.ones((1, 1))
+        tensor_2 = gs.ones((0, 1))
 
-            tensor_1 + tensor_2
+        tensor_1 + tensor_2
 
     @geomstats.tests.pytorch_only
     def test_cumsum(self):

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -25,8 +25,7 @@ class TestConnectionMethods(geomstats.tests.TestCase):
         result = self.euc_metric.inner_product_matrix(base_point)
         expected = gs.array([gs.eye(self.dimension)])
 
-        with self.session():
-            self.assertAllClose(result, expected)
+        self.assertAllClose(result, expected)
 
     def test_cometric_matrix(self):
         base_point = gs.array([0., 1., 0., 0.])
@@ -34,8 +33,7 @@ class TestConnectionMethods(geomstats.tests.TestCase):
         result = self.euc_metric.inner_product_inverse_matrix(base_point)
         expected = gs.array([gs.eye(self.dimension)])
 
-        with self.session():
-            self.assertAllClose(result, expected)
+        self.assertAllClose(result, expected)
 
     @geomstats.tests.np_only
     def test_metric_derivative(self):

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -15,6 +15,7 @@ import examples.plot_geodesics_se3 as plot_geodesics_se3
 import examples.plot_geodesics_so3 as plot_geodesics_so3
 import examples.plot_grid_h2 as plot_grid_h2
 import examples.plot_kmeans_manifolds as plot_kmeans_manifolds
+import examples.plot_knn_s2 as plot_knn_s2
 import examples.plot_online_kmeans_s1 as plot_online_kmeans_s1
 import examples.plot_online_kmeans_s2 as plot_online_kmeans_s2
 import examples.plot_pole_ladder_s2 as plot_pole_ladder_s2
@@ -102,6 +103,10 @@ class TestExamples(geomstats.tests.TestCase):
     @geomstats.tests.np_only
     def test_plot_kmeans_manifolds(self):
         plot_kmeans_manifolds.main()
+
+    @geomstats.tests.np_only
+    def test_plot_knn_s2(self):
+        plot_knn_s2.main()
 
     @geomstats.tests.np_only
     def test_plot_online_kmeans_s1(self):

--- a/tests/test_hyperbolic.py
+++ b/tests/test_hyperbolic.py
@@ -111,16 +111,14 @@ class TestHyperbolicMethods(geomstats.tests.TestCase):
         METRIC = H2.metric
 
         base_point = gs.array([1., 0., 0.])
-        with self.session():
-            self.assertTrue(gs.eval(H2.belongs(base_point)))
+        self.assertTrue(gs.eval(H2.belongs(base_point)))
 
         tangent_vec = H2.projection_to_tangent_space(
             vector=gs.array([1., 2., 1.]),
             base_point=base_point)
         exp = METRIC.exp(tangent_vec=tangent_vec,
                          base_point=base_point)
-        with self.session():
-            self.assertTrue(gs.eval(H2.belongs(exp)))
+        self.assertTrue(gs.eval(H2.belongs(exp)))
 
     @geomstats.tests.np_and_pytorch_only
     def test_exp_vectorization(self):
@@ -149,12 +147,11 @@ class TestHyperbolicMethods(geomstats.tests.TestCase):
 
         expected = gs.zeros((n_samples, dim))
 
-        with self.session():
-            for i in range(n_samples):
-                expected[i] = gs.eval(
-                    self.metric.exp(n_tangent_vecs[i], one_base_point))
-            expected = helper.to_vector(gs.array(expected))
-            self.assertAllClose(result, expected)
+        for i in range(n_samples):
+            expected[i] = gs.eval(
+                self.metric.exp(n_tangent_vecs[i], one_base_point))
+        expected = helper.to_vector(gs.array(expected))
+        self.assertAllClose(result, expected)
 
         one_tangent_vec = self.space.projection_to_tangent_space(
             one_vec, base_point=n_base_points)
@@ -162,12 +159,11 @@ class TestHyperbolicMethods(geomstats.tests.TestCase):
         self.assertAllClose(gs.shape(result), (n_samples, dim))
 
         expected = gs.zeros((n_samples, dim))
-        with self.session():
-            for i in range(n_samples):
-                expected[i] = gs.eval(self.metric.exp(one_tangent_vec[i],
-                                      n_base_points[i]))
-            expected = helper.to_vector(gs.array(expected))
-            self.assertAllClose(result, expected)
+        for i in range(n_samples):
+            expected[i] = gs.eval(self.metric.exp(one_tangent_vec[i],
+                                  n_base_points[i]))
+        expected = helper.to_vector(gs.array(expected))
+        self.assertAllClose(result, expected)
 
         n_tangent_vecs = self.space.projection_to_tangent_space(
             n_vecs, base_point=n_base_points)
@@ -175,12 +171,11 @@ class TestHyperbolicMethods(geomstats.tests.TestCase):
         self.assertAllClose(gs.shape(result), (n_samples, dim))
 
         expected = gs.zeros((n_samples, dim))
-        with self.session():
-            for i in range(n_samples):
-                expected[i] = gs.eval(self.metric.exp(n_tangent_vecs[i],
-                                      n_base_points[i]))
-            expected = helper.to_vector(gs.array(expected))
-            self.assertAllClose(result, expected)
+        for i in range(n_samples):
+            expected[i] = gs.eval(self.metric.exp(n_tangent_vecs[i],
+                                  n_base_points[i]))
+        expected = helper.to_vector(gs.array(expected))
+        self.assertAllClose(result, expected)
 
     def test_log_vectorization(self):
         n_samples = 3
@@ -231,8 +226,7 @@ class TestHyperbolicMethods(geomstats.tests.TestCase):
         expected = minkowski_space.metric.inner_product(
             tangent_vec_a, tangent_vec_b, base_point)
 
-        with self.session():
-            self.assertAllClose(result, expected)
+        self.assertAllClose(result, expected)
 
     def test_squared_norm_and_squared_dist(self):
         """
@@ -245,8 +239,7 @@ class TestHyperbolicMethods(geomstats.tests.TestCase):
         result = self.metric.squared_norm(vector=log)
         expected = self.metric.squared_dist(point_a, point_b)
 
-        with self.session():
-            self.assertAllClose(result, expected)
+        self.assertAllClose(result, expected)
 
     def test_norm_and_dist(self):
         """
@@ -259,8 +252,7 @@ class TestHyperbolicMethods(geomstats.tests.TestCase):
         result = self.metric.norm(vector=log)
         expected = self.metric.dist(point_a, point_b)
 
-        with self.session():
-            self.assertAllClose(result, expected)
+        self.assertAllClose(result, expected)
 
     def test_log_and_exp_edge_case(self):
         """
@@ -284,8 +276,7 @@ class TestHyperbolicMethods(geomstats.tests.TestCase):
         result = self.metric.exp(tangent_vec=log, base_point=base_point)
         expected = point
 
-        with self.session():
-            self.assertAllClose(result, expected)
+        self.assertAllClose(result, expected)
 
     @geomstats.tests.np_and_tf_only
     def test_exp_and_log_and_projection_to_tangent_space_general_case(self):
@@ -306,8 +297,7 @@ class TestHyperbolicMethods(geomstats.tests.TestCase):
         result = self.metric.log(point=exp, base_point=base_point)
 
         expected = vector
-        with self.session():
-            self.assertAllClose(result, expected)
+        self.assertAllClose(result, expected)
 
     def test_dist(self):
         # Distance between a point and itself is 0.
@@ -315,9 +305,7 @@ class TestHyperbolicMethods(geomstats.tests.TestCase):
         point_b = point_a
         result = self.metric.dist(point_a, point_b)
         expected = gs.array([[0]])
-
-        with self.session():
-            self.assertAllClose(result, expected)
+        self.assertAllClose(result, expected)
 
     @geomstats.tests.np_and_pytorch_only
     def test_dist_poincare(self):
@@ -333,8 +321,7 @@ class TestHyperbolicMethods(geomstats.tests.TestCase):
         result = dist_a_b
         expected = gs.array([[2.887270927429199]])
 
-        with self.session():
-            self.assertAllClose(result, expected)
+        self.assertAllClose(result, expected)
 
     def test_exp_poincare(self):
 
@@ -342,8 +329,7 @@ class TestHyperbolicMethods(geomstats.tests.TestCase):
         result = 0
         expected = 0
         self.space.metric.coords_type = 'extrinsic'
-        with self.session():
-            self.assertAllClose(result, expected)
+        self.assertAllClose(result, expected)
 
     @geomstats.tests.np_only
     def test_log_poincare(self):
@@ -356,8 +342,7 @@ class TestHyperbolicMethods(geomstats.tests.TestCase):
         expected = gs.array([[-0.01733576, 0.21958634]])
 
         self.space.metric.coords_type = 'extrinsic'
-        with self.session():
-            self.assertAllClose(result, expected)
+        self.assertAllClose(result, expected)
 
     def test_exp_and_dist_and_projection_to_tangent_space(self):
         base_point = gs.array([4.0, 1., 3.0, math.sqrt(5)])
@@ -372,8 +357,7 @@ class TestHyperbolicMethods(geomstats.tests.TestCase):
         sq_norm = self.metric.embedding_metric.squared_norm(
             tangent_vec)
         expected = sq_norm
-        with self.session():
-            self.assertAllClose(result, expected, atol=1e-2)
+        self.assertAllClose(result, expected, atol=1e-2)
 
     def test_geodesic_and_belongs(self):
         # TODO(nina): Fix this tests, as it fails when geodesic goes "too far"
@@ -394,8 +378,7 @@ class TestHyperbolicMethods(geomstats.tests.TestCase):
         result = self.space.belongs(points)
         expected = gs.array(n_geodesic_points * [[True]])
 
-        with self.session():
-            self.assertAllClose(expected, result)
+        self.assertAllClose(expected, result)
 
     def test_exp_and_log_and_projection_to_tangent_space_edge_case(self):
         """

--- a/tests/test_invariant_metric.py
+++ b/tests/test_invariant_metric.py
@@ -26,7 +26,7 @@ class TestInvariantMetricMethods(geomstats.tests.TestCase):
 
         left_diag_metric = InvariantMetric(
             group=group,
-            inner_product_mat_at_identity=diag_mat_at_identity,
+            inner_product_mat_at_identity=None,
             left_or_right='left')
         right_diag_metric = InvariantMetric(
             group=group,
@@ -72,7 +72,7 @@ class TestInvariantMetricMethods(geomstats.tests.TestCase):
     @geomstats.tests.np_and_tf_only
     def test_inner_product_matrix(self):
         base_point = self.group.identity
-        result = self.left_metric.inner_product_matrix(base_point=base_point)
+        result = self.left_metric.inner_product_matrix(base_point=None)
 
         expected = self.left_metric.inner_product_mat_at_identity
         self.assertAllClose(result, expected)
@@ -152,6 +152,12 @@ class TestInvariantMetricMethods(geomstats.tests.TestCase):
         # - exp then log
         # For left metric: point_1 and point_small
         result = helper.left_exp_then_log_from_identity(
+            metric=self.left_metric,
+            tangent_vec=self.point_1)
+        expected = self.point_1
+        self.assertAllClose(result, expected)
+
+        result = helper.exp_then_log(
             metric=self.left_metric,
             tangent_vec=self.point_1)
         expected = self.point_1

--- a/tests/test_knn.py
+++ b/tests/test_knn.py
@@ -26,7 +26,7 @@ class TestKNearestNeighborsClassifier(geomstats.tests.TestCase):
         labels = [0, 0, 1, 1]
 
         neigh = KNearestNeighborsClassifier(n_neighbors=self.n_neighbors,
-                                            metric=self.metric.dist)
+                                            metric=self.metric)
         neigh.fit(training_dataset, labels)
         result = neigh.predict([[1.1]])
         expected = gs.array([0])
@@ -38,7 +38,7 @@ class TestKNearestNeighborsClassifier(geomstats.tests.TestCase):
         training_dataset = gs.array([[0], [1], [2], [3]])
         labels = [0, 0, 1, 1]
         neigh = KNearestNeighborsClassifier(n_neighbors=self.n_neighbors,
-                                            metric=self.metric.dist)
+                                            metric=self.metric)
         neigh.fit(training_dataset, labels)
         result = neigh.predict_proba([[0.9]])
         expected = gs.array([[2 / 3, 1 / 3]])

--- a/tests/test_knn.py
+++ b/tests/test_knn.py
@@ -26,7 +26,7 @@ class TestKNearestNeighborsClassifier(geomstats.tests.TestCase):
         labels = [0, 0, 1, 1]
 
         neigh = KNearestNeighborsClassifier(n_neighbors=self.n_neighbors,
-                                            metric=self.metric)
+                                            metric=self.metric.dist)
         neigh.fit(training_dataset, labels)
         result = neigh.predict([[1.1]])
         expected = gs.array([0])
@@ -38,7 +38,7 @@ class TestKNearestNeighborsClassifier(geomstats.tests.TestCase):
         training_dataset = gs.array([[0], [1], [2], [3]])
         labels = [0, 0, 1, 1]
         neigh = KNearestNeighborsClassifier(n_neighbors=self.n_neighbors,
-                                            metric=self.metric)
+                                            metric=self.metric.dist)
         neigh.fit(training_dataset, labels)
         result = neigh.predict_proba([[0.9]])
         expected = gs.array([[2 / 3, 1 / 3]])

--- a/tests/test_knn.py
+++ b/tests/test_knn.py
@@ -17,7 +17,7 @@ class TestKNearestNeighborsClassifier(geomstats.tests.TestCase):
         self.n_neighbors = 3
         self.dimension = 2
         self.space = Euclidean(dimension=self.dimension)
-        self.metric = self.space.metric
+        self.distance = self.space.metric.dist
 
     @geomstats.tests.np_only
     def test_predict(self):
@@ -26,7 +26,7 @@ class TestKNearestNeighborsClassifier(geomstats.tests.TestCase):
         labels = [0, 0, 1, 1]
 
         neigh = KNearestNeighborsClassifier(n_neighbors=self.n_neighbors,
-                                            metric=self.metric)
+                                            metric=self.distance)
         neigh.fit(training_dataset, labels)
         result = neigh.predict([[1.1]])
         expected = gs.array([0])
@@ -38,7 +38,7 @@ class TestKNearestNeighborsClassifier(geomstats.tests.TestCase):
         training_dataset = gs.array([[0], [1], [2], [3]])
         labels = [0, 0, 1, 1]
         neigh = KNearestNeighborsClassifier(n_neighbors=self.n_neighbors,
-                                            metric=self.metric)
+                                            metric=self.distance)
         neigh.fit(training_dataset, labels)
         result = neigh.predict_proba([[0.9]])
         expected = gs.array([[2 / 3, 1 / 3]])

--- a/tests/test_knn.py
+++ b/tests/test_knn.py
@@ -1,0 +1,46 @@
+"""Unit tests for the KNN classifier."""
+
+import geomstats.backend as gs
+import geomstats.tests
+from geomstats.geometry.euclidean import EuclideanMetric
+from geomstats.learning.knn import KNearestNeighborsClassifier
+
+TOLERANCE = 1e-4
+
+
+class TestOnlineKmeansMethods(geomstats.tests.TestCase):
+    """Class defining the Poincare polydisk tests."""
+
+    def setUp(self):
+        """Define the parameters to test."""
+        gs.random.seed(1234)
+        self.n_neighbors = 3
+        self.metric = EuclideanMetric
+        self.dimension = 2
+
+    @geomstats.tests.np_only
+    def test_predict(self):
+        """Test the 'predict' class method."""
+        training_dataset = gs.array([[0], [1], [2], [3]])
+        labels = [0, 0, 1, 1]
+
+        neigh = KNearestNeighborsClassifier(n_neighbors=self.n_neighbors,
+                                            metric=self.metric,
+                                            dimension=self.dimension)
+        neigh.fit(training_dataset, labels)
+        result = neigh.predict([[1.1]])
+        expected = gs.array([0])
+        self.assertAllClose(expected, result)
+
+    @geomstats.tests.np_only
+    def test_predict_proba(self):
+        """Test the 'predict_proba' class method."""
+        training_dataset = gs.array([[0], [1], [2], [3]])
+        labels = [0, 0, 1, 1]
+        neigh = KNearestNeighborsClassifier(n_neighbors=self.n_neighbors,
+                                            metric=self.metric,
+                                            dimension=self.dimension)
+        neigh.fit(training_dataset, labels)
+        result = neigh.predict_proba([[0.9]])
+        expected = gs.array([[2 / 3, 1 / 3]])
+        self.assertAllClose(expected, result, atol=TOLERANCE)

--- a/tests/test_knn.py
+++ b/tests/test_knn.py
@@ -2,21 +2,22 @@
 
 import geomstats.backend as gs
 import geomstats.tests
-from geomstats.geometry.euclidean import EuclideanMetric
+from geomstats.geometry.euclidean import Euclidean
 from geomstats.learning.knn import KNearestNeighborsClassifier
 
 TOLERANCE = 1e-4
 
 
-class TestOnlineKmeansMethods(geomstats.tests.TestCase):
+class TestKNearestNeighborsClassifier(geomstats.tests.TestCase):
     """Class defining the Poincare polydisk tests."""
 
     def setUp(self):
         """Define the parameters to test."""
         gs.random.seed(1234)
         self.n_neighbors = 3
-        self.metric = EuclideanMetric
         self.dimension = 2
+        self.space = Euclidean(dimension=self.dimension)
+        self.metric = self.space.metric
 
     @geomstats.tests.np_only
     def test_predict(self):
@@ -25,8 +26,7 @@ class TestOnlineKmeansMethods(geomstats.tests.TestCase):
         labels = [0, 0, 1, 1]
 
         neigh = KNearestNeighborsClassifier(n_neighbors=self.n_neighbors,
-                                            metric=self.metric,
-                                            dimension=self.dimension)
+                                            metric=self.metric)
         neigh.fit(training_dataset, labels)
         result = neigh.predict([[1.1]])
         expected = gs.array([0])
@@ -38,8 +38,7 @@ class TestOnlineKmeansMethods(geomstats.tests.TestCase):
         training_dataset = gs.array([[0], [1], [2], [3]])
         labels = [0, 0, 1, 1]
         neigh = KNearestNeighborsClassifier(n_neighbors=self.n_neighbors,
-                                            metric=self.metric,
-                                            dimension=self.dimension)
+                                            metric=self.metric)
         neigh.fit(training_dataset, labels)
         result = neigh.predict_proba([[0.9]])
         expected = gs.array([[2 / 3, 1 / 3]])

--- a/tests/test_matrices.py
+++ b/tests/test_matrices.py
@@ -185,3 +185,12 @@ class TestMatricesMethods(geomstats.tests.TestCase):
         expected = gs.matmul(base_point, expected)
 
         self.assertAllClose(result, expected)
+
+    def test_belongs(self):
+        base_point = gs.array([
+            [1., 2., 3.],
+            [0., 0., 0.],
+            [3., 1., 1.]])
+        result = self.space.belongs(base_point)
+        expected = True
+        self.assertAllClose(result, expected)

--- a/tests/test_minkowski.py
+++ b/tests/test_minkowski.py
@@ -86,16 +86,15 @@ class TestMinkowskiMethods(geomstats.tests.TestCase):
         self.assertAllClose(gs.shape(result_on), (n_samples, 1))
         self.assertAllClose(gs.shape(result_nn), (n_samples, 1))
 
-        with self.session():
-            expected = np.zeros(n_samples)
-            for i in range(n_samples):
-                expected[i] = gs.eval(gs.dot(n_points_a[i],
-                                             n_points_b[i]))
-                expected[i] -= (2 * gs.eval(n_points_a[i, self.time_like_dim])
-                                * gs.eval(n_points_b[i, self.time_like_dim]))
-            expected = helper.to_scalar(gs.array(expected))
+        expected = np.zeros(n_samples)
+        for i in range(n_samples):
+            expected[i] = gs.eval(gs.dot(n_points_a[i],
+                                         n_points_b[i]))
+            expected[i] -= (2 * gs.eval(n_points_a[i, self.time_like_dim])
+                            * gs.eval(n_points_b[i, self.time_like_dim]))
+        expected = helper.to_scalar(gs.array(expected))
 
-            self.assertAllClose(result_nn, expected)
+        self.assertAllClose(result_nn, expected)
 
     def test_squared_norm(self):
         point = gs.array([-2., 4.])

--- a/tests/test_spd_matrices.py
+++ b/tests/test_spd_matrices.py
@@ -472,7 +472,7 @@ class TestSPDMatricesMethods(geomstats.tests.TestCase):
 
         self.assertAllClose(gs.shape(result), (1, 1))
 
-    @geomstats.tests.np_only
+    @geomstats.tests.np_and_tf_only
     def test_parallel_transport_affine_invariant(self):
         """Test of SPDMetricAffine.parallel_transport method with power=1."""
         n_samples = self.n_samples

--- a/tests/test_spd_matrices.py
+++ b/tests/test_spd_matrices.py
@@ -14,7 +14,10 @@ from geomstats.geometry.spd_matrices import (
 
 
 class TestSPDMatricesMethods(geomstats.tests.TestCase):
+    """Test of SPDMatrices methods."""
+
     def setUp(self):
+        """Set up the test."""
         warnings.simplefilter('ignore', category=ImportWarning)
 
         gs.random.seed(1234)
@@ -28,6 +31,7 @@ class TestSPDMatricesMethods(geomstats.tests.TestCase):
         self.n_samples = 4
 
     def test_belongs(self):
+        """Test of belongs method."""
         mats = gs.array([
             [[1., 1.], [1., 1.]],
             [[1., 2.], [2., 1.]],
@@ -37,6 +41,7 @@ class TestSPDMatricesMethods(geomstats.tests.TestCase):
         self.assertAllClose(result, expected)
 
     def test_random_uniform_and_belongs(self):
+        """Test of random_uniform and belongs methods."""
         points = self.space.random_uniform(4)
         result = self.space.belongs(points)
         expected = gs.array([True] * 4)
@@ -44,6 +49,7 @@ class TestSPDMatricesMethods(geomstats.tests.TestCase):
 
     @geomstats.tests.np_and_tf_only
     def vector_from_symmetric_matrix_and_symmetric_matrix_from_vector(self):
+        """Test for matrix to vector and vector to matrix conversions."""
         sym_mat_1 = gs.array([[1., 0.6, -3.],
                               [0.6, 7., 0.],
                               [-3., 0., 8.]])
@@ -62,6 +68,7 @@ class TestSPDMatricesMethods(geomstats.tests.TestCase):
 
     @geomstats.tests.np_and_tf_only
     def vector_and_symmetric_matrix_vectorization(self):
+        """Test of vectorization."""
         n_samples = self.n_samples
         vector = gs.random.rand(n_samples, 6)
         sym_mat = self.space.symmetric_matrix_from_vector(vector)
@@ -78,6 +85,7 @@ class TestSPDMatricesMethods(geomstats.tests.TestCase):
         self.assertTrue(gs.allclose(result, expected))
 
     def test_differential_power(self):
+        """Test of differential_power method."""
         base_point = gs.array([[1., 0., 0.],
                                [0., 2.5, 1.5],
                                [0., 1.5, 2.5]])
@@ -95,6 +103,7 @@ class TestSPDMatricesMethods(geomstats.tests.TestCase):
         self.assertAllClose(result, expected)
 
     def test_inverse_differential_power(self):
+        """Test of inverse_differential_power method."""
         base_point = gs.array([[1., 0., 0.],
                                [0., 2.5, 1.5],
                                [0., 1.5, 2.5]])
@@ -113,6 +122,7 @@ class TestSPDMatricesMethods(geomstats.tests.TestCase):
 
     @geomstats.tests.np_only
     def test_differential_log(self):
+        """Test of differential_log method."""
         base_point = gs.array([[1., 0., 0.],
                                [0., 1., 0.],
                                [0., 0., 4.]])
@@ -128,6 +138,7 @@ class TestSPDMatricesMethods(geomstats.tests.TestCase):
 
     @geomstats.tests.np_only
     def test_inverse_differential_log(self):
+        """Test of inverse_differential_log method."""
         base_point = gs.array([[1., 0., 0.],
                                [0., 1., 0.],
                                [0., 0., 4.]])
@@ -143,6 +154,7 @@ class TestSPDMatricesMethods(geomstats.tests.TestCase):
 
     @geomstats.tests.np_only
     def test_differential_exp(self):
+        """Test of differential_exp method."""
         base_point = gs.array([[1., 0., 0.],
                                [0., 1., 0.],
                                [0., 0., -1.]])
@@ -159,6 +171,7 @@ class TestSPDMatricesMethods(geomstats.tests.TestCase):
 
     @geomstats.tests.np_only
     def test_inverse_differential_exp(self):
+        """Test of inverse_differential_exp method."""
         base_point = gs.array([[1., 0., 0.],
                                [0., 1., 0.],
                                [0., 0., -1.]])
@@ -175,6 +188,7 @@ class TestSPDMatricesMethods(geomstats.tests.TestCase):
 
     @geomstats.tests.np_only
     def test_procrustes_inner_product(self):
+        """Test of SPDMetricProcrustes.inner_product method."""
         base_point = gs.array([[1., 0., 0.],
                                [0., 1.5, .5],
                                [0., .5, 1.5]])
@@ -192,6 +206,7 @@ class TestSPDMatricesMethods(geomstats.tests.TestCase):
 
     @geomstats.tests.np_only
     def test_power_affine_inner_product(self):
+        """Test of SPDMetricAffine.inner_product method."""
         base_point = gs.array([[1., 0., 0.],
                                [0., 2.5, 1.5],
                                [0., 1.5, 2.5]])
@@ -206,6 +221,7 @@ class TestSPDMatricesMethods(geomstats.tests.TestCase):
 
     @geomstats.tests.np_only
     def test_power_euclidean_inner_product(self):
+        """Test of SPDMetricEuclidean.inner_product method."""
         base_point = gs.array([[1., 0., 0.],
                                [0., 2.5, 1.5],
                                [0., 1.5, 2.5]])
@@ -220,6 +236,7 @@ class TestSPDMatricesMethods(geomstats.tests.TestCase):
 
     @geomstats.tests.np_only
     def test_euclidean_exp_domain(self):
+        """Test of SPDMetricEuclidean.exp_domain method."""
         base_point = gs.array([[1., 0., 0.],
                                [0., 2., 0.],
                                [0., 0., 3.]])
@@ -234,6 +251,7 @@ class TestSPDMatricesMethods(geomstats.tests.TestCase):
 
     @geomstats.tests.np_only
     def test_log_euclidean_inner_product(self):
+        """Test of SPDMetricLogEuclidean.inner_product method."""
         base_point = gs.array([[1., 0., 0.],
                                [0., 1., 0.],
                                [0., 0., 4.]])
@@ -249,6 +267,7 @@ class TestSPDMatricesMethods(geomstats.tests.TestCase):
 
     @geomstats.tests.np_and_tf_only
     def test_log_and_exp_affine_invariant(self):
+        """Test of SPDMetricAffine.log and exp methods with power=1."""
         base_point = gs.array([[5., 0., 0.],
                                [0., 7., 2.],
                                [0., 2., 8.]])
@@ -265,6 +284,7 @@ class TestSPDMatricesMethods(geomstats.tests.TestCase):
 
     @geomstats.tests.np_only
     def test_log_and_exp_power_affine(self):
+        """Test of SPDMetricAffine.log and exp methods with power!=1."""
         base_point = gs.array([[5., 0., 0.],
                                [0., 7., 2.],
                                [0., 2., 8.]])
@@ -279,6 +299,7 @@ class TestSPDMatricesMethods(geomstats.tests.TestCase):
 
     @geomstats.tests.np_only
     def test_log_and_exp_logeuclidean(self):
+        """Test of SPDMetricLogEuclidean.log and exp methods."""
         base_point = gs.array([[5., 0., 0.],
                                [0., 7., 2.],
                                [0., 2., 8.]])
@@ -295,6 +316,7 @@ class TestSPDMatricesMethods(geomstats.tests.TestCase):
 
     @geomstats.tests.np_and_tf_only
     def test_exp_and_belongs(self):
+        """Test of SPDMetricAffine.exp with power=1 and belongs methods."""
         n_samples = self.n_samples
         base_point = self.space.random_uniform(n_samples=1)
         tangent_vec = self.space.random_tangent_vec_uniform(
@@ -308,6 +330,7 @@ class TestSPDMatricesMethods(geomstats.tests.TestCase):
 
     @geomstats.tests.np_and_tf_only
     def test_exp_vectorization(self):
+        """Test of SPDMetricAffine.exp with power=1 and vectorization."""
         n_samples = self.n_samples
         one_base_point = self.space.random_uniform(n_samples=1)
         n_base_point = self.space.random_uniform(n_samples=n_samples)
@@ -332,6 +355,7 @@ class TestSPDMatricesMethods(geomstats.tests.TestCase):
 
     @geomstats.tests.np_and_tf_only
     def test_log_vectorization(self):
+        """Test of SPDMetricAffine.log with power 1 and vectorization."""
         n_samples = self.n_samples
         one_base_point = self.space.random_uniform(n_samples=1)
         n_base_point = self.space.random_uniform(n_samples=n_samples)
@@ -360,6 +384,7 @@ class TestSPDMatricesMethods(geomstats.tests.TestCase):
 
     @geomstats.tests.np_and_tf_only
     def test_geodesic_and_belongs(self):
+        """Test of SPDMetricAffine.geodesic with power 1 and belongs."""
         initial_point = self.space.random_uniform()
         initial_tangent_vec = self.space.random_tangent_vec_uniform(
             n_samples=1, base_point=initial_point)
@@ -378,6 +403,7 @@ class TestSPDMatricesMethods(geomstats.tests.TestCase):
 
     @geomstats.tests.np_only
     def test_squared_dist_is_symmetric(self):
+        """Test of SPDMetricAffine.squared_dist (power=1) and is_symmetric."""
         n_samples = self.n_samples
 
         point_1 = self.space.random_uniform(n_samples=1)
@@ -415,6 +441,7 @@ class TestSPDMatricesMethods(geomstats.tests.TestCase):
 
     @geomstats.tests.np_and_tf_only
     def test_squared_dist_vectorization(self):
+        """Test of SPDMetricAffine.squared_dist (power=1) and vectorization."""
         n_samples = self.n_samples
         point_1 = self.space.random_uniform(n_samples=n_samples)
         point_2 = self.space.random_uniform(n_samples=n_samples)
@@ -447,6 +474,7 @@ class TestSPDMatricesMethods(geomstats.tests.TestCase):
 
     @geomstats.tests.np_only
     def test_parallel_transport_affine_invariant(self):
+        """Test of SPDMetricAffine.parallel_transport method with power=1."""
         n_samples = self.n_samples
         gs.random.seed(1)
         point = self.space.random_uniform(n_samples)

--- a/tests/test_special_orthogonal.py
+++ b/tests/test_special_orthogonal.py
@@ -2559,10 +2559,9 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
             expected = group.regularize(point)
             inv_expected = - expected
 
-            with self.session():
-                self.assertTrue(
-                    gs.eval(gs.allclose(result, expected))
-                    or gs.eval(gs.allclose(result, inv_expected)))
+            self.assertTrue(
+                gs.eval(gs.allclose(result, expected))
+                or gs.eval(gs.allclose(result, inv_expected)))
 
     def test_quaternion_and_rotation_vector_vectorization(self):
         n = 3
@@ -3407,10 +3406,9 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
             expected = group.regularize(tangent_vec)
             inv_expected = - expected
 
-            with self.session():
-                self.assertTrue(
-                    gs.eval(gs.allclose(result, expected))
-                    or gs.eval(gs.allclose(result, inv_expected)))
+            self.assertTrue(
+                gs.eval(gs.allclose(result, expected))
+                or gs.eval(gs.allclose(result, inv_expected)))
 
     def test_group_log_then_exp_from_identity(self):
         """
@@ -3447,10 +3445,9 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
             expected = group.regularize(point)
             inv_expected = - expected
 
-            with self.session():
-                self.assertTrue(
-                    gs.eval(gs.allclose(result, expected))
-                    or gs.eval(gs.allclose(result, inv_expected)))
+            self.assertTrue(
+                gs.eval(gs.allclose(result, expected))
+                or gs.eval(gs.allclose(result, inv_expected)))
 
     @geomstats.tests.np_only
     def test_group_exp_then_log(self):

--- a/tests/test_symmetric_matrices.py
+++ b/tests/test_symmetric_matrices.py
@@ -1,0 +1,29 @@
+"""Unit tests for the vector space of symmetric matrices."""
+
+import warnings
+
+import geomstats.backend as gs
+import geomstats.tests
+from geomstats.geometry.symmetric_matrices import SymmetricMatrices
+
+
+
+class TestSymmetricMatricesMethods(geomstats.tests.TestCase):
+    def setUp(self):
+        warnings.simplefilter('ignore', category=ImportWarning)
+
+        gs.random.seed(1234)
+
+        self.n = 3
+
+    def test_belongs(self):
+        Sym_n = SymmetricMatrices(self.n)
+        mat_sym = gs.array([[1., 2., 3.],
+                            [2., 4., 5.],
+                            [3., 5., 6.]])
+        mat_not_sym = gs.array([[1., 0., 3.],
+                                [2., 4., 5.],
+                                [3., 5., 6.]])
+        result = Sym_n.belongs(mat_sym) and not Sym_n.belongs(mat_not_sym)
+        expected = True
+        self.assertAllClose(result, expected)

--- a/tests/test_symmetric_matrices.py
+++ b/tests/test_symmetric_matrices.py
@@ -7,9 +7,11 @@ import geomstats.tests
 from geomstats.geometry.symmetric_matrices import SymmetricMatrices
 
 
-
 class TestSymmetricMatricesMethods(geomstats.tests.TestCase):
+    """Test of SymmetricMatrices methods."""
+
     def setUp(self):
+        """Set up the test."""
         warnings.simplefilter('ignore', category=ImportWarning)
 
         gs.random.seed(1234)
@@ -17,6 +19,7 @@ class TestSymmetricMatricesMethods(geomstats.tests.TestCase):
         self.n = 3
 
     def test_belongs(self):
+        """Test of belongs method."""
         Sym_n = SymmetricMatrices(self.n)
         mat_sym = gs.array([[1., 2., 3.],
                             [2., 4., 5.],

--- a/tests/test_symmetric_matrices.py
+++ b/tests/test_symmetric_matrices.py
@@ -20,13 +20,13 @@ class TestSymmetricMatricesMethods(geomstats.tests.TestCase):
 
     def test_belongs(self):
         """Test of belongs method."""
-        Sym_n = SymmetricMatrices(self.n)
+        sym_n = SymmetricMatrices(self.n)
         mat_sym = gs.array([[1., 2., 3.],
                             [2., 4., 5.],
                             [3., 5., 6.]])
         mat_not_sym = gs.array([[1., 0., 3.],
                                 [2., 4., 5.],
                                 [3., 5., 6.]])
-        result = Sym_n.belongs(mat_sym) and not Sym_n.belongs(mat_not_sym)
+        result = sym_n.belongs(mat_sym) and not sym_n.belongs(mat_not_sym)
         expected = True
         self.assertAllClose(result, expected)

--- a/tests/test_vectorization.py
+++ b/tests/test_vectorization.py
@@ -10,27 +10,21 @@ import geomstats.vectorization
 
 class TestVectorizationMethods(geomstats.tests.TestCase):
     def setUp(self):
-        @geomstats.vectorization.decorator(
-            ['tangent_vec_a', 'tangent_vec_b'],
-            ['vector', 'vector'])
+        @geomstats.vectorization.decorator(['vector', 'vector'])
         def foo(tangent_vec_a, tangent_vec_b):
             result = gs.einsum(
                 'ni,ni->ni', tangent_vec_a, tangent_vec_b)
             result = helper.to_vector(result)
             return result
 
-        @geomstats.vectorization.decorator(
-            ['tangent_vec_a', 'tangent_vec_b'],
-            ['vector', 'vector'])
+        @geomstats.vectorization.decorator(['vector', 'vector'])
         def foo_scalar_output(tangent_vec_a, tangent_vec_b):
             result = gs.einsum(
                 'ni,ni->n', tangent_vec_a, tangent_vec_b)
             result = helper.to_scalar(result)
             return result
 
-        @geomstats.vectorization.decorator(
-            ['tangent_vec_a', 'tangent_vec_b', 'in_scalar'],
-            ['vector', 'vector', 'scalar'])
+        @geomstats.vectorization.decorator(['vector', 'vector', 'scalar'])
         def foo_scalar_input_output(tangent_vec_a, tangent_vec_b, in_scalar):
             aux = gs.einsum(
                 'ni,ni->n', tangent_vec_a, tangent_vec_b)
@@ -38,9 +32,29 @@ class TestVectorizationMethods(geomstats.tests.TestCase):
             result = helper.to_scalar(result)
             return result
 
+        @geomstats.vectorization.decorator(['vector', 'vector', 'scalar'])
+        def foo_optional_input(tangent_vec_a, tangent_vec_b, in_scalar=None):
+            if in_scalar is None:
+                in_scalar = gs.array([[1.]])
+            aux = gs.einsum(
+                'ni,ni->n', tangent_vec_a, tangent_vec_b)
+            result = gs.einsum('n,nk->n', aux, in_scalar)
+            result = helper.to_scalar(result)
+            return result
+
+        @geomstats.vectorization.decorator(
+            ['else', 'vector', 'else', 'vector', 'scalar'])
+        def foo_else(else_a, tangent_vec_a, else_b, tangent_vec_b):
+            result = (else_a + else_b) * gs.einsum(
+                'ni,ni->n', tangent_vec_a, tangent_vec_b)
+            result = helper.to_scalar(result)
+            return result
+
         self.foo = foo
         self.foo_scalar_output = foo_scalar_output
         self.foo_scalar_input_output = foo_scalar_input_output
+        self.foo_optional_input = foo_optional_input
+        self.foo_else = foo_else
 
     def test_decorator_with_squeeze_dim0(self):
         vec_a = gs.array([1, 2, 3])
@@ -93,4 +107,22 @@ class TestVectorizationMethods(geomstats.tests.TestCase):
         expected = gs.array([2, 2])
 
         self.assertAllClose(result.shape, expected.shape)
+        self.assertAllClose(result, expected)
+
+    def test_decorator_optional_input(self):
+        vec_a = gs.array([1, 2, 3])
+        vec_b = gs.array([0, 1, 0])
+        result = self.foo_optional_input(vec_a, vec_b)
+        expected = 2
+
+        self.assertAllClose(result, expected)
+
+    def test_decorator_else(self):
+        vec_a = gs.array([1, 2, 3])
+        vec_b = gs.array([0, 1, 0])
+        else_a = 1
+        else_b = 1
+        result = self.foo_else(else_a, vec_a, else_b, vec_b)
+        expected = 4
+
         self.assertAllClose(result, expected)

--- a/tests/test_vectorization.py
+++ b/tests/test_vectorization.py
@@ -35,7 +35,7 @@ class TestVectorizationMethods(geomstats.tests.TestCase):
         @geomstats.vectorization.decorator(['vector', 'vector', 'scalar'])
         def foo_optional_input(tangent_vec_a, tangent_vec_b, in_scalar=None):
             if in_scalar is None:
-                in_scalar = gs.array([[1.]])
+                in_scalar = gs.array([[1]])
             aux = gs.einsum(
                 'ni,ni->n', tangent_vec_a, tangent_vec_b)
             result = gs.einsum('n,nk->n', aux, in_scalar)


### PR DESCRIPTION
This is the first of a series of PRs to tackle issue #338.

The vectorization decorator allows to tackle cases where vectorized functions have led to ambiguities, for example not being able to distinguish between:
- n input vectors of dimension n,
- one matrix of shape n x n.

This PR:
- simplifies the signature of the decorator, removing the `param_names` parameter,
- allows the decorator to work on methods,
    - by adding the flag `'else'` that refers to a method's input that is not expected to vectorized/not-vectorized: for example `self`,
- allows the decorator to work on methods with optional parameters,
with the corresponding unit tests.

This PR also updates docstrings in the vectorization.py file.