### PR TITLE
Docstring on some backend functions

### DIFF
--- a/geomstats/_backend/numpy/__init__.py
+++ b/geomstats/_backend/numpy/__init__.py
@@ -99,7 +99,7 @@ def get_mask_i_float(i, n):
 
     Parameters
     ----------
-    i: int
+    i : int
         Index of the non-zero element.
     n: n
         Length of the created array.
@@ -210,7 +210,7 @@ def get_slice(x, indices):
     Parameters
     ----------
     x : array-like, shape=[dimension]
-        Initial array, shape=[dimension].
+        Initial array.
     indices : iterable(iterable(int))
         Indices which are kept along each axis, starting from 0.
 
@@ -243,12 +243,12 @@ def cast(x, dtype):
 
 
 def set_diag(x, new_diag):
-    """Sets the diagonal along the last two axis.
+    """Set the diagonal along the last two axis.
 
     Parameters
     ----------
     x : array-like, shape=[dimension]
-        Initial array, shape=[dimension].
+        Initial array.
     new_diag : array-like, shape=[dimension[-2]]
         Values to set on the diagonal.
 

--- a/geomstats/_backend/numpy/__init__.py
+++ b/geomstats/_backend/numpy/__init__.py
@@ -211,7 +211,7 @@ def get_slice(x, indices):
     ----------
     x : array-like, shape=[dimension]
         Initial array, shape=[dimension].
-    indices : {iterable(iterable(int))}
+    indices : iterable(iterable(int))
         Indices which are kept along each axis, starting from 0.
 
     Returns
@@ -274,5 +274,23 @@ def copy(x):
 
 
 def array_from_sparse(indices, data, target_shape):
+    """Create an array of given shape, with values at specific indices.
+
+    The rest of the array will be filled with zeros.
+
+    Parameters
+    ----------
+    indices : iterable(tuple(int))
+        Index of each element which will be assigned a specific value.
+    data : iterable(scalar)
+        Value associated at each index.
+    target_shape : tuple(int)
+        Shape of the output array.
+
+    Returns
+    -------
+    a : array, shape=target_shape
+        Array of zeros with specified values assigned to specified indices.
+    """
     return array(
         coo_matrix((data, list(zip(*indices))), target_shape).todense())

--- a/geomstats/_backend/numpy/__init__.py
+++ b/geomstats/_backend/numpy/__init__.py
@@ -151,11 +151,11 @@ def assignment_by_sum(x, values, indices, axis=0):
 
     Parameters
     ----------
-    x: array-like, shape=[dimension]
+    x : array-like, shape=[dimension]
         Initial array.
-    values: {float, list(float)}
+    values : {float, list(float)}
         Value or list of values to be assigned.
-    indices: {int, tuple, list(int), list(tuple)}
+    indices : {int, tuple, list(int), list(tuple)}
         Single int or tuple, or list of ints or tuples of indices where value
         is assigned.
         If the length of the tuples is shorter than ndim(x), values are
@@ -191,6 +191,30 @@ def assignment_by_sum(x, values, indices, axis=0):
 
 
 def get_slice(x, indices):
+    """Return a slice of an array, following Numpy's style.
+
+    Parameters
+    ----------
+    x : array-like, shape=[dimension]
+        Initial array, shape=[dimension].
+    indices : {iterable(iterable(int))}
+        Indices which are kept along each axis, starting from 0.
+
+    Returns
+    -------
+    slice : array-like
+        Slice of x given by indices.
+
+    Notes
+    -----
+    This follows Numpy's convention: indices are grouped by axis.
+
+    Examples
+    --------
+    >>> a = np.array(range(30)).reshape(3,10)
+    >>> get_slice(a, ((0, 2), (8, 9)))
+    array([8, 29])
+    """
     return x[indices]
 
 
@@ -205,6 +229,24 @@ def cast(x, dtype):
 
 
 def set_diag(x, new_diag):
