### PR TITLE
Generalize tf's and pytorch's einsum to match numpy behavior on squeezed dims

### DIFF
--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -296,8 +296,14 @@ def einsum(*args, **kwargs):
         if len(input_str_list) > 2:
             raise NotImplementedError(
                 'Ellipsis support not implemented for >2 input tensors')
+        ndims = [len(input_str[3:]) for input_str in input_str_list]
+
         tensor_a = input_tensors_list[0]
         tensor_b = input_tensors_list[1]
+
+        tensor_a = to_ndarray(tensor_a, to_ndim=ndims[0] + 1)
+        tensor_b = to_ndarray(tensor_b, to_ndim=ndims[1] + 1)
+
         n_tensor_a = tensor_a.shape[0]
         n_tensor_b = tensor_b.shape[0]
 
@@ -324,7 +330,12 @@ def einsum(*args, **kwargs):
         input_str = input_str_list[0] + ',' + input_str_list[1]
         einsum_str = input_str + '->' + output_str
 
-        return torch.einsum(einsum_str, tensor_a, tensor_b, **kwargs)
+        result = torch.einsum(einsum_str, tensor_a, tensor_b, **kwargs)
+
+        if n_tensor_a == n_tensor_b == 1:
+            result = squeeze(result, axis=0)
+        return result
+
     return torch.einsum(*args, **kwargs)
 
 

--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -300,7 +300,10 @@ def einsum(*args, **kwargs):
 
         tensor_a = input_tensors_list[0]
         tensor_b = input_tensors_list[1]
-
+        #print('\noriginal tensors')
+        #print(tensor_a.shape, tensor_b.shape)
+        initial_ndim_a = tensor_a.ndim
+        initial_ndim_b = tensor_b.ndim
         tensor_a = to_ndarray(tensor_a, to_ndim=ndims[0] + 1)
         tensor_b = to_ndarray(tensor_b, to_ndim=ndims[1] + 1)
 
@@ -330,9 +333,16 @@ def einsum(*args, **kwargs):
         input_str = input_str_list[0] + ',' + input_str_list[1]
         einsum_str = input_str + '->' + output_str
 
+        #print('\n in einsum')
+        #print(einsum_str, tensor_a.shape, tensor_b.shape)
         result = torch.einsum(einsum_str, tensor_a, tensor_b, **kwargs)
 
-        if n_tensor_a == n_tensor_b == 1:
+        cond = (
+            n_tensor_a == n_tensor_b == 1
+            and initial_ndim_a != tensor_a.ndim
+            and initial_ndim_b != tensor_b.ndim)
+
+        if cond:
             result = squeeze(result, axis=0)
         return result
 

--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -280,6 +280,8 @@ def sum(x, axis=None, keepdims=None, **kwargs):
 
 
 def einsum(*args, **kwargs):
+    # TODO(ninamiolane): Allow this to work when '->' is not provided
+    # TODO(ninamiolane): Allow this to work for cases like n...k
     einsum_str = args[0]
     input_tensors_list = args[1:]
 
@@ -308,7 +310,17 @@ def einsum(*args, **kwargs):
         n_tensor_a = tensor_a.shape[0]
         n_tensor_b = tensor_b.shape[0]
 
-        if n_tensor_a != n_tensor_b:
+        cond = (
+            n_tensor_a == n_tensor_b == 1
+            and initial_ndim_a != tensor_a.ndim
+            and initial_ndim_b != tensor_b.ndim)
+
+        if cond:
+            tensor_a = squeeze(tensor_a, axis=0)
+            tensor_b = squeeze(tensor_b, axis=0)
+            input_prefix_list = ['', '']
+            output_prefix = ''
+        elif n_tensor_a != n_tensor_b:
             if n_tensor_a == 1:
                 tensor_a = squeeze(tensor_a, axis=0)
                 input_prefix_list = ['', 'r']
@@ -333,13 +345,6 @@ def einsum(*args, **kwargs):
 
         result = torch.einsum(einsum_str, tensor_a, tensor_b, **kwargs)
 
-        cond = (
-            n_tensor_a == n_tensor_b == 1
-            and initial_ndim_a != tensor_a.ndim
-            and initial_ndim_b != tensor_b.ndim)
-
-        if cond:
-            result = squeeze(result, axis=0)
         return result
 
     return torch.einsum(*args, **kwargs)

