### PR TITLE
Update codecov options to set explicit coverage targets during PR

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,4 +1,3 @@
-# Team Yaml
 coverage:
   round: up
   precision: 2
@@ -7,23 +6,27 @@ coverage:
       default:
         target: 90%
         threshold: 2%
-    numpy:
-      target: 90%
-      flags:
-          - numpy
-    pytorch:
-      target: 40%
-      flags:
-          - pytorch
-    tensorflow:
-      target: 40%
-      flags:
-          - tensorflow
-
-# Repository Yaml
-coverage:
-  round: up
-  range: 50..80
+        base: auto
+       # advanced
+        branches:
+          - master
+        if_not_found: success
+        if_ci_failed: error
+        informational: False
+        only_pulls: false
+    patch:
+      default:
+        # basic
+        target: 90%
+        threshold: 2%
+        base: auto
+        # advanced
+        branches:
+          - master
+        if_no_uploads: error
+        if_not_found: success
+        if_ci_failed: error
+        only_pulls: false
 
 # Files to ignore
 ignore:

--- a/geomstats/geometry/hypersphere.py
+++ b/geomstats/geometry/hypersphere.py
@@ -249,9 +249,10 @@ class Hypersphere(EmbeddedManifold):
         """
         point_intrinsic = gs.to_ndarray(point_intrinsic, to_ndim=2)
 
-        # FIXME: The next line needs to be guarded against taking the sqrt of
-        #        negative numbers.
-        coord_0 = gs.sqrt(1. - gs.linalg.norm(point_intrinsic, axis=-1) ** 2)
+        sq_coord_0 = 1. - gs.linalg.norm(point_intrinsic, axis=-1) ** 2
+        if gs.less(sq_coord_0, 0.):
+            raise ValueError('Square-root of a negative number.')
+        coord_0 = gs.sqrt(sq_coord_0)
         coord_0 = gs.to_ndarray(coord_0, to_ndim=2, axis=-1)
 
         point_extrinsic = gs.concatenate([coord_0, point_intrinsic], axis=-1)

--- a/geomstats/geometry/hypersphere.py
+++ b/geomstats/geometry/hypersphere.py
@@ -250,7 +250,7 @@ class Hypersphere(EmbeddedManifold):
         point_intrinsic = gs.to_ndarray(point_intrinsic, to_ndim=2)
 
         sq_coord_0 = 1. - gs.linalg.norm(point_intrinsic, axis=-1) ** 2
-        if gs.less(sq_coord_0, 0.):
+        if gs.any(gs.less(sq_coord_0, 0.)):
             raise ValueError('Square-root of a negative number.')
         coord_0 = gs.sqrt(sq_coord_0)
         coord_0 = gs.to_ndarray(coord_0, to_ndim=2, axis=-1)


### PR DESCRIPTION
This PR:
- Removes the codecov flags that are not triggered
- Update the target options for `default` and `patch` code coverage: set their respective coverage targets to 90%.
- Address a FIXME in the hypersphere, in order to test these coverage updates.