### PR TITLE
Add unit tests for invariant metrics when `point_type='matrix'`

### DIFF
--- a/examples/empirical_frechet_mean_uncertainty_sn.py
+++ b/examples/empirical_frechet_mean_uncertainty_sn.py
@@ -214,7 +214,7 @@ def multi_plot_modulation_factor(dim, n_expectation=1000, n_theta=20):
     return plt
 
 
-def main():
+def main(test=False):
     """Visualise the uncertainty of the empirical Fréchet mean on the sphere.
 
     The variance of the Fréchet mean FM_n of a sample of n IID random variables
@@ -223,6 +223,12 @@ def main():
          alpha = Var( FM_n) / ( n * Var)
     for isotropic distributions on hyper-spheres of radius 0 < theta < Pi in
     the sphere S_dim (called here a bubble).
+
+    Parameters
+    ----------
+    test : bool
+        Wether the method is called from a unit test.
+        Use `True` to run only one plot and `False` to run the full example.
     """
     n_expectation = 10
 
@@ -245,23 +251,25 @@ def main():
                          n_expectation=n_expectation)))
 
     plot_modulation_factor(2, 2, n_expectation=n_expectation)
-    plot_modulation_factor(4, 2, n_expectation=n_expectation)
-    plot_modulation_factor(6, 2, n_expectation=n_expectation)
 
-    multi_plot_modulation_factor(
-        2, n_expectation=n_expectation)
+    if not test:
+        plot_modulation_factor(4, 2, n_expectation=n_expectation)
+        plot_modulation_factor(6, 2, n_expectation=n_expectation)
 
-    plot_modulation_factor(2, 3, n_expectation=n_expectation)
-    plot_modulation_factor(4, 3, n_expectation=n_expectation)
-    plot_modulation_factor(6, 3, n_expectation=n_expectation)
+        multi_plot_modulation_factor(
+            2, n_expectation=n_expectation)
 
-    multi_plot_modulation_factor(3, n_expectation=n_expectation)
+        plot_modulation_factor(2, 3, n_expectation=n_expectation)
+        plot_modulation_factor(4, 3, n_expectation=n_expectation)
+        plot_modulation_factor(6, 3, n_expectation=n_expectation)
 
-    plot_modulation_factor(2, 4, n_expectation=n_expectation)
-    plot_modulation_factor(4, 4, n_expectation=n_expectation)
-    plot_modulation_factor(6, 4, n_expectation=n_expectation)
+        multi_plot_modulation_factor(3, n_expectation=n_expectation)
 
-    multi_plot_modulation_factor(4, n_expectation=n_expectation)
+        plot_modulation_factor(2, 4, n_expectation=n_expectation)
+        plot_modulation_factor(4, 4, n_expectation=n_expectation)
+        plot_modulation_factor(6, 4, n_expectation=n_expectation)
+
+        multi_plot_modulation_factor(4, n_expectation=n_expectation)
 
     plt.figure()
     plt.show()

--- a/examples/empirical_frechet_mean_uncertainty_sn.py
+++ b/examples/empirical_frechet_mean_uncertainty_sn.py
@@ -251,19 +251,17 @@ def main(test=False):
                          n_expectation=n_expectation)))
 
     plot_modulation_factor(2, 2, n_expectation=n_expectation)
+    multi_plot_modulation_factor(3, n_expectation=n_expectation)
 
     if not test:
         plot_modulation_factor(4, 2, n_expectation=n_expectation)
         plot_modulation_factor(6, 2, n_expectation=n_expectation)
 
-        multi_plot_modulation_factor(
-            2, n_expectation=n_expectation)
+        multi_plot_modulation_factor(2, n_expectation=n_expectation)
 
         plot_modulation_factor(2, 3, n_expectation=n_expectation)
         plot_modulation_factor(4, 3, n_expectation=n_expectation)
         plot_modulation_factor(6, 3, n_expectation=n_expectation)
