### PR TITLE
Adapt einsum functions in tf and pytorch backends

### DIFF
--- a/geomstats/backend/pytorch/__init__.py
+++ b/geomstats/backend/pytorch/__init__.py
@@ -295,9 +295,9 @@ def einsum(*args, **kwargs):
     input_str_list = input_str.split(',')
 
     is_ellipsis = [input_str[:3] == '...' for input_str in input_str_list]
-    at_least_one_ellipsis = bool(_np.sum(is_ellipsis))
+    all_ellipsis = bool(_np.prod(is_ellipsis))
 
-    if at_least_one_ellipsis:
+    if all_ellipsis:
         if len(input_str_list) > 2:
             raise NotImplementedError(
                 'Ellipsis support not implemented for >2 input tensors')

--- a/geomstats/backend/pytorch/__init__.py
+++ b/geomstats/backend/pytorch/__init__.py
@@ -309,17 +309,17 @@ def einsum(*args, **kwargs):
         if n_tensor_a != n_tensor_b:
             if n_tensor_a == 1:
                 tensor_a = squeeze(tensor_a, axis=0)
-                input_prefix_list = ['', 'n']
-                output_prefix = 'n'
+                input_prefix_list = ['', 'r']
+                output_prefix = 'r'
             elif n_tensor_b == 1:
                 tensor_b = squeeze(tensor_b, axis=0)
-                input_prefix_list = ['n', '']
-                output_prefix = 'n'
+                input_prefix_list = ['r', '']
+                output_prefix = 'r'
             else:
                 raise ValueError('Shape mismatch for einsum.')
         else:
