### PR TITLE
Alias argument names of backend functions

### DIFF
--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -45,16 +45,13 @@ from torch import (  # NOQA
 
 from . import linalg  # NOQA
 from . import random  # NOQA
+from geomstats._backend.utils import mark_not_supported
 
 
-def _raise_not_implemented_error(*args, **kwargs):
-    raise NotImplementedError
-
-
-flip = _raise_not_implemented_error
-hsplit = _raise_not_implemented_error
-searchsorted = _raise_not_implemented_error
-vectorize = _raise_not_implemented_error
+flip = mark_not_supported
+hsplit = mark_not_supported
+searchsorted = mark_not_supported
+vectorize = mark_not_supported
 
 
 def empty(shape, dtype=float64):

--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -45,13 +45,16 @@ from torch import (  # NOQA
 
 from . import linalg  # NOQA
 from . import random  # NOQA
-from geomstats._backend.utils import mark_not_supported
+from geomstats._backend.utils import mark_not_supported, alias_argument_names
 
 
 flip = mark_not_supported
 hsplit = mark_not_supported
 searchsorted = mark_not_supported
 vectorize = mark_not_supported
+
+
+clip = alias_argument_names(a="input", a_min="min", a_max="max")(clip)
 
 
 def empty(shape, dtype=float64):

--- a/geomstats/_backend/utils.py
+++ b/geomstats/_backend/utils.py
@@ -7,3 +7,16 @@ class NotSupportedError(Exception):
 
 def mark_not_supported(*args, **kwargs):
     raise NotSupportedError
+
+
+def alias_argument_names(**mapping):
+    def decorator(function):
+        @functools.wraps(function)
+        def wrapper(*args, **kwargs):
+            for name, alias in mapping.items():
+                if name in kwargs:
+                    kwargs[alias] = kwargs[name]
+                    del kwargs[name]
+            return function(*args, **kwargs)
+        return wrapper
+    return decorator

--- a/geomstats/_backend/utils.py
+++ b/geomstats/_backend/utils.py
@@ -1,0 +1,9 @@
+import functools
+
+
+class NotSupportedError(Exception):
+    pass
+
+
+def mark_not_supported(*args, **kwargs):
+    raise NotSupportedError


### PR DESCRIPTION
This is just a quick PoC to demonstrate how we might alias argument names for backend functions which offer the same behavior as their Numpy counterpart but use different argument names. Without special handling, this currently prevents the use of keyword arguments for functions where argument names diverge from Numpy's interface.

The PR demonstrates this for PyTorch's `clamp` function (aliased `clip`), which accepts arguments `input`, `min`, `max` instead of `a`, `a_min`, `a_max` as in Numpy's case. To remap arguments, we could wrap the function using the provided `alias_argument_names` decorator (factory):
```python
clip = alias_argument_names(a="input", a_min="min", a_max="max")(clip)
```
It's questionable though whether this is really more convenient than simply doing
```python
def clip(a, a_min, a_max):
    return torch.clamp(input=a, min=a_min, max=a_max)
```

The alternative is what we pretty much already do, albeit somewhat coincidentally. We might simply make it a convention that keyword arguments are not allowed unless for arguments with default values.

I'd be interested to hear your views on this.