### PR TITLE
Adapt vectorization decorator to kwargs arguments

### DIFF
--- a/geomstats/vectorization.py
+++ b/geomstats/vectorization.py
@@ -12,7 +12,7 @@ POINT_TYPES_TO_NDIMS = {
     'matrix': 3}
 
 
-def squeeze_output_dim_0(initial_shapes, point_types):
+def squeeze_output_dim_0(in_shapes, point_types):
     """Determine if the output needs to be squeezed on dim 0.
 
     The dimension 0 is squeezed iff all input parameters:
@@ -23,7 +23,7 @@ def squeeze_output_dim_0(initial_shapes, point_types):
 
     Parameters
     ----------
-    initial_ndims : list
+    in_ndims : list
         Initial ndims of input parameters, as entered by the user.
     point_types : list
         Associated list of point_type of input parameters.
@@ -33,7 +33,7 @@ def squeeze_output_dim_0(initial_shapes, point_types):
     squeeze : bool
         Boolean deciding whether to squeeze dim 0 of the output.
     """
-    for in_shape, point_type in zip(initial_shapes, point_types):
+    for in_shape, point_type in zip(in_shapes, point_types):
         in_ndim = None
         if in_shape is not None:
             in_ndim = len(in_shape)
@@ -65,7 +65,7 @@ def is_scalar(vect_array):
     return has_singleton_dim_1
 
 
-def squeeze_output_dim_1(result, initial_shapes, point_types):
+def squeeze_output_dim_1(result, in_shapes, point_types):
     """Determine if the output needs to be squeezed on dim 1.
 
     This happens if the user represents scalars as array of shapes:
@@ -78,7 +78,7 @@ def squeeze_output_dim_1(result, initial_shapes, point_types):
     ----------
     result: array-like
         Result output by the function, before reshaping.
-    initial_shapes : list
+    in_shapes : list
         Initial shapes of input parameters, as entered by the user.
     point_types : list
         Associated list of point_type of input parameters.
@@ -91,7 +91,7 @@ def squeeze_output_dim_1(result, initial_shapes, point_types):
     if not is_scalar(result):
         return False
 
-    for shape, point_type in zip(initial_shapes, point_types):
+    for shape, point_type in zip(in_shapes, point_types):
         if point_type != 'else' and shape is not None:
             ndim = len(shape)
             if point_type == 'scalar':
@@ -137,7 +137,6 @@ def decorator(point_types):
 
             in_shapes = initial_shapes(args_point_types, args)
             kw_in_shapes = initial_shapes(kwargs_point_types, kwargs.values())
-
             in_shapes.extend(kw_in_shapes)
 
             vect_args = vectorize_args(args_point_types, args)
@@ -172,10 +171,10 @@ def initial_shapes(point_types, args):
 
     Returns
     -------
-    initial_shapes : list
+    in_shapes : list
         Shapes of array-like input args, or kwargs values.
     """
-    initial_shapes = []
+    in_shapes = []
 
     for i_arg, arg in enumerate(args):
         point_type = point_types[i_arg]
@@ -184,10 +183,10 @@ def initial_shapes(point_types, args):
             arg = gs.array(arg)
 
         if point_type == 'else' or arg is None:
-            initial_shapes.append(None)
+            in_shapes.append(None)
         else:
-            initial_shapes.append(gs.shape(arg))
-    return initial_shapes
+            in_shapes.append(gs.shape(arg))
+    return in_shapes
 
 
 def vectorize_args(point_types, args):

--- a/geomstats/vectorization.py
+++ b/geomstats/vectorization.py
@@ -158,22 +158,22 @@ def decorator(point_types):
 
 
 def initial_shapes(point_types, args):
-    """Extract shapes and ndims of input args.
+    """Extract shapes and ndims of input args or kwargs values.
 
-    Return a list with the shapes of the input args
-    that are array-like, with None otherwise.
+    Store the shapes of the input args, or kwargs values,
+    that are array-like, store None otherwise.
 
     Parameters
     ----------
-    point_types :  list
-        Point types corresponding to the args.
+    point_types : list
+        Point types corresponding to the args, or kwargs values.
     args : tuple or dict_values
         Args, or kwargs values, of a function.
 
     Returns
     -------
     initial_shapes : list
