### PR TITLE
Inverse and random_uniform work in matrix form with all backends

### DIFF
--- a/geomstats/backend/pytorch/__init__.py
+++ b/geomstats/backend/pytorch/__init__.py
@@ -29,6 +29,10 @@ def logical_or(x, y):
 
 
 def logical_and(x, y):
+    if torch.is_tensor(x):
+        return x.eq(y)
+    elif torch.is_tensor(y):
+        return y.eq(x)
     return x and y
 
 
@@ -109,7 +113,7 @@ def array(val):
         if not isinstance(val[0], torch.Tensor):
             val = _np.copy(_np.array(val))
         else:
-            val = concatenate(val)
+            val = stack(val)
 
     if isinstance(val, bool):
         val = _np.array(val)

--- a/geomstats/backend/pytorch/__init__.py
+++ b/geomstats/backend/pytorch/__init__.py
@@ -115,7 +115,7 @@ def array(val):
         else:
             val = stack(val)
 
-    if isinstance(val, bool):
+    if isinstance(val, (bool, int, float)):
         val = _np.array(val)
     if isinstance(val, _np.ndarray):
         if val.dtype == bool:
@@ -524,7 +524,7 @@ def gather(x, indices, axis=0):
 
 
 def get_mask_i_float(i, n):
-    range_n = arange(cast(array(n), int32)[0])
+    range_n = arange(cast(array(n), int32))
     i_float = cast(array(i), int32)
     mask_i = equal(range_n, i_float)
     mask_i_float = cast(mask_i, float32)

--- a/geomstats/backend/pytorch/__init__.py
+++ b/geomstats/backend/pytorch/__init__.py
@@ -31,7 +31,7 @@ def logical_or(x, y):
 def logical_and(x, y):
     if torch.is_tensor(x):
         return x.eq(y)
-    elif torch.is_tensor(y):
+    if torch.is_tensor(y):
         return y.eq(x)
     return x and y
 

--- a/geomstats/geometry/special_euclidean.py
+++ b/geomstats/geometry/special_euclidean.py
@@ -399,13 +399,12 @@ class SpecialEuclidean(LieGroup):
                 [inverse_rotation, inverse_translation], axis=1)
 
         elif point_type == 'matrix':
-            inverse_point = gs.empty_like(point)
-            inverse_point[:, :self.n, :self.n] = gs.transpose(
+            inv_rot = gs.transpose(
                 point[:, :self.n, :self.n], axes=(0, 2, 1))
-            inverse_point[:, :self.n, self.n:] = gs.matmul(
-                inverse_point[:, :self.n, :self.n],
-                - point[:, :self.n, self.n:])
-            inverse_point[:, self.n:, :] = point[:, self.n:, :]
+            inv_trans = gs.matmul(inv_rot, - point[:, :self.n, self.n:])
+            last_line = point[:, self.n:, :]
+            inverse_point = gs.concatenate((inv_rot, inv_trans), axis=2)
+            inverse_point = gs.concatenate((inverse_point, last_line), axis=1)
 
         inverse_point = self.regularize(inverse_point, point_type=point_type)
         return inverse_point
@@ -699,12 +698,8 @@ class SpecialEuclidean(LieGroup):
         elif point_type == 'matrix':
             random_rotation = self.rotations.random_uniform(
                 n_samples, point_type=point_type)
-            if n_samples == 1:
-                random_translation = gs.to_ndarray(
-                    gs.transpose(random_translation), to_ndim=3)
-            else:
-                random_translation = gs.transpose(gs.to_ndarray(
-                    random_translation, to_ndim=3))
+            random_translation = gs.transpose(gs.to_ndarray(
+                random_translation, to_ndim=3, axis=1), (0, 2, 1))
             random_point = gs.concatenate(
                 (random_rotation, random_translation), axis=2)
             last_line = gs.zeros((n_samples, 1, self.n + 1))

--- a/geomstats/geometry/special_euclidean.py
+++ b/geomstats/geometry/special_euclidean.py
@@ -695,7 +695,7 @@ class SpecialEuclidean(LieGroup):
                 [random_rot_vec, random_translation],
                 axis=1)
 