-
-        multi_plot_modulation_factor(3, n_expectation=n_expectation)
 
         plot_modulation_factor(2, 4, n_expectation=n_expectation)
         plot_modulation_factor(4, 4, n_expectation=n_expectation)

--- a/geomstats/geometry/invariant_metric.py
+++ b/geomstats/geometry/invariant_metric.py
@@ -106,9 +106,8 @@ class InvariantMetric(RiemannianMetric):
                 ' by matrices.')
             tangent_vec_a = gs.to_ndarray(tangent_vec_a, to_ndim=3)
             tangent_vec_b = gs.to_ndarray(tangent_vec_b, to_ndim=3)
-            aux_prod = gs.matmul(gs.transpose(tangent_vec_a, axes=(0, 2, 1)),
-                                 tangent_vec_b)
-            inner_prod = gs.trace(aux_prod)
+            aux_prod = tangent_vec_a * tangent_vec_b
+            inner_prod = gs.sum(aux_prod, axis=0)
 
         return inner_prod
 

--- a/geomstats/geometry/special_euclidean.py
+++ b/geomstats/geometry/special_euclidean.py
@@ -182,6 +182,10 @@ class SpecialEuclidean(LieGroup):
         elif point_type == 'matrix':
             regularized_point = gs.to_ndarray(point, to_ndim=3)
 