-        Shapes of array-like input args.
+        Shapes of array-like input args, or kwargs values.
     """
     initial_shapes = []
 
@@ -191,7 +191,29 @@ def initial_shapes(point_types, args):
 
 
 def vectorize_args(point_types, args):
-    """Vectorize input args."""
+    """Vectorize input args.
+
+    Transform input array-like args into their fully-vectorized form,
+
+    where "fully-vectorized" means that:
+    - one scalar has shape [1, 1],
+    - n scalars have shape [n, 1],
+    - one d-D vector has shape [1, d],
+    - n d-D vectors have shape [n, d],
+    etc.
+
+    Parameters
+    ----------
+    point_types : list
+        Point types corresponding to the args.
+    args : tuple
+        Args of a function.
+
+    Returns
+    -------
+    vect_args : tuple
+        Args of the function in their fully-vectorized form.
+    """
     vect_args = []
     for i_arg, arg in enumerate(args):
         point_type = point_types[i_arg]
@@ -208,7 +230,29 @@ def vectorize_args(point_types, args):
 
 
 def vectorize_kwargs(point_types, kwargs):
-    """Vectorize input kwargs."""
+    """Vectorize input kwargs.
+
+    Transform input array-like kwargs into their fully-vectorized form,
+
+    where "fully-vectorized" means that:
+    - one scalar has shape [1, 1],
+    - n scalars have shape [n, 1],
+    - one d-D vector has shape [1, d],
+    - n d-D vectors have shape [n, d],
+    etc.
+
+    Parameters
+    ----------
+    point_types :list
+        Point types corresponding to the args.
+    kwargs : dict
+        Kwargs of a function.
+
+    Returns
+    -------
+    vect_kwargs : dict
+        Kwargs of the function in their fully-vectorized form.
+    """
     vect_kwargs = {}
     for i_arg, key_arg in enumerate(kwargs.keys()):
         point_type = point_types[i_arg]

--- a/geomstats/vectorization.py
+++ b/geomstats/vectorization.py
@@ -135,10 +135,8 @@ def decorator(point_types):
             args_point_types = point_types[:len(args)]
             kwargs_point_types = point_types[len(args):]
 
-            in_shapes = args_initial_shapes(
-                args_point_types, args)
-            kw_in_shapes = kwargs_initial_shapes(
-                kwargs_point_types, kwargs)
+            in_shapes = initial_shapes(args_point_types, args)
+            kw_in_shapes = initial_shapes(kwargs_point_types, kwargs.values())
 
             in_shapes.extend(kw_in_shapes)
 
@@ -159,7 +157,7 @@ def decorator(point_types):
     return aux_decorator
 
 
-def args_initial_shapes(point_types, args):
+def initial_shapes(point_types, args):
     """Extract shapes and ndims of input args.
 
     Return a list with the shapes of the input args
@@ -169,8 +167,8 @@ def args_initial_shapes(point_types, args):
     ----------
     point_types :  list
         Point types corresponding to the args.
-    args : tuple
-        Args of a given function.
+    args : tuple or dict_values
+        Args, or kwargs values, of a function.
 
     Returns
     -------
@@ -180,39 +178,6 @@ def args_initial_shapes(point_types, args):
     initial_shapes = []
 
     for i_arg, arg in enumerate(args):
-        point_type = point_types[i_arg]
-
-        if point_type == 'scalar':
-            arg = gs.array(arg)
-
-        if point_type == 'else' or arg is None:
-            initial_shapes.append(None)
-        else:
-            initial_shapes.append(gs.shape(arg))
-    return initial_shapes
-
-
-def kwargs_initial_shapes(point_types, kwargs):
-    """Extract shapes and ndims of input kwargs.
-
-    Return a list with the shapes of the input kwargs
-    that are array-like, with None otherwise.
-
-    Parameters
-    ----------
-    point_types :  list
-        Point types corresponding to the kwargs.
-    args : dict
-        Kwargs of a given function.
-
-    Returns
-    -------
-    initial_shapes : list
-        Shapes of array-like input kwargs.
-    """
-    initial_shapes = []
-
-    for i_arg, arg in enumerate(kwargs.values()):
         point_type = point_types[i_arg]
 
         if point_type == 'scalar':