-            input_prefix_list = ['n', 'n']
-            output_prefix = 'n'
+            input_prefix_list = ['r', 'r']
+            output_prefix = 'r'
 
         input_str_list = [
             input_str.replace('...', prefix) for input_str, prefix in zip(

--- a/geomstats/backend/tensorflow/__init__.py
+++ b/geomstats/backend/tensorflow/__init__.py
@@ -1,5 +1,6 @@
 """Tensorflow based computation backend."""
 
+import numpy as _np
 import tensorflow as tf
 
 from .common import array, ndim, to_ndarray  # NOQA
@@ -241,6 +242,52 @@ def sum(*args, **kwargs):
 
 
 def einsum(equation, *inputs, **kwargs):
+    einsum_str = equation
+    input_tensors_list = inputs
+
+    einsum_list = einsum_str.split('->')
+    input_str = einsum_list[0]
+    output_str = einsum_list[1]
+
+    input_str_list = input_str.split(',')
+
+    is_ellipsis = [input_str[:3] == '...' for input_str in input_str_list]
+    at_least_one_ellipsis = bool(_np.sum(is_ellipsis))
+
+    if at_least_one_ellipsis:
+        if len(input_str_list) > 2:
+            raise NotImplementedError(
+                'Ellipsis support not implemented for >2 input tensors')
+        tensor_a = input_tensors_list[0]
+        tensor_b = input_tensors_list[1]
+        n_tensor_a = tensor_a.shape[0]
+        n_tensor_b = tensor_b.shape[0]
+
+        if n_tensor_a != n_tensor_b:
+            if n_tensor_a == 1:
+                tensor_a = squeeze(tensor_a, axis=0)
+                input_prefix_list = ['', 'n']
+                output_prefix = 'n'
+            elif n_tensor_b == 1:
+                tensor_b = squeeze(tensor_b, axis=0)
+                input_prefix_list = ['n', '']
+                output_prefix = 'n'
+            else:
+                raise ValueError('Shape mismatch for einsum.')
+        else:
+            input_prefix_list = ['n', 'n']
+            output_prefix = 'n'
+
+        input_str_list = [
+            input_str.replace('...', prefix) for input_str, prefix in zip(
+                input_str_list, input_prefix_list)]
+        output_str = output_str.replace('...', output_prefix)
+
+        input_str = input_str_list[0] + ',' + input_str_list[1]
+        einsum_str = input_str + '->' + output_str
+
+        return tf.einsum(einsum_str, tensor_a, tensor_b, **kwargs)
+
     return tf.einsum(equation, *inputs, **kwargs)
 
 

--- a/geomstats/backend/tensorflow/__init__.py
+++ b/geomstats/backend/tensorflow/__init__.py
@@ -266,17 +266,17 @@ def einsum(equation, *inputs, **kwargs):
         if n_tensor_a != n_tensor_b:
             if n_tensor_a == 1:
                 tensor_a = squeeze(tensor_a, axis=0)
-                input_prefix_list = ['', 'n']
-                output_prefix = 'n'
+                input_prefix_list = ['', 'r']
+                output_prefix = 'r'
             elif n_tensor_b == 1:
                 tensor_b = squeeze(tensor_b, axis=0)
-                input_prefix_list = ['n', '']
-                output_prefix = 'n'
+                input_prefix_list = ['r', '']
+                output_prefix = 'r'
             else:
                 raise ValueError('Shape mismatch for einsum.')
         else:
-            input_prefix_list = ['n', 'n']
-            output_prefix = 'n'
+            input_prefix_list = ['r', 'r']
+            output_prefix = 'r'
 
         input_str_list = [
             input_str.replace('...', prefix) for input_str, prefix in zip(

--- a/geomstats/backend/tensorflow/__init__.py
+++ b/geomstats/backend/tensorflow/__init__.py
@@ -252,9 +252,9 @@ def einsum(equation, *inputs, **kwargs):
     input_str_list = input_str.split(',')
 
     is_ellipsis = [input_str[:3] == '...' for input_str in input_str_list]
-    at_least_one_ellipsis = bool(_np.sum(is_ellipsis))
+    all_ellipsis = bool(_np.prod(is_ellipsis))
 
-    if at_least_one_ellipsis:
+    if all_ellipsis:
         if len(input_str_list) > 2:
             raise NotImplementedError(
                 'Ellipsis support not implemented for >2 input tensors')

--- a/geomstats/geometry/hyperbolic.py
+++ b/geomstats/geometry/hyperbolic.py
@@ -267,7 +267,7 @@ class Hyperbolic(EmbeddedManifold):
                                                          vector)
 
         coef = inner_prod / sq_norm
-        tangent_vec = vector - gs.einsum('ni,nj->nj', coef, base_point)
+        tangent_vec = vector - gs.einsum('...i,...j->...j', coef, base_point)
         return tangent_vec
 
     @staticmethod
@@ -668,8 +668,8 @@ class HyperbolicMetric(RiemannianMetric):
                 (gs.sinh(norm_tangent_vec) / (norm_tangent_vec)))
 
             exp = (
-                gs.einsum('ni,nj->nj', coef_1, base_point)
-                + gs.einsum('ni,nj->nj', coef_2, tangent_vec))
+                gs.einsum('...i,...j->...j', coef_1, base_point)
+                + gs.einsum('...i,...j->...j', coef_2, tangent_vec))
 
             hyperbolic_space = Hyperbolic(dimension=self.dimension)
             exp = hyperbolic_space.regularize(exp)
@@ -761,8 +761,8 @@ class HyperbolicMetric(RiemannianMetric):
             coef_1 += mask_else_float * (angle / gs.sinh(angle))
             coef_2 += mask_else_float * (angle / gs.tanh(angle))
 
-            log = (gs.einsum('ni,nj->nj', coef_1, point) -
-                   gs.einsum('ni,nj->nj', coef_2, base_point))
+            log = (gs.einsum('...i,...j->...j', coef_1, point) -
+                   gs.einsum('...i,...j->...j', coef_2, base_point))
             return log
 
         elif self.coords_type == 'ball':

--- a/geomstats/geometry/hypersphere.py
+++ b/geomstats/geometry/hypersphere.py
@@ -150,7 +150,7 @@ class Hypersphere(EmbeddedManifold):
         sq_norm = self.embedding_metric.squared_norm(base_point)
         inner_prod = self.embedding_metric.inner_product(base_point, vector)
         coef = inner_prod / sq_norm
-        tangent_vec = vector - gs.einsum('ni,nj->nj', coef, base_point)
+        tangent_vec = vector - gs.einsum('...i,...j->...j', coef, base_point)
 
         return tangent_vec
 
@@ -527,8 +527,8 @@ class HypersphereMetric(RiemannianMetric):
         coef_1 += mask_else_float * angle / gs.sin(angle)
         coef_2 += mask_else_float * angle / gs.tan(angle)
 
-        log = (gs.einsum('ni,nj->nj', coef_1, point)
-               - gs.einsum('ni,nj->nj', coef_2, base_point))
+        log = (gs.einsum('...i,...j->...j', coef_1, point)
+               - gs.einsum('...i,...j->...j', coef_2, base_point))
 
         mask_same_values = gs.isclose(point, base_point)
 

--- a/geomstats/geometry/special_orthogonal.py
+++ b/geomstats/geometry/special_orthogonal.py
@@ -390,7 +390,7 @@ class SpecialOrthogonal(LieGroup, EmbeddedManifold):
         if self.n == 2:  # SO(2)
             id_skew = gs.array([[[0., 1.], [-1., 0.]]] * n_vecs)
             skew_mat = gs.einsum(
-                'nij,ni->nij', gs.cast(id_skew, gs.float32), vec)
+                '...ij,...i->...ij', gs.cast(id_skew, gs.float32), vec)
 
         elif self.n == 3:  # SO(3)
             # This avois dividing by 0.

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -239,30 +239,30 @@ class TestBackends(geomstats.tests.TestCase):
         self.assertAllClose(result, expected)
 
     def test_einsum(self):