+        else:
+            raise ValueError('Invalid point_type, expected \'vector\' or '
+                             '\'matrix\'')
+
         return regularized_point
 
     def regularize_tangent_vec_at_identity(

--- a/geomstats/geometry/special_orthogonal.py
+++ b/geomstats/geometry/special_orthogonal.py
@@ -255,13 +255,17 @@ class SpecialOrthogonal(LieGroup, EmbeddedManifold):
                 regularized_vec = tangent_vec
 
         elif point_type == 'matrix':
-            regularized_vec = tangent_vec
+            is_vectorized = gs.ndim(gs.array(tangent_vec)) == 3
+            axes = (0, 2, 1) if is_vectorized else (1, 0)
+            regularized_vec = \
+                1. / 2 * (tangent_vec - gs.transpose(tangent_vec, axes))
+        else:
+            raise ValueError('point_type should be \'vector\' or \'matrix\'.')
 
         return regularized_vec
 
     def regularize_tangent_vec(
-            self, tangent_vec, base_point,
-            metric=None, point_type=None):
+            self, tangent_vec, base_point, metric=None, point_type=None):
         """Regularize tangent vector at a base point.
 
         In 3D, regularize a tangent_vector by getting the norm of its parallel
@@ -270,6 +274,9 @@ class SpecialOrthogonal(LieGroup, EmbeddedManifold):
         Parameters
         ----------
         tangent_vec : array-like, shape=[n_samples, {dimension, [n, n]}]
+            Tangent vector at base point.
+        base_point : array-like, shape=[n_samples, {dimension, [n, n]}]
+            Point on the manifold.
         metric : RiemannianMetric, optional
             default: self.left_canonical_metric
         point_type : str, {'vector', 'matrix'}, optional
@@ -317,7 +324,18 @@ class SpecialOrthogonal(LieGroup, EmbeddedManifold):
                 regularized_tangent_vec = tangent_vec
 
         elif point_type == 'matrix':
-            regularized_tangent_vec = tangent_vec
+            if gs.allclose(base_point, self.identity):
+                return self.regularize_tangent_vec_at_identity(
+                    tangent_vec, point_type=point_type)
+            inv_base_point = self.inverse(base_point)
+            tangent_vec_at_id = self.compose(inv_base_point, tangent_vec)
+            regularized_tangent_vec = self.regularize_tangent_vec_at_identity(
+                tangent_vec_at_id, point_type=point_type)
+            regularized_tangent_vec = self.compose(
+                base_point, regularized_tangent_vec)
+
+        else:
+            raise ValueError('point_type should be \'vector\' or \'matrix\'.')
 
         return regularized_tangent_vec
 
@@ -440,7 +458,7 @@ class SpecialOrthogonal(LieGroup, EmbeddedManifold):
             upper_triangle_indices = gs.triu_indices(mat_dim, k=1)
             for i in range(n_vecs):
                 skew_mat[i][upper_triangle_indices] = vec[i]
-                skew_mat[i] = skew_mat[i] - skew_mat[i].transpose()
+                skew_mat[i] = skew_mat[i] - gs.transpose(skew_mat[i])
         assert gs.ndim(skew_mat) == 3
         return skew_mat
 
@@ -1534,7 +1552,7 @@ class SpecialOrthogonal(LieGroup, EmbeddedManifold):
                 jacobian = self.matrix_from_rotation_vector(point)
 
         elif point_type == 'matrix':
-            raise NotImplementedError()
+            jacobian = point
 
         return jacobian
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -46,7 +46,7 @@ class TestExamples(geomstats.tests.TestCase):
 
     @geomstats.tests.np_only
     def test_empirical_frechet_mean_uncertainty_sn(self):
-        empirical_frechet_mean_uncertainty_sn.main()
+        empirical_frechet_mean_uncertainty_sn.main(True)
 
     @geomstats.tests.np_only
     def test_gradient_descent_s2(self):

--- a/tests/test_invariant_metric.py
+++ b/tests/test_invariant_metric.py
@@ -35,7 +35,17 @@ class TestInvariantMetricMethods(geomstats.tests.TestCase):
 
         # General left and right invariant metrics
         # TODO(nina): Replace the matrix below by a general SPD matrix.
-        sym_mat_at_identity = gs.eye(group.dimension)
+        rotation_part = gs.zeros(group.dimension)
+        rotation_part[0] = 1. / 4
+        diagonal_part = gs.ones_like(rotation_part)
+        diagonal_part[0] = 2
+        diagonal_part = gs.diag(diagonal_part)
+        rotation_part = SpecialEuclidean(
+            group.dimension).rotations.matrix_from_rotation_vector(
+            rotation_part)[0]
+        spd = group.compose(rotation_part, diagonal_part, point_type='matrix')
+        sym_mat_at_identity = group.compose(
+            spd, gs.transpose(rotation_part), point_type='matrix')
 
         left_metric = InvariantMetric(
             group=group,
@@ -54,7 +64,7 @@ class TestInvariantMetricMethods(geomstats.tests.TestCase):
 
         # General case for the point
         point_1 = gs.array([[-0.2, 0.9, 0.5, 5., 5., 5.]])
-        point_2 = gs.array([[0., 2., -0.1, 30., 400., 2.]])
+        point_2 = gs.array([[0., 20., -0.1, 30., 400., 2.]])
         # Edge case for the point, angle < epsilon,
         point_small = gs.array([[-1e-7, 0., -7 * 1e-8, 6., 5., 9.]])
 

--- a/tests/test_invariant_metric.py
+++ b/tests/test_invariant_metric.py
@@ -9,7 +9,9 @@ import tests.helper as helper
 import geomstats.backend as gs
 import geomstats.tests
 from geomstats.geometry.invariant_metric import InvariantMetric
+from geomstats.geometry.skew_symmetric_matrices import SkewSymmetricMatrices
 from geomstats.geometry.special_euclidean import SpecialEuclidean
+from geomstats.geometry.special_orthogonal import SpecialOrthogonal
 
 
 class TestInvariantMetricMethods(geomstats.tests.TestCase):
@@ -20,6 +22,7 @@ class TestInvariantMetricMethods(geomstats.tests.TestCase):
 
         n = 3
         group = SpecialEuclidean(n=n)
+        matrix_group = SpecialOrthogonal(n=n, point_type='matrix')
 
         # Diagonal left and right invariant metrics
         diag_mat_at_identity = gs.eye(group.dimension)
@@ -34,18 +37,8 @@ class TestInvariantMetricMethods(geomstats.tests.TestCase):
             left_or_right='right')
 
         # General left and right invariant metrics
-        # TODO(nina): Replace the matrix below by a general SPD matrix.
-        rotation_part = gs.zeros(group.dimension)
-        rotation_part[0] = 1. / 4
-        diagonal_part = gs.ones_like(rotation_part)
-        diagonal_part[0] = 2
-        diagonal_part = gs.diag(diagonal_part)
-        rotation_part = SpecialEuclidean(
-            group.dimension).rotations.matrix_from_rotation_vector(
-            rotation_part)[0]
-        spd = group.compose(rotation_part, diagonal_part, point_type='matrix')
-        sym_mat_at_identity = group.compose(
-            spd, gs.transpose(rotation_part), point_type='matrix')
+        # FIXME(nina): This is valid only for bi-invariant metrics
+        sym_mat_at_identity = gs.eye(group.dimension)
 
         left_metric = InvariantMetric(
             group=group,
@@ -57,26 +50,35 @@ class TestInvariantMetricMethods(geomstats.tests.TestCase):
             inner_product_mat_at_identity=sym_mat_at_identity,
             left_or_right='right')
 
-        metrics = {'left_diag': left_diag_metric,
-                   'right_diag_metric': right_diag_metric,
-                   'left': left_metric,
-                   'right': right_metric}
+        matrix_left_metric = InvariantMetric(group=matrix_group)
+
+        matrix_right_metric = InvariantMetric(
+            group=matrix_group,
+            left_or_right='right')
 
         # General case for the point
         point_1 = gs.array([[-0.2, 0.9, 0.5, 5., 5., 5.]])
-        point_2 = gs.array([[0., 20., -0.1, 30., 400., 2.]])
+        point_2 = gs.array([[0., 2., -0.1, 30., 400., 2.]])
+        point_1_matrix = matrix_group.matrix_from_rotation_vector(
+            point_1[:, :3])
+        point_2_matrix = matrix_group.matrix_from_rotation_vector(
+            point_2[:, :3])
         # Edge case for the point, angle < epsilon,
         point_small = gs.array([[-1e-7, 0., -7 * 1e-8, 6., 5., 9.]])
 
         self.group = group
-        self.metrics = metrics
+        self.matrix_group = matrix_group
 
         self.left_diag_metric = left_diag_metric
         self.right_diag_metric = right_diag_metric
         self.left_metric = left_metric
         self.right_metric = right_metric
+        self.matrix_left_metric = matrix_left_metric
+        self.matrix_right_metric = matrix_right_metric
         self.point_1 = point_1
         self.point_2 = point_2
+        self.point_1_matrix = point_1_matrix
+        self.point_2_matrix = point_2_matrix
         self.point_small = point_small
 
     @geomstats.tests.np_and_tf_only
@@ -98,6 +100,69 @@ class TestInvariantMetricMethods(geomstats.tests.TestCase):
         result = gs.matmul(inv_inner_prod_mat, inner_prod_mat)
         expected = gs.eye(self.group.dimension)
         expected = gs.to_ndarray(expected, to_ndim=3, axis=0)
+        self.assertAllClose(result, expected)
+
+    @geomstats.tests.np_and_pytorch_only
+    def test_inner_product_at_identity(self):
+        lie_algebra = SkewSymmetricMatrices(3)
+        tangent_vec_a = lie_algebra.matrix_representation([1., 0, 2.])[0]
+        tangent_vec_b = lie_algebra.matrix_representation([1., 0, 0.5])[0]
+        result = self.matrix_left_metric.inner_product_at_identity(
+            tangent_vec_a, tangent_vec_b)
+        expected = 4.
+        self.assertAllClose(result, expected)
+
+        tangent_vec_a = lie_algebra.matrix_representation(
+            [[1., 0, 2.], [0, 3., 5.]])
+        result = self.matrix_left_metric.inner_product_at_identity(
+            tangent_vec_a, tangent_vec_b)
+        expected = gs.array([4., 5.])
+        self.assertAllClose(result, expected)
+
+    @geomstats.tests.np_and_pytorch_only
+    def test_inner_product_left(self):
+        lie_algebra = SkewSymmetricMatrices(3)
+        tangent_vec_a = lie_algebra.matrix_representation([1., 0, 2.])[0]
+        tangent_vec_a = self.matrix_group.compose(
+            self.point_1_matrix, tangent_vec_a)
+        tangent_vec_b = lie_algebra.matrix_representation([1., 0, 0.5])[0]
+        tangent_vec_b = self.matrix_group.compose(
+            self.point_1_matrix, tangent_vec_b)
+        result = self.matrix_left_metric.inner_product(
+            tangent_vec_a, tangent_vec_b, self.point_1_matrix)
+        expected = 4.
+        self.assertAllClose(result, expected)
+
+        tangent_vec_a = lie_algebra.matrix_representation(
+            [[1., 0, 2.], [0, 3., 5.]])
+        tangent_vec_a = self.matrix_group.compose(
+            self.point_1_matrix, tangent_vec_a)
+        result = self.matrix_left_metric.inner_product(
+            tangent_vec_a, tangent_vec_b, self.point_1_matrix)
+        expected = gs.array([4., 5.])
+        self.assertAllClose(result, expected)
+
+    @geomstats.tests.np_and_pytorch_only
+    def test_inner_product_right(self):
+        lie_algebra = SkewSymmetricMatrices(3)
+        tangent_vec_a = lie_algebra.matrix_representation([1., 0, 2.])[0]
+        tangent_vec_a = self.matrix_group.compose(
+            tangent_vec_a, self.point_1_matrix)
+        tangent_vec_b = lie_algebra.matrix_representation([1., 0, 0.5])[0]
+        tangent_vec_b = self.matrix_group.compose(
+            tangent_vec_b, self.point_1_matrix)
+        result = self.matrix_right_metric.inner_product(
+            tangent_vec_a, tangent_vec_b, self.point_1_matrix)
+        expected = 4.
+        self.assertAllClose(result, expected)
+
+        tangent_vec_a = lie_algebra.matrix_representation(
+            [[1., 0, 2.], [0, 3., 5.]])
+        tangent_vec_a = self.matrix_group.compose(
+            tangent_vec_a, self.point_1_matrix)
+        result = self.matrix_right_metric.inner_product(
+            tangent_vec_a, tangent_vec_b, self.point_1_matrix)
+        expected = gs.array([4., 5.])
         self.assertAllClose(result, expected)
 
     @geomstats.tests.np_and_tf_only
@@ -335,21 +400,23 @@ class TestInvariantMetricMethods(geomstats.tests.TestCase):
         Riemannian logarithm are inverse.
         Expect their composition to give the identity function.
         """