+    """Sets the diagonal along the last two axis.
+
+    Parameters
+    ----------
+    x : array-like, shape=[dimension]
+        Initial array, shape=[dimension].
+    new_diag : array-like, shape=[dimension[-2]]
+        Values to set on the diagonal.
+
+    Returns
+    -------
+    None
+
+    Notes
+    -----
+    This mimics tensorflow.linalg.set_diag(x, new_diag), when new_diag is a
+    1-D array, but modifies x instead of creating a copy.
+    """
     arr_shape = x.shape
     x[..., range(arr_shape[-2]), range(arr_shape[-1])] = new_diag
 

--- a/geomstats/_backend/numpy/__init__.py
+++ b/geomstats/_backend/numpy/__init__.py
@@ -95,6 +95,20 @@ def flatten(x):
 
 
 def get_mask_i_float(i, n):
+    """Create a 1D array of zeros with one element at one, with floating type.
+
+    Parameters
+    ----------
+    i: int
+        Index of the non-zero element.
+    n: n
+        Length of the created array.
+
+    Returns
+    -------
+    mask_i_float : array-like, shape=[n,]
+        1D array of zeros except at index i, where it is one
+    """
     range_n = arange(n)
     i_float = cast(array([i]), int32)[0]
     mask_i = equal(range_n, i_float)

--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -419,6 +419,20 @@ def mean(x, axis=None):
 
 
 def get_mask_i_float(i, n):
+    """Create a 1D array of zeros with one element at one, with floating type.
+
+    Parameters
+    ----------
+    i: int
+        Index of the non-zero element.
+    n: n
+        Length of the created array.
+
+    Returns
+    -------
+    mask_i_float : array-like, shape=[n,]
+        1D array of zeros except at index i, where it is one
+    """
     range_n = arange(cast(array(n), int32))
     i_float = cast(array(i), int32)
     mask_i = equal(range_n, i_float)

--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -161,7 +161,7 @@ def get_slice(x, indices):
     Parameters
     ----------
     x : array-like, shape=[dimension]
-        Initial array, shape=[dimension].
+        Initial array.
     indices : iterable(iterable(int))
         Indices which are kept along each axis, starting from 0.
 
@@ -384,12 +384,12 @@ def diagonal(x, offset=0, axis1=0, axis2=1):
 
 
 def set_diag(x, new_diag):
-    """Sets the diagonal along the last two axis.
+    """Set the diagonal along the last two axis.
 
     Parameters
     ----------
     x : array-like, shape=[dimension]
-        Initial array, shape=[dimension].
+        Initial array.
     new_diag : array-like, shape=[dimension[-2]]
         Values to set on the diagonal.
 
@@ -423,7 +423,7 @@ def get_mask_i_float(i, n):
 
     Parameters
     ----------
-    i: int
+    i : int
         Index of the non-zero element.
     n: n
         Length of the created array.

--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -156,6 +156,30 @@ def all(x, axis=None):
 
 
 def get_slice(x, indices):
+    """Return a slice of an array, following Numpy's style.
+
+        Parameters
+        ----------
+        x : array-like, shape=[dimension]
+            Initial array, shape=[dimension].
+        indices : {iterable(iterable(int))}
+            Indices which are kept along each axis, starting from 0.
+
+        Returns
+        -------
+        slice : array-like
+            Slice of x given by indices.
+
+        Notes
+        -----
+        This follows Numpy's convention: indices are grouped by axis.
+
+        Examples
+        --------
+        >>> a = torch.tensor(range(30)).reshape(3,10)
+        >>> get_slice(a, ((0, 2), (8, 9)))
+        tensor([8, 29])
+        """
     return x[indices]
 
 
@@ -360,6 +384,24 @@ def diagonal(x, offset=0, axis1=0, axis2=1):
 
 
 def set_diag(x, new_diag):
+    """Sets the diagonal along the last two axis.
+
+    Parameters
+    ----------
+    x : array-like, shape=[dimension]
+        Initial array, shape=[dimension].
+    new_diag : array-like, shape=[dimension[-2]]
+        Values to set on the diagonal.
+
+    Returns
+    -------
+    None
+
+    Notes
+    -----
+    This mimics tensorflow.linalg.set_diag(x, new_diag), when new_diag is a
+    1-D array, but modifies x instead of creating a copy.
+    """
     arr_shape = x.shape
     x[..., range(arr_shape[-2]), range(arr_shape[-1])] = new_diag
 

