### PR TITLE
Improve unit testing of invariant metric

### DIFF
--- a/geomstats/geometry/invariant_metric.py
+++ b/geomstats/geometry/invariant_metric.py
@@ -47,7 +47,6 @@ class InvariantMetric(RiemannianMetric):
         mask_null_eigval = gs.isclose(eigenvalues, 0.)
         n_null_eigval = gs.sum(gs.cast(mask_null_eigval, gs.int32))
 
-
         self.inner_product_mat_at_identity = inner_product_mat_at_identity
         self.left_or_right = left_or_right
         self.signature = (n_pos_eigval, n_null_eigval, n_neg_eigval)

--- a/geomstats/geometry/invariant_metric.py
+++ b/geomstats/geometry/invariant_metric.py
@@ -28,6 +28,9 @@ class InvariantMetric(RiemannianMetric):
     def __init__(self, group,
                  inner_product_mat_at_identity=None,
                  left_or_right='left'):
+
+        self.group = group
+
         if inner_product_mat_at_identity is None:
             inner_product_mat_at_identity = gs.eye(self.group.dimension)
         inner_product_mat_at_identity = gs.to_ndarray(
@@ -44,9 +47,6 @@ class InvariantMetric(RiemannianMetric):
         mask_null_eigval = gs.isclose(eigenvalues, 0.)
         n_null_eigval = gs.sum(gs.cast(mask_null_eigval, gs.int32))
 
-        self.group = group
-        if inner_product_mat_at_identity is None:
-            inner_product_mat_at_identity = gs.eye(self.group.dimension)
 
         self.inner_product_mat_at_identity = inner_product_mat_at_identity
         self.left_or_right = left_or_right

--- a/geomstats/geometry/lie_algebra.py
+++ b/geomstats/geometry/lie_algebra.py
@@ -21,7 +21,7 @@ class MatrixLieAlgebra:
         dimension: int
             The dimension of the Lie algebra as a real vector space
         n: int
-            The amount of rows and columns in the matrx representation of the
+            The amount of rows and columns in the matrix representation of the
             Lie algebra
         """
         self.dimension = dimension

--- a/geomstats/geometry/matrices.py
+++ b/geomstats/geometry/matrices.py
@@ -113,6 +113,22 @@ class Matrices(Euclidean):
         return cls.equal(mat, cls.transpose(mat), atol)
 
     @classmethod
+    def is_skew_symmetric(cls, mat, atol=TOLERANCE):
+        """
+        Check if a matrix is skew symmetric.
+
+        Parameters
+        ----------
+        mat : array-like, shape=[n_samples, n, n]
+        atol : float, absolute tolerance. defaults to TOLERANCE
+
+        Returns
+        -------
+        is_skew_sym : array-like boolean, shape=[n_samples]
+        """
+        return cls.equal(mat, - cls.transpose(mat), atol)
+
+    @classmethod
     def make_symmetric(cls, mat):
         """
         Make a matrix symmetric, by averaging with its transpose.

--- a/geomstats/geometry/skew_symmetric_matrices.py
+++ b/geomstats/geometry/skew_symmetric_matrices.py
@@ -6,6 +6,10 @@ of the matrices (and a -1 in its lower triangular part).
 """
 import geomstats.backend as gs
 from geomstats.geometry.lie_algebra import MatrixLieAlgebra
+from geomstats.geometry.matrices import Matrices
+
+
+TOLERANCE = 1e-12
 
 
 class SkewSymmetricMatrices(MatrixLieAlgebra):
@@ -30,6 +34,10 @@ class SkewSymmetricMatrices(MatrixLieAlgebra):
                 self.basis[loop_index, row, col] = 1
                 self.basis[loop_index, col, row] = -1
                 loop_index += 1
+
+    def belongs(self, mat, atol=TOLERANCE):
+        """Check if mat belongs to the vector space of symmetric matrices."""
+        return Matrices(self.n, self.n).is_skew_symmetric(mat=mat, atol=atol)
 
     def basis_representation(self, matrix_representation):
         """Calculate the coefficients of given matrix in the basis.

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -45,7 +45,7 @@ def exp_then_log_from_identity(metric, tangent_vec):
     return result
 
 
-def log_then_exp(metric, point, base_point):
+def log_then_exp(metric, point, base_point=None):
     aux = metric.log(point=point,
                      base_point=base_point)
     result = metric.exp(tangent_vec=aux,
@@ -53,7 +53,7 @@ def log_then_exp(metric, point, base_point):
     return result
 
 
-def exp_then_log(metric, tangent_vec, base_point):
+def exp_then_log(metric, tangent_vec, base_point=None):
     aux = metric.exp(tangent_vec=tangent_vec,
                      base_point=base_point)
     result = metric.log(point=aux,

--- a/tests/test_invariant_metric.py
+++ b/tests/test_invariant_metric.py
@@ -26,7 +26,7 @@ class TestInvariantMetricMethods(geomstats.tests.TestCase):
 
         left_diag_metric = InvariantMetric(
             group=group,
-            inner_product_mat_at_identity=diag_mat_at_identity,
+            inner_product_mat_at_identity=None,
             left_or_right='left')
         right_diag_metric = InvariantMetric(
             group=group,
@@ -72,7 +72,7 @@ class TestInvariantMetricMethods(geomstats.tests.TestCase):
     @geomstats.tests.np_and_tf_only
     def test_inner_product_matrix(self):
         base_point = self.group.identity
-        result = self.left_metric.inner_product_matrix(base_point=base_point)
+        result = self.left_metric.inner_product_matrix(base_point=None)
 
         expected = self.left_metric.inner_product_mat_at_identity
         self.assertAllClose(result, expected)
@@ -152,6 +152,12 @@ class TestInvariantMetricMethods(geomstats.tests.TestCase):
         # - exp then log
         # For left metric: point_1 and point_small
         result = helper.left_exp_then_log_from_identity(
+            metric=self.left_metric,
+            tangent_vec=self.point_1)
+        expected = self.point_1
+        self.assertAllClose(result, expected)
+
+        result = helper.exp_then_log(
             metric=self.left_metric,
             tangent_vec=self.point_1)
         expected = self.point_1

--- a/tests/test_lie_algebra.py
+++ b/tests/test_lie_algebra.py
@@ -16,14 +16,17 @@ class TestLieAlgebraMethods(geomstats.tests.TestCase):
         expected = self.dimension
         self.assertAllClose(result, expected)
 
-    def test_basis_and_matrix_representation(self):
+    @geomstats.tests.np_only
+    def test_matrix_representation_and_belongs(self):
         n_samples = 2
-        expected = gs.random.rand(n_samples * self.dimension)
-        expected = gs.reshape(expected, (n_samples, self.dimension))
-        mat = self.algebra.matrix_representation(expected)
-        result = self.algebra.belongs(mat)
+        point = gs.random.rand(n_samples * self.dimension)
+        point = gs.reshape(point, (n_samples, self.dimension))
+        mat = self.algebra.matrix_representation(point)
+        result = self.algebra.belongs(mat).all()
+        expected = True
         self.assertAllClose(result, expected)
 
+    @geomstats.tests.np_only
     def test_basis_and_matrix_representation(self):
         n_samples = 2
         expected = gs.random.rand(n_samples * self.dimension)

--- a/tests/test_lie_algebra.py
+++ b/tests/test_lie_algebra.py
@@ -1,0 +1,33 @@
+"""Unit tests for Lie algebra."""
+
+import geomstats.backend as gs
+import geomstats.tests
+from geomstats.geometry.skew_symmetric_matrices import SkewSymmetricMatrices
+
+
+class TestLieAlgebraMethods(geomstats.tests.TestCase):
+    def setUp(self):
+        self.n = 4
+        self.dimension = int(self.n * (self.n - 1) / 2)
+        self.algebra = SkewSymmetricMatrices(n=self.n)
+
+    def test_dimension(self):
+        result = self.algebra.dimension
+        expected = self.dimension
+        self.assertAllClose(result, expected)
+
+    def test_basis_and_matrix_representation(self):
+        n_samples = 2
+        expected = gs.random.rand(n_samples * self.dimension)
+        expected = gs.reshape(expected, (n_samples, self.dimension))
+        mat = self.algebra.matrix_representation(expected)
+        result = self.algebra.belongs(mat)
+        self.assertAllClose(result, expected)
+
+    def test_basis_and_matrix_representation(self):
+        n_samples = 2
+        expected = gs.random.rand(n_samples * self.dimension)
+        expected = gs.reshape(expected, (n_samples, self.dimension))
+        mat = self.algebra.matrix_representation(expected)
+        result = self.algebra.basis_representation(mat)
+        self.assertAllClose(result, expected)

--- a/tests/test_lie_group.py
+++ b/tests/test_lie_group.py
@@ -1,6 +1,4 @@
-"""
-Unit tests for Lie groups.
-"""
+"""Unit tests for Lie groups."""
 
 import geomstats.tests
 from geomstats.geometry.lie_group import LieGroup

--- a/tests/test_matrices.py
+++ b/tests/test_matrices.py
@@ -85,7 +85,7 @@ class TestMatricesMethods(geomstats.tests.TestCase):
         self.assertAllClose(result, expected)
 
     @geomstats.tests.np_only
-    def test_is_symmetric(self):
+    def test_is_skew_symmetric(self):
         skew_mat = gs.array([[0, - 2.],
                             [2., 0]])
         result = self.space.is_skew_symmetric(skew_mat)

--- a/tests/test_matrices.py
+++ b/tests/test_matrices.py
@@ -84,6 +84,21 @@ class TestMatricesMethods(geomstats.tests.TestCase):
         expected = gs.array(False)
         self.assertAllClose(result, expected)
 
+    @geomstats.tests.np_only
+    def test_is_symmetric(self):
+        skew_mat = gs.array([[0, - 2.],
+                            [2., 0]])
+        result = self.space.is_skew_symmetric(skew_mat)
+        expected = gs.array(True)
+        self.assertAllClose(result, expected)
+
+        not_a_sym_mat = gs.array([[1., 0.6, -3.],
+                                  [6., -7., 0.],
+                                  [0., 7., 8.]])
+        result = self.space.is_skew_symmetric(not_a_sym_mat)
+        expected = gs.array(False)
+        self.assertAllClose(result, expected)
+
     @geomstats.tests.np_and_tf_only
     def test_is_symmetric_vectorization(self):
         points = gs.array([


### PR DESCRIPTION
- test when `base_point=None`
-test when `inner_product_mat_at_identity=None`: there was a duplicate check in this case, and a reference to `self.group` before assignment