-        # FIXME:
+        # FIXME: lower numerical accuracy with tensorflow
         # General case for the reference point
-        # base_point = self.point_2
+        base_point = self.point_2
 
         # General point
-        # result = helper.log_then_exp(self.left_diag_metric,
-        #                              base_point, self.point_1)
-        # expected = self.group.regularize(self.point_1)
-        # self.assertAllClose(result, expected)
+        result = helper.log_then_exp(
+            self.left_diag_metric, self.point_1, base_point)
+        expected = self.group.regularize(self.point_1)
+        result = self.group.regularize(result)
+        self.assertAllClose(result, expected, atol=1e-4, rtol=1e-4)
 
         # Edge case, small angle
-        # result = helper.log_then_exp(self.left_diag_metric,
-        #                              base_point, self.point_small)
-        # expected = self.group.regularize(self.point_small)
-        # self.assertAllClose(result, expected)
+        result = helper.log_then_exp(
+            self.left_diag_metric, self.point_small, base_point)
+        expected = self.group.regularize(self.point_small)
+        result = self.group.regularize(result)
+        self.assertAllClose(result, expected, atol=1e-4, rtol=1e-4)
 
     @geomstats.tests.np_and_tf_only
     def test_exp_and_log_left_metrics(self):
@@ -358,20 +425,20 @@ class TestInvariantMetricMethods(geomstats.tests.TestCase):
         Riemannian logarithm are inverse.
         Expect their composition to give the identity function.
         """
-        # FIXME
+        # FIXME: lower numerical accuracy with tensorflow
         # General case for the reference point
-        # base_point = self.point_2
+        base_point = self.point_2
 
         # For left metric: point and point_small
-        # result = helper.log_then_exp(self.left_metric,
-        #                              base_point, self.point_1)
-        # expected = self.point_1
-        # self.assertAllClose(result, expected)
+        result = helper.log_then_exp(
+            self.left_metric, self.point_1, base_point)
+        expected = self.point_1
+        self.assertAllClose(result, expected, atol=1e-4, rtol=1e-4)
 
-        # result = helper.log_then_exp(self.left_metric,
-        #                              base_point, self.point_small)
-        # expected = self.point_small
-        # self.assertAllClose(result, expected)
+        result = helper.log_then_exp(
+            self.left_metric, self.point_small, base_point)
+        expected = self.point_small
+        self.assertAllClose(result, expected, atol=1e-4, rtol=1e-4)
 
     @geomstats.tests.np_and_tf_only
     def test_exp_and_log_right_diag_metrics(self):
@@ -380,19 +447,19 @@ class TestInvariantMetricMethods(geomstats.tests.TestCase):
         Riemannian logarithm are inverse.
         Expect their composition to give the identity function.
         """
