### PR TITLE
Add `point_type` logic to vectorization's decorator

### DIFF
--- a/geomstats/vectorization.py
+++ b/geomstats/vectorization.py
@@ -54,34 +54,12 @@ def decorator(point_types):
 
     def aux_decorator(function):
         def wrapper(*args, **kwargs):
-
-            # print('\nbefore')
-            # print('args_types')
-            # print(args_types)
-            # print('kwargs_types')
-            # print(kwargs_types)
-            # print('opt_kwargs_types')
-            # print(opt_kwargs_types)
-            # print('args')
-            # print(args)
-            # print('kwargs')
-            # print(kwargs)
             args_types, kwargs_types, opt_kwargs_types, is_scal = get_types(
                 point_types, args, kwargs)
 
             args_types, kwargs_types = adapt_types(
                 args_types, kwargs_types, opt_kwargs_types, args, kwargs)
             args_kwargs_types = args_types + kwargs_types
-
-            # print('\nafter')
-            # print('args_types')
-            # print(args_types)
-            # print('kwargs_types')
-            # print(kwargs_types)
-            # print('args')
-            # print(args)
-            # print('kwargs')
-            # print(kwargs)
 
             args_shapes = get_initial_shapes(args_types, args)
             kwargs_shapes = get_initial_shapes(kwargs_types, kwargs.values())

--- a/geomstats/vectorization.py
+++ b/geomstats/vectorization.py
@@ -206,7 +206,7 @@ def get_initial_shapes(input_types, args):
         if input_type == 'scalar':
             arg = gs.array(arg)
 
-        if input_type in POINT_TYPES:
+        if input_type in POINT_TYPES and arg is not None:
             in_shapes.append(gs.shape(arg))
         elif input_type in OTHER_TYPES or arg is None:
             in_shapes.append(None)
@@ -244,7 +244,7 @@ def vectorize_args(input_types, args):
         if input_type == 'scalar':
             vect_arg = gs.to_ndarray(arg, to_ndim=1)
             vect_arg = gs.to_ndarray(vect_arg, to_ndim=2, axis=1)
-        elif input_type in POINT_TYPES:
+        elif input_type in POINT_TYPES and arg is not None:
             vect_arg = gs.to_ndarray(
                 arg, to_ndim=POINT_TYPES_TO_NDIMS[input_type])
         elif input_type in OTHER_TYPES or arg is None:
@@ -285,7 +285,7 @@ def vectorize_kwargs(input_types, kwargs):
         if input_type == 'scalar':
             vect_arg = gs.to_ndarray(arg, to_ndim=1)
             vect_arg = gs.to_ndarray(vect_arg, to_ndim=2, axis=1)
-        elif input_type in POINT_TYPES:
+        elif input_type in POINT_TYPES and arg is not None:
             vect_arg = gs.to_ndarray(
                 arg, to_ndim=POINT_TYPES_TO_NDIMS[input_type])
         elif input_type in OTHER_TYPES or arg is None:

--- a/geomstats/vectorization.py
+++ b/geomstats/vectorization.py
@@ -242,7 +242,6 @@ def vectorize_args(input_types, args):
         if input_type == 'scalar':
             vect_arg = gs.to_ndarray(arg, to_ndim=1)
             vect_arg = gs.to_ndarray(vect_arg, to_ndim=2, axis=1)
-
         elif input_type in POINT_TYPES:
             vect_arg = gs.to_ndarray(
                 arg, to_ndim=POINT_TYPES_TO_NDIMS[input_type])
@@ -281,14 +280,14 @@ def vectorize_kwargs(input_types, kwargs):
     for i_arg, key_arg in enumerate(kwargs.keys()):
         input_type = input_types[i_arg]
         arg = kwargs[key_arg]
-        if input_type in ['else', 'point_type'] or arg is None:
-            vect_arg = arg
-        elif input_type == 'scalar':
+        if input_type == 'scalar':
             vect_arg = gs.to_ndarray(arg, to_ndim=1)
             vect_arg = gs.to_ndarray(vect_arg, to_ndim=2, axis=1)
-        elif input_type in ['vector', 'matrix']:
+        elif input_type in POINT_TYPES:
             vect_arg = gs.to_ndarray(
                 arg, to_ndim=POINT_TYPES_TO_NDIMS[input_type])
+        elif input_type in OTHER_TYPES or arg is None:
+            vect_arg = arg
         else:
             raise ValueError('Invalid point type.')
         vect_kwargs[key_arg] = vect_arg

--- a/geomstats/vectorization.py
+++ b/geomstats/vectorization.py
@@ -60,11 +60,19 @@ def decorator(input_types):
 
     def aux_decorator(function):
         def wrapper(*args, **kwargs):
