### PR TITLE
Adapt cos/sin from pytorch's backend to match numpy's behavior

### DIFF
--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -1,5 +1,7 @@
 """Pytorch based computation backend."""
 
+from functools import wraps
+
 import numpy as _np
 import torch
 from torch import (  # NOQA
@@ -12,6 +14,7 @@ from torch import (  # NOQA
     atan2 as arctan2,
     ceil,
     clamp as clip,
+    cos,
     cosh,
     div as divide,
     empty_like,
@@ -41,6 +44,7 @@ from torch import (  # NOQA
     repeat_interleave as repeat,
     reshape,
     sign,
+    sin,
     sinh,
     stack,
     std,
@@ -64,16 +68,21 @@ searchsorted = _raise_not_implemented_error
 vectorize = _raise_not_implemented_error
 
 
-def sin(x):
-    if not torch.is_tensor(x):
-        x = torch.tensor(x)
-    return torch.sin(x)
+def _box_scalar(function):
+    @wraps(function)
+    def wrapper(x):
+        if not torch.is_tensor(x):
+            x = torch.tensor(x)
+        return function(x)
+    return wrapper
 
 
-def cos(x):
-    if not torch.is_tensor(x):
-        x = torch.tensor(x)
-    return torch.cos(x)
+cos = _box_scalar(cos)
+cosh = _box_scalar(cosh)
+exp = _box_scalar(exp)
+log = _box_scalar(log)
+sin = _box_scalar(sin)
+sinh = _box_scalar(sinh)
 
 
 def empty(shape, dtype=float64):

--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -12,7 +12,6 @@ from torch import (  # NOQA
     atan2 as arctan2,
     ceil,
     clamp as clip,
-    cos,
     cosh,
     div as divide,
     empty_like,
@@ -42,7 +41,6 @@ from torch import (  # NOQA
     repeat_interleave as repeat,
     reshape,
     sign,
-    sin,
     sinh,
     stack,
     std,
@@ -64,6 +62,18 @@ def _raise_not_implemented_error(*args, **kwargs):
 
 searchsorted = _raise_not_implemented_error
 vectorize = _raise_not_implemented_error
+
+
+def sin(x):
+    if not torch.is_tensor(x):
+        x = torch.tensor(x)
+    return torch.sin(x)
+
+
+def cos(x):
+    if not torch.is_tensor(x):
+        x = torch.tensor(x)
+    return torch.cos(x)
 
 
 def empty(shape, dtype=float64):

--- a/tests/test_special_orthogonal.py
+++ b/tests/test_special_orthogonal.py
@@ -664,7 +664,7 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
 
         self.assertAllClose(result, expected)
 
-        angle = gs.array(gs.pi / 6.)
+        angle = gs.pi / 6.
         cos_angle = gs.cos(angle)
         sin_angle = gs.sin(angle)
 
@@ -714,7 +714,7 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
 
         self.assertAllClose(result, expected)
 
-        angle = gs.array(gs.pi / 6.)
+        angle = gs.pi / 6.
         cos_angle = gs.cos(angle)
         sin_angle = gs.sin(angle)
 
@@ -758,7 +758,7 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
 
         self.assertAllClose(result, expected)
 
-        angle = gs.array(gs.pi / 6.)
+        angle = gs.pi / 6.
         cos_angle = gs.cos(angle)
         sin_angle = gs.sin(angle)
 
@@ -789,7 +789,7 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
 
         self.assertAllClose(result, expected)
 
-        angle_bis = gs.array(gs.pi / 7.)
+        angle_bis = gs.pi / 7.
         cos_angle_bis = gs.cos(angle_bis)
         sin_angle_bis = gs.sin(angle_bis)
 
@@ -850,7 +850,7 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
 
         self.assertAllClose(result, expected)
 
-        angle = gs.array(gs.pi / 6.)
+        angle = gs.pi / 6.
         cos_angle = gs.cos(angle)
         sin_angle = gs.sin(angle)
 
@@ -894,7 +894,7 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
 
         self.assertAllClose(result, expected)
 
-        angle = gs.array(gs.pi / 6.)
+        angle = gs.pi / 6.
         cos_angle = gs.cos(angle)
         sin_angle = gs.sin(angle)
 
@@ -977,7 +977,7 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
         order = 'zyx'
         extrinsic_or_intrinsic = 'extrinsic'
 
-        angle = gs.array(gs.pi / 7.)
+        angle = gs.pi / 7.
         cos_angle = gs.cos(angle)
         sin_angle = gs.sin(angle)
 
@@ -1039,7 +1039,7 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
                             result,
                             expected))
 
-        angle_bis = gs.array(gs.pi / 8.)
+        angle_bis = gs.pi / 8.
         cos_angle_bis = gs.cos(angle_bis)
         sin_angle_bis = gs.sin(angle_bis)
 
@@ -1122,7 +1122,7 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
                             result,
                             expected))
 
-        angle = gs.array(gs.pi / 6.)
+        angle = gs.pi / 6.
 
         tait_bryan_angles = gs.array([angle, 0., 0.])
         matrix = group.matrix_from_tait_bryan_angles(
@@ -1239,7 +1239,7 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
                             result,
                             expected))
 
