### PR TITLE
Square distance on hypersphere

### DIFF
--- a/geomstats/geometry/hypersphere.py
+++ b/geomstats/geometry/hypersphere.py
@@ -574,6 +574,22 @@ class HypersphereMetric(RiemannianMetric):
 
         return dist
 
+    def squared_dist(self, point_a, point_b):
+        """Squared geodesic distance between two points.
+
+        Parameters
+        ----------
+        point_a : array-like, shape=[n_samples, dimension]
+            Point on the hypersphere.
+        point_b : array-like, shape=[n_samples, dimension]
+            Point on the hypersphere.
+
+        Returns
+        -------
+        sq_dist : array-like, shape=[n_samples,]
+        """
+        return self.dist(point_a, point_b) ** 2
+
     def parallel_transport(self, tangent_vec_a, tangent_vec_b, base_point):
         """Compute the parallel transport of a tangent vector.
 

--- a/geomstats/learning/frechet_mean.py
+++ b/geomstats/learning/frechet_mean.py
@@ -251,6 +251,9 @@ def _adaptive_gradient_descent(points,
             ' implemented for lists of vectors, and not matrices.')
     n_points = gs.shape(points)[0]
 
+    if n_points == 1:
+        return points
+
     if weights is None:
         weights = gs.ones((n_points, 1))
 

--- a/tests/test_frechet_mean.py
+++ b/tests/test_frechet_mean.py
@@ -34,7 +34,8 @@ class TestFrechetMean(geomstats.tests.TestCase):
             # take 2 random points, compute their mean, and verify that
             # log of each at the mean is opposite
             points = self.sphere.random_uniform(n_samples=2)
-            mean = estimator.fit(points).estimate_
+            estimator.fit(points)
+            mean = estimator.estimate_
 
             logs = self.sphere.metric.log(point=points, base_point=mean)
             result[i] = gs.linalg.norm(logs[1, :] + logs[0, :])

--- a/tests/test_frechet_mean.py
+++ b/tests/test_frechet_mean.py
@@ -10,7 +10,6 @@ from geomstats.geometry.euclidean import Euclidean
 from geomstats.geometry.hyperbolic import Hyperbolic
 from geomstats.geometry.hypersphere import Hypersphere
 from geomstats.geometry.minkowski import Minkowski
-from geomstats.learning.frechet_mean import _adaptive_gradient_descent
 from geomstats.learning.frechet_mean import FrechetMean
 from geomstats.learning.frechet_mean import variance
 
@@ -29,13 +28,13 @@ class TestFrechetMean(geomstats.tests.TestCase):
         n_tests = 100
         result = gs.zeros(n_tests)
         expected = gs.zeros(n_tests)
+        estimator = FrechetMean(metric=self.sphere.metric, method='adaptive')
 
         for i in range(n_tests):
             # take 2 random points, compute their mean, and verify that
             # log of each at the mean is opposite
             points = self.sphere.random_uniform(n_samples=2)
-            mean = _adaptive_gradient_descent(
-                points=points, metric=self.sphere.metric)
+            mean = estimator.fit(points).estimate_
 
             logs = self.sphere.metric.log(point=points, base_point=mean)
             result[i] = gs.linalg.norm(logs[1, :] + logs[0, :])


### PR DESCRIPTION
- override `squared_dist` method for hypersphere using `dist(point_b, point_a)` instead of using `squared_norm(log(point_b, point_a))` which is slower.
- fix error from previous commit, to return point when only one sample is given to the `_adaptive_gradient_distance`.