### PR TITLE
Remove tensorflow sessions

### DIFF
--- a/geomstats/tests.py
+++ b/geomstats/tests.py
@@ -64,18 +64,6 @@ def np_and_pytorch_only(test_item):
         test_item)
 
 
-class DummySession:
-    """Class for dummy sessions."""
-
-    def __enter__(self):
-        """Enter."""
-        pass
-
-    def __exit__(self, a, b, c):
-        """Exit."""
-        pass
-
-
 _TestBaseClass = unittest.TestCase
 if tf_backend():
     import tensorflow as tf
@@ -97,11 +85,6 @@ class TestCase(_TestBaseClass):
         else:
             are_same = np.all(a == np_a)
         return are_same_shape and are_same
-
-    def session(self):
-        if tf_backend():
-            return super().test_session()
-        return DummySession()
 
     def assertShapeEqual(self, a, b):
         if tf_backend():

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -209,24 +209,22 @@ class TestBackends(geomstats.tests.TestCase):
     @geomstats.tests.tf_only
     def test_vstack(self):
         import tensorflow as tf
-        with self.test_session():
-            tensor_1 = tf.convert_to_tensor([[1., 2., 3.], [4., 5., 6.]])
-            tensor_2 = tf.convert_to_tensor([[7., 8., 9.]])
+        tensor_1 = tf.convert_to_tensor([[1., 2., 3.], [4., 5., 6.]])
+        tensor_2 = tf.convert_to_tensor([[7., 8., 9.]])
 
-            result = gs.vstack([tensor_1, tensor_2])
-            expected = tf.convert_to_tensor([
-                [1., 2., 3.],
-                [4., 5., 6.],
-                [7., 8., 9.]])
-            self.assertAllClose(result, expected)
+        result = gs.vstack([tensor_1, tensor_2])
+        expected = tf.convert_to_tensor([
+            [1., 2., 3.],
+            [4., 5., 6.],
+            [7., 8., 9.]])
+        self.assertAllClose(result, expected)
 
     @geomstats.tests.tf_only
     def test_tensor_addition(self):
-        with self.test_session():
-            tensor_1 = gs.ones((1, 1))
-            tensor_2 = gs.ones((0, 1))
+        tensor_1 = gs.ones((1, 1))
+        tensor_2 = gs.ones((0, 1))
 
-            tensor_1 + tensor_2
+        tensor_1 + tensor_2
 
     @geomstats.tests.pytorch_only
     def test_cumsum(self):

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -25,8 +25,7 @@ class TestConnectionMethods(geomstats.tests.TestCase):
         result = self.euc_metric.inner_product_matrix(base_point)
         expected = gs.array([gs.eye(self.dimension)])
 
-        with self.session():
-            self.assertAllClose(result, expected)
+        self.assertAllClose(result, expected)
 
     def test_cometric_matrix(self):
         base_point = gs.array([0., 1., 0., 0.])
@@ -34,8 +33,7 @@ class TestConnectionMethods(geomstats.tests.TestCase):
         result = self.euc_metric.inner_product_inverse_matrix(base_point)
         expected = gs.array([gs.eye(self.dimension)])
 
-        with self.session():
-            self.assertAllClose(result, expected)
+        self.assertAllClose(result, expected)
 
     @geomstats.tests.np_only
     def test_metric_derivative(self):

--- a/tests/test_hyperbolic.py
+++ b/tests/test_hyperbolic.py
@@ -111,16 +111,14 @@ class TestHyperbolicMethods(geomstats.tests.TestCase):
         METRIC = H2.metric
 
         base_point = gs.array([1., 0., 0.])
-        with self.session():
-            self.assertTrue(gs.eval(H2.belongs(base_point)))
+        self.assertTrue(gs.eval(H2.belongs(base_point)))
 
         tangent_vec = H2.projection_to_tangent_space(
             vector=gs.array([1., 2., 1.]),
             base_point=base_point)
         exp = METRIC.exp(tangent_vec=tangent_vec,
                          base_point=base_point)
-        with self.session():
-            self.assertTrue(gs.eval(H2.belongs(exp)))
+        self.assertTrue(gs.eval(H2.belongs(exp)))
 
     @geomstats.tests.np_and_pytorch_only
     def test_exp_vectorization(self):
@@ -149,12 +147,11 @@ class TestHyperbolicMethods(geomstats.tests.TestCase):
 
         expected = gs.zeros((n_samples, dim))
 
-        with self.session():
-            for i in range(n_samples):
-                expected[i] = gs.eval(
-                    self.metric.exp(n_tangent_vecs[i], one_base_point))
-            expected = helper.to_vector(gs.array(expected))
-            self.assertAllClose(result, expected)
+        for i in range(n_samples):
+            expected[i] = gs.eval(
+                self.metric.exp(n_tangent_vecs[i], one_base_point))
+        expected = helper.to_vector(gs.array(expected))
+        self.assertAllClose(result, expected)
 
         one_tangent_vec = self.space.projection_to_tangent_space(
             one_vec, base_point=n_base_points)