--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -300,8 +300,6 @@ def einsum(*args, **kwargs):
 
         tensor_a = input_tensors_list[0]
         tensor_b = input_tensors_list[1]
-        #print('\noriginal tensors')
-        #print(tensor_a.shape, tensor_b.shape)
         initial_ndim_a = tensor_a.ndim
         initial_ndim_b = tensor_b.ndim
         tensor_a = to_ndarray(tensor_a, to_ndim=ndims[0] + 1)
@@ -333,8 +331,6 @@ def einsum(*args, **kwargs):
         input_str = input_str_list[0] + ',' + input_str_list[1]
         einsum_str = input_str + '->' + output_str
 
-        #print('\n in einsum')
-        #print(einsum_str, tensor_a.shape, tensor_b.shape)
         result = torch.einsum(einsum_str, tensor_a, tensor_b, **kwargs)
 
         cond = (

--- a/geomstats/_backend/tensorflow/__init__.py
+++ b/geomstats/_backend/tensorflow/__init__.py
@@ -510,6 +510,8 @@ def eye(n, m=None):
 
 
 def einsum(equation, *inputs, **kwargs):
+    # TODO(ninamiolane): Allow this to work when '->' is not provided
+    # TODO(ninamiolane): Allow this to work for cases like n...k
     einsum_str = equation
     input_tensors_list = inputs
 

--- a/geomstats/_backend/tensorflow/__init__.py
+++ b/geomstats/_backend/tensorflow/__init__.py
@@ -526,8 +526,15 @@ def einsum(equation, *inputs, **kwargs):
         if len(input_str_list) > 2:
             raise NotImplementedError(
                 'Ellipsis support not implemented for >2 input tensors')
+        ndims = [len(input_str[3:]) for input_str in input_str_list]
+
         tensor_a = input_tensors_list[0]
         tensor_b = input_tensors_list[1]
+        initial_ndim_a = tensor_a.ndim
+        initial_ndim_b = tensor_b.ndim
+        tensor_a = to_ndarray(tensor_a, to_ndim=ndims[0] + 1)
+        tensor_b = to_ndarray(tensor_b, to_ndim=ndims[1] + 1)
+
         n_tensor_a = tensor_a.shape[0]
         n_tensor_b = tensor_b.shape[0]
 
@@ -554,7 +561,16 @@ def einsum(equation, *inputs, **kwargs):
         input_str = input_str_list[0] + ',' + input_str_list[1]
         einsum_str = input_str + '->' + output_str
 
-        return tf.einsum(einsum_str, tensor_a, tensor_b, **kwargs)
+        result = tf.einsum(einsum_str, tensor_a, tensor_b, **kwargs)
+
+        cond = (
+            n_tensor_a == n_tensor_b == 1
+            and initial_ndim_a != tensor_a.ndim
+            and initial_ndim_b != tensor_b.ndim)
+
+        if cond:
+            result = squeeze(result, axis=0)
+        return result
 
     return tf.einsum(equation, *inputs, **kwargs)
 

--- a/geomstats/geometry/hyperboloid.py
+++ b/geomstats/geometry/hyperboloid.py
@@ -397,9 +397,9 @@ class HyperboloidMetric(HyperbolicMetric):
 
         coef_1 += mask_else_float * (angle / gs.sinh(angle))
         coef_2 += mask_else_float * (angle / gs.tanh(angle))
-
-        log = (gs.einsum('...,...j->...j', coef_1, point) -
-               gs.einsum('...,...j->...j', coef_2, base_point))
+        log_term_1 = gs.einsum('...,...j->...j', coef_1, point)
+        log_term_2 = - gs.einsum('...,...j->...j', coef_2, base_point)
+        log = log_term_1 + log_term_2
         return log
 
     def dist(self, point_a, point_b):

--- a/geomstats/geometry/riemannian_metric.py
+++ b/geomstats/geometry/riemannian_metric.py
@@ -142,6 +142,7 @@ class RiemannianMetric(Connection):
         aux = gs.einsum('...j,...jk->...k', tangent_vec_a, inner_prod_mat)
 
         inner_prod = gs.einsum('...k,...k->...', aux, tangent_vec_b)
+        inner_prod = gs.to_ndarray(inner_prod, to_ndim=1)
         inner_prod = gs.to_ndarray(inner_prod, to_ndim=2, axis=1)
 
         return inner_prod

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -267,6 +267,42 @@ class TestBackends(geomstats.tests.TestCase):
 
         self.assertAllCloseToNp(gs_result, np_result)
 
+        np_array_1 = _np.array([5])
+        np_array_2 = _np.array([[1, 2, 3]])
+        array_1 = gs.array([5])
+        array_2 = gs.array([[1, 2, 3]])
+
+        np_result = _np.einsum('...,...i->...i', np_array_1, np_array_2)
+        gs_result = gs.einsum('...,...i->...i', array_1, array_2)
+        self.assertAllCloseToNp(gs_result, np_result)
+
+        np_array_1 = _np.array(5)
+        np_array_2 = _np.array([[1, 2, 3]])
+        array_1 = gs.array(5)
+        array_2 = gs.array([[1, 2, 3]])
+
+        np_result = _np.einsum('...,...i->...i', np_array_1, np_array_2)
+        gs_result = gs.einsum('...,...i->...i', array_1, array_2)
+        self.assertAllCloseToNp(gs_result, np_result)
+
+        np_array_1 = _np.array([5])
+        np_array_2 = _np.array([1, 2, 3])
+        array_1 = gs.array([5])
+        array_2 = gs.array([1, 2, 3])
+
+        np_result = _np.einsum('...,...i->...i', np_array_1, np_array_2)
+        gs_result = gs.einsum('...,...i->...i', array_1, array_2)
+        self.assertAllCloseToNp(gs_result, np_result)
+
+        np_array_1 = _np.array(5)
+        np_array_2 = _np.array([1, 2, 3])
+        array_1 = gs.array(5)
+        array_2 = gs.array([1, 2, 3])
+
+        np_result = _np.einsum('...,...i->...i', np_array_1, np_array_2)
+        gs_result = gs.einsum('...,...i->...i', array_1, array_2)
+        self.assertAllCloseToNp(gs_result, np_result)
+
     def test_assignment(self):
         np_array_1 = _np.ones(3)
         gs_array_1 = gs.ones_like(gs.array(np_array_1))

--- a/tests/test_poincare_polydisk.py
+++ b/tests/test_poincare_polydisk.py
@@ -33,17 +33,20 @@ class TestPoincarePolydiskMethods(geomstats.tests.TestCase):
     def test_product_distance_extrinsic_representation(self):
         """Test the distance using the extrinsic representation."""
         coords_type = 'extrinsic'
-        point_a_intrinsic = gs.array([[0.01, 0.0]])
-        point_b_intrinsic = gs.array([[0.0, 0.0]])
+        point_a_intrinsic = gs.array([0.01, 0.0])
+        point_b_intrinsic = gs.array([0.0, 0.0])
         hyperbolic_space = Hyperboloid(dimension=2)
         point_a = hyperbolic_space.from_coordinates(
-            point_a_intrinsic, "intrinsic")
+            point_a_intrinsic, 'intrinsic')
         point_b = hyperbolic_space.from_coordinates(
-            point_b_intrinsic, "intrinsic")
+            point_b_intrinsic, 'intrinsic')
+
         duplicate_point_a = gs.vstack([point_a, point_a])
         duplicate_point_b = gs.vstack([point_b, point_b])
+
         single_disk = PoincarePolydisk(n_disks=1, coords_type=coords_type)
         two_disks = PoincarePolydisk(n_disks=2, coords_type=coords_type)
+
         distance_single_disk = single_disk.metric.dist(point_a, point_b)
         distance_two_disks = two_disks.metric.dist(
             duplicate_point_a, duplicate_point_b)


### PR DESCRIPTION
The new einsum in tf and pytorch can:
- Add a singleton dimension on axis 0,
- Remove it to send the result if both input tensors didn't have that dimension to start with.

This allows to do:
```
a = gs.array([1])
b = gs.array([[1, 2, 3]])
gs.einsum('...,...i->...i', a, b)
```
gives [[1, 2, 3]]

but:
```
a = gs.array(1)
b = gs.array([1, 2, 3])
gs.einsum('...,...i->...i', a, b)
```
gives [1, 2, 3],

which follows numpy's behavior.