### PR TITLE
Regularize tangent vec special euclidean

### DIFF
--- a/tests/test_special_euclidean.py
+++ b/tests/test_special_euclidean.py
@@ -333,7 +333,7 @@ class TestSpecialEuclideanMethods(geomstats.tests.TestCase):
         self.assertAllClose(result, expected)
 
         tangent_vec = gs.array([[.5, -2., 4., 12.],
-                                [2., 0.,  -4.5, 13.],
+                                [2., 0., -4.5, 13.],
                                 [-4., 4.5, 0., 14.],
                                 [0.5, 0., 0., 0.]])
         regularized = self.group.regularize_tangent_vec_at_identity(

--- a/tests/test_special_euclidean.py
+++ b/tests/test_special_euclidean.py
@@ -349,6 +349,7 @@ class TestSpecialEuclideanMethods(geomstats.tests.TestCase):
         self.group.default_point_type = 'matrix'
         n = self.group.n
         tangent_vecs = gs.arange(self.n_samples * (self.group.n + 1) ** 2)
+        tangent_vecs = gs.cast(tangent_vecs, gs.float32)
         tangent_vecs = gs.reshape(
             tangent_vecs, (self.n_samples,) + (n + 1,) * 2)
         regularized = self.group.regularize_tangent_vec_at_identity(


### PR DESCRIPTION
Add the method to regularize tangent vectors represented by matrices for the special euclidean group, without assignement so that it works will all backends