### PR TITLE
Vectorization of LieGroup and InvariantMetric

### DIFF
--- a/geomstats/geometry/invariant_metric.py
+++ b/geomstats/geometry/invariant_metric.py
@@ -36,8 +36,6 @@ class InvariantMetric(RiemannianMetric):
         self.group = group
         if inner_product_mat_at_identity is None:
             inner_product_mat_at_identity = gs.eye(self.group.dimension)
-        inner_product_mat_at_identity = gs.to_ndarray(
-            inner_product_mat_at_identity, to_ndim=3)
 
         geomstats.error.check_parameter_accepted_values(
             left_or_right, 'left_or_right', ['left', 'right'])

--- a/geomstats/geometry/invariant_metric.py
+++ b/geomstats/geometry/invariant_metric.py
@@ -73,39 +73,14 @@ class InvariantMetric(RiemannianMetric):
             ['vector', 'matrix'])
 
         if self.group.default_point_type == 'vector':
-            #tangent_vec_a = gs.to_ndarray(tangent_vec_a, to_ndim=2)
-            #tangent_vec_b = gs.to_ndarray(tangent_vec_b, to_ndim=2)
-
-            #n_tangent_vec_a = tangent_vec_a.shape[0]
-            #n_tangent_vec_b = tangent_vec_b.shape[0]
-
-            #assert (tangent_vec_a.shape == tangent_vec_b.shape
-            #        or n_tangent_vec_a == 1
-            #        or n_tangent_vec_b == 1)
-
-            #if n_tangent_vec_a == 1:
-            #    tangent_vec_a = gs.array([tangent_vec_a[0]] * n_tangent_vec_b)
-
-            #if n_tangent_vec_b == 1:
-            #    tangent_vec_b = gs.array([tangent_vec_b[0]] * n_tangent_vec_a)
-
-            # inner_product_mat_at_identity = gs.array(
-            #     [self.inner_product_mat_at_identity[0]] *
-            #     max(n_tangent_vec_a, n_tangent_vec_b))
             inner_product_mat_at_identity = self.inner_product_mat_at_identity
 
-            #tangent_vec_a = gs.to_ndarray(tangent_vec_a, to_ndim=2)
-            #tangent_vec_b = gs.to_ndarray(tangent_vec_b, to_ndim=2)
-            #inner_product_mat_at_identity = gs.to_ndarray(
-            #    inner_product_mat_at_identity, to_ndim=3)
             inner_prod = gs.einsum(
                 '...i,...ij->...j',
                 tangent_vec_a,
                 inner_product_mat_at_identity)
             inner_prod = gs.einsum(
                 '...j,...j->...', inner_prod, tangent_vec_b)
-
-            #inner_prod = gs.to_ndarray(inner_prod, to_ndim=2, axis=1)
 
         else:
             # TODO(nguigs): allow for diagonal metric_matrices

--- a/geomstats/geometry/invariant_metric.py
+++ b/geomstats/geometry/invariant_metric.py
@@ -189,11 +189,9 @@ class InvariantMetric(RiemannianMetric):
         inv_jacobian = GeneralLinear.inv(jacobian)
         inv_jacobian_transposed = Matrices.transpose(inv_jacobian)
 
-        inner_product_mat_at_id = self.inner_product_mat_at_identity[0]
-
         metric_mat = gs.einsum(
             '...ij,...jk->...ik',
-            inv_jacobian_transposed, inner_product_mat_at_id)
+            inv_jacobian_transposed, self.inner_product_mat_at_identity)
         metric_mat = gs.einsum(
             '...ij,...jk->...ik', metric_mat, inv_jacobian)
         return metric_mat
@@ -225,7 +223,7 @@ class InvariantMetric(RiemannianMetric):
             metric=self)
         sqrt_inner_product_mat = gs.linalg.sqrtm(
             self.inner_product_mat_at_identity)
-        mat = gs.transpose(sqrt_inner_product_mat, axes=(0, 2, 1))
+        mat = Matrices.transpose(sqrt_inner_product_mat)
 
         n_tangent_vecs, _ = tangent_vec.shape
         n_mats, _, _ = mat.shape

--- a/geomstats/geometry/invariant_metric.py
+++ b/geomstats/geometry/invariant_metric.py
@@ -4,7 +4,6 @@ import logging
 
 import geomstats.backend as gs
 import geomstats.error
-import geomstats.vectorization
 from geomstats.geometry.general_linear import GeneralLinear
 from geomstats.geometry.matrices import Matrices
 from geomstats.geometry.riemannian_metric import RiemannianMetric
@@ -206,7 +205,6 @@ class InvariantMetric(RiemannianMetric):
         exp = self.group.regularize(exp)
         return exp
 