+            print('args')
+            print(args)
+            print('kwargs')
+            print(kwargs)
             args_types, kwargs_types, opt_kwargs_types, is_scal = get_types(
                 input_types, args, kwargs)
 
-            args_types, kwargs_types = adapt_types(
+            args_types, kwargs_types, kwargs = adapt_types(
                 args_types, kwargs_types, opt_kwargs_types, args, kwargs)
+            print('args_types')
+            print(args_types)
+            print('kwargs_types')
+            print(kwargs_types)
             args_kwargs_types = args_types + kwargs_types
 
             args_shapes = get_initial_shapes(args_types, args)
@@ -168,8 +176,13 @@ def adapt_types(
             input_type = kwargs['point_type']
 
         elif in_optional:
+            print('found optional type')
             obj = args[0]
             input_type = obj.default_point_type
+            print('input_type')
+            print(input_type)
+            kwargs['point_type'] = input_type
+            kwargs_types.append('point_type')
 
         args_types = [
             input_type if pt == FLEXIBLE_TYPE else pt
@@ -177,7 +190,7 @@ def adapt_types(
         kwargs_types = [
             input_type if pt == FLEXIBLE_TYPE else pt
             for pt in kwargs_types]
-    return args_types, kwargs_types
+    return args_types, kwargs_types, kwargs
 
 
 def get_initial_shapes(input_types, args):

--- a/geomstats/vectorization.py
+++ b/geomstats/vectorization.py
@@ -239,14 +239,15 @@ def vectorize_args(input_types, args):
     vect_args = []
     for i_arg, arg in enumerate(args):
         input_type = input_types[i_arg]
-        if input_type in ['else', 'point_type'] or arg is None:
-            vect_arg = arg
-        elif input_type == 'scalar':
+        if input_type == 'scalar':
             vect_arg = gs.to_ndarray(arg, to_ndim=1)
             vect_arg = gs.to_ndarray(vect_arg, to_ndim=2, axis=1)
-        elif input_type in ['vector', 'matrix']:
+
+        elif input_type in POINT_TYPES:
             vect_arg = gs.to_ndarray(
                 arg, to_ndim=POINT_TYPES_TO_NDIMS[input_type])
+        elif input_type in OTHER_TYPES or arg is None:
+            vect_arg = arg
         else:
             raise ValueError('Invalid point type: %s' % input_type)
         vect_args.append(vect_arg)

--- a/geomstats/vectorization.py
+++ b/geomstats/vectorization.py
@@ -170,9 +170,11 @@ def adapt_types(
             input_type = obj.default_point_type
 
         args_types = [
-            pt if pt != 'point' else input_type for pt in args_types]
+            input_type if pt == FLEXIBLE_TYPE else pt
+            for pt in args_types]
         kwargs_types = [
-            pt if pt != 'point' else input_type for pt in kwargs_types]
+            input_type if pt == FLEXIBLE_TYPE else pt
+            for pt in kwargs_types]
     return args_types, kwargs_types
 
 

--- a/geomstats/vectorization.py
+++ b/geomstats/vectorization.py
@@ -356,9 +356,9 @@ def squeeze_output_dim_0(result, in_shapes, input_types):
         return False
 
     for in_shape, input_type in zip(in_shapes, input_types):
-        in_ndim = None
-        if input_type not in ['scalar', 'vector', 'matrix']:
+        if input_type not in POINT_TYPES:
             continue
+        in_ndim = None
         if in_shape is not None:
             in_ndim = len(in_shape)
         if in_ndim is not None:

--- a/geomstats/vectorization.py
+++ b/geomstats/vectorization.py
@@ -6,7 +6,8 @@ This abstracts the backend type.
 import geomstats.backend as gs
 
 POINT_TYPES = ['scalar', 'vector', 'matrix']
-OTHER_TYPES = ['point', 'point_type', 'else']
+FLEXIBLE_TYPE = 'point'
+OTHER_TYPES = ['point_type', 'else']
 
 POINT_TYPES_TO_NDIMS = {
     'scalar': 2,
@@ -201,10 +202,10 @@ def get_initial_shapes(input_types, args):
         if input_type == 'scalar':
             arg = gs.array(arg)
 
-        if input_type in ['else', 'point_type'] or arg is None:
-            in_shapes.append(None)
-        elif input_type in POINT_TYPES:
+        if input_type in POINT_TYPES:
             in_shapes.append(gs.shape(arg))
+        elif input_type in OTHER_TYPES or arg is None:
+            in_shapes.append(None)
         else:
             raise ValueError('Invalid point type.')
     return in_shapes

--- a/geomstats/vectorization.py
+++ b/geomstats/vectorization.py
@@ -14,6 +14,8 @@ POINT_TYPES_TO_NDIMS = {
     'vector': 2,
     'matrix': 3}
 
+ERROR_MSG = 'Invalid type: %s.'
+
 
 def decorator(input_types):
     """Vectorize geomstats functions.
@@ -209,7 +211,7 @@ def get_initial_shapes(input_types, args):
         elif input_type in OTHER_TYPES or arg is None:
             in_shapes.append(None)
         else:
-            raise ValueError('Invalid point type.')
+            raise ValueError(ERROR_MSG % input_type)
     return in_shapes
 
 
@@ -248,7 +250,7 @@ def vectorize_args(input_types, args):
         elif input_type in OTHER_TYPES or arg is None:
             vect_arg = arg
         else:
-            raise ValueError('Invalid point type: %s' % input_type)
+            raise ValueError(ERROR_MSG % input_type)
         vect_args.append(vect_arg)
     return tuple(vect_args)
 
@@ -289,7 +291,7 @@ def vectorize_kwargs(input_types, kwargs):
         elif input_type in OTHER_TYPES or arg is None:
             vect_arg = arg
         else:
-            raise ValueError('Invalid point type.')
+            raise ValueError(ERROR_MSG % input_type)
         vect_kwargs[key_arg] = vect_arg
     return vect_kwargs
 

--- a/geomstats/vectorization.py
+++ b/geomstats/vectorization.py
@@ -118,9 +118,11 @@ def get_types(input_types, args, kwargs):
     is_scal = True
     if len(input_types) > len_total:
         opt_kwargs_types = input_types[len_total:]
-        if input_types[-1] == 'no_is_scal':
-            is_scal = False
-            opt_kwargs_types = input_types[len_total:-1]
+        last_input_type = input_types[-1]
+        if 'output_' in last_input_type:
+            if last_input_type != 'output_scalar':
+                is_scal = False
+                opt_kwargs_types = input_types[len_total:-1]
     return (args_types, kwargs_types, opt_kwargs_types, is_scal)
 
 

--- a/geomstats/vectorization.py
+++ b/geomstats/vectorization.py
@@ -204,9 +204,7 @@ def get_initial_shapes(input_types, args):
     """
     in_shapes = []
 
-    for i_arg, arg in enumerate(args):
-        input_type = input_types[i_arg]
-
+    for arg, input_type in zip(args, input_types):
         if input_type == 'scalar':
             arg = gs.array(arg)
 
@@ -243,8 +241,7 @@ def vectorize_args(input_types, args):
         Args of the function in their fully-vectorized form.
     """
     vect_args = []
-    for i_arg, arg in enumerate(args):
-        input_type = input_types[i_arg]
+    for arg, input_type in zip(args, input_types):
         if input_type == 'scalar':
             vect_arg = gs.to_ndarray(arg, to_ndim=1)
             vect_arg = gs.to_ndarray(vect_arg, to_ndim=2, axis=1)
@@ -283,8 +280,7 @@ def vectorize_kwargs(input_types, kwargs):
         Kwargs of the function in their fully-vectorized form.
     """
     vect_kwargs = {}
-    for i_arg, key_arg in enumerate(kwargs.keys()):
-        input_type = input_types[i_arg]
+    for key_arg, input_type in zip(kwargs.keys(), input_types):
         arg = kwargs[key_arg]
         if input_type == 'scalar':
             vect_arg = gs.to_ndarray(arg, to_ndim=1)

--- a/geomstats/vectorization.py
+++ b/geomstats/vectorization.py
@@ -5,13 +5,16 @@ This abstracts the backend type.
 
 import geomstats.backend as gs
 
+POINT_TYPES = ['scalar', 'vector', 'matrix']
+OTHER_TYPES = ['point', 'point_type', 'else']
+
 POINT_TYPES_TO_NDIMS = {
     'scalar': 2,
     'vector': 2,
     'matrix': 3}
 
 
-def decorator(point_types):
+def decorator(input_types):
     """Vectorize geomstats functions.
 
     This decorator assumes that its function:
@@ -30,7 +33,7 @@ def decorator(point_types):
         - args,
         - kwargs,
         - optional kwargs,
-            - e.g. point_type=None,
+            - e.g. input_type=None,
     - gets the type of the output of its function,
         - e.g. distinguishes between 1D 'vector' vs 'scalar',
     - gets the initial shapes of all inputs of its function,
@@ -44,18 +47,18 @@ def decorator(point_types):
 
     Parameters
     ----------
-    point_types : list
-        List of inputs' point_types, including for optional inputs.
-        The `point_type`s of optional inputs will not be read
+    input_types : list
+        List of inputs' input_types, including for optional inputs.
+        The `input_type`s of optional inputs will not be read
         by the decorator if the corresponding input is not given.
     """
-    if not isinstance(point_types, list):
-        point_types = list(point_types)
+    if not isinstance(input_types, list):
+        input_types = list(input_types)
 
     def aux_decorator(function):
         def wrapper(*args, **kwargs):
             args_types, kwargs_types, opt_kwargs_types, is_scal = get_types(
-                point_types, args, kwargs)
+                input_types, args, kwargs)
 
             args_types, kwargs_types = adapt_types(
                 args_types, kwargs_types, opt_kwargs_types, args, kwargs)
@@ -78,13 +81,13 @@ def decorator(point_types):
     return aux_decorator
 
 
-def get_types(point_types, args, kwargs):
+def get_types(input_types, args, kwargs):
     """Extract the types of args, kwargs, optional kwargs and output.
 
     Parameters
     ----------
-    point_types : list
-        List of inputs' point_types, including for optional inputs.
+    input_types : list
+        List of inputs' input_types, including for optional inputs.
     args : tuple
         Args of a function.
     kwargs : dict
@@ -105,23 +108,23 @@ def get_types(point_types, args, kwargs):
     len_kwargs = len(kwargs)
     len_total = len_args + len_kwargs
 
-    args_types = point_types[:len_args]
-    kwargs_types = point_types[len_args:len_total]
+    args_types = input_types[:len_args]
+    kwargs_types = input_types[len_args:len_total]
 
     opt_kwargs_types = []
     is_scal = True
-    if len(point_types) > len_total:
-        opt_kwargs_types = point_types[len_total:]
-        if point_types[-1] == 'no_is_scal':
+    if len(input_types) > len_total:
+        opt_kwargs_types = input_types[len_total:]
+        if input_types[-1] == 'no_is_scal':
             is_scal = False
-            opt_kwargs_types = point_types[len_total:-1]
+            opt_kwargs_types = input_types[len_total:-1]
     return (args_types, kwargs_types, opt_kwargs_types, is_scal)
 
 
 def adapt_types(
         args_types, kwargs_types,
         opt_kwargs_types, args, kwargs):
-    """Adapt the list of input point_types.
+    """Adapt the list of input input_types.
 
     Some functions are implemented with array-like arguments that can be either
     'vector' or 'matrix' depending on the value of the 'point_type'
@@ -147,7 +150,7 @@ def adapt_types(
     -------
     args_types : list
         Adapted types of args.
-    kwargs : list
+    kwargs_types : list
         Adapted types of kwargs
     """
     in_args = 'point_type' in args_types
@@ -156,23 +159,23 @@ def adapt_types(
 
     if in_args or in_kwargs or in_optional:
         if in_args:
-            i_point_type = args_types.index('point_type')
-            point_type = args[i_point_type]
+            i_input_type = args_types.index('point_type')
+            input_type = args[i_input_type]
         elif in_kwargs:
-            point_type = kwargs['point_type']
+            input_type = kwargs['point_type']
 
         elif in_optional:
             obj = args[0]
-            point_type = obj.default_point_type
+            input_type = obj.default_point_type
 
         args_types = [
-            pt if pt != 'point' else point_type for pt in args_types]
+            pt if pt != 'point' else input_type for pt in args_types]
         kwargs_types = [
-            pt if pt != 'point' else point_type for pt in kwargs_types]
+            pt if pt != 'point' else input_type for pt in kwargs_types]
     return args_types, kwargs_types
 
 
-def get_initial_shapes(point_types, args):
+def get_initial_shapes(input_types, args):
     """Extract shapes and ndims of input args or kwargs values.
 
     Store the shapes of the input args, or kwargs values,
@@ -180,7 +183,7 @@ def get_initial_shapes(point_types, args):
 
     Parameters
     ----------
-    point_types : list
+    input_types : list
         Point types corresponding to the args, or kwargs values.
     args : tuple or dict_values
         Args, or kwargs values, of a function.
@@ -193,19 +196,21 @@ def get_initial_shapes(point_types, args):
     in_shapes = []
 
     for i_arg, arg in enumerate(args):
-        point_type = point_types[i_arg]
+        input_type = input_types[i_arg]
 
-        if point_type == 'scalar':
+        if input_type == 'scalar':
             arg = gs.array(arg)
 
-        if point_type in ['else', 'point_type'] or arg is None:
+        if input_type in ['else', 'point_type'] or arg is None:
             in_shapes.append(None)
-        else:
+        elif input_type in POINT_TYPES:
             in_shapes.append(gs.shape(arg))
+        else:
+            raise ValueError('Invalid point type.')
     return in_shapes
 
 
-def vectorize_args(point_types, args):
+def vectorize_args(input_types, args):
     """Vectorize input args.
 
     Transform input array-like args into their fully-vectorized form,
@@ -218,7 +223,7 @@ def vectorize_args(point_types, args):
 
     Parameters
     ----------
-    point_types : list
+    input_types : list
         Point types corresponding to the args.
     args : tuple
         Args of a function.
@@ -230,22 +235,22 @@ def vectorize_args(point_types, args):
     """
     vect_args = []
     for i_arg, arg in enumerate(args):
-        point_type = point_types[i_arg]
-        if point_type in ['else', 'point_type'] or arg is None:
+        input_type = input_types[i_arg]
+        if input_type in ['else', 'point_type'] or arg is None:
             vect_arg = arg
-        elif point_type == 'scalar':
+        elif input_type == 'scalar':
             vect_arg = gs.to_ndarray(arg, to_ndim=1)
             vect_arg = gs.to_ndarray(vect_arg, to_ndim=2, axis=1)
-        elif point_type in ['vector', 'matrix']:
+        elif input_type in ['vector', 'matrix']:
             vect_arg = gs.to_ndarray(
-                arg, to_ndim=POINT_TYPES_TO_NDIMS[point_type])
+                arg, to_ndim=POINT_TYPES_TO_NDIMS[input_type])
         else:
-            raise ValueError('Invalid point type: %s' % point_type)
+            raise ValueError('Invalid point type: %s' % input_type)
         vect_args.append(vect_arg)
     return tuple(vect_args)
 
 
-def vectorize_kwargs(point_types, kwargs):
+def vectorize_kwargs(input_types, kwargs):
     """Vectorize input kwargs.
 
     Transform input array-like kwargs into their fully-vectorized form,
@@ -258,7 +263,7 @@ def vectorize_kwargs(point_types, kwargs):
 
     Parameters
     ----------
-    point_types :list
+    input_types :list
         Point types corresponding to the args.
     kwargs : dict
         Kwargs of a function.
@@ -270,16 +275,16 @@ def vectorize_kwargs(point_types, kwargs):
     """
     vect_kwargs = {}
     for i_arg, key_arg in enumerate(kwargs.keys()):
-        point_type = point_types[i_arg]
+        input_type = input_types[i_arg]
         arg = kwargs[key_arg]
-        if point_type in ['else', 'point_type'] or arg is None:
+        if input_type in ['else', 'point_type'] or arg is None:
             vect_arg = arg
-        elif point_type == 'scalar':
+        elif input_type == 'scalar':
             vect_arg = gs.to_ndarray(arg, to_ndim=1)
             vect_arg = gs.to_ndarray(vect_arg, to_ndim=2, axis=1)
-        elif point_type in ['vector', 'matrix']:
+        elif input_type in ['vector', 'matrix']:
             vect_arg = gs.to_ndarray(
-                arg, to_ndim=POINT_TYPES_TO_NDIMS[point_type])
+                arg, to_ndim=POINT_TYPES_TO_NDIMS[input_type])
         else:
             raise ValueError('Invalid point type.')
         vect_kwargs[key_arg] = vect_arg
@@ -321,7 +326,7 @@ def adapt_result(result, initial_shapes, args_kwargs_types, is_scal):
     return result
 
 
-def squeeze_output_dim_0(result, in_shapes, point_types):
+def squeeze_output_dim_0(result, in_shapes, input_types):
     """Determine if the output needs to be squeezed on dim 0.
 
     The dimension 0 is squeezed iff all input parameters:
@@ -334,8 +339,8 @@ def squeeze_output_dim_0(result, in_shapes, point_types):
     ----------
     in_ndims : list
         Initial ndims of input parameters, as entered by the user.
-    point_types : list
-        Associated list of point_type of input parameters.
+    input_types : list
+        Associated list of input_type of input parameters.
 
     Returns
     -------
@@ -347,14 +352,14 @@ def squeeze_output_dim_0(result, in_shapes, point_types):
     if isinstance(result, list):
         return False
 
-    for in_shape, point_type in zip(in_shapes, point_types):
+    for in_shape, input_type in zip(in_shapes, input_types):
         in_ndim = None
-        if point_type not in ['scalar', 'vector', 'matrix']:
+        if input_type not in ['scalar', 'vector', 'matrix']:
             continue
         if in_shape is not None:
             in_ndim = len(in_shape)
         if in_ndim is not None:
-            vect_ndim = POINT_TYPES_TO_NDIMS[point_type]
+            vect_ndim = POINT_TYPES_TO_NDIMS[input_type]
             if in_ndim > vect_ndim:
                 raise ValueError(
                     'Fully-vectorizing an input can only increase its ndim.')
@@ -363,12 +368,12 @@ def squeeze_output_dim_0(result, in_shapes, point_types):
     return True
 
 
-def squeeze_output_dim_1(result, in_shapes, point_types, is_scal=True):
+def squeeze_output_dim_1(result, in_shapes, input_types, is_scal=True):
     """Determine if the output needs to be squeezed on dim 1.
 
     This happens if the user represents scalars as array of shapes:
     [n_samples,] instead of [n_samples, 1]
-    Dimension 1 is squeezed by default if point_type is 'scalar'.
+    Dimension 1 is squeezed by default if input_type is 'scalar'.
     Dimension 1 is not squeezed if the user inputs at least one scalar with
     a singleton in dimension 1.
 
@@ -378,8 +383,8 @@ def squeeze_output_dim_1(result, in_shapes, point_types, is_scal=True):
         Result output by the function, before reshaping.
     in_shapes : list
         Initial shapes of input parameters, as entered by the user.
-    point_types : list
-        Associated list of point_type of input parameters.
+    input_types : list
+        Associated list of input_type of input parameters.
 
     Returns
     -------
@@ -391,8 +396,8 @@ def squeeze_output_dim_1(result, in_shapes, point_types, is_scal=True):
     if not is_scalar(result):
         return False
 
-    for shape, point_type in zip(in_shapes, point_types):
-        if point_type == 'scalar':
+    for shape, input_type in zip(in_shapes, input_types):
+        if input_type == 'scalar':
             ndim = len(shape)
             if ndim > 2:
                 raise ValueError('The ndim of a scalar cannot be > 2.')

--- a/geomstats/vectorization.py
+++ b/geomstats/vectorization.py
@@ -355,7 +355,9 @@ def squeeze_output_dim_0(result, in_shapes, point_types):
             in_ndim = len(in_shape)
         if in_ndim is not None:
             vect_ndim = POINT_TYPES_TO_NDIMS[point_type]
-            assert in_ndim <= vect_ndim
+            if in_ndim > vect_ndim:
+                raise ValueError(
+                    'Fully-vectorizing an input can only increase its ndim.')
             if in_ndim == vect_ndim:
                 return False
     return True
@@ -392,7 +394,8 @@ def squeeze_output_dim_1(result, in_shapes, point_types, is_scal=True):
     for shape, point_type in zip(in_shapes, point_types):
         if point_type == 'scalar':
             ndim = len(shape)
-            assert ndim <= 2
+            if ndim > 2:
+                raise ValueError('The ndim of a scalar cannot be > 2.')
             if ndim == 2:
                 return False
     return True

--- a/geomstats/vectorization.py
+++ b/geomstats/vectorization.py
@@ -198,7 +198,7 @@ def get_initial_shapes(point_types, args):
         if point_type == 'scalar':
             arg = gs.array(arg)
 
-        if point_type == 'else' or arg is None:
+        if point_type in ['else', 'point_type'] or arg is None:
             in_shapes.append(None)
         else:
             in_shapes.append(gs.shape(arg))

--- a/geomstats/vectorization.py
+++ b/geomstats/vectorization.py
@@ -60,19 +60,11 @@ def decorator(input_types):
 
     def aux_decorator(function):
         def wrapper(*args, **kwargs):
-            print('args')
-            print(args)
-            print('kwargs')
-            print(kwargs)
             args_types, kwargs_types, opt_kwargs_types, is_scal = get_types(
                 input_types, args, kwargs)
 
             args_types, kwargs_types, kwargs = adapt_types(
                 args_types, kwargs_types, opt_kwargs_types, args, kwargs)
-            print('args_types')
-            print(args_types)
-            print('kwargs_types')
-            print(kwargs_types)
             args_kwargs_types = args_types + kwargs_types
 
             args_shapes = get_initial_shapes(args_types, args)
@@ -176,11 +168,8 @@ def adapt_types(
             input_type = kwargs['point_type']
 
         elif in_optional:
-            print('found optional type')
             obj = args[0]
             input_type = obj.default_point_type
-            print('input_type')
-            print(input_type)
             kwargs['point_type'] = input_type
             kwargs_types.append('point_type')
 

--- a/tests/test_vectorization.py
+++ b/tests/test_vectorization.py
@@ -103,7 +103,7 @@ class TestVectorizationMethods(geomstats.tests.TestCase):
             return is_matrix_vec
 
         @geomstats.vectorization.decorator(
-            ['else', 'point', 'point_type', 'no_is_scal'])
+            ['else', 'point', 'point_type', 'output_point'])
         def output_1d_vector(obj, point, point_type=None):
             n_samples = point.shape[0]
             result = gs.array([[5.]] * n_samples)

--- a/tests/test_vectorization.py
+++ b/tests/test_vectorization.py
@@ -362,13 +362,22 @@ class TestVectorizationMethods(geomstats.tests.TestCase):
 
     def test_is_vector_vectorized_with_point_type(self):
         vector = gs.array([1.3, 3.3])
-        result = self.is_vector_vectorized(vector=vector)
+        result = self.is_vector_vectorized_with_point_type(
+            self.obj, point=vector, point_type='vector')
+        expected = True
+        self.assertAllClose(result, expected)
+
+    def test_is_vector_vectorized_with_optional_point_type(self):
+        vector = gs.array([1.3, 3.3])
+        result = self.is_vector_vectorized_with_point_type(
+            self.obj, point=vector)
         expected = True
         self.assertAllClose(result, expected)
 
     def test_is_matrix_vectorized_with_point_type(self):
         matrix = gs.array([[1.3, 3.3], [1.2, 3.1]])
-        result = self.is_matrix_vectorized(matrix)
+        result = self.is_matrix_vectorized_with_point_type(
+            self.obj, matrix, point_type='matrix')
         expected = True
         self.assertAllClose(result, expected)
 

--- a/tests/test_vectorization.py
+++ b/tests/test_vectorization.py
@@ -9,6 +9,11 @@ import geomstats.vectorization
 
 class TestVectorizationMethods(geomstats.tests.TestCase):
     def setUp(self):
+
+        class Obj:
+            def __init__(self):
+                self.default_point_type = 'vector'
+
         @geomstats.vectorization.decorator(['vector', 'vector'])
         def foo(tangent_vec_a, tangent_vec_b):
             result = gs.einsum(
@@ -69,6 +74,20 @@ class TestVectorizationMethods(geomstats.tests.TestCase):
             is_matrix_vec = helper.to_scalar(is_matrix_vec)
             return is_matrix_vec
 
+        @geomstats.vectorization.decorator(
+            ['else', 'point', 'point_type'])
+        def is_point_type_vector(obj, point, point_type=None):
+            is_vector_vec = gs.ndim(point) == 2
+            is_vector_vec = helper.to_scalar(is_vector_vec)
+            return is_vector_vec
+
+        @geomstats.vectorization.decorator(
+            ['else', 'point', 'point_type'])
+        def is_point_type_matrix(obj, point, point_type=None):
+            is_matrix_vec = gs.ndim(point) == 3
+            is_matrix_vec = helper.to_scalar(is_matrix_vec)
+            return is_matrix_vec
+
         self.foo = foo
         self.foo_scalar_output = foo_scalar_output
         self.foo_scalar_input_output = foo_scalar_input_output
@@ -77,6 +96,9 @@ class TestVectorizationMethods(geomstats.tests.TestCase):
         self.is_scalar_vectorized = is_scalar_vectorized
         self.is_vector_vectorized = is_vector_vectorized
         self.is_matrix_vectorized = is_matrix_vectorized
+        self.is_point_type_vector = is_point_type_vector
+        self.is_point_type_matrix = is_point_type_matrix
+        self.obj = Obj()
 
     def test_decorator_with_squeeze_dim0(self):
         vec_a = gs.array([1, 2, 3])
@@ -289,4 +311,25 @@ class TestVectorizationMethods(geomstats.tests.TestCase):
         result = gs.array([result_dict[key] for key in keys])
         expected = gs.array([expected_dict[key] for key in keys])
 
+        self.assertAllClose(result, expected)
+
+    def test_is_point_type_vector(self):
+        point = gs.array([1., 2., 3.])
+        result = self.is_point_type_vector(
+            self.obj, point, point_type='vector')
+        expected = True
+        self.assertAllClose(result, expected)
+
+    def test_is_point_type_vector_optional(self):
+        point = gs.array([1., 2., 3.])
+        result = self.is_point_type_vector(
+            self.obj, point)
+        expected = True
+        self.assertAllClose(result, expected)
+
+    def test_is_point_type_matrix(self):
+        point = gs.array([[1., 2., 3.], [2., 3., 4.]])
+        result = self.is_point_type_matrix(
+            self.obj, point, point_type='matrix')
+        expected = True
         self.assertAllClose(result, expected)

--- a/tests/test_vectorization.py
+++ b/tests/test_vectorization.py
@@ -89,6 +89,20 @@ class TestVectorizationMethods(geomstats.tests.TestCase):
             return is_point_type_matrix
 
         @geomstats.vectorization.decorator(
+            ['else', 'point', 'point_type'])
+        def is_vector_vectorized_with_point_type(obj, point, point_type=None):
+            is_vector_vec = gs.ndim(point) == 2
+            is_vector_vec = helper.to_scalar(is_vector_vec)
+            return is_vector_vec
+
+        @geomstats.vectorization.decorator(
+            ['else', 'point', 'point_type'])
+        def is_matrix_vectorized_with_point_type(obj, point, point_type=None):
+            is_matrix_vec = gs.ndim(point) == 3
+            is_matrix_vec = helper.to_scalar(is_matrix_vec)
+            return is_matrix_vec
+
+        @geomstats.vectorization.decorator(
             ['else', 'point', 'point_type', 'no_is_scal'])
         def output_1d_vector(obj, point, point_type=None):
             n_samples = point.shape[0]
@@ -105,6 +119,10 @@ class TestVectorizationMethods(geomstats.tests.TestCase):
         self.is_matrix_vectorized = is_matrix_vectorized
         self.is_point_type_vector = is_point_type_vector
         self.is_point_type_matrix = is_point_type_matrix
+        self.is_vector_vectorized_with_point_type = \
+            is_vector_vectorized_with_point_type
+        self.is_matrix_vectorized_with_point_type = \
+            is_matrix_vectorized_with_point_type
         self.output_1d_vector = output_1d_vector
         self.obj = Obj()
 
@@ -339,6 +357,18 @@ class TestVectorizationMethods(geomstats.tests.TestCase):
         point = gs.array([[1., 2., 3.], [2., 3., 4.]])
         result = self.is_point_type_matrix(
             self.obj, point, point_type='matrix')
+        expected = True
+        self.assertAllClose(result, expected)
+
+    def test_is_vector_vectorized_with_point_type(self):
+        vector = gs.array([1.3, 3.3])
+        result = self.is_vector_vectorized(vector=vector)
+        expected = True
+        self.assertAllClose(result, expected)
+
+    def test_is_matrix_vectorized_with_point_type(self):
+        matrix = gs.array([[1.3, 3.3], [1.2, 3.1]])
+        result = self.is_matrix_vectorized(matrix)
         expected = True
         self.assertAllClose(result, expected)
 

--- a/tests/test_vectorization.py
+++ b/tests/test_vectorization.py
@@ -77,16 +77,16 @@ class TestVectorizationMethods(geomstats.tests.TestCase):
         @geomstats.vectorization.decorator(
             ['else', 'point', 'point_type'])
         def is_point_type_vector(obj, point, point_type=None):
-            is_vector_vec = gs.ndim(point) == 2
-            is_vector_vec = helper.to_scalar(is_vector_vec)
-            return is_vector_vec
+            is_point_type_vector = point_type == 'vector'
+            is_point_type_vector = helper.to_scalar(is_point_type_vector)
+            return is_point_type_vector
 
         @geomstats.vectorization.decorator(
             ['else', 'point', 'point_type'])
         def is_point_type_matrix(obj, point, point_type=None):
-            is_matrix_vec = gs.ndim(point) == 3
-            is_matrix_vec = helper.to_scalar(is_matrix_vec)
-            return is_matrix_vec
+            is_point_type_matrix = point_type == 'matrix'
+            is_point_type_matrix = helper.to_scalar(is_point_type_matrix)
+            return is_point_type_matrix
 
         @geomstats.vectorization.decorator(
             ['else', 'point', 'point_type', 'no_is_scal'])

--- a/tests/test_vectorization.py
+++ b/tests/test_vectorization.py
@@ -88,6 +88,13 @@ class TestVectorizationMethods(geomstats.tests.TestCase):
             is_matrix_vec = helper.to_scalar(is_matrix_vec)
             return is_matrix_vec
 
+        @geomstats.vectorization.decorator(
+            ['else', 'point', 'point_type', 'no_is_scal'])
+        def output_1d_vector(obj, point, point_type=None):
+            n_samples = point.shape[0]
+            result = gs.array([[5.]] * n_samples)
+            return result
+
         self.foo = foo
         self.foo_scalar_output = foo_scalar_output
         self.foo_scalar_input_output = foo_scalar_input_output
@@ -98,6 +105,7 @@ class TestVectorizationMethods(geomstats.tests.TestCase):
         self.is_matrix_vectorized = is_matrix_vectorized
         self.is_point_type_vector = is_point_type_vector
         self.is_point_type_matrix = is_point_type_matrix
+        self.output_1d_vector = output_1d_vector
         self.obj = Obj()
 
     def test_decorator_with_squeeze_dim0(self):
@@ -332,4 +340,18 @@ class TestVectorizationMethods(geomstats.tests.TestCase):
         result = self.is_point_type_matrix(
             self.obj, point, point_type='matrix')
         expected = True
+        self.assertAllClose(result, expected)
+
+    def test_output_single_1d_vector(self):
+        point = gs.array([1., 2., 3.])
+        result = self.output_1d_vector(
+            self.obj, point)
+        expected = gs.array([5.])
+        self.assertAllClose(result, expected)
+
+    def test_output_multiple_1d_vector(self):
+        point = gs.array([[1., 2., 3.], [2., 3., 4.]])
+        result = self.output_1d_vector(
+            self.obj, point)
+        expected = gs.array([[5.], [5.]])
         self.assertAllClose(result, expected)


### PR DESCRIPTION
This PR continues to address issue #338, by adding the 'point_type' logic to the decorator, which can now reads the `point_type` parameter, which can be 'vector' or 'matrix' and adapt the types of the input args or kwargs.

Additionally, this PR:
- allows the decorator to know if the expected type of the output is meant to be a scalar - this allows to distinguish between scalars and 1D vectors, that appear in SO(2) for example,
- clean the code of the vectorization module to improve readability.