-        elif point_type == 'matrix':
+        if point_type == 'matrix':
             random_rotation = self.rotations.random_uniform(
                 n_samples, point_type=point_type)
             random_translation = gs.transpose(gs.to_ndarray(

--- a/tests/test_special_euclidean.py
+++ b/tests/test_special_euclidean.py
@@ -19,6 +19,7 @@ from geomstats.geometry.special_euclidean import SpecialEuclidean
 # Tolerance for errors on predicted vectors, relative to the *norm*
 # of the vector, as opposed to the standard behavior of gs.allclose
 # where it is relative to each element of the array
+
 RTOL = 1e-5
 
 # TODO(nina): Speed up tf tests
@@ -190,7 +191,6 @@ class TestSpecialEuclideanMethods(geomstats.tests.TestCase):
         expected = gs.array([True] * n_samples)
         self.assertAllClose(result, expected)
 
-    @geomstats.tests.np_only
     def test_random_and_belongs_vectorization_matrix_form(self):
         local_point_type = 'matrix'
         n_samples = self.n_samples
@@ -283,7 +283,6 @@ class TestSpecialEuclideanMethods(geomstats.tests.TestCase):
             expected = helper.to_vector(expected)
             self.assertAllClose(result, expected)
 
-    @geomstats.tests.np_only
     def test_regularize_matrix_form(self):
         old_point_type = self.group.default_point_type
         self.group.default_point_type = 'matrix'
@@ -306,7 +305,6 @@ class TestSpecialEuclideanMethods(geomstats.tests.TestCase):
             gs.shape(regularized_points),
             (n_samples, *self.group.get_point_type_shape()))
 
-    @geomstats.tests.np_only
     def test_regularize_vectorization_matrix_form(self):
         old_point_type = self.group.default_point_type
         self.group.default_point_type = 'matrix'
@@ -321,7 +319,6 @@ class TestSpecialEuclideanMethods(geomstats.tests.TestCase):
 
         self.group.default_point_type = old_point_type
 
-    @geomstats.tests.np_only
     def test_compose(self):
         # Composition by identity, on the right
         # Expect the original transformation
@@ -350,7 +347,6 @@ class TestSpecialEuclideanMethods(geomstats.tests.TestCase):
             expected = helper.to_vector(expected)
             self.assertAllClose(result, expected)
 
-    @geomstats.tests.np_only
     def test_compose_matrix_form(self):
         # Composition by identity, on the right
         # Expect the original transformation
@@ -379,7 +375,6 @@ class TestSpecialEuclideanMethods(geomstats.tests.TestCase):
             expected = helper.to_vector(expected)
             self.assertAllClose(result, expected)
 
-    @geomstats.tests.np_only
     def test_compose_and_inverse(self):
         point = self.elements_all['point_1']
         inv_point = self.group.inverse(point)
@@ -398,7 +393,6 @@ class TestSpecialEuclideanMethods(geomstats.tests.TestCase):
             expected = helper.to_vector(expected)
             self.assertAllClose(result, expected)
 
-    @geomstats.tests.np_only
     def test_compose_and_inverse_matrix_form(self):
         old_point_type = self.group.default_point_type
         self.group.default_point_type = 'matrix'
@@ -423,7 +417,6 @@ class TestSpecialEuclideanMethods(geomstats.tests.TestCase):
 
         self.group.default_point_type = old_point_type
 
-    @geomstats.tests.np_only
     def test_compose_vectorization(self):
         n_samples = self.n_samples
         n_points_a = self.group.random_uniform(n_samples=n_samples)
@@ -449,7 +442,6 @@ class TestSpecialEuclideanMethods(geomstats.tests.TestCase):
                 gs.shape(result),
                 (n_samples, *self.group.get_point_type_shape()))
 
-    @geomstats.tests.np_only
     def test_compose_vectorization_matrix_form(self):
         old_point_type = self.group.default_point_type
         self.group.default_point_type = 'matrix'
@@ -465,7 +457,6 @@ class TestSpecialEuclideanMethods(geomstats.tests.TestCase):
         self.assertAllClose(
             gs.shape(result), (n_samples, *self.group.get_point_type_shape()))
 
-    @geomstats.tests.np_only
     def test_inverse_vectorization_matrix_form(self):
         old_point_type = self.group.default_point_type
         self.group.default_point_type = 'matrix'
@@ -474,7 +465,6 @@ class TestSpecialEuclideanMethods(geomstats.tests.TestCase):
 
         self.group.default_point_type = old_point_type
 
-    @geomstats.tests.np_only
     def test_left_jacobian_vectorization(self):
         n_samples = self.n_samples
         points = self.group.random_uniform(n_samples=n_samples)
@@ -485,7 +475,6 @@ class TestSpecialEuclideanMethods(geomstats.tests.TestCase):
             (n_samples, *self.group.get_point_type_shape(),
              *self.group.get_point_type_shape()))
 
-    @geomstats.tests.np_only
     def test_exp_from_identity_vectorization(self):
         n_samples = self.n_samples
         for metric in self.metrics.values():
@@ -499,7 +488,6 @@ class TestSpecialEuclideanMethods(geomstats.tests.TestCase):
             if geomstats.tests.tf_backend():
                 break
 
-    @geomstats.tests.np_only
     def test_log_from_identity_vectorization(self):
         n_samples = self.n_samples
         for metric in self.metrics.values():
@@ -513,7 +501,6 @@ class TestSpecialEuclideanMethods(geomstats.tests.TestCase):
             if geomstats.tests.tf_backend():
                 break
 
-    @geomstats.tests.np_only
     def test_exp_vectorization(self):
         n_samples = self.n_samples
 
@@ -546,7 +533,6 @@ class TestSpecialEuclideanMethods(geomstats.tests.TestCase):
                 gs.shape(result),
                 (n_samples, *self.group.get_point_type_shape()))
 