-        np_array_1 = _np.array([[1, 1]])
-        np_array_2 = _np.array([[1, 1]])
-        array_1 = gs.array([[1, 1]])
-        array_2 = gs.array([[1, 1]])
+        np_array_1 = _np.array([[1, 4]])
+        np_array_2 = _np.array([[2, 3]])
+        array_1 = gs.array([[1, 4]])
+        array_2 = gs.array([[2, 3]])
 
         np_result = _np.einsum('...i,...i->...', np_array_1, np_array_2)
         gs_result = gs.einsum('...i,...i->...', array_1, array_2)
 
         self.assertAllCloseToNp(gs_result, np_result)
 
-        np_array_1 = _np.array([[1, 1], [1, 1]])
-        np_array_2 = _np.array([[1, 1]])
-        array_1 = gs.array([[1, 1], [1, 1]])
-        array_2 = gs.array([[1, 1]])
+        np_array_1 = _np.array([[1, 4], [-1, 5]])
+        np_array_2 = _np.array([[2, 3]])
+        array_1 = gs.array([[1, 4], [-1, 5]])
+        array_2 = gs.array([[2, 3]])
 
         np_result = _np.einsum('...i,...i->...', np_array_1, np_array_2)
         gs_result = gs.einsum('...i,...i->...', array_1, array_2)
 
         self.assertAllCloseToNp(gs_result, np_result)
 
-        np_array_1 = _np.array([[1, 1]])
-        np_array_2 = _np.array([[1, 1], [1, 1]])
-        array_1 = gs.array([[1, 1]])
-        array_2 = gs.array([[1, 1], [1, 1]])
+        np_array_1 = _np.array([[1, 4]])
+        np_array_2 = _np.array([[2, 3], [5, 6]])
+        array_1 = gs.array([[1, 4]])
+        array_2 = gs.array([[2, 3], [5, 6]])
 
         np_result = _np.einsum('...i,...i->...', np_array_1, np_array_2)
         gs_result = gs.einsum('...i,...i->...', array_1, array_2)

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -7,7 +7,7 @@ In exceptional cases, numpy's results or API may not be followed.
 
 import warnings
 
-import numpy as np
+import numpy as _np
 import scipy.linalg
 
 import geomstats.backend as gs