--- a/geomstats/vectorization.py
+++ b/geomstats/vectorization.py
@@ -34,7 +34,9 @@ def squeeze_output_dim_0(initial_shapes, point_types):
         Boolean deciding whether to squeeze dim 0 of the output.
     """
     for in_shape, point_type in zip(initial_shapes, point_types):
-        in_ndim = len(in_shape)
+        in_ndim = None
+        if in_shape is not None:
+            in_ndim = len(in_shape)
         if point_type != 'else' and in_ndim is not None:
             vect_ndim = POINT_TYPES_TO_NDIMS[point_type]
             assert in_ndim <= vect_ndim

--- a/geomstats/vectorization.py
+++ b/geomstats/vectorization.py
@@ -46,7 +46,18 @@ def squeeze_output_dim_0(initial_shapes, point_types):
 
 
 def is_scalar(vect_array):
-    """Test if an array represents a scalar."""
+    """Test if an array represents a scalar.
+
+    Parameters
+    ----------
+    vect_array :  array-like
+        Array to be tested.
+
+    Returns
+    -------
+    is_scalar : bool
+        Boolean determining if vect_array is a fully-vectorized scalar.
+    """
     has_ndim_2 = vect_array.ndim == 2
     if not has_ndim_2:
         return False
@@ -151,7 +162,20 @@ def decorator(point_types):
 def args_initial_shapes(point_types, args):
     """Extract shapes and ndims of input args.
 
