### PR TITLE
Add flag -unit to codecov.yml to trigger coverage with github

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -7,6 +7,8 @@ coverage:
         target: 90%
         threshold: 2%
         base: auto
+        flags:
+          - unit
        # advanced
         branches:
           - master
@@ -20,6 +22,8 @@ coverage:
         target: 90%
         threshold: 2%
         base: auto
+        flags:
+          - unit
         # advanced
         branches:
           - master


### PR DESCRIPTION
This PR adds flags to have automatic checks about coverage during Travis unit tests.