@@ -31,11 +31,11 @@ class TestBackends(geomstats.tests.TestCase):
                  [0., 0., 1.]]
         gs_mat_a = gs.array(mat_a)
         gs_mat_b = gs.array(mat_b)
-        np_mat_a = np.array(mat_a)
-        np_mat_b = np.array(mat_b)
+        np_mat_a = _np.array(mat_a)
+        np_mat_b = _np.array(mat_b)
 
         gs_result = gs.matmul(gs_mat_a, gs_mat_b)
-        np_result = np.matmul(np_mat_a, np_mat_b)
+        np_result = _np.matmul(np_mat_a, np_mat_b)
 
         self.assertAllCloseToNp(gs_result, np_result)
 
@@ -53,12 +53,12 @@ class TestBackends(geomstats.tests.TestCase):
         gs_mat_a = gs.array(mat_a)
         gs_mat_b = gs.array(mat_b)
         gs_mat_c = gs.array(mat_c)
-        np_mat_a = np.array(mat_a)
-        np_mat_b = np.array(mat_b)
-        np_mat_c = np.array(mat_c)
+        np_mat_a = _np.array(mat_a)
+        np_mat_b = _np.array(mat_b)
+        np_mat_c = _np.array(mat_c)
 
         gs_result = gs.matmul(gs_mat_a, [gs_mat_b, gs_mat_c])
-        np_result = np.matmul(np_mat_a, [np_mat_b, np_mat_c])
+        np_result = _np.matmul(np_mat_a, [np_mat_b, np_mat_c])
 
         self.assertAllCloseToNp(gs_result, np_result)
 
@@ -73,7 +73,7 @@ class TestBackends(geomstats.tests.TestCase):
                              [0., 0., 1.38629436]])
         self.assertAllClose(result, expected)
 