@@ -162,12 +159,11 @@ class TestHyperbolicMethods(geomstats.tests.TestCase):
         self.assertAllClose(gs.shape(result), (n_samples, dim))
 
         expected = gs.zeros((n_samples, dim))
-        with self.session():
-            for i in range(n_samples):
-                expected[i] = gs.eval(self.metric.exp(one_tangent_vec[i],
-                                      n_base_points[i]))
-            expected = helper.to_vector(gs.array(expected))
-            self.assertAllClose(result, expected)
+        for i in range(n_samples):
+            expected[i] = gs.eval(self.metric.exp(one_tangent_vec[i],
+                                  n_base_points[i]))
+        expected = helper.to_vector(gs.array(expected))
+        self.assertAllClose(result, expected)
 
         n_tangent_vecs = self.space.projection_to_tangent_space(
             n_vecs, base_point=n_base_points)
@@ -175,12 +171,11 @@ class TestHyperbolicMethods(geomstats.tests.TestCase):
         self.assertAllClose(gs.shape(result), (n_samples, dim))
 
         expected = gs.zeros((n_samples, dim))
-        with self.session():
-            for i in range(n_samples):
-                expected[i] = gs.eval(self.metric.exp(n_tangent_vecs[i],
-                                      n_base_points[i]))
-            expected = helper.to_vector(gs.array(expected))
-            self.assertAllClose(result, expected)
+        for i in range(n_samples):
+            expected[i] = gs.eval(self.metric.exp(n_tangent_vecs[i],
+                                  n_base_points[i]))
+        expected = helper.to_vector(gs.array(expected))
+        self.assertAllClose(result, expected)
 
     def test_log_vectorization(self):
         n_samples = 3
@@ -231,8 +226,7 @@ class TestHyperbolicMethods(geomstats.tests.TestCase):
         expected = minkowski_space.metric.inner_product(
             tangent_vec_a, tangent_vec_b, base_point)
 
-        with self.session():
-            self.assertAllClose(result, expected)
+        self.assertAllClose(result, expected)
 
     def test_squared_norm_and_squared_dist(self):
         """
@@ -245,8 +239,7 @@ class TestHyperbolicMethods(geomstats.tests.TestCase):
         result = self.metric.squared_norm(vector=log)
         expected = self.metric.squared_dist(point_a, point_b)
 
-        with self.session():
-            self.assertAllClose(result, expected)
+        self.assertAllClose(result, expected)
 
     def test_norm_and_dist(self):
         """
@@ -259,8 +252,7 @@ class TestHyperbolicMethods(geomstats.tests.TestCase):
         result = self.metric.norm(vector=log)
         expected = self.metric.dist(point_a, point_b)
 
-        with self.session():
-            self.assertAllClose(result, expected)
+        self.assertAllClose(result, expected)
 
     def test_log_and_exp_edge_case(self):
         """
@@ -284,8 +276,7 @@ class TestHyperbolicMethods(geomstats.tests.TestCase):
         result = self.metric.exp(tangent_vec=log, base_point=base_point)
         expected = point
 
-        with self.session():
-            self.assertAllClose(result, expected)
+        self.assertAllClose(result, expected)
 
     @geomstats.tests.np_and_tf_only
     def test_exp_and_log_and_projection_to_tangent_space_general_case(self):
@@ -306,8 +297,7 @@ class TestHyperbolicMethods(geomstats.tests.TestCase):
         result = self.metric.log(point=exp, base_point=base_point)
 
         expected = vector
-        with self.session():
-            self.assertAllClose(result, expected)
+        self.assertAllClose(result, expected)
 
     def test_dist(self):
         # Distance between a point and itself is 0.
@@ -315,9 +305,7 @@ class TestHyperbolicMethods(geomstats.tests.TestCase):
         point_b = point_a
         result = self.metric.dist(point_a, point_b)
         expected = gs.array([[0]])
-
-        with self.session():
-            self.assertAllClose(result, expected)
+        self.assertAllClose(result, expected)
 
     @geomstats.tests.np_and_pytorch_only
     def test_dist_poincare(self):
@@ -333,8 +321,7 @@ class TestHyperbolicMethods(geomstats.tests.TestCase):
         result = dist_a_b
         expected = gs.array([[2.887270927429199]])
 
-        with self.session():
-            self.assertAllClose(result, expected)
+        self.assertAllClose(result, expected)
 
     def test_exp_poincare(self):
 
@@ -342,8 +329,7 @@ class TestHyperbolicMethods(geomstats.tests.TestCase):
         result = 0
         expected = 0
         self.space.metric.coords_type = 'extrinsic'
-        with self.session():
-            self.assertAllClose(result, expected)
+        self.assertAllClose(result, expected)
 
     @geomstats.tests.np_only
     def test_log_poincare(self):
@@ -356,8 +342,7 @@ class TestHyperbolicMethods(geomstats.tests.TestCase):
         expected = gs.array([[-0.01733576, 0.21958634]])
 
         self.space.metric.coords_type = 'extrinsic'
-        with self.session():
-            self.assertAllClose(result, expected)
+        self.assertAllClose(result, expected)
 
     def test_exp_and_dist_and_projection_to_tangent_space(self):
         base_point = gs.array([4.0, 1., 3.0, math.sqrt(5)])
@@ -372,8 +357,7 @@ class TestHyperbolicMethods(geomstats.tests.TestCase):
         sq_norm = self.metric.embedding_metric.squared_norm(
             tangent_vec)
         expected = sq_norm
-        with self.session():
-            self.assertAllClose(result, expected, atol=1e-2)
+        self.assertAllClose(result, expected, atol=1e-2)
 
     def test_geodesic_and_belongs(self):
         # TODO(nina): Fix this tests, as it fails when geodesic goes "too far"
@@ -394,8 +378,7 @@ class TestHyperbolicMethods(geomstats.tests.TestCase):
         result = self.space.belongs(points)
         expected = gs.array(n_geodesic_points * [[True]])
 
-        with self.session():
-            self.assertAllClose(expected, result)
+        self.assertAllClose(expected, result)
 
     def test_exp_and_log_and_projection_to_tangent_space_edge_case(self):
         """