--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -158,28 +158,28 @@ def all(x, axis=None):
 def get_slice(x, indices):
     """Return a slice of an array, following Numpy's style.
 
-        Parameters
-        ----------
-        x : array-like, shape=[dimension]
-            Initial array, shape=[dimension].
-        indices : {iterable(iterable(int))}
-            Indices which are kept along each axis, starting from 0.
+    Parameters
+    ----------
+    x : array-like, shape=[dimension]
+        Initial array, shape=[dimension].
+    indices : iterable(iterable(int))
+        Indices which are kept along each axis, starting from 0.
 
-        Returns
-        -------
-        slice : array-like
-            Slice of x given by indices.
+    Returns
+    -------
+    slice : array-like
+        Slice of x given by indices.
 
-        Notes
-        -----
-        This follows Numpy's convention: indices are grouped by axis.
+    Notes
+    -----
+    This follows Numpy's convention: indices are grouped by axis.
 
-        Examples
-        --------
-        >>> a = torch.tensor(range(30)).reshape(3,10)
-        >>> get_slice(a, ((0, 2), (8, 9)))
-        tensor([8, 29])
-        """
+    Examples
+    --------
+    >>> a = torch.tensor(range(30)).reshape(3,10)
+    >>> get_slice(a, ((0, 2), (8, 9)))
+    tensor([8, 29])
+    """
     return x[indices]
 
 
@@ -541,6 +541,24 @@ def cumsum(x, axis=None):
 
 
 def array_from_sparse(indices, data, target_shape):
+    """Create an array of given shape, with values at specific indices.
+
+    The rest of the array will be filled with zeros.
+
+    Parameters
+    ----------
+    indices : iterable(tuple(int))
+        Index of each element which will be assigned a specific value.
+    data : iterable(scalar)
+        Value associated at each index.
+    target_shape : tuple(int)
+        Shape of the output array.
+
+    Returns
+    -------
+    a : array, shape=target_shape
+        Array of zeros with specified values assigned to specified indices.
+    """
     return torch.sparse.FloatTensor(
         torch.LongTensor(indices).t(),
         torch.FloatTensor(cast(data, float32)),

--- a/geomstats/_backend/tensorflow/__init__.py
+++ b/geomstats/_backend/tensorflow/__init__.py
@@ -139,7 +139,7 @@ def get_mask_i_float(i, n):
 
     Parameters
     ----------
-    i: int
+    i : int
         Index of the non-zero element.
     n: n
         Length of the created array.
@@ -431,7 +431,7 @@ def get_slice(x, indices):
     Parameters
     ----------
     x : array-like, shape=[dimension]
-        Initial array, shape=[dimension].
+        Initial array.
     indices : iterable(iterable(int))
         Indices which are kept along each axis, starting from 0.
 

--- a/geomstats/_backend/tensorflow/__init__.py
+++ b/geomstats/_backend/tensorflow/__init__.py
@@ -394,6 +394,30 @@ def array_from_sparse(indices, data, target_shape):
 
 
 def get_slice(x, indices):
+    """Return a slice of an array, following Numpy's style.
+
+        Parameters
+        ----------
+        x : array-like, shape=[dimension]
+            Initial array, shape=[dimension].
+        indices : {iterable(iterable(int))}
+            Indices which are kept along each axis, starting from 0.
+
+        Returns
+        -------
+        slice : array-like
+            Slice of x given by indices.
+
+        Notes
+        -----
+        This follows Numpy's convention: indices are grouped by axis.
+
+        Examples
+        --------
+        >>> a = tf.reshape(tf.convert_to_tensor(range(30)), (3,10))
+        >>> get_slice(a, ((0, 2), (8, 9)))
+        <tf.Tensor: id=41, shape=(2,), dtype=int32, numpy=array([ 8, 29])>
+        """
     return tf.gather_nd(x, list(zip(*indices)))
 
 

--- a/geomstats/_backend/tensorflow/__init__.py
+++ b/geomstats/_backend/tensorflow/__init__.py
@@ -135,6 +135,20 @@ def any(x, axis=None):
 
 
 def get_mask_i_float(i, n):
+    """Create a 1D array of zeros with one element at one, with floating type.
+
+    Parameters
+    ----------
+    i: int
+        Index of the non-zero element.
+    n: n
+        Length of the created array.
+
+    Returns
+    -------
+    mask_i_float : array-like, shape=[n,]
+        1D array of zeros except at index i, where it is one
+    """
     range_n = arange(n)
     i_float = cast(array([i]), int32)[0]
     mask_i = equal(range_n, i_float)

--- a/geomstats/_backend/tensorflow/__init__.py
+++ b/geomstats/_backend/tensorflow/__init__.py
@@ -428,28 +428,28 @@ def array_from_sparse(indices, data, target_shape):
 def get_slice(x, indices):
     """Return a slice of an array, following Numpy's style.
 