-        np_point = np.array(
+        np_point = _np.array(
             [[2., 0., 0.],
              [0., 3., 0.],
              [0., 0., 4.]])
@@ -89,7 +89,7 @@ class TestBackends(geomstats.tests.TestCase):
         expected = point
         self.assertAllClose(result, expected)
 
-        np_point = np.array(
+        np_point = _np.array(
             [[2., 0., 0.],
              [0., 3., 0.],
              [0., 0., 4.]])
@@ -237,3 +237,34 @@ class TestBackends(geomstats.tests.TestCase):
         result = gs.cumsum(gs.arange(10).reshape(2, 5), axis=1)
         expected = gs.array(([[0, 1, 3, 6, 10], [5, 11, 18, 26, 35]]))
         self.assertAllClose(result, expected)
+
+    def test_einsum(self):
+        np_array_1 = _np.array([[1, 1]])
+        np_array_2 = _np.array([[1, 1]])
+        array_1 = gs.array([[1, 1]])
+        array_2 = gs.array([[1, 1]])
+
+        np_result = _np.einsum('...i,...i->...', np_array_1, np_array_2)
+        gs_result = gs.einsum('...i,...i->...', array_1, array_2)
+
+        self.assertAllCloseToNp(gs_result, np_result)
+
+        np_array_1 = _np.array([[1, 1], [1, 1]])
+        np_array_2 = _np.array([[1, 1]])
+        array_1 = gs.array([[1, 1], [1, 1]])
+        array_2 = gs.array([[1, 1]])
+
+        np_result = _np.einsum('...i,...i->...', np_array_1, np_array_2)
+        gs_result = gs.einsum('...i,...i->...', array_1, array_2)
+
+        self.assertAllCloseToNp(gs_result, np_result)
+
+        np_array_1 = _np.array([[1, 1]])
+        np_array_2 = _np.array([[1, 1], [1, 1]])
+        array_1 = gs.array([[1, 1]])
+        array_2 = gs.array([[1, 1], [1, 1]])
+
+        np_result = _np.einsum('...i,...i->...', np_array_1, np_array_2)
+        gs_result = gs.einsum('...i,...i->...', array_1, array_2)
+
+        self.assertAllCloseToNp(gs_result, np_result)

--- a/tests/test_product_manifold.py
+++ b/tests/test_product_manifold.py
@@ -82,7 +82,7 @@ class TestProductManifoldMethods(geomstats.tests.TestCase):
         base_point = self.space_matrix.random_uniform(n_samples)
         logs = self.space_matrix.metric.log(point, base_point)
         logs = gs.einsum(
-            '..., ...j->...j',
+            '...k, ...jl->...jl',
             1. / self.space_matrix.metric.norm(logs, base_point),
             logs)
         point = self.space_matrix.metric.exp(logs, base_point)

--- a/tests/test_special_orthogonal.py
+++ b/tests/test_special_orthogonal.py
@@ -202,6 +202,7 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
 
         self.assertAllClose(result, expected)
 
+    @geomstats.tests.np_and_tf_only
     def test_skew_matrix_from_vector_vectorization(self):
         point_type = 'vector'
         n_samples = self.n_samples

--- a/tests/test_vectorization.py
+++ b/tests/test_vectorization.py
@@ -42,6 +42,7 @@ class TestVectorizationMethods(geomstats.tests.TestCase):
         self.foo_scalar_output = foo_scalar_output
         self.foo_scalar_input_output = foo_scalar_input_output
 
+    @geomstats.tests.np_and_tf_only
     def test_decorator_with_squeeze_dim0(self):
         vec_a = gs.array([1, 2, 3])
         vec_b = gs.array([0, 1, 0])
@@ -51,6 +52,7 @@ class TestVectorizationMethods(geomstats.tests.TestCase):
         self.assertAllClose(result.shape, expected.shape)
         self.assertAllClose(result, expected)
 
+    @geomstats.tests.np_and_tf_only
     def test_decorator_without_squeeze_dim0(self):
         vec_a = gs.array([[1, 2, 3]])
         vec_b = gs.array([0, 1, 0])
@@ -60,6 +62,7 @@ class TestVectorizationMethods(geomstats.tests.TestCase):
         self.assertAllClose(result.shape, expected.shape)
         self.assertAllClose(result, expected)
 
+    @geomstats.tests.np_and_tf_only
     def test_decorator_vectorization(self):
         vec_a = gs.array([[1, 2, 3], [1, 2, 3]])
         vec_b = gs.array([0, 1, 0])
@@ -69,6 +72,7 @@ class TestVectorizationMethods(geomstats.tests.TestCase):
         self.assertAllClose(result.shape, expected.shape)
         self.assertAllClose(result, expected)
 
+    @geomstats.tests.np_and_tf_only
     def test_decorator_scalar_with_squeeze_dim1(self):
         vec_a = gs.array([1, 2, 3])
         vec_b = gs.array([0, 1, 0])
@@ -77,6 +81,7 @@ class TestVectorizationMethods(geomstats.tests.TestCase):
 
         self.assertAllClose(result, expected)
 
+    @geomstats.tests.np_and_tf_only
     def test_decorator_scalar_without_squeeze_dim1(self):
         vec_a = gs.array([1, 2, 3])
         vec_b = gs.array([0, 1, 0])
@@ -86,6 +91,7 @@ class TestVectorizationMethods(geomstats.tests.TestCase):
 
         self.assertAllClose(result, expected)
 
+    @geomstats.tests.np_and_tf_only
     def test_decorator_scalar_output_vectorization(self):
         vec_a = gs.array([[1, 2, 3], [1, 2, 3]])
         vec_b = gs.array([0, 1, 0])


### PR DESCRIPTION
This PR adapts the einsum function is tf and pytorch backends:
- Pytorch was using numpy's einsum function the cover, now pytorch's einsum is used. This has led to a few modifications in the code and the unit tests.
- Tf's and pytorch's einsum are less flexible on ellipsis than numpy. For example, einsum('...i,...i->...', a, b) with a of shape [1, d] and b of shape [n, d] does not work with tf and pytorch. This PR adapts the einsum's code in both tf and pytorch backends to address this.

The unit tests are added correspondingly.