--- a/tests/test_minkowski.py
+++ b/tests/test_minkowski.py
@@ -86,16 +86,15 @@ class TestMinkowskiMethods(geomstats.tests.TestCase):
         self.assertAllClose(gs.shape(result_on), (n_samples, 1))
         self.assertAllClose(gs.shape(result_nn), (n_samples, 1))
 
-        with self.session():
-            expected = np.zeros(n_samples)
-            for i in range(n_samples):
-                expected[i] = gs.eval(gs.dot(n_points_a[i],
-                                             n_points_b[i]))
-                expected[i] -= (2 * gs.eval(n_points_a[i, self.time_like_dim])
-                                * gs.eval(n_points_b[i, self.time_like_dim]))
-            expected = helper.to_scalar(gs.array(expected))
+        expected = np.zeros(n_samples)
+        for i in range(n_samples):
+            expected[i] = gs.eval(gs.dot(n_points_a[i],
+                                         n_points_b[i]))
+            expected[i] -= (2 * gs.eval(n_points_a[i, self.time_like_dim])
+                            * gs.eval(n_points_b[i, self.time_like_dim]))
+        expected = helper.to_scalar(gs.array(expected))
 
-            self.assertAllClose(result_nn, expected)
+        self.assertAllClose(result_nn, expected)
 
     def test_squared_norm(self):
         point = gs.array([-2., 4.])

--- a/tests/test_special_orthogonal.py
+++ b/tests/test_special_orthogonal.py
@@ -2559,10 +2559,9 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
             expected = group.regularize(point)
             inv_expected = - expected
 
-            with self.session():
-                self.assertTrue(
-                    gs.eval(gs.allclose(result, expected))
-                    or gs.eval(gs.allclose(result, inv_expected)))
+            self.assertTrue(
+                gs.eval(gs.allclose(result, expected))
+                or gs.eval(gs.allclose(result, inv_expected)))
 
     def test_quaternion_and_rotation_vector_vectorization(self):
         n = 3
@@ -3407,10 +3406,9 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
             expected = group.regularize(tangent_vec)
             inv_expected = - expected
 
-            with self.session():
-                self.assertTrue(
-                    gs.eval(gs.allclose(result, expected))
-                    or gs.eval(gs.allclose(result, inv_expected)))
+            self.assertTrue(
+                gs.eval(gs.allclose(result, expected))
+                or gs.eval(gs.allclose(result, inv_expected)))
 
     def test_group_log_then_exp_from_identity(self):
         """
@@ -3447,10 +3445,9 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
             expected = group.regularize(point)
             inv_expected = - expected
 
-            with self.session():
-                self.assertTrue(
-                    gs.eval(gs.allclose(result, expected))
-                    or gs.eval(gs.allclose(result, inv_expected)))
+            self.assertTrue(
+                gs.eval(gs.allclose(result, expected))
+                or gs.eval(gs.allclose(result, inv_expected)))
 
     @geomstats.tests.np_only
     def test_group_exp_then_log(self):


### PR DESCRIPTION
With the move to TF2, we no longer need to run TF tests inside sessions since TF2 uses eager execution by default.