-        # FIXME
+        # FIXME: lower numerical accuracy with tensorflow
         # General case for the reference point
-        # base_point = self.point_2
+        base_point = self.point_2
         # For right diagonal metric: point and point_small
-        # result = helper.log_then_exp(self.right_diag_metric,
-        #                              base_point, self.point_1)
-        # expected = self.group.regularize(self.point_1)
-        # self.assertAllClose(result, expected)
+        result = helper.log_then_exp(
+            self.right_diag_metric, self.point_1, base_point)
+        expected = self.group.regularize(self.point_1)
+        self.assertAllClose(result, expected, atol=1e-4, rtol=1e-4)
 
-        # result = helper.log_then_exp(self.right_diag_metric,
-        #                              base_point, self.point_small)
-        # expected = self.group.regularize(self.point_small)
-        # self.assertAllClose(result, expected)
+        result = helper.log_then_exp(
+            self.right_diag_metric, self.point_small, base_point)
+        expected = self.group.regularize(self.point_small)
+        self.assertAllClose(result, expected, atol=1e-4, rtol=1e-4)
 
     @geomstats.tests.np_and_tf_only
     def test_exp_and_log_right_metrics(self):
@@ -401,19 +468,19 @@ class TestInvariantMetricMethods(geomstats.tests.TestCase):
         Riemannian logarithm are inverse.
         Expect their composition to give the identity function.
         """
-        # FIXME
+        # FIXME: lower numerical accuracy with tensorflow
         # General case for the reference point
-        # base_point = self.point_2
+        base_point = self.point_2
         # For right metric: point and point_small
-        # result = helper.log_then_exp(self.right_metric,
-        #                              base_point, self.point_1)
-        # expected = self.point_1
-        # self.assertAllClose(result, expected)
+        result = helper.log_then_exp(
+            self.right_metric, self.point_1, base_point)
+        expected = self.point_1
+        self.assertAllClose(result, expected, atol=1e-4, rtol=1e-4)
 
-        # result = helper.log_then_exp(self.right_metric,
-        #                              base_point, self.point_small)
-        # expected = self.point_small
-        # self.assertAllClose(result, expected)
+        result = helper.log_then_exp(
+            self.right_metric, self.point_small, base_point)
+        expected = self.point_small
+        self.assertAllClose(result, expected, atol=1e-4, rtol=1e-4)
 
     @geomstats.tests.np_and_tf_only
     def test_squared_dist_left_diag_metrics(self):
@@ -444,13 +511,10 @@ class TestInvariantMetricMethods(geomstats.tests.TestCase):
 
     @geomstats.tests.np_and_tf_only
     def test_squared_dist_and_squared_norm_left_metrics(self):
-        result = self.left_metric.squared_dist(self.point_1,
-                                               self.point_2)
-        log = self.left_diag_metric.log(base_point=self.point_1,
-                                        point=self.point_2)
+        result = self.left_metric.squared_dist(self.point_1, self.point_2)
+        log = self.left_metric.log(base_point=self.point_1, point=self.point_2)
         expected = self.left_metric.squared_norm(
-            vector=log,
-            base_point=self.point_1)
+            vector=log, base_point=self.point_1)
         self.assertAllClose(result, expected)
 
     @geomstats.tests.np_and_tf_only
@@ -465,11 +529,9 @@ class TestInvariantMetricMethods(geomstats.tests.TestCase):
 
     @geomstats.tests.np_and_tf_only
     def test_squared_dist_and_squared_norm_right_metrics(self):
-        result = self.right_metric.squared_dist(self.point_1,
-                                                self.point_2)
-        log = self.right_diag_metric.log(base_point=self.point_1,
-                                         point=self.point_2)
+        result = self.right_metric.squared_dist(self.point_1, self.point_2)
+        log = self.right_metric.log(
+            base_point=self.point_1, point=self.point_2)
         expected = self.right_metric.squared_norm(
-            vector=log,
-            base_point=self.point_1)
+            vector=log, base_point=self.point_1)
         self.assertAllClose(result, expected)

--- a/tests/test_special_orthogonal.py
+++ b/tests/test_special_orthogonal.py
@@ -329,6 +329,7 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
                     self.assertAllClose(
                         gs.shape(result), (n_samples, n, n))
 
+    @geomstats.tests.np_only
     def test_regularize_tangent_vec_matrix(self):
         point_type = 'matrix'
         for n in self.n_seq:

--- a/tests/test_special_orthogonal.py
+++ b/tests/test_special_orthogonal.py
@@ -329,6 +329,28 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
                     self.assertAllClose(
                         gs.shape(result), (n_samples, n, n))
 
+    def test_regularize_tangent_vec_matrix(self):
+        point_type = 'matrix'
+        for n in self.n_seq:
+            group = self.so[n]
+            group.default_point_type = point_type
+
+            n_samples = self.n_samples
+            rot_vecs = group.random_uniform(n_samples=n_samples)
+            tangent_vecs = group.log_from_identity(rot_vecs)
+            result = group.regularize_tangent_vec_at_identity(
+                tangent_vecs)
+            expected = tangent_vecs
+            self.assertAllClose(result, expected)
+
+            n_samples = self.n_samples
+            base_points = group.random_uniform(n_samples=n_samples)
+            tangent_vecs = group.compose(base_points, tangent_vecs)
+            result = group.regularize_tangent_vec(
+                tangent_vecs, base_points)
+            expected = tangent_vecs
+            self.assertAllClose(result, expected)
+
     def test_matrix_from_rotation_vector(self):
         n = 3
         group = self.so[n]


### PR DESCRIPTION
- re-implement inner_product when `point_type='matrix'`
- fix `regularize_tangent_vec` in special_orthogonal
- add parameter to example on empirical_frechet_mean to run it only once when unit-testing

Generally, I think there is a confusion between the methods of invariant-metric and the exponential on groups. Using the group exp at identity to implement the left-invariant metric Riemannian exp is only valid for bi-invariant metrics, with identity inner-product matrix at identity.