-    Return a lists that stores the shapes of the input args.
+    Return a list with the shapes of the input args
+    that are array-like, with None otherwise.
+
+    Parameters
+    ----------
+    point_types :  list
+        Point types corresponding to the args.
+    args : tuple
+        Args of a given function.
+
+    Returns
+    -------
+    initial_shapes : list
+        Shapes of array-like input args.
     """
     initial_shapes = []
 
@@ -169,7 +193,23 @@ def args_initial_shapes(point_types, args):
 
 
 def kwargs_initial_shapes(point_types, kwargs):
-    """Extract shapes and ndims of input kwargs."""
+    """Extract shapes and ndims of input kwargs.
+
+    Return a list with the shapes of the input kwargs
+    that are array-like, with None otherwise.
+
+    Parameters
+    ----------
+    point_types :  list
+        Point types corresponding to the kwargs.
+    args : dict
+        Kwargs of a given function.
+
+    Returns
+    -------
+    initial_shapes : list
+        Shapes of array-like input kwargs.
+    """
     initial_shapes = []
 
     for i_arg, arg in enumerate(kwargs.values()):

--- a/tests/test_vectorization.py
+++ b/tests/test_vectorization.py
@@ -12,14 +12,14 @@ class TestVectorizationMethods(geomstats.tests.TestCase):
         @geomstats.vectorization.decorator(['vector', 'vector'])
         def foo(tangent_vec_a, tangent_vec_b):
             result = gs.einsum(
-                'ni,ni->ni', tangent_vec_a, tangent_vec_b)
+                '...i,...i->...i', tangent_vec_a, tangent_vec_b)
             result = helper.to_vector(result)
             return result
 
         @geomstats.vectorization.decorator(['vector', 'vector'])
         def foo_scalar_output(tangent_vec_a, tangent_vec_b):
             result = gs.einsum(
-                'ni,ni->n', tangent_vec_a, tangent_vec_b)
+                '...i,...i->...', tangent_vec_a, tangent_vec_b)
             result = helper.to_scalar(result)
             return result
 
@@ -78,7 +78,6 @@ class TestVectorizationMethods(geomstats.tests.TestCase):
         self.is_vector_vectorized = is_vector_vectorized
         self.is_matrix_vectorized = is_matrix_vectorized
 
-    @geomstats.tests.np_and_tf_only
     def test_decorator_with_squeeze_dim0(self):
         vec_a = gs.array([1, 2, 3])
         vec_b = gs.array([0, 1, 0])
@@ -88,7 +87,15 @@ class TestVectorizationMethods(geomstats.tests.TestCase):
         self.assertAllClose(result.shape, expected.shape)
         self.assertAllClose(result, expected)
 
-    @geomstats.tests.np_and_tf_only
+    def test_decorator_with_squeeze_dim0_with_kwargs(self):
+        vec_a = gs.array([1, 2, 3])
+        vec_b = gs.array([0, 1, 0])
+        result = self.foo(tangent_vec_a=vec_a, tangent_vec_b=vec_b)
+        expected = gs.array([0, 2, 0])
+
+        self.assertAllClose(result.shape, expected.shape)
+        self.assertAllClose(result, expected)
+
     def test_decorator_without_squeeze_dim0(self):
         vec_a = gs.array([[1, 2, 3]])
         vec_b = gs.array([0, 1, 0])
@@ -98,7 +105,15 @@ class TestVectorizationMethods(geomstats.tests.TestCase):
         self.assertAllClose(result.shape, expected.shape)
         self.assertAllClose(result, expected)
 
-    @geomstats.tests.np_and_tf_only
+    def test_decorator_without_squeeze_dim0_with_kwargs(self):
+        vec_a = gs.array([[1, 2, 3]])
+        vec_b = gs.array([0, 1, 0])
+        result = self.foo(tangent_vec_a=vec_a, tangent_vec_b=vec_b)
+        expected = gs.array([[0, 2, 0]])
+
+        self.assertAllClose(result.shape, expected.shape)
+        self.assertAllClose(result, expected)
+
     def test_decorator_vectorization(self):
         vec_a = gs.array([[1, 2, 3], [1, 2, 3]])
         vec_b = gs.array([0, 1, 0])
@@ -108,7 +123,15 @@ class TestVectorizationMethods(geomstats.tests.TestCase):
         self.assertAllClose(result.shape, expected.shape)
         self.assertAllClose(result, expected)
 
-    @geomstats.tests.np_and_tf_only
+    def test_decorator_vectorization_with_kwargs(self):
+        vec_a = gs.array([[1, 2, 3], [1, 2, 3]])
+        vec_b = gs.array([0, 1, 0])
+        result = self.foo(tangent_vec_a=vec_a, tangent_vec_b=vec_b)
+        expected = gs.array([[0, 2, 0], [0, 2, 0]])
+
+        self.assertAllClose(result.shape, expected.shape)
+        self.assertAllClose(result, expected)
+
     def test_decorator_scalar_with_squeeze_dim1(self):
         vec_a = gs.array([1, 2, 3])
         vec_b = gs.array([0, 1, 0])
@@ -117,7 +140,15 @@ class TestVectorizationMethods(geomstats.tests.TestCase):
 
         self.assertAllClose(result, expected)
 
-    @geomstats.tests.np_and_tf_only
+    def test_decorator_scalar_with_squeeze_dim1_with_kwargs(self):
+        vec_a = gs.array([1, 2, 3])
+        vec_b = gs.array([0, 1, 0])
+        result = self.foo_scalar_output(
+            tangent_vec_a=vec_a, tangent_vec_b=vec_b)
+        expected = 2
+
+        self.assertAllClose(result, expected)
+
     def test_decorator_scalar_without_squeeze_dim1(self):
         vec_a = gs.array([1, 2, 3])
         vec_b = gs.array([0, 1, 0])
@@ -127,7 +158,16 @@ class TestVectorizationMethods(geomstats.tests.TestCase):
 
         self.assertAllClose(result, expected)
 
-    @geomstats.tests.np_and_tf_only
+    def test_decorator_scalar_without_squeeze_dim1_with_kwargs(self):
+        vec_a = gs.array([1, 2, 3])
+        vec_b = gs.array([0, 1, 0])
+        scalar = 4
+        result = self.foo_scalar_input_output(
+            tangent_vec_a=vec_a, tangent_vec_b=vec_b, in_scalar=scalar)
+        expected = 8
+
+        self.assertAllClose(result, expected)
+
     def test_decorator_scalar_output_vectorization(self):
         vec_a = gs.array([[1, 2, 3], [1, 2, 3]])
         vec_b = gs.array([0, 1, 0])
@@ -137,10 +177,38 @@ class TestVectorizationMethods(geomstats.tests.TestCase):
         self.assertAllClose(result.shape, expected.shape)
         self.assertAllClose(result, expected)
 
+    def test_decorator_scalar_output_vectorization_with_kwargs(self):
+        vec_a = gs.array([[1, 2, 3], [1, 2, 3]])
+        vec_b = gs.array([0, 1, 0])
+        result = self.foo_scalar_output(
+            tangent_vec_a=vec_a, tangent_vec_b=vec_b)
+        expected = gs.array([2, 2])
+
+        self.assertAllClose(result.shape, expected.shape)
+        self.assertAllClose(result, expected)
+
     def test_decorator_optional_input(self):
         vec_a = gs.array([1, 2, 3])
         vec_b = gs.array([0, 1, 0])
         result = self.foo_optional_input(vec_a, vec_b)
+        expected = 2
+
+        self.assertAllClose(result, expected)
+
+    def test_decorator_optional_input_with_kwargs(self):
+        vec_a = gs.array([1, 2, 3])
+        vec_b = gs.array([0, 1, 0])
+        result = self.foo_optional_input(
+            tangent_vec_a=vec_a, tangent_vec_b=vec_b, in_scalar=3)
+        expected = 6
+
+        self.assertAllClose(result, expected)
+
+    def test_decorator_optional_input_with_optional_kwargs(self):
+        vec_a = gs.array([1, 2, 3])
+        vec_b = gs.array([0, 1, 0])
+        result = self.foo_optional_input(
+            tangent_vec_a=vec_a, tangent_vec_b=vec_b)
         expected = 2
 
         self.assertAllClose(result, expected)
@@ -155,9 +223,27 @@ class TestVectorizationMethods(geomstats.tests.TestCase):
 
         self.assertAllClose(result, expected)
 
+    def test_decorator_else_with_kwargs(self):
+        vec_a = gs.array([1, 2, 3])
+        vec_b = gs.array([0, 1, 0])
+        else_a = 1
+        else_b = 1
+        result = self.foo_else(
+            else_a=else_a, tangent_vec_a=vec_a,
+            else_b=else_b, tangent_vec_b=vec_b)
+        expected = 4
+
+        self.assertAllClose(result, expected)
+
     def test_is_scalar_vectorized(self):
         scalar = 1.3
         result = self.is_scalar_vectorized(scalar)
+        expected = True
+        self.assertAllClose(result, expected)
+
+    def test_is_scalar_vectorized_with_kwargs(self):
+        scalar = 1.3
+        result = self.is_scalar_vectorized(scalar=scalar)
         expected = True
         self.assertAllClose(result, expected)
 
@@ -167,8 +253,40 @@ class TestVectorizationMethods(geomstats.tests.TestCase):
         expected = True
         self.assertAllClose(result, expected)
 
+    def test_is_vector_vectorizedi_with_kwargs(self):
+        vector = gs.array([1.3, 3.3])
+        result = self.is_vector_vectorized(vector=vector)
+        expected = True
+        self.assertAllClose(result, expected)
+
     def test_is_matrix_vectorized(self):
         matrix = gs.array([[1.3, 3.3], [1.2, 3.1]])
         result = self.is_matrix_vectorized(matrix)
         expected = True
+        self.assertAllClose(result, expected)
+
+    def test_is_matrix_vectorized_with_kwargs(self):
+        matrix = gs.array([[1.3, 3.3], [1.2, 3.1]])
+        result = self.is_matrix_vectorized(matrix=matrix)
+        expected = True
+        self.assertAllClose(result, expected)
+
+    def test_vectorize_args(self):
+        point_types = ['scalar']
+        args = (1.3,)
+        result = geomstats.vectorization.vectorize_args(point_types, args)
+        expected = (gs.array([[1.3]]),)
+        self.assertAllClose(result, expected)
+
+    def test_vectorize_kwargs(self):
+        point_types = ['scalar']
+        kwargs = {'scalar_name': 1.3}
+        result_dict = geomstats.vectorization.vectorize_kwargs(
+            point_types, kwargs)
+        expected_dict = {'scalar_name': gs.array([[1.3]])}
+
+        keys = expected_dict.keys()
+        result = gs.array([result_dict[key] for key in keys])
+        expected = gs.array([expected_dict[key] for key in keys])
+
         self.assertAllClose(result, expected)


### PR DESCRIPTION
This PR prepares the vectorization refactorization, as mentioned in issue #338.

It builds on the vectorization decorator, to be put on top of some (as less as possible) geomstats functions, in order to:
- convert their arguments into their fully-vectorized forms,
- call the function,
- reshape the output if needed.

This PR enhances the decorator by allowing it to take into account kwargs arguments.