-        Parameters
-        ----------
-        x : array-like, shape=[dimension]
-            Initial array, shape=[dimension].
-        indices : iterable(iterable(int))
-            Indices which are kept along each axis, starting from 0.
+    Parameters
+    ----------
+    x : array-like, shape=[dimension]
+        Initial array, shape=[dimension].
+    indices : iterable(iterable(int))
+        Indices which are kept along each axis, starting from 0.
 
-        Returns
-        -------
-        slice : array-like
-            Slice of x given by indices.
+    Returns
+    -------
+    slice : array-like
+        Slice of x given by indices.
 
-        Notes
-        -----
-        This follows Numpy's convention: indices are grouped by axis.
+    Notes
+    -----
+    This follows Numpy's convention: indices are grouped by axis.
 
-        Examples
-        --------
-        >>> a = tf.reshape(tf.convert_to_tensor(range(30)), (3,10))
-        >>> get_slice(a, ((0, 2), (8, 9)))
-        <tf.Tensor: id=41, shape=(2,), dtype=int32, numpy=array([ 8, 29])>
-        """
+    Examples
+    --------
+    >>> a = tf.reshape(tf.convert_to_tensor(range(30)), (3,10))
+    >>> get_slice(a, ((0, 2), (8, 9)))
+    <tf.Tensor: id=41, shape=(2,), dtype=int32, numpy=array([ 8, 29])>
+    """
     return tf.gather_nd(x, list(zip(*indices)))
 
 

--- a/geomstats/_backend/tensorflow/__init__.py
+++ b/geomstats/_backend/tensorflow/__init__.py
@@ -403,6 +403,24 @@ def assignment(x, values, indices, axis=0):
 
 
 def array_from_sparse(indices, data, target_shape):
+    """Create an array of given shape, with values at specific indices.
+
+    The rest of the array will be filled with zeros.
+
+    Parameters
+    ----------
+    indices : iterable(tuple(int))
+        Index of each element which will be assigned a specific value.
+    data : iterable(scalar)
+        Value associated at each index.
+    target_shape : tuple(int)
+        Shape of the output array.
+
+    Returns
+    -------
+    a : array, shape=target_shape
+        Array of zeros with specified values assigned to specified indices.
+    """
     return tf.sparse.to_dense(tf.sparse.reorder(
         tf.SparseTensor(indices, data, target_shape)))
 
@@ -414,7 +432,7 @@ def get_slice(x, indices):
         ----------
         x : array-like, shape=[dimension]
             Initial array, shape=[dimension].
-        indices : {iterable(iterable(int))}
+        indices : iterable(iterable(int))
             Indices which are kept along each axis, starting from 0.
 
         Returns

--- a/tests/test_special_orthogonal.py
+++ b/tests/test_special_orthogonal.py
@@ -3261,7 +3261,7 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
 
             normal_rv = gs.random.normal(size=dim)
             tangent_sample = gs.zeros((n, n))
-            tangent_sample[list(gs.triu_indices(n, k=1))] = normal_rv
+            tangent_sample[tuple(gs.triu_indices(n, k=1))] = normal_rv
             tangent_sample = tangent_sample - gs.transpose(tangent_sample)
 
             result = gs.reshape(


### PR DESCRIPTION
Documentation for `get_slice`, `array_from_sparse` and `get_mask_i_float` backend functions, which are exported but not "straightforward" to understand.