### PR TITLE
Updated Grassmannian.belongs, and fixed hardcoded dimensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 
 .ipynb_checkpoints
 */.ipynb_checkpoints/*
+*.ipynb
 
 # IPython
 profile_default/

--- a/geomstats/geometry/grassmannian.py
+++ b/geomstats/geometry/grassmannian.py
@@ -28,7 +28,7 @@ class Grassmannian(EmbeddedManifold):
 
         self.n = n
         self.k = k
-        self.metric = GrassmannianCanonicalMetric(3, 2)
+        self.metric = GrassmannianCanonicalMetric(n, k)
 
         dimension = int(k * (n - k))
         super(Grassmannian, self).__init__(
@@ -50,9 +50,29 @@ class Grassmannian(EmbeddedManifold):
         -------
         belongs : bool
         """
-        raise NotImplementedError(
-            'The Grassmann `belongs` is not implemented.'
-            'It shall test whether p*=p, p^2 = p and rank(p) = k.')
+        
+        point = gs.to_ndarray(point, to_ndim=3)
+        n_points, n, p = point.shape
+
+        # check square
+        if (n, p) != (self.n, self.n):
+            return gs.array([[False]] * n_points)
+
+        point_transpose = gs.transpose(point, axes=(0, 2, 1))
+
+        # check symmetry
+        sym_diff = gs.einsum('nij, njk->nik', point, point_transpose) - point
+        sym = gs.linalg.norm(sym_diff, axis=(1, 2))
+
+        # check idempotency
+        idem_diff = gs.einsum('nij, njk->nik', point, point) - point
+        idem = gs.linalg.norm(idem_diff, axis=(1, 2))
+
+        # check rank
+        trace = gs.einsum('nii', point) - self.k
+        belongs = gs.all(gs.stack([sym, idem, trace], axis=0), axis=0)
+
+        return belongs
 
 
 class GrassmannianCanonicalMetric(RiemannianMetric):

--- a/geomstats/geometry/grassmannian.py
+++ b/geomstats/geometry/grassmannian.py
@@ -80,7 +80,7 @@ class Grassmannian(EmbeddedManifold):
 
         [n_points, n, p] = point.shape
 
-        return [n==p]*n_points
+        return [n == p] * n_points
 
     @staticmethod
     def _check_symmetric(point):
@@ -100,7 +100,7 @@ class Grassmannian(EmbeddedManifold):
     @staticmethod
     def _check_idempotent(point, tolerance):
         """Check that a point is idempotent.
-        
+
         Parameters
         ----------
         point
@@ -111,8 +111,6 @@ class Grassmannian(EmbeddedManifold):
         belongs : bool
         """
 
-        point_transpose = Matrices.transpose(point)
-        
         diff = gs.einsum('...ij,...jk->...ik', point, point) - point
         diff_norm = gs.linalg.norm(diff, axis=(1, 2))
 
@@ -120,7 +118,7 @@ class Grassmannian(EmbeddedManifold):
 
     @staticmethod
     def _check_rank(point, rank, tolerance):
-        """Check that the rank of the point is equal to the 
+        """Check that the rank of the point is equal to the
         subspace dimension.  Matrix rank is equal to number of
         singular values greater than 0.
 
@@ -135,12 +133,9 @@ class Grassmannian(EmbeddedManifold):
         belongs : bool
         """
 
-        [_,s,_] = gs.linalg.svd(point)
-        
-        return gs.sum(s>tolerance, axis=1) == rank
+        [_, s, _] = gs.linalg.svd(point)
 
-
-
+        return gs.sum(s > tolerance, axis=1) == rank
 
 
 class GrassmannianCanonicalMetric(RiemannianMetric):

--- a/geomstats/geometry/grassmannian.py
+++ b/geomstats/geometry/grassmannian.py
@@ -50,7 +50,6 @@ class Grassmannian(EmbeddedManifold):
         -------
         belongs : bool
         """
-        
         point = gs.to_ndarray(point, to_ndim=3)
         n_points, n, p = point.shape
 
@@ -62,14 +61,19 @@ class Grassmannian(EmbeddedManifold):
 
         # check symmetry
         sym_diff = gs.einsum('nij, njk->nik', point, point_transpose) - point
-        sym = gs.linalg.norm(sym_diff, axis=(1, 2))
+        sym_norm = gs.linalg.norm(sym_diff, axis=(1, 2))
+        sym = gs.less_equal(sym_norm, tolerance)
 
         # check idempotency
         idem_diff = gs.einsum('nij, njk->nik', point, point) - point
-        idem = gs.linalg.norm(idem_diff, axis=(1, 2))
+        idem_norm = gs.linalg.norm(idem_diff, axis=(1, 2))
+        idem = gs.less_equal(idem_norm, tolerance)
 
         # check rank
-        trace = gs.einsum('nii', point) - self.k
+        trace_diff = gs.einsum('nii', point) - self.k
+        trace_norm = gs.linalg.norm(trace_diff, axis=(1, 2))
+        trace = gs.less_equal(trace_norm, tolerance)
+
         belongs = gs.all(gs.stack([sym, idem, trace], axis=0), axis=0)
 
         return belongs


### PR DESCRIPTION
The master branch previously raised a "Not Implemented" error upon calling Grassmannian.belongs.  I updated the method to check that the **point** parameter is square, symmetric, idempotent, and of rank K -- i.e. that the point is an orthogonal projector.

Also, in the Grassmannian initialization, the GrassmannianCanonicalMetric parameters were hardcoded to (3, 2) -- I updated this to take in the (n, k) parameters.