### PR TITLE
Include dtype option in array unit test

### DIFF
--- a/geomstats/_backend/__init__.py
+++ b/geomstats/_backend/__init__.py
@@ -10,6 +10,7 @@ BACKEND_ATTRIBUTES = {
         'int64',
         'float32',
         'float64',
+        'uint8',
         # Functions
         'abs',
         'all',

--- a/geomstats/_backend/numpy/__init__.py
+++ b/geomstats/_backend/numpy/__init__.py
@@ -79,6 +79,7 @@ from autograd.numpy import (  # NOQA
     tril_indices,
     searchsorted,
     tril,
+    uint8,
     vstack,
     where,
     zeros,

--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -114,6 +114,8 @@ def any(x, axis=None):
 
 
 def cast(x, dtype):
+    if torch.is_tensor(x):
+        return x.to(dtype)
     return array(x).to(dtype)
 
 
@@ -185,8 +187,9 @@ def array(val, dtype=None):
     if not isinstance(val, torch.Tensor):
         val = torch.Tensor([val])
 
-    if dtype is not None and val.dtype != dtype:
-        cast(val, dtype)
+    if dtype is not None:
+        if val.dtype != dtype:
+            val = cast(val, dtype)
     elif val.dtype == torch.float64:
         val = val.float()
     return val

--- a/geomstats/_backend/tensorflow/__init__.py
+++ b/geomstats/_backend/tensorflow/__init__.py
@@ -52,6 +52,7 @@ from tensorflow import (  # NOQA
     tan,
     tanh,
     tile,
+    uint8,
     where,
     zeros,
     zeros_like

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -27,12 +27,16 @@ class TestBackends(geomstats.tests.TestCase):
         np_mat = _np.array([_np.ones(3), _np.ones(3)])
         self.assertAllCloseToNp(gs_mat, np_mat)
 
-        gs_mat = gs.array([[gs.ones(3)], [gs.ones(3)]])
-        np_mat = _np.array([[_np.ones(3)], [_np.ones(3)]])
+        gs_mat = gs.array([gs.ones(3), gs.ones(3)], dtype=gs.float64)
+        np_mat = _np.array([_np.ones(3), _np.ones(3)], dtype=_np.float64)
         self.assertAllCloseToNp(gs_mat, np_mat)
 
-        gs_mat = gs.array([gs.ones(3), [0, 0, 0]])
-        np_mat = _np.array([_np.ones(3), [0, 0, 0]])
+        gs_mat = gs.array([[gs.ones(3)], [gs.ones(3)]], dtype=gs.uint8)
+        np_mat = _np.array([[_np.ones(3)], [_np.ones(3)]], dtype=_np.uint8)
+        self.assertAllCloseToNp(gs_mat, np_mat)
+
+        gs_mat = gs.array([gs.ones(3), [0, 0, 0]], dtype=gs.int32)
+        np_mat = _np.array([_np.ones(3), [0, 0, 0]], dtype=_np.int32)
         self.assertAllCloseToNp(gs_mat, np_mat)
 
     def test_matmul(self):

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -23,20 +23,27 @@ class TestBackends(geomstats.tests.TestCase):
         self.n_samples = 2
 
     def test_array(self):
+        gs_mat = gs.array(1.5)
+        np_mat = _np.array(1.5)
+        self.assertAllCloseToNp(gs_mat, np_mat)
+
         gs_mat = gs.array([gs.ones(3), gs.ones(3)])
         np_mat = _np.array([_np.ones(3), _np.ones(3)])
         self.assertAllCloseToNp(gs_mat, np_mat)
 
         gs_mat = gs.array([gs.ones(3), gs.ones(3)], dtype=gs.float64)
         np_mat = _np.array([_np.ones(3), _np.ones(3)], dtype=_np.float64)
+        assert gs_mat.dtype == gs.float64
         self.assertAllCloseToNp(gs_mat, np_mat)
 
         gs_mat = gs.array([[gs.ones(3)], [gs.ones(3)]], dtype=gs.uint8)
         np_mat = _np.array([[_np.ones(3)], [_np.ones(3)]], dtype=_np.uint8)
+        assert gs_mat.dtype == gs.uint8
         self.assertAllCloseToNp(gs_mat, np_mat)
 
         gs_mat = gs.array([gs.ones(3), [0, 0, 0]], dtype=gs.int32)
         np_mat = _np.array([_np.ones(3), [0, 0, 0]], dtype=_np.int32)
+        assert gs_mat.dtype == gs.int32
         self.assertAllCloseToNp(gs_mat, np_mat)
 
     def test_matmul(self):


### PR DESCRIPTION
This PR adds various `dtype` options to the `array` unit test. It also adds `uint8` to the backend functions accessible outside. This is for the test only at the moment.