### PR TITLE
Make Pytorch's array closer to Numpy's

### DIFF
--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -192,7 +192,6 @@ def array(val, dtype=None):
     return val
 
 
-
 def all(x, axis=None):
     if axis is None and torch.is_tensor(x):
         return x.bool().all()

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -22,6 +22,19 @@ class TestBackends(geomstats.tests.TestCase):
         self.so3_group = SpecialOrthogonal(n=3)
         self.n_samples = 2
 
+    def test_array(self):
+        gs_mat = gs.array([gs.ones(3), gs.ones(3)])
+        np_mat = _np.array([_np.ones(3), _np.ones(3)])
+        self.assertAllCloseToNp(gs_mat, np_mat)
+
+        gs_mat = gs.array([[gs.ones(3)], [gs.ones(3)]])
+        np_mat = _np.array([[_np.ones(3)], [_np.ones(3)]])
+        self.assertAllCloseToNp(gs_mat, np_mat)
+
+        gs_mat = gs.array([gs.ones(3), [0, 0, 0]])
+        np_mat = _np.array([_np.ones(3), [0, 0, 0]])
+        self.assertAllCloseToNp(gs_mat, np_mat)
+
     def test_matmul(self):
         mat_a = [[2., 0., 0.],
                  [0., 3., 0.],


### PR DESCRIPTION
This commit aims at having `array` functions with behaviors as similar as possible between the various backends, and especially Pytorch.
A few points are open questions, which need to be discussed @ninamiolane @nkoep @nguigs 
- The main problem was that Pytorch's `array` did not allow things like `gs.array([gs.ones(2), [0,0]])`, which numpy and tensorflow would seamlessly deal with. This is now dealt with recursively (to handle, e.g., `array([[[gs.ones(2)], [gs.ones(2)]]])`)
- Pytorch is restrictive when  `dtypes` are considered : it won't stack a `float32` tensor with a `float64` one, for instance. I had to add casting "on the fly", and an arbitrary type order to get a unified dtype at the end. This is (slightly) unelegant, and more importantly I don't know how much that could impact the running time.
- About the floating dtype, for now `Float32` was privileged, see the `val = val.float()` line. This is logical since most computations can be carried out in 32-bits to go faster. However, Numpy has a clear tendancy to go to 64-bits as soon as it can (which is not necessarily a behavior which should be copied). Maybe the choice between 32 and 64-bits for pytorch and tensorflow could be encoded by a backend variable ?