### PR TITLE
Test GenralLinear with pytorch

### DIFF
--- a/geomstats/geometry/general_linear.py
+++ b/geomstats/geometry/general_linear.py
@@ -14,7 +14,7 @@ class GeneralLinear(Matrices):
     def belongs(point):
         """Test if a matrix is invertible."""
         det = gs.linalg.det(point)
-        return gs.where(det != 0., True, False)
+        return gs.where(det != 0., gs.array(True), gs.array(False))
 
     def identity(self):
         """Return the identity matrix."""

--- a/tests/test_general_linear.py
+++ b/tests/test_general_linear.py
@@ -18,7 +18,6 @@ class TestGeneralLinearMethods(geomstats.tests.TestCase):
 
         warnings.simplefilter('ignore', category=ImportWarning)
 
-    @geomstats.tests.np_only
     def test_belongs(self):
         mats = gs.array([
             [[1., 0.], [0., 1]],
@@ -51,7 +50,6 @@ class TestGeneralLinearMethods(geomstats.tests.TestCase):
         result = self.group.inv(mat_a)
         self.assertAllClose(result, expected)
 
-    @geomstats.tests.np_and_tf_only
     def test_inv_vectorized(self):
         mat_a = gs.array([
             [0., 1., 0.],
@@ -71,7 +69,6 @@ class TestGeneralLinearMethods(geomstats.tests.TestCase):
         expected = point
         self.assertAllClose(result, expected)
 
-    @geomstats.tests.np_and_tf_only
     def test_exp_vectorization(self):
         point = gs.array([[[2., 0., 0.],
                            [0., 3., 0.],


### PR DESCRIPTION
This PR removes a few decorators where possible to improve testing with the pytorch backend.
Only the log, which is not yet implemented with pytorch if I understood remains not tested.