### PR TITLE
Add joblib version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 autograd
+joblib==0.14.1
 matplotlib
 numpy>=1.18.1
 scikit-learn>=0.22.1


### PR DESCRIPTION
This fixes a potential bug.

With a former version of joblib, nose2 tests would fail on product_manifold.py at:
`pool = joblib.Parallel(n_jobs=self.n_jobs, prefer='threads')` with the error:

`TypeError: __init__() got an unexpected keyword argument 'prefer'`