### PR TITLE
Don't configure logging module in backend

### DIFF
--- a/geomstats/__init__.py
+++ b/geomstats/__init__.py
@@ -1,5 +1,6 @@
 __version__ = '1.17'
 
+import geomstats._logging
 import geomstats.geometry.discretized_curves
 import geomstats.geometry.euclidean
 import geomstats.geometry.hyperbolic

--- a/geomstats/_logging.py
+++ b/geomstats/_logging.py
@@ -1,0 +1,8 @@
+import logging
+
+
+logging.basicConfig(format='%(levelname)s: %(message)s')
+logging.getLogger().setLevel(logging.INFO)
+loggers = [logging.getLogger(name) for name in logging.root.manager.loggerDict]
+if loggers and loggers[0].name.startswith('nose2'):
+    logging.getLogger().setLevel(logging.WARNING)

--- a/geomstats/backend/__init__.py
+++ b/geomstats/backend/__init__.py
@@ -3,9 +3,6 @@ import os
 
 from numpy import pi  # NOQA
 
-logging.basicConfig(format='%(levelname)s: %(message)s')
-logging.getLogger().setLevel(logging.INFO)
-
 
 _BACKEND = os.environ.get('GEOMSTATS_BACKEND')
 if _BACKEND is None:
@@ -20,7 +17,3 @@ elif _BACKEND == 'tensorflow':
 else:
     raise RuntimeError('Unknown backend \'{:s}\''.format(_BACKEND))
 logging.info('Using {:s} backend'.format(_BACKEND))
-
-loggers = [logging.getLogger(name) for name in logging.root.manager.loggerDict]
-if loggers and loggers[0].name.startswith('nose2'):
-    logging.getLogger().setLevel(logging.WARNING)

--- a/geomstats/learning/frechet_mean.py
+++ b/geomstats/learning/frechet_mean.py
@@ -161,7 +161,7 @@ def _default_gradient_descent(points, metric, weights,
 
     if last_iteration == n_max_iterations:
         logging.warning(
-            'Maximum number of iterations {} reached.'
+            'Maximum number of iterations {} reached. '
             'The mean may be inaccurate'.format(n_max_iterations))
 
     if verbose:
@@ -294,7 +294,7 @@ def _adaptive_gradient_descent(points,
 
     if iteration == n_max_iterations:
         logging.warning(
-            'Maximum number of iterations {} reached.'
+            'Maximum number of iterations {} reached. '
             'The mean may be inaccurate'.format(n_max_iterations))
 
     return gs.to_ndarray(current_mean, to_ndim=2)


### PR DESCRIPTION
This moves the `logging` module configuration to its own module in the toplevel `geomstats` package.