-        angle = gs.array(gs.pi / 6.)
+        angle = gs.pi / 6.
 
         tait_bryan_angles = gs.array([angle, 0., 0.])
         matrix = group.matrix_from_tait_bryan_angles(
@@ -1336,7 +1336,7 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
         order = 'xyz'
         extrinsic_or_intrinsic = 'intrinsic'
 
-        angle = gs.array(gs.pi / 6.)
+        angle = gs.pi / 6.
         cos_angle = gs.cos(angle)
         sin_angle = gs.sin(angle)
 
@@ -1501,7 +1501,7 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
                             result,
                             expected))
 
-        angle = gs.array(gs.pi / 6.)
+        angle = gs.pi / 6.
 
         tait_bryan_angles = gs.array([angle, 0., 0.])
         matrix = group.matrix_from_tait_bryan_angles(
@@ -1618,7 +1618,7 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
                             result,
                             expected))
 
-        angle = gs.array(gs.pi / 6.)
+        angle = gs.pi / 6.
 
         tait_bryan_angles = gs.array([angle, 0., 0.])
         matrix = group.matrix_from_tait_bryan_angles(
@@ -1715,7 +1715,7 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
                         ' expected = {}.'.format(
                             result,
                             expected))
-        angle = gs.array(gs.pi / 6.)
+        angle = gs.pi / 6.
         cos_half_angle = gs.cos(angle / 2.)
         sin_half_angle = gs.sin(angle / 2.)
 
@@ -1771,7 +1771,7 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
                         ' expected = {}.'.format(
                             result,
                             expected))
-        angle = gs.array(gs.pi / 6.)
+        angle = gs.pi / 6.
         cos_half_angle = gs.cos(angle / 2.)
         sin_half_angle = gs.sin(angle / 2.)
 
@@ -1838,7 +1838,7 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
                             result,
                             expected))
 
-        angle = gs.array(gs.pi / 6.)
+        angle = gs.pi / 6.
         cos_half_angle = gs.cos(angle / 2.)
         sin_half_angle = gs.sin(angle / 2.)
 
@@ -1905,7 +1905,7 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
                             result,
                             expected))
 
-        angle = gs.array(gs.pi / 6.)
+        angle = gs.pi / 6.
         cos_half_angle = gs.cos(angle / 2.)
         sin_half_angle = gs.sin(angle / 2.)
 

--- a/tests/test_special_orthogonal.py
+++ b/tests/test_special_orthogonal.py
@@ -412,7 +412,7 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
         n = 3
         group = self.so[n]
 
