### PR TITLE
Improve unit tests of the invariant metric

### DIFF
--- a/geomstats/geometry/invariant_metric.py
+++ b/geomstats/geometry/invariant_metric.py
@@ -28,6 +28,8 @@ class InvariantMetric(RiemannianMetric):
     def __init__(self, group,
                  inner_product_mat_at_identity=None,
                  left_or_right='left'):
+
+        self.group = group
         if inner_product_mat_at_identity is None:
             inner_product_mat_at_identity = gs.eye(self.group.dimension)
         inner_product_mat_at_identity = gs.to_ndarray(
@@ -43,10 +45,6 @@ class InvariantMetric(RiemannianMetric):
         n_neg_eigval = gs.sum(gs.cast(mask_neg_eigval, gs.int32))
         mask_null_eigval = gs.isclose(eigenvalues, 0.)
         n_null_eigval = gs.sum(gs.cast(mask_null_eigval, gs.int32))
-
-        self.group = group
-        if inner_product_mat_at_identity is None:
-            inner_product_mat_at_identity = gs.eye(self.group.dimension)
 
         self.inner_product_mat_at_identity = inner_product_mat_at_identity
         self.left_or_right = left_or_right

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -45,7 +45,7 @@ def exp_then_log_from_identity(metric, tangent_vec):
     return result
 
 
-def log_then_exp(metric, point, base_point):
+def log_then_exp(metric, point, base_point=None):
     aux = metric.log(point=point,
                      base_point=base_point)
     result = metric.exp(tangent_vec=aux,
@@ -53,7 +53,7 @@ def log_then_exp(metric, point, base_point):
     return result
 
 
-def exp_then_log(metric, tangent_vec, base_point):
+def exp_then_log(metric, tangent_vec, base_point=None):
     aux = metric.exp(tangent_vec=tangent_vec,
                      base_point=base_point)
     result = metric.log(point=aux,

--- a/tests/test_invariant_metric.py
+++ b/tests/test_invariant_metric.py
@@ -26,7 +26,7 @@ class TestInvariantMetricMethods(geomstats.tests.TestCase):
 
         left_diag_metric = InvariantMetric(
             group=group,
-            inner_product_mat_at_identity=diag_mat_at_identity,
+            inner_product_mat_at_identity=None,
             left_or_right='left')
         right_diag_metric = InvariantMetric(
             group=group,
@@ -72,7 +72,7 @@ class TestInvariantMetricMethods(geomstats.tests.TestCase):
     @geomstats.tests.np_and_tf_only
     def test_inner_product_matrix(self):
         base_point = self.group.identity
-        result = self.left_metric.inner_product_matrix(base_point=base_point)
+        result = self.left_metric.inner_product_matrix(base_point=None)
 
         expected = self.left_metric.inner_product_mat_at_identity
         self.assertAllClose(result, expected)
@@ -152,6 +152,12 @@ class TestInvariantMetricMethods(geomstats.tests.TestCase):
         # - exp then log
         # For left metric: point_1 and point_small
         result = helper.left_exp_then_log_from_identity(
+            metric=self.left_metric,
+            tangent_vec=self.point_1)
+        expected = self.point_1
+        self.assertAllClose(result, expected)
+
+        result = helper.exp_then_log(
             metric=self.left_metric,
             tangent_vec=self.point_1)
         expected = self.point_1


### PR DESCRIPTION
- test when base_point=None
- test when inner_product_mat_at_identity=None: there was a duplicate check in this case, and a reference to self.group before assignment