-    @geomstats.tests.np_only
     def test_log_vectorization(self):
         n_samples = self.n_samples
         for metric_type in self.metrics:
@@ -980,6 +966,10 @@ class TestSpecialEuclideanMethods(geomstats.tests.TestCase):
         are inverse.
         Expect their composition to give the identity function.
         """
+        if geomstats.tests.np_backend():
+            atol = 1e-5
+        else:
+            atol = 5e-5
         angle_types = self.angles_close_to_pi
         # Canonical inner product on the lie algebra
         for metric in [self.metrics_all['right_canonical'],
@@ -995,10 +985,9 @@ class TestSpecialEuclideanMethods(geomstats.tests.TestCase):
                     [- expected[:, :3], expected[:, 3:6]],
                     axis=1)
                 inv_expected = helper.to_vector(inv_expected)
-
                 self.assertTrue(
-                    gs.allclose(result, expected, atol=1e-5)
-                    or gs.allclose(result, inv_expected, atol=1e-5))
+                    gs.allclose(result, expected, atol=atol)
+                    or gs.allclose(result, inv_expected, atol=atol))
 
     @geomstats.tests.np_only
     def test_exp_left(self):
@@ -1321,7 +1310,6 @@ class TestSpecialEuclideanMethods(geomstats.tests.TestCase):
         #             if geomstats.tests.tf_backend():
         #                 break
 
-    @geomstats.tests.np_only
     def test_inner_product_at_identity_vectorization(self):
         n_samples = self.n_samples
         for metric in self.metrics.values():
@@ -1342,7 +1330,6 @@ class TestSpecialEuclideanMethods(geomstats.tests.TestCase):
             result = metric.inner_product(n_vector_a, n_vector_b)
             self.assertAllClose(gs.shape(result), (n_samples, 1))
 
-    @geomstats.tests.np_only
     def test_inner_product_one_base_point_vectorization(self):
         n_samples = self.n_samples
         for metric in self.metrics.values():
@@ -1368,7 +1355,6 @@ class TestSpecialEuclideanMethods(geomstats.tests.TestCase):
                                           one_base_point)
             self.assertAllClose(gs.shape(result), (n_samples, 1))
 
-    @geomstats.tests.np_only
     def test_inner_product_n_base_point_vectorization(self):
         n_samples = self.n_samples
         for metric in self.metrics.values():
@@ -1425,7 +1411,6 @@ class TestSpecialEuclideanMethods(geomstats.tests.TestCase):
                     if geomstats.tests.tf_backend():
                         break
 
-    @geomstats.tests.np_only
     def test_squared_dist_vectorization(self):
         n_samples = self.n_samples
         for metric_type in self.metrics:
@@ -1465,7 +1450,6 @@ class TestSpecialEuclideanMethods(geomstats.tests.TestCase):
             result = metric.squared_dist(n_point_1, n_point_2)
             self.assertAllClose(gs.shape(result), (n_samples, 1))
 
-    @geomstats.tests.np_only
     def test_dist_vectorization(self):
         n_samples = self.n_samples
         for metric_type in self.metrics:
@@ -1504,7 +1488,6 @@ class TestSpecialEuclideanMethods(geomstats.tests.TestCase):
             result = metric.dist(n_point_1, n_point_2)
             self.assertAllClose(gs.shape(result), (n_samples, 1))
 
-    @geomstats.tests.np_only
     def test_group_exponential_barycenter(self):
         """Test group exponential barycenter."""
         # FIXME
@@ -1532,7 +1515,6 @@ class TestSpecialEuclideanMethods(geomstats.tests.TestCase):
 
         #     self.assertTrue(self.group.belongs(result_3))
 
-    @geomstats.tests.np_only
     def test_geodesic_and_belongs(self):
         initial_point = self.group.random_uniform()
         initial_tangent_vec = gs.array([2., 0., -1., 0., 2., 3.])
@@ -1546,7 +1528,6 @@ class TestSpecialEuclideanMethods(geomstats.tests.TestCase):
         expected = True
         self.assertAllClose(result, expected)
 
-    @geomstats.tests.np_only
     def test_geodesic_subsample(self):
         initial_point = gs.array([-1.1, 0., 0.99, 10., 2., 3.])
         initial_tangent_vec = gs.array([1., 0., 2., 1., 1., 1.])


### PR DESCRIPTION
Only failing tests are Pytorch and Tensorflow giving wrong output in some log and exp tests (especially Pytorch), for which the decorator `@...np_only` was kept.
I removed the other decorators around the tests which all backends succeed, except `dist_is_symmetric` which takes ages. Better to slow down even the tests even more, or coverage completeness ? (Tensorflow is already tested with less testcases)

`logical_and` and `array` were modified in Pytorch backend to have behavior more similar to numpy's: the former can be applied to a bool and a Tensor for instance; the latter gives an nd_array with the same dimension.