-        angle = gs.array(.12)
+        angle = .12
         rot_mat = gs.array([[1., 0., 0.],
                             [0., gs.cos(angle), -gs.sin(angle)],
                             [0, gs.sin(angle), gs.cos(angle)]])
@@ -468,7 +468,7 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
 
         self.assertAllClose(result, expected)
 
-        angle = gs.array(gs.pi / 6.)
+        angle = gs.pi / 6.
         cos_angle = gs.cos(angle)
         sin_angle = gs.sin(angle)
 
@@ -511,7 +511,7 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
 
         self.assertAllClose(result, expected)
 
-        angle = gs.array(gs.pi / 6.)
+        angle = gs.pi / 6.
         cos_angle = gs.cos(angle)
         sin_angle = gs.sin(angle)
 
@@ -542,7 +542,7 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
 
         self.assertAllClose(result, expected)
 
-        angle_bis = gs.array(gs.pi / 7.)
+        angle_bis = gs.pi / 7.
         cos_angle_bis = gs.cos(angle_bis)
         sin_angle_bis = gs.sin(angle_bis)
 
@@ -606,7 +606,7 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
 
         self.assertAllClose(result, expected)
 
-        angle = gs.array(gs.pi / 6.)
+        angle = gs.pi / 6.
         cos_angle = gs.cos(angle)
         sin_angle = gs.sin(angle)
 

--- a/tests/test_special_orthogonal.py
+++ b/tests/test_special_orthogonal.py
@@ -2054,7 +2054,7 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
                             result,
                             expected))
 
-        angle = gs.array(gs.pi / 6.)
+        angle = gs.pi / 6.
         cos_half_angle = gs.cos(angle / 2.)
         sin_half_angle = gs.sin(angle / 2.)
 
@@ -2263,7 +2263,7 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
                             result,
                             expected))
 
-        angle = gs.array(gs.pi / 6.)
+        angle = gs.pi / 6.
 
         tait_bryan_angles = gs.array([angle, 0., 0.])
         quaternion = group.quaternion_from_tait_bryan_angles(
@@ -2605,11 +2605,11 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
 
                     self.assertAllClose(result, expected)
 
-                angle = gs.array(gs.pi / 9.)
+                angle = gs.pi / 9.
                 cos_angle = gs.cos(angle)
                 sin_angle = gs.sin(angle)
 
-                angle_bis = gs.array(gs.pi / 7.)
+                angle_bis = gs.pi / 7.
                 cos_angle_bis = gs.cos(angle_bis)
                 sin_angle_bis = gs.sin(angle_bis)
 
@@ -2723,7 +2723,7 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
                             or gs.allclose(result, inv_expected))
 
             else:
-                angle = gs.array(0.986)
+                angle = 0.986
                 point = gs.array([
                     [gs.cos(angle), -gs.sin(angle)],
                     [gs.sin(angle), gs.cos(angle)]])
@@ -2755,7 +2755,7 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
                     expected = helper.to_vector(group.identity)
                     self.assertAllClose(result, expected)
             else:
-                angle = gs.array(0.986)
+                angle = 0.986
                 point = gs.array([
                     [gs.cos(angle), -gs.sin(angle)],
                     [gs.sin(angle), gs.cos(angle)]])

--- a/tests/test_special_orthogonal.py
+++ b/tests/test_special_orthogonal.py
@@ -299,7 +299,7 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
                 self.assertAllClose(result, expected)
 
             else:
-                angle = gs.array(0.345)
+                angle = 0.345
                 point = gs.array([[
                     [gs.cos(angle), -gs.sin(angle)],
                     [gs.sin(angle), gs.cos(angle)]]])


### PR DESCRIPTION
Currently, pytorch's cos and sin only accept tensors as inputs. However, numpy accepts both arrays and values as inputs.

This PR:
- adapts the behavior of cos/sin from pytorch's backend to match numpy's behavior,
- adapts special_orthogonal's unit tests to use the new syntax.

@pchauchat @nguigs 