-    @geomstats.vectorization.decorator(['else', 'vector'])
     def exp_from_identity(self, tangent_vec):
         """Compute Riemannian exponential of tangent vector from the identity.
 
@@ -230,7 +228,6 @@ class InvariantMetric(RiemannianMetric):
         exp = self.group.regularize(exp)
         return exp
 
-    @geomstats.vectorization.decorator(['else', 'vector', 'vector'])
     def exp(self, tangent_vec, base_point=None):
         """Compute Riemannian exponential of tan. vector wrt to base point.
 
@@ -247,11 +244,7 @@ class InvariantMetric(RiemannianMetric):
             Point in the group equal to the Riemannian exponential
             of tangent_vec at the base point.
         """
-        point_type = self.group.default_point_type
-
-        identity = gs.to_ndarray(
-            self.group.identity,
-            to_ndim=geomstats.vectorization.POINT_TYPES_TO_NDIMS[point_type])
+        identity = self.group.identity
 
         if base_point is None:
             base_point = identity
@@ -261,8 +254,7 @@ class InvariantMetric(RiemannianMetric):
             return self.exp_from_identity(tangent_vec)
 
         jacobian = self.group.jacobian_translation(
-            point=base_point,
-            left_or_right=self.left_or_right)
+            point=base_point, left_or_right=self.left_or_right)
         inv_jacobian = gs.linalg.inv(jacobian)
         inv_jacobian_transposed = Matrices.transpose(inv_jacobian)
         tangent_vec_at_id = gs.einsum(
@@ -279,7 +271,6 @@ class InvariantMetric(RiemannianMetric):
 
         return exp
 
-    @geomstats.vectorization.decorator(['else', 'vector'])
     def left_log_from_identity(self, point):
         """Compute Riemannian log of a point wrt. id of left-invar. metric.
 
@@ -335,7 +326,6 @@ class InvariantMetric(RiemannianMetric):
 
         return log
 
-    @geomstats.vectorization.decorator(['else', 'vector', 'vector'])
     def log(self, point, base_point=None):
         """Compute Riemannian logarithm of a point from a base point.
 
@@ -353,11 +343,7 @@ class InvariantMetric(RiemannianMetric):
             Tangent vector at the base point equal to the Riemannian logarithm
             of point at the base point.
         """
-        point_type = self.group.default_point_type
-
-        identity = gs.to_ndarray(
-            self.group.identity,
-            to_ndim=geomstats.vectorization.POINT_TYPES_TO_NDIMS[point_type])
+        identity = self.group.identity
 
         if base_point is None:
             base_point = identity

--- a/geomstats/geometry/lie_group.py
+++ b/geomstats/geometry/lie_group.py
@@ -6,6 +6,7 @@ import geomstats.geometry.riemannian_metric as riemannian_metric
 import geomstats.vectorization
 from geomstats.geometry.invariant_metric import InvariantMetric
 from geomstats.geometry.manifold import Manifold
+from geomstats.geometry.matrices import Matrices
 
 
 def loss(y_pred, y_true, group, metric=None):
@@ -190,8 +191,6 @@ class LieGroup(Manifold):
             'The group exponential from the identity is not implemented.'
         )
 
-    @geomstats.vectorization.decorator(
-        ['else', 'point', 'point', 'point_type'])
     def exp_not_from_identity(self, tangent_vec, base_point, point_type=None):
         """Calculate the group exponential at base_point.
 
@@ -213,16 +212,11 @@ class LieGroup(Manifold):
             inv_jacobian = gs.linalg.inv(jacobian)
 
             tangent_vec_at_id = gs.einsum(
-                'ni,nij->nj',
-                tangent_vec,
-                gs.transpose(inv_jacobian, axes=(0, 2, 1)),
-            )
+                '...i,...ij->...j', tangent_vec, Matrices.transpose(inv_jacobian))
             exp_from_identity = self.exp_from_identity(
-                tangent_vec=tangent_vec_at_id, point_type=point_type
-            )
+                tangent_vec=tangent_vec_at_id, point_type=point_type)
             exp = self.compose(
-                base_point, exp_from_identity, point_type=point_type
-            )
+                base_point, exp_from_identity, point_type=point_type)
             exp = self.regularize(exp, point_type=point_type)
             return exp
 
@@ -254,26 +248,26 @@ class LieGroup(Manifold):
             The exponentiated tangent vector
         """
         identity = self.get_identity(point_type=point_type)
-        identity = gs.to_ndarray(
-            identity,
-            to_ndim=geomstats.vectorization.POINT_TYPES_TO_NDIMS[point_type])
+        #identity = gs.to_ndarray(
+        #    identity,
+        #    to_ndim=geomstats.vectorization.POINT_TYPES_TO_NDIMS[point_type])
         if base_point is None:
             base_point = identity
         base_point = self.regularize(base_point, point_type=point_type)
 
-        n_tangent_vecs = tangent_vec.shape[0]
-        n_base_points = base_point.shape[0]
+        # n_tangent_vecs = tangent_vec.shape[0]
+        # n_base_points = base_point.shape[0]
 
-        if not (tangent_vec.shape == base_point.shape
-                or n_tangent_vecs == 1
-                or n_base_points == 1):
-            raise NotImplementedError
+        # if not (tangent_vec.shape == base_point.shape
+        #         or n_tangent_vecs == 1
+        #         or n_base_points == 1):
+        #     raise NotImplementedError
 
-        if n_tangent_vecs == 1:
-            tangent_vec = gs.array([tangent_vec[0]] * n_base_points)
+        # if n_tangent_vecs == 1:
+        #     tangent_vec = gs.array([tangent_vec[0]] * n_base_points)
 
-        if n_base_points == 1:
-            base_point = gs.array([base_point[0]] * n_tangent_vecs)
+        # if n_base_points == 1:
+        #     base_point = gs.array([base_point[0]] * n_tangent_vecs)
 
         if gs.allclose(base_point, identity):
             result = self.exp_from_identity(tangent_vec, point_type=point_type)

--- a/geomstats/geometry/special_euclidean.py
+++ b/geomstats/geometry/special_euclidean.py
@@ -250,7 +250,7 @@ class SpecialEuclidean(LieGroup):
             rot_base_point = base_point[:, :dim_rotations]
 
             metric_mat = metric.inner_product_mat_at_identity
-            rot_metric_mat = metric_mat[:, :dim_rotations, :dim_rotations]
+            rot_metric_mat = metric_mat[:dim_rotations, :dim_rotations]
             rot_metric = InvariantMetric(
                 group=rotations,
                 inner_product_mat_at_identity=rot_metric_mat,

--- a/geomstats/geometry/special_orthogonal.py
+++ b/geomstats/geometry/special_orthogonal.py
@@ -174,7 +174,7 @@ class SpecialOrthogonal(LieGroup, EmbeddedManifold):
                     - (1. - 2. * gs.pi * k / angle))
 
                 regularized_point = gs.einsum(
-                    'n,ni->ni', norms_ratio, regularized_point)
+                    '...,...i->...i', norms_ratio, regularized_point)
 
         elif point_type == 'matrix':
             regularized_point = point

--- a/tests/test_invariant_metric.py
+++ b/tests/test_invariant_metric.py
@@ -82,29 +82,41 @@ class TestInvariantMetricMethods(geomstats.tests.TestCase):
         self.point_small = point_small
 
     @geomstats.tests.np_and_tf_only
-    def test_inner_product_matrix(self):
-        # TODO(ninamiolane): Fix this test when invariant metric
-        # is properly vectorized
-        # base_point = self.group.identity
+    def test_inner_product_mat_at_identity_shape(self):
         dim = self.left_metric.group.dimension
-        result = self.left_metric.inner_product_matrix(base_point=None)
+
+        result = self.left_metric.inner_product_mat_at_identity
         self.assertAllClose(gs.shape(result), (dim, dim))
 
-        # expected = self.left_metric.inner_product_mat_at_identity
-        # self.assertAllClose(result, expected)
+    @geomstats.tests.np_and_tf_only
+    def test_inner_product_matrix_shape(self):
+        base_point = None
+        dim = self.left_metric.group.dimension
+        result = self.left_metric.inner_product_matrix(base_point=base_point)
+        self.assertAllClose(gs.shape(result), (dim, dim))
 
-        # result = self.right_metric.inner_product_matrix(
-        #     base_point=base_point)
+        base_point = self.group.identity
+        dim = self.left_metric.group.dimension
+        result = self.left_metric.inner_product_matrix(base_point=base_point)
+        self.assertAllClose(gs.shape(result), (dim, dim))
 
-        # expected = self.right_metric.inner_product_mat_at_identity
-        # self.assertAllClose(result, expected)
+    @geomstats.tests.np_and_tf_only
+    def test_inner_product_matrix_and_inner_product_mat_at_identity(self):
+        base_point = None
+        result = self.left_metric.inner_product_matrix(base_point=base_point)
+        expected = self.left_metric.inner_product_mat_at_identity
+        self.assertAllClose(result, expected)
+
+        base_point = self.group.identity
+        result = self.right_metric.inner_product_matrix(base_point=base_point)
+        expected = self.right_metric.inner_product_mat_at_identity
+        self.assertAllClose(result, expected)
 
     def test_inner_product_matrix_and_its_inverse(self):
         inner_prod_mat = self.left_diag_metric.inner_product_mat_at_identity
         inv_inner_prod_mat = gs.linalg.inv(inner_prod_mat)
         result = gs.matmul(inv_inner_prod_mat, inner_prod_mat)
         expected = gs.eye(self.group.dimension)
-        expected = gs.to_ndarray(expected, to_ndim=3, axis=0)
         self.assertAllClose(result, expected)
 
     @geomstats.tests.np_and_pytorch_only

--- a/tests/test_special_euclidean.py
+++ b/tests/test_special_euclidean.py
@@ -1329,16 +1329,16 @@ class TestSpecialEuclideanMethods(geomstats.tests.TestCase):
             n_vector_b = self.group.random_uniform(n_samples=n_samples)
 
             result = metric.inner_product(one_vector_a, n_vector_b)
-            self.assertAllClose(gs.shape(result), (n_samples, 1))
+            self.assertAllClose(gs.shape(result), (n_samples,))
 
             if geomstats.tests.tf_backend():
                 break
 
             result = metric.inner_product(n_vector_a, one_vector_b)
-            self.assertAllClose(gs.shape(result), (n_samples, 1))
+            self.assertAllClose(gs.shape(result), (n_samples,))
 
             result = metric.inner_product(n_vector_a, n_vector_b)
-            self.assertAllClose(gs.shape(result), (n_samples, 1))
+            self.assertAllClose(gs.shape(result), (n_samples,))
 
     def test_inner_product_one_base_point_vectorization(self):
         n_samples = self.n_samples

--- a/tests/test_special_orthogonal.py
+++ b/tests/test_special_orthogonal.py
@@ -3717,8 +3717,9 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
             [0., 0., 0.]])
         second_tan = first_tan
 
-        result = space.lie_bracket(first_tan, second_tan, base_point)
-        expected = gs.zeros((1, dim, dim))
+        result = space.lie_bracket(
+            first_tan, second_tan, base_point, point_type='matrix')
+        expected = gs.zeros((dim, dim))
 
         self.assertAllClose(result, expected)
 
@@ -3731,11 +3732,12 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
             [0., 0., 0.],
             [1., 0., 0.]])
 
-        result = space.lie_bracket(first_tan, second_tan, base_point)
-        expected = gs.array([[
+        result = space.lie_bracket(
+            first_tan, second_tan, base_point, point_type='matrix')
+        expected = gs.array([
             [0., 0., 0.],
             [0., 0., -1.],
-            [0., 1., 0.]]])
+            [0., 1., 0.]])
 
         self.assertAllClose(result, expected)
 
@@ -3753,10 +3755,14 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
             [[0., 0., -1.], [0., 0., 0.], [1., 0., 0.]]
         ])
 
-        result = space.lie_bracket(first_tan, second_tan, base_point)
+        result = space.lie_bracket(
+            first_tan, second_tan, base_point, point_type='matrix')
         expected = gs.array([
             gs.zeros((dim, dim)),
-            gs.array([[0., 0., 0.], [0., 0., -1.], [0., 1., 0.]])
+            gs.array([
+                [0., 0., 0.],
+                [0., 0., -1.],
+                [0., 1., 0.]])
         ])
 
         self.assertAllClose(result, expected)
@@ -3766,19 +3772,31 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
         space = self.so[dim]
 
         base_point = gs.array([
-            [[-1., 0., 0.], [0., -1., 0.], [0., 0., 1.]]])
+            [-1., 0., 0.],
+            [0., -1., 0.],
+            [0., 0., 1.]])
         first_tan = gs.matmul(
             base_point,
-            gs.array([[0., -1., 0.], [1., 0., 0.], [0., 0., 0.]])
+            gs.array([
+                [0., -1., 0.],
+                [1., 0., 0.],
+                [0., 0., 0.]])
         )
         second_tan = gs.matmul(
             base_point,
-            gs.array([[0., 0., -1.], [0., 0., 0.], [1., 0., 0.]])
+            gs.array([
+                [0., 0., -1.],
+                [0., 0., 0.],
+                [1., 0., 0.]])
         )
 
-        result = space.lie_bracket(first_tan, second_tan, base_point)
+        result = space.lie_bracket(
+            first_tan, second_tan, base_point, point_type='matrix')
         expected = gs.matmul(
             base_point,
-            gs.array([[[0., 0., 0.], [0., 0., -1.], [0., 1., 0.]]]))
+            gs.array([
+                [0., 0., 0.],
+                [0., 0., -1.],
+                [0., 1., 0.]]))
 
         self.assertAllClose(result, expected)


### PR DESCRIPTION
This PR continues to address issue #338. The strategy behind the refactorization/vectorization PRs is explained in a post in the associated issue #338.

This PR gets rid of the vectorization decorators in lie_group and invariant_metric.