### PR TITLE
Change dimension to dim and add default_point_type

### DIFF
--- a/examples/empirical_frechet_mean_uncertainty_sn.py
+++ b/examples/empirical_frechet_mean_uncertainty_sn.py
@@ -44,8 +44,8 @@ def empirical_frechet_var_bubble(n_samples, theta, dim,
     """
     assert dim > 1, 'Dim > 1 needed to draw a uniform sample on sub-sphere'
     var = []
-    sphere = Hypersphere(dimension=dim)
-    bubble = Hypersphere(dimension=dim - 1)
+    sphere = Hypersphere(dim=dim)
+    bubble = Hypersphere(dim=dim - 1)
 
     north_pole = gs.zeros(dim + 1)
     north_pole[dim] = 1.0

--- a/examples/empirical_frechet_mean_uncertainty_sn.py
+++ b/examples/empirical_frechet_mean_uncertainty_sn.py
@@ -28,15 +28,18 @@ def empirical_frechet_var_bubble(n_samples, theta, dim,
 
     The bubble distribution is an isotropic distributions on a Riemannian
     hyper sub-sphere of radius 0 < theta < Pi around the north pole of the
-    sphere of dim dim.
+    sphere of dimension dim.
 
     Parameters
     ----------
     n_samples : int
         Number of samples to draw.
-    theta: radius of the bubble distribution
-    dim: dim of the sphere (embedded in R^{dim+1})
-    n_expectation: number of computations for approximating the expectation
+    theta: float
+        Radius of the bubble distribution.
+    dim : int
+        Dimension of the sphere (embedded in R^{dim+1}).
+    n_expectation: int, optional (defaults to 1000)
+        Number of computations for approximating the expectation.
 
     Returns
     -------
@@ -77,14 +80,18 @@ def modulation_factor(n_samples, theta, dim, n_expectation=1000):
     Fréchet mean on the manifold to the variance in a Euclidean space,
     for n_sampless drawn from an isotropic distributions on a Riemannian
     hyper sub-sphere of radius 0 < theta < Pi around the north pole of the
-    sphere of dim dim.
+    sphere of dimension dim.
 
     Parameters
     ----------
-    n_samples: number of samples to draw
-    theta: radius of the bubble distribution
-    dim: dim of the sphere (embedded in R^{dim+1})
-    n_expectation: number of computations for approximating the expectation
+    n_samples : int
+        Number of samples to draw.
+    theta : float
+        Radius of the bubble distribution.
+    dim : int
+        Dimension of the sphere (embedded in R^{dim+1}).
+    n_expectation: int, optional (defaults to 1000)
+        Number of computations for approximating the expectation.
 
     Returns
     -------
@@ -100,8 +107,10 @@ def asymptotic_modulation(dim, theta):
 
     Parameters
     ----------
-    dim: dim of the sphere (embedded in R^{dim+1})
-    theta: radius of the bubble distribution
+    dim : int
+        Dimension of the sphere (embedded in R^{dim+1}).
+    theta : float
+        Radius of the bubble distribution.
 
     Returns
     -------
@@ -121,10 +130,14 @@ def plot_modulation_factor(n_samples, dim, n_expectation=1000, n_theta=20):
 
     Parameters
     ----------
-    n_samples: number of samples to draw
-    dim: dim of the sphere (embedded in R^{dim+1})
-    n_expectation: number of computations for approximating the expectation
-    n_theta: number of sampled radii for the bubble distribution
+    n_samples : int
+        Number of samples to draw
+    dim : int
+        Dimension of the sphere (embedded in R^{dim+1}).
+    n_expectation: int, optional (defaults to 1000)
+        Number of computations for approximating the expectation.
+    n_theta: int, optional (defaults to 20)
+        Number of sampled radii for the bubble distribution.
 
     Returns
     -------
@@ -173,12 +186,6 @@ def main():
          alpha = Var( FM_n) / ( n * Var)
     for isotropic distributions on hyper-spheres of radius 0 < theta < Pi in
     the sphere S_dim (called here a bubble).
-
-    Parameters
-    ----------
-    test : bool
-        Wether the method is called from a unit test.
-        Use `True` to run only one plot and `False` to run the full example.
     """
     n_expectation = 10
 

--- a/examples/empirical_frechet_mean_uncertainty_sn.py
+++ b/examples/empirical_frechet_mean_uncertainty_sn.py
@@ -28,14 +28,14 @@ def empirical_frechet_var_bubble(n_samples, theta, dim,
 
     The bubble distribution is an isotropic distributions on a Riemannian
     hyper sub-sphere of radius 0 < theta < Pi around the north pole of the
-    sphere of dimension dim.
+    sphere of dim dim.
 
     Parameters
     ----------
     n_samples : int
         Number of samples to draw.
     theta: radius of the bubble distribution
-    dim: dimension of the sphere (embedded in R^{dim+1})
+    dim: dim of the sphere (embedded in R^{dim+1})
     n_expectation: number of computations for approximating the expectation
 
     Returns
@@ -77,13 +77,13 @@ def modulation_factor(n_samples, theta, dim, n_expectation=1000):
     Fréchet mean on the manifold to the variance in a Euclidean space,
     for n_sampless drawn from an isotropic distributions on a Riemannian
     hyper sub-sphere of radius 0 < theta < Pi around the north pole of the
-    sphere of dimension dim.
+    sphere of dim dim.
 
     Parameters
     ----------
     n_samples: number of samples to draw
     theta: radius of the bubble distribution
-    dim: dimension of the sphere (embedded in R^{dim+1})
+    dim: dim of the sphere (embedded in R^{dim+1})
     n_expectation: number of computations for approximating the expectation
 
     Returns
@@ -100,7 +100,7 @@ def asymptotic_modulation(dim, theta):
 
     Parameters
     ----------
-    dim: dimension of the sphere (embedded in R^{dim+1})
+    dim: dim of the sphere (embedded in R^{dim+1})
     theta: radius of the bubble distribution
 
     Returns
@@ -122,7 +122,7 @@ def plot_modulation_factor(n_samples, dim, n_expectation=1000, n_theta=20):
     Parameters
     ----------
     n_samples: number of samples to draw
-    dim: dimension of the sphere (embedded in R^{dim+1})
+    dim: dim of the sphere (embedded in R^{dim+1})
     n_expectation: number of computations for approximating the expectation
     n_theta: number of sampled radii for the bubble distribution
 

--- a/examples/gradient_descent_s2.py
+++ b/examples/gradient_descent_s2.py
@@ -25,7 +25,7 @@ from geomstats.geometry.hypersphere import Hypersphere
 from geomstats.geometry.spd_matrices import SPDMatrices
 
 
-SPHERE2 = Hypersphere(dimension=2)
+SPHERE2 = Hypersphere(dim=2)
 METRIC = SPHERE2.metric
 
 

--- a/examples/gradient_descent_s2.py
+++ b/examples/gradient_descent_s2.py
@@ -7,7 +7,7 @@ We solve the following optimization problem:
     such than: x^{T}x = 1
 
 Using by operating a gradient descent of the quadratic form
-on the sphere. We solve this in 3 dim on the 2-sphere
+on the sphere. We solve this in dimension 3 on the 2-sphere
 manifold so that we can visualize and render the path as a video.
 """
 

--- a/examples/gradient_descent_s2.py
+++ b/examples/gradient_descent_s2.py
@@ -7,7 +7,7 @@ We solve the following optimization problem:
     such than: x^{T}x = 1
 
 Using by operating a gradient descent of the quadratic form
-on the sphere. We solve this in 3 dimension on the 2-sphere
+on the sphere. We solve this in 3 dim on the 2-sphere
 manifold so that we can visualize and render the path as a video.
 """
 

--- a/examples/learning_graph_structured_data_h2.py
+++ b/examples/learning_graph_structured_data_h2.py
@@ -17,11 +17,11 @@ def log_sigmoid(vector):
 
     Parameters
     ----------
-    vector : array-like, shape=[n_samples, dimension]
+    vector : array-like, shape=[n_samples, dim]
 
     Returns
     -------
-    result : array-like, shape=[n_samples, dimension]
+    result : array-like, shape=[n_samples, dim]
     """
     return gs.log((1 / (1 + gs.exp(-vector))))
 
@@ -31,11 +31,11 @@ def grad_log_sigmoid(vector):
 
     Parameters
     ----------
-    vector : array-like, shape=[n_samples, dimension]
+    vector : array-like, shape=[n_samples, dim]
 
     Returns
     -------
-    gradient : array-like, shape=[n_samples, dimension]
+    gradient : array-like, shape=[n_samples, dim]
     """
     return (1 / (1 + gs.exp(vector)))
 
@@ -48,9 +48,9 @@ def grad_squared_distance(point_a, point_b):
 
     Parameters
     ----------
-    point_a : array-like, shape=[n_samples, dimension]
+    point_a : array-like, shape=[n_samples, dim]
         First point in hyperbolic space.
-    point_b : array-like, shape=[n_samples, dimension]
+    point_b : array-like, shape=[n_samples, dim]
         Second point in hyperbolic space.
 
     Returns

--- a/examples/plot_agglomerative_hierarchical_clustering_s2.py
+++ b/examples/plot_agglomerative_hierarchical_clustering_s2.py
@@ -14,7 +14,7 @@ from geomstats.learning.agglomerative_hierarchical_clustering \
 
 def main():
     """Plot an Agglomerative Hierarchical Clustering on the sphere."""
-    sphere = Hypersphere(dimension=2)
+    sphere = Hypersphere(dim=2)
     sphere_distance = sphere.metric.dist
 
     n_clusters = 2

--- a/examples/plot_geodesics_h2.py
+++ b/examples/plot_geodesics_h2.py
@@ -14,7 +14,7 @@ import geomstats.backend as gs
 import geomstats.visualization as visualization
 from geomstats.geometry.hyperboloid import Hyperboloid
 
-H2 = Hyperboloid(dimension=2, coords_type='extrinsic')
+H2 = Hyperboloid(dim=2, coords_type='extrinsic')
 METRIC = H2.metric
 
 

--- a/examples/plot_geodesics_s2.py
+++ b/examples/plot_geodesics_s2.py
@@ -9,7 +9,7 @@ import numpy as np
 import geomstats.visualization as visualization
 from geomstats.geometry.hypersphere import Hypersphere
 
-SPHERE2 = Hypersphere(dimension=2)
+SPHERE2 = Hypersphere(dim=2)
 METRIC = SPHERE2.metric
 
 

--- a/examples/plot_grid_h2.py
+++ b/examples/plot_grid_h2.py
@@ -12,7 +12,7 @@ import numpy as np
 import geomstats.visualization as visualization
 from geomstats.geometry.hyperboloid import Hyperboloid
 
-H2 = Hyperboloid(dimension=2)
+H2 = Hyperboloid(dim=2)
 METRIC = H2.metric
 
 

--- a/examples/plot_kmeans_manifolds.py
+++ b/examples/plot_kmeans_manifolds.py
@@ -25,7 +25,7 @@ def kmean_poincare_ball():
     n_samples = 20
     dim = 2
     n_clusters = 2
-    manifold = PoincareBall(dimension=dim)
+    manifold = PoincareBall(dim=dim)
     metric = manifold.metric
 
     cluster_1 = gs.random.uniform(low=0.5, high=0.6, size=(n_samples, dim))

--- a/examples/plot_knn_s2.py
+++ b/examples/plot_knn_s2.py
@@ -13,7 +13,7 @@ from geomstats.learning.knn import KNearestNeighborsClassifier
 
 def main():
     """Plot the result of a KNN classification on the sphere."""
-    sphere = Hypersphere(dimension=2)
+    sphere = Hypersphere(dim=2)
     sphere_distance = sphere.metric.dist
 
     n_labels = 2

--- a/examples/plot_online_kmeans_s1.py
+++ b/examples/plot_online_kmeans_s1.py
@@ -19,7 +19,7 @@ TOLERANCE = 1e-6
 
 
 def main():
-    circle = Hypersphere(dimension=1)
+    circle = Hypersphere(dim=1)
 
     data = circle.random_uniform(n_samples=1000)
 

--- a/examples/plot_online_kmeans_s2.py
+++ b/examples/plot_online_kmeans_s2.py
@@ -14,7 +14,7 @@ from geomstats.learning.online_kmeans import OnlineKMeans
 
 
 def main():
-    sphere = Hypersphere(dimension=2)
+    sphere = Hypersphere(dim=2)
 
     data = sphere.random_von_mises_fisher(kappa=10, n_samples=1000)
 

--- a/examples/plot_square_h2_klein_disk.py
+++ b/examples/plot_square_h2_klein_disk.py
@@ -11,7 +11,7 @@ import numpy as np
 import geomstats.visualization as visualization
 from geomstats.geometry.hyperboloid import Hyperboloid
 
-H2 = Hyperboloid(dimension=2)
+H2 = Hyperboloid(dim=2)
 METRIC = H2.metric
 
 SQUARE_SIZE = 50

--- a/examples/plot_square_h2_poincare_disk.py
+++ b/examples/plot_square_h2_poincare_disk.py
@@ -9,7 +9,7 @@ import numpy as np
 import geomstats.visualization as visualization
 from geomstats.geometry.hyperboloid import Hyperboloid
 
-H2 = Hyperboloid(dimension=2)
+H2 = Hyperboloid(dim=2)
 METRIC = H2.metric
 
 SQUARE_SIZE = 50

--- a/examples/plot_square_h2_poincare_half_plane.py
+++ b/examples/plot_square_h2_poincare_half_plane.py
@@ -9,7 +9,7 @@ import numpy as np
 import geomstats.visualization as visualization
 from geomstats.geometry.hyperboloid import Hyperboloid
 
-H2 = Hyperboloid(dimension=2)
+H2 = Hyperboloid(dim=2)
 METRIC = H2.metric
 
 SQUARE_SIZE = 50

--- a/examples/tangent_pca_h2.py
+++ b/examples/tangent_pca_h2.py
@@ -15,7 +15,7 @@ def main():
     """Perform tangent PCA at the mean."""
     fig = plt.figure(figsize=(15, 5))
 
-    hyperbolic_plane = Hyperbolic(dimension=2)
+    hyperbolic_plane = Hyperbolic(dim=2)
 
     data = hyperbolic_plane.random_uniform(n_samples=140)
 

--- a/examples/tangent_pca_s2.py
+++ b/examples/tangent_pca_s2.py
@@ -15,7 +15,7 @@ def main():
     """Perform tangent PCA at the mean."""
     fig = plt.figure(figsize=(15, 5))
 
-    sphere = Hypersphere(dimension=2)
+    sphere = Hypersphere(dim=2)
 
     data = sphere.random_von_mises_fisher(kappa=15, n_samples=140)
 

--- a/geomstats/_backend/numpy/__init__.py
+++ b/geomstats/_backend/numpy/__init__.py
@@ -123,7 +123,7 @@ def assignment(x, values, indices, axis=0):
 
     Parameters
     ----------
-    x: array-like, shape=[dimension]
+    x: array-like, shape=[dim]
         Initial array.
     values: {float, list(float)}
         Value or list of values to be assigned.
@@ -137,7 +137,7 @@ def assignment(x, values, indices, axis=0):
 
     Returns
     -------
-    x_new : array-like, shape=[dimension]
+    x_new : array-like, shape=[dim]
         Copy of x with the values assigned at the given indices.
 
     Notes
@@ -167,7 +167,7 @@ def assignment_by_sum(x, values, indices, axis=0):
 
     Parameters
     ----------
-    x : array-like, shape=[dimension]
+    x : array-like, shape=[dim]
         Initial array.
     values : {float, list(float)}
         Value or list of values to be assigned.
@@ -181,7 +181,7 @@ def assignment_by_sum(x, values, indices, axis=0):
 
     Returns
     -------
-    x_new : array-like, shape=[dimension]
+    x_new : array-like, shape=[dim]
         Copy of x with the values assigned at the given indices.
 
     Notes
@@ -211,7 +211,7 @@ def get_slice(x, indices):
 
     Parameters
     ----------
-    x : array-like, shape=[dimension]
+    x : array-like, shape=[dim]
         Initial array.
     indices : iterable(iterable(int))
         Indices which are kept along each axis, starting from 0.
@@ -249,9 +249,9 @@ def set_diag(x, new_diag):
 
     Parameters
     ----------
-    x : array-like, shape=[dimension]
+    x : array-like, shape=[dim]
         Initial array.
-    new_diag : array-like, shape=[dimension[-2]]
+    new_diag : array-like, shape=[dim[-2]]
         Values to set on the diagonal.
 
     Returns

--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -207,7 +207,7 @@ def get_slice(x, indices):
 
     Parameters
     ----------
-    x : array-like, shape=[dimension]
+    x : array-like, shape=[dim]
         Initial array.
     indices : iterable(iterable(int))
         Indices which are kept along each axis, starting from 0.
@@ -457,9 +457,9 @@ def set_diag(x, new_diag):
 
     Parameters
     ----------
-    x : array-like, shape=[dimension]
+    x : array-like, shape=[dim]
         Initial array.
-    new_diag : array-like, shape=[dimension[-2]]
+    new_diag : array-like, shape=[dim[-2]]
         Values to set on the diagonal.
 
     Returns
@@ -514,7 +514,7 @@ def assignment(x, values, indices, axis=0):
 
     Parameters
     ----------
-    x: array-like, shape=[dimension]
+    x: array-like, shape=[dim]
         Initial array.
     values: {float, list(float)}
         Value or list of values to be assigned.
@@ -528,7 +528,7 @@ def assignment(x, values, indices, axis=0):
 
     Returns
     -------
-    x_new : array-like, shape=[dimension]
+    x_new : array-like, shape=[dim]
         Copy of x with the values assigned at the given indices.
 
     Notes
@@ -559,7 +559,7 @@ def assignment_by_sum(x, values, indices, axis=0):
 
     Parameters
     ----------
-    x: array-like, shape=[dimension]
+    x: array-like, shape=[dim]
         Initial array.
     values: {float, list(float)}
         Value or list of values to be assigned.
@@ -573,7 +573,7 @@ def assignment_by_sum(x, values, indices, axis=0):
 
     Returns
     -------
-    x_new : array-like, shape=[dimension]
+    x_new : array-like, shape=[dim]
         Copy of x with the values assigned at the given indices.
 
     Notes

--- a/geomstats/_backend/tensorflow/__init__.py
+++ b/geomstats/_backend/tensorflow/__init__.py
@@ -219,7 +219,7 @@ def _vectorized_mask_from_indices(
     Parameters
     ----------
     n_samples: int
-        Number of copies of the mask along the additional dim.
+        Number of copies of the mask along the additional dimension.
     indices : {tuple, list(tuple)}
         Single tuple, or list of tuples of indices where ones will be.
     mask_shape : tuple

--- a/geomstats/_backend/tensorflow/__init__.py
+++ b/geomstats/_backend/tensorflow/__init__.py
@@ -195,7 +195,7 @@ def _duplicate_array(x, n_samples, axis=0):
 
     Parameters
     ----------
-    x: array-like, shape=[dimension]
+    x: array-like, shape=[dim]
         Initial array which will be copied.
     n_samples: int
         Number of copies of the array to create.
@@ -204,8 +204,8 @@ def _duplicate_array(x, n_samples, axis=0):
 
     Returns
     -------
-    tiled_array: array, shape=[dimension[:axis], n_samples, dimension[axis:]]
-        Copies of x stacked along dimension axis
+    tiled_array: array, shape=[dim[:axis], n_samples, dim[axis:]]
+        Copies of x stacked along dim axis
     """
     multiples = _np.ones(ndim(x) + 1, dtype=_np.int32)
     multiples[axis] = n_samples
@@ -219,7 +219,7 @@ def _vectorized_mask_from_indices(
     Parameters
     ----------
     n_samples: int
-        Number of copies of the mask along the additional dimension.
+        Number of copies of the mask along the additional dim.
     indices : {tuple, list(tuple)}
         Single tuple, or list of tuples of indices where ones will be.
     mask_shape : tuple
@@ -242,7 +242,7 @@ def _assignment_single_value_by_sum(x, value, indices, axis=0):
 
     Parameters
     ----------
-    x: array-like, shape=[dimension]
+    x: array-like, shape=[dim]
         Initial array.
     value: float
         Value to be added.
@@ -256,7 +256,7 @@ def _assignment_single_value_by_sum(x, value, indices, axis=0):
 
     Returns
     -------
-    x_new : array-like, shape=[dimension]
+    x_new : array-like, shape=[dim]
         Copy of x where value was added at all indices (and possibly along
         an axis).
     """
@@ -283,7 +283,7 @@ def assignment_by_sum(x, values, indices, axis=0):
 
     Parameters
     ----------
-    x: array-like, shape=[dimension]
+    x: array-like, shape=[dim]
         Initial array.
     values: {float, list(float)}
         Value or list of values to be assigned.
@@ -297,7 +297,7 @@ def assignment_by_sum(x, values, indices, axis=0):
 
     Returns
     -------
-    x_new : array-like, shape=[dimension]
+    x_new : array-like, shape=[dim]
         Copy of x as the sum of x and the values at the given indices.
 
     Notes
@@ -325,7 +325,7 @@ def _assignment_single_value(x, value, indices, axis=0):
 
     Parameters
     ----------
-    x: array-like, shape=[dimension]
+    x: array-like, shape=[dim]
         Initial array.
     value: float
         Value to be added.
@@ -339,7 +339,7 @@ def _assignment_single_value(x, value, indices, axis=0):
 
     Returns
     -------
-    x_new : array-like, shape=[dimension]
+    x_new : array-like, shape=[dim]
         Copy of x where value was assigned at all indices (and possibly
         along an axis).
     """
@@ -368,7 +368,7 @@ def assignment(x, values, indices, axis=0):
 
     Parameters
     ----------
-    x: array-like, shape=[dimension]
+    x: array-like, shape=[dim]
         Initial array.
     values: {float, list(float)}
         Value or list of values to be assigned.
@@ -382,7 +382,7 @@ def assignment(x, values, indices, axis=0):
 
     Returns
     -------
-    x_new : array-like, shape=[dimension]
+    x_new : array-like, shape=[dim]
         Copy of x with the values assigned at the given indices.
 
     Notes
@@ -432,7 +432,7 @@ def get_slice(x, indices):
 
     Parameters
     ----------
-    x : array-like, shape=[dimension]
+    x : array-like, shape=[dim]
         Initial array.
     indices : iterable(iterable(int))
         Indices which are kept along each axis, starting from 0.

--- a/geomstats/geometry/beta_distributions.py
+++ b/geomstats/geometry/beta_distributions.py
@@ -225,13 +225,13 @@ class BetaMetric(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec : array-like, shape=[n_samples, dimension]
-        base_point : array-like, shape=[n_samples, dimension]
+        tangent_vec : array-like, shape=[n_samples, dim]
+        base_point : array-like, shape=[n_samples, dim]
         n_steps : int
 
         Returns
         -------
-        exp : array-like, shape=[n_samples, dimension]
+        exp : array-like, shape=[n_samples, dim]
         """
         base_point = gs.to_ndarray(base_point, to_ndim=2)
         tangent_vec = gs.to_ndarray(tangent_vec, to_ndim=2)
@@ -259,13 +259,13 @@ class BetaMetric(RiemannianMetric):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dimension]
-        base_point : array-like, shape=[n_samples, dimension]
+        point : array-like, shape=[n_samples, dim]
+        base_point : array-like, shape=[n_samples, dim]
         n_steps : int
 
         Returns
         -------
-        tangent_vec : array-like, shape=[n_samples, dimension]
+        tangent_vec : array-like, shape=[n_samples, dim]
             the initial velocity of the geodesic starting at base_point and
             reaching point at time 1
         """

--- a/geomstats/geometry/beta_distributions.py
+++ b/geomstats/geometry/beta_distributions.py
@@ -23,7 +23,7 @@ class BetaDistributions(EmbeddedManifold):
 
     def __init__(self):
         super(BetaDistributions, self).__init__(
-            dimension=2, embedding_manifold=Euclidean(dimension=2))
+            dim=2, embedding_manifold=Euclidean(dim=2))
 
     def belongs(self, point, point_type=None):
         """Evaluate if a point belongs to the manifold of beta distributions.
@@ -43,7 +43,7 @@ class BetaDistributions(EmbeddedManifold):
         """
         point = gs.to_ndarray(point, to_ndim=2)
         n_points, point_dim = point.shape
-        belongs = point_dim == self.dimension
+        belongs = point_dim == self.dim
         belongs = gs.to_ndarray(belongs, to_ndim=1)
         belongs = gs.tile(belongs, n_points)
         belongs = belongs * gs.greater(point, 0).all(axis=1)
@@ -127,7 +127,7 @@ class BetaMetric(RiemannianMetric):
     """Class for the Fisher information metric on beta distributions."""
 
     def __init__(self):
-        super(RiemannianMetric, self).__init__(dimension=2)
+        super(RiemannianMetric, self).__init__(dim=2)
 
     @staticmethod
     def metric_det(param_a, param_b):
@@ -277,7 +277,7 @@ class BetaMetric(RiemannianMetric):
         def initialize(end_point, start_point):
             a0, b0 = start_point
             a1, b1 = end_point
-            lin_init = gs.zeros([2 * self.dimension, n_steps])
+            lin_init = gs.zeros([2 * self.dim, n_steps])
             lin_init[0, :] = gs.linspace(a0, a1, n_steps)
             lin_init[1, :] = gs.linspace(b0, b1, n_steps)
             lin_init[2, :-1] = (lin_init[0, 1:] - lin_init[0, :-1]) * n_steps

--- a/geomstats/geometry/connection.py
+++ b/geomstats/geometry/connection.py
@@ -24,7 +24,7 @@ class Connection:
     def __init__(
             self, dim, default_point_type='vector',
             default_coords_type='intrinsic'):
-        geomstats.error.check_integer(dim, 'dimension')
+        geomstats.error.check_integer(dim, 'dim')
         geomstats.error.check_parameter_accepted_values(
             default_point_type, 'default_point_type', ['vector', 'matrix'])
 
@@ -37,12 +37,12 @@ class Connection:
 
         Parameters
         ----------
-        base_point : array-like, shape=[n_samples, dimension]
+        base_point : array-like, shape=[n_samples, dim]
             Point on the manifold.
 
         Returns
         -------
-        gamma : array-like, shape=[n_samples, dimension, dimension, dimension]
+        gamma : array-like, shape=[n_samples, dim, dim, dim]
             Values of the christoffel symbols, with the covariant index on
             the first dimension.
         """
@@ -57,11 +57,11 @@ class Connection:
 
         Parameters
         ----------
-        tangent_vec_a : array-like, shape=[n_samples, dimension]
+        tangent_vec_a : array-like, shape=[n_samples, dim]
             Tangent vector at base point.
-        tangent_vec_b : array-like, shape=[n_samples, dimension]
+        tangent_vec_b : array-like, shape=[n_samples, dim]
             Tangent vector at base point.
-        base_point : array-like, shape=[n_samples, dimension]
+        base_point : array-like, shape=[n_samples, dim]
             Point on the manifold.
         """
         raise NotImplementedError(
@@ -72,15 +72,15 @@ class Connection:
 
         Parameters
         ----------
-        velocity : array-like, shape=[n_samples, dimension]
+        velocity : array-like, shape=[n_samples, dim]
             Tangent vector at the position.
-        position : array-like, shape=[n_samples, dimension]
+        position : array-like, shape=[n_samples, dim]
             Point on the manifold, the position at which to compute the
             geodesic ODE.
 
         Returns
         -------
-        geodesic_ode : array-like, shape=[n_samples, dimension]
+        geodesic_ode : array-like, shape=[n_samples, dim]
             Value of the vector field to be integrated at position.
         """
         gamma = self.christoffels(position)
@@ -97,9 +97,9 @@ class Connection:
 
         Parameters
         ----------
-        tangent_vec : array-like, shape=[n_samples, dimension]
+        tangent_vec : array-like, shape=[n_samples, dim]
             Tangent vector at the base point.
-        base_point : array-like, shape=[n_samples, dimension]
+        base_point : array-like, shape=[n_samples, dim]
             Point on the manifold.
         n_steps : int
             The number of discrete time steps to take in the integration.
@@ -110,7 +110,7 @@ class Connection:
 
         Returns
         -------
-        exp : array-like, shape=[n_samples, dimension]
+        exp : array-like, shape=[n_samples, dim]
             Point on the manifold.
         """
         tangent_vec = gs.to_ndarray(tangent_vec, to_ndim=2)
@@ -128,9 +128,9 @@ class Connection:
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dimension]
+        point : array-like, shape=[n_samples, dim]
             Point on the manifold.
-        base_point : array-like, shape=[n_samples, dimension]
+        base_point : array-like, shape=[n_samples, dim]
             Point on the manifold.
         n_steps : int
             The number of discrete time steps to take in the integration.
@@ -139,7 +139,7 @@ class Connection:
 
         Returns
         -------
-        tangent_vec : array-like, shape=[n_samples, dimension]
+        tangent_vec : array-like, shape=[n_samples, dim]
             Tangent vector at the base point.
         """
         point = gs.to_ndarray(point, to_ndim=2)
@@ -177,11 +177,11 @@ class Connection:
 
         Parameters
         ----------
-        base_point : array-like, shape=[n_samples, dimension]
+        base_point : array-like, shape=[n_samples, dim]
             Point on the manifold, from which to transport.
-        next_point : array-like, shape=[n_samples, dimension]
+        next_point : array-like, shape=[n_samples, dim]
             Point on the manifold, to transport to.
-        base_shoot : array-like, shape=[n_samples, dimension]
+        base_shoot : array-like, shape=[n_samples, dim]
             Point on the manifold, end point of the geodesics starting
             from the base point with initial speed to be transported.
         return_geodesics : bool, optional (defaults to False)
@@ -191,9 +191,9 @@ class Connection:
         Returns
         -------
         next_step : dict of array-like and callable with following keys:
-            next_tangent_vec : array-like, shape=[n_samples, dimension]
+            next_tangent_vec : array-like, shape=[n_samples, dim]
                 Tangent vector at end point.
-            end_point : array-like, shape=[n_samples, dimension]
+            end_point : array-like, shape=[n_samples, dim]
                 Point on the manifold, closes the geodesic parallelogram of the
                 construction.
             geodesics : list of callable, len=3 (only if
@@ -255,11 +255,11 @@ class Connection:
 
         Parameters
         ----------
-        base_point : array-like, shape=[n_samples, dimension]
+        base_point : array-like, shape=[n_samples, dim]
             Point on the manifold, from which to transport.
-        next_point : array-like, shape=[n_samples, dimension]
+        next_point : array-like, shape=[n_samples, dim]
             Point on the manifold, to transport to.
-        base_shoot : array-like, shape=[n_samples, dimension]
+        base_shoot : array-like, shape=[n_samples, dim]
             Point on the manifold, end point of the geodesics starting
             from the base point with initial speed to be transported.
         return_geodesics : bool, optional (defaults to False)
@@ -268,9 +268,9 @@ class Connection:
 
         Returns
         -------
-        transported_tangent_vector : array-like, shape=[n_samples, dimension]
+        transported_tangent_vector : array-like, shape=[n_samples, dim]
             Tangent vector at end point.
-        end_point : array-like, shape=[n_samples, dimension]
+        end_point : array-like, shape=[n_samples, dim]
             Point on the manifold, closes the geodesic parallelogram of the
             construction.
 
@@ -338,12 +338,12 @@ class Connection:
 
         Parameters
         ----------
-        tangent_vec_a : array-like, shape=[n_samples, dimension]
+        tangent_vec_a : array-like, shape=[n_samples, dim]
             Tangent vector at base point to transport.
-        tangent_vec_b : array-like, shape=[n_samples, dimension]
+        tangent_vec_b : array-like, shape=[n_samples, dim]
             Tangent vector at base point, initial speed of the geodesic along
             which to transport.
-        base_point : array-like, shape=[n_samples, dimension]
+        base_point : array-like, shape=[n_samples, dim]
             Point on the manifold, initial position of the geodesic along
             which to transport.
         n_steps : int
@@ -405,7 +405,7 @@ class Connection:
 
         Parameters
         ----------
-        base_point: array-like, shape=[n_samples, dimension]
+        base_point: array-like, shape=[n_samples, dim]
             Point on the manifold.
         """
         raise NotImplementedError(
@@ -422,12 +422,12 @@ class Connection:
 
         Parameters
         ----------
-        initial_point : array-like, shape=[n_samples, dimension]
+        initial_point : array-like, shape=[n_samples, dim]
             Point on the manifold, initial point of the geodesic.
-        end_point : array-like, shape=[n_samples, dimension], optional
+        end_point : array-like, shape=[n_samples, dim], optional
             Point on the manifold, end point of the geodesic. If None,
             an initial tangent vector must be given.
-        initial_tangent_vec : array-like, shape=[n_samples, dimension],
+        initial_tangent_vec : array-like, shape=[n_samples, dim],
             optional
             Tangent vector at base point, the initial speed of the geodesics.
             If None, an end point must be given and a logarithm is computed.
@@ -506,7 +506,7 @@ class Connection:
 
         Parameters
         ----------
-        base_point: array-like, shape=[n_samples, dimension]
+        base_point: array-like, shape=[n_samples, dim]
             Point on the manifold.
         """
         raise NotImplementedError(

--- a/geomstats/geometry/connection.py
+++ b/geomstats/geometry/connection.py
@@ -17,13 +17,20 @@ class Connection:
 
     Parameters
     ----------
-    dimension: int
+    dim: int
         Dimension of the underlying manifold.
     """
 
-    def __init__(self, dimension):
-        geomstats.error.check_integer(dimension, 'dimension')
-        self.dimension = dimension
+    def __init__(
+            self, dim, default_point_type='vector',
+            default_coords_type='intrinsic'):
+        geomstats.error.check_integer(dim, 'dimension')
+        geomstats.error.check_parameter_accepted_values(
+            default_point_type, 'default_point_type', ['vector', 'matrix'])
+
+        self.dim = dim
+        self.default_point_type = default_point_type
+        self.default_coords_type = default_coords_type
 
     def christoffels(self, base_point):
         """Christoffel symbols associated with the connection.
@@ -143,7 +150,7 @@ class Connection:
             """Define the objective function."""
             velocity = velocity.reshape(base_point.shape)
             delta = self.exp(velocity, base_point, n_steps, step) - point
-            loss = 1. / self.dimension * gs.sum(delta ** 2, axis=1)
+            loss = 1. / self.dim * gs.sum(delta ** 2, axis=1)
             return 1. / n_samples * gs.sum(loss)
 
         objective_grad = autograd.elementwise_grad(objective)

--- a/geomstats/geometry/discretized_curves.py
+++ b/geomstats/geometry/discretized_curves.py
@@ -10,8 +10,8 @@ from geomstats.geometry.landmarks import L2Metric
 from geomstats.geometry.manifold import Manifold
 from geomstats.geometry.riemannian_metric import RiemannianMetric
 
-R2 = Euclidean(dimension=2)
-R3 = Euclidean(dimension=3)
+R2 = Euclidean(dim=2)
+R3 = Euclidean(dim=3)
 
 
 class DiscretizedCurves(Manifold):
@@ -19,7 +19,7 @@ class DiscretizedCurves(Manifold):
 
     def __init__(self, ambient_manifold):
         """Initialize DiscretizedCurves object."""
-        super(DiscretizedCurves, self).__init__(dimension=math.inf)
+        super(DiscretizedCurves, self).__init__(dim=math.inf)
         self.ambient_manifold = ambient_manifold
         self.l2_metric = L2Metric(self.ambient_manifold)
         self.square_root_velocity_metric = SRVMetric(self.ambient_manifold)
@@ -50,7 +50,7 @@ class SRVMetric(RiemannianMetric):
     """
 
     def __init__(self, ambient_manifold):
-        super(SRVMetric, self).__init__(dimension=math.inf,
+        super(SRVMetric, self).__init__(dim=math.inf,
                                         signature=(math.inf, 0, 0))
         self.ambient_metric = ambient_manifold.metric
         self.l2_metric = L2Metric(ambient_manifold=ambient_manifold)

--- a/geomstats/geometry/embedded_manifold.py
+++ b/geomstats/geometry/embedded_manifold.py
@@ -8,14 +8,17 @@ class EmbeddedManifold(Manifold):
 
     Parameters
     ----------
-    dimension : int
+    dim : int
         Dimension of the embedded manifold.
     embedding_manifold : Manifold
         Embedding manifold.
     """
 
-    def __init__(self, dimension, embedding_manifold):
-        super(EmbeddedManifold, self).__init__(dimension=dimension)
+    def __init__(self, dim, embedding_manifold, default_point_type='vector',
+                 default_coords_type='intrinsic'):
+        super(EmbeddedManifold, self).__init__(
+            dim=dim, default_point_type=default_point_type,
+            default_coords_type=default_coords_type)
         self.embedding_manifold = embedding_manifold
 
     def intrinsic_to_extrinsic_coords(self, point_intrinsic):

--- a/geomstats/geometry/euclidean.py
+++ b/geomstats/geometry/euclidean.py
@@ -21,7 +21,7 @@ class Euclidean(Manifold):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dimension]
+        point : array-like, shape=[n_samples, dim]
                 Input points.
 
         Returns
@@ -45,7 +45,7 @@ class Euclidean(Manifold):
 
         Returns
         -------
-        point : array-like, shape=[n_samples, dimension]
+        point : array-like, shape=[n_samples, dim]
         """
         size = (self.dim,)
         if n_samples != 1:
@@ -73,11 +73,11 @@ class EuclideanMetric(RiemannianMetric):
 
         Parameters
         ----------
-        base_point: array-like, shape=[n_samples, dimension]
+        base_point: array-like, shape=[n_samples, dim]
 
         Returns
         -------
-        inner_prod_mat: array-like, shape=[n_samples, dimension, dimension]
+        inner_prod_mat: array-like, shape=[n_samples, dim, dim]
         """
         mat = gs.eye(self.dim)
         return mat
@@ -89,16 +89,16 @@ class EuclideanMetric(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec: array-like, shape=[n_samples, dimension]
-                                 or shape=[1, dimension]
+        tangent_vec: array-like, shape=[n_samples, dim]
+                                 or shape=[1, dim]
 
-        base_point: array-like, shape=[n_samples, dimension]
-                                or shape=[1, dimension]
+        base_point: array-like, shape=[n_samples, dim]
+                                or shape=[1, dim]
 
         Returns
         -------
-        exp: array-like, shape=[n_samples, dimension]
-                          or shape-[n_samples, dimension]
+        exp: array-like, shape=[n_samples, dim]
+                          or shape-[n_samples, dim]
         """
         exp = base_point + tangent_vec
         return exp
@@ -110,16 +110,16 @@ class EuclideanMetric(RiemannianMetric):
 
         Parameters
         ----------
-        point: array-like, shape=[n_samples, dimension]
-                           or shape=[1, dimension]
+        point: array-like, shape=[n_samples, dim]
+                           or shape=[1, dim]
 
-        base_point: array-like, shape=[n_samples, dimension]
-                                or shape=[1, dimension]
+        base_point: array-like, shape=[n_samples, dim]
+                                or shape=[1, dim]
 
         Returns
         -------
-        log: array-like, shape=[n_samples, dimension]
-                          or shape-[n_samples, dimension]
+        log: array-like, shape=[n_samples, dim]
+                          or shape-[n_samples, dim]
         """
         log = point - base_point
         return log

--- a/geomstats/geometry/euclidean.py
+++ b/geomstats/geometry/euclidean.py
@@ -12,9 +12,9 @@ class Euclidean(Manifold):
     dimension, equipped with a Euclidean metric.
     """
 
-    def __init__(self, dimension):
-        super(Euclidean, self).__init__(dimension=dimension)
-        self.metric = EuclideanMetric(dimension)
+    def __init__(self, dim):
+        super(Euclidean, self).__init__(dim=dim)
+        self.metric = EuclideanMetric(dim)
 
     def belongs(self, point):
         """Evaluate if a point belongs to the Euclidean space.
@@ -29,7 +29,7 @@ class Euclidean(Manifold):
         belongs : array-like, shape=[n_samples,]
         """
         point_dim = point.shape[-1]
-        belongs = point_dim == self.dimension
+        belongs = point_dim == self.dim
         if gs.ndim(point) == 2:
             belongs = gs.tile([belongs], (point.shape[0],))
 
@@ -47,9 +47,9 @@ class Euclidean(Manifold):
         -------
         point : array-like, shape=[n_samples, dimension]
         """
-        size = (self.dimension,)
+        size = (self.dim,)
         if n_samples != 1:
-            size = (n_samples, self.dimension)
+            size = (n_samples, self.dim)
         point = bound * (gs.random.rand(*size) - 0.5) * 2
 
         return point
@@ -64,9 +64,9 @@ class EuclideanMetric(RiemannianMetric):
     where dimension is the dimension of the Euclidean space.
     """
 
-    def __init__(self, dimension):
+    def __init__(self, dim):
         super(EuclideanMetric, self).__init__(
-            dimension=dimension, signature=(dimension, 0, 0))
+            dim=dim, signature=(dim, 0, 0))
 
     def inner_product_matrix(self, base_point=None):
         """Compute inner product matrix, independent of the base point.
@@ -79,7 +79,7 @@ class EuclideanMetric(RiemannianMetric):
         -------
         inner_prod_mat: array-like, shape=[n_samples, dimension, dimension]
         """
-        mat = gs.eye(self.dimension)
+        mat = gs.eye(self.dim)
         return mat
 
     def exp(self, tangent_vec, base_point):

--- a/geomstats/geometry/grassmannian.py
+++ b/geomstats/geometry/grassmannian.py
@@ -26,10 +26,15 @@ class Grassmannian(EmbeddedManifold):
             raise ValueError(
                 'k <= n is required: k-dimensional subspaces in n dimensions.')
 
-        dimension = int(k * (n - k))
+        self.n = n
+        self.k = k
+        self.metric = GrassmannianCanonicalMetric(3, 2)
+
+        dim = int(k * (n - k))
         super(Grassmannian, self).__init__(
-            dimension=dimension,
-            embedding_manifold=Matrices(n, n))
+            dim=dim,
+            embedding_manifold=Matrices(n, n),
+            default_point_type='matrix')
 
         self.n = n
         self.k = k
@@ -67,10 +72,10 @@ class GrassmannianCanonicalMetric(RiemannianMetric):
         if p > n:
             raise ValueError('p <= n is required.')
 
-        dimension = int(p * (n - p))
+        dim = int(p * (n - p))
         super(GrassmannianCanonicalMetric, self).__init__(
-            dimension=dimension,
-            signature=(dimension, 0, 0))
+            dim=dim,
+            signature=(dim, 0, 0))
 
         self.n = n
         self.p = p

--- a/geomstats/geometry/hyperbolic.py
+++ b/geomstats/geometry/hyperbolic.py
@@ -54,12 +54,12 @@ class Hyperbolic(Manifold):
 
         Parameters
         ----------
-        point_extrinsic : array-like, shape=[n_samples, dimension + 1]
+        point_extrinsic : array-like, shape=[n_samples, dim + 1]
             Point in hyperbolic space in extrinsic coordinates.
 
         Returns
         -------
-        point_intrinsic : array-like, shape=[n_samples, dimension]
+        point_intrinsic : array-like, shape=[n_samples, dim]
             Point in hyperbolic space in intrinsic coordinates.
         """
         return gs.to_ndarray(point, to_ndim=2)
@@ -74,12 +74,12 @@ class Hyperbolic(Manifold):
 
         Parameters
         ----------
-        point_intrinsic : array-like, shape=[n_samples, dimension]
+        point_intrinsic : array-like, shape=[n_samples, dim]
             Point in hyperbolic space in intrinsic coordinates.
 
         Returns
         -------
-        point_extrinsic : array-like, shape=[n_samples, dimension + 1]
+        point_extrinsic : array-like, shape=[n_samples, dim + 1]
             Point in hyperbolic space in extrinsic coordinates.
         """
         point_intrinsic = gs.to_ndarray(point_intrinsic, to_ndim=2)
@@ -101,12 +101,12 @@ class Hyperbolic(Manifold):
 
         Parameters
         ----------
-        point_extrinsic : array-like, shape=[n_samples, dimension + 1]
+        point_extrinsic : array-like, shape=[n_samples, dim + 1]
             Point in hyperbolic space in extrinsic coordinates.
 
         Returns
         -------
-        point_intrinsic : array-like, shape=[n_samples, dimension]
+        point_intrinsic : array-like, shape=[n_samples, dim]
         """
         point_extrinsic = gs.to_ndarray(point_extrinsic, to_ndim=2)
 
@@ -124,12 +124,12 @@ class Hyperbolic(Manifold):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dimension + 1]
+        point : array-like, shape=[n_samples, dim + 1]
             Point in hyperbolic space in extrinsic coordinates.
 
         Returns
         -------
-        point_ball : array-like, shape=[n_samples, dimension]
+        point_ball : array-like, shape=[n_samples, dim]
             Point in hyperbolic space in Poincare ball coordinates.
         """
         return point[:, 1:] / (1 + point[:, :1])
@@ -144,12 +144,12 @@ class Hyperbolic(Manifold):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dimension]
+        point : array-like, shape=[n_samples, dim]
             Point in hyperbolic space in Poincare ball coordinates.
 
         Returns
         -------
-        extrinsic : array-like, shape=[n_samples, dimension + 1]
+        extrinsic : array-like, shape=[n_samples, dim + 1]
             Point in hyperbolic space in extrinsic coordinates.
         """
         squared_norm = gs.sum(point**2, -1)
@@ -244,8 +244,8 @@ class Hyperbolic(Manifold):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dimension]
-                            or shape=[n_samples, dimension + 1]
+        point : array-like, shape=[n_samples, dim]
+                            or shape=[n_samples, dim + 1]
             Point in hyperbolic space.
         from_coordinates_system : str, {'extrinsic', 'intrinsic', etc}
             Coordinates type.
@@ -254,8 +254,8 @@ class Hyperbolic(Manifold):
 
         Returns
         -------
-        point_to : array-like, shape=[n_samples, dimension]
-                               or shape=[n_sample, dimension + 1]
+        point_to : array-like, shape=[n_samples, dim]
+                               or shape=[n_sample, dim + 1]
             Point in hyperbolic space in coordinates given by to_point_type.
         """
         coords_transform = {
@@ -295,7 +295,7 @@ class Hyperbolic(Manifold):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dimension]
+        point : array-like, shape=[n_samples, dim]
             Point to be tested.
         tolerance : float, optional
             Tolerance at which to evaluate how close the squared norm
@@ -317,16 +317,16 @@ class Hyperbolic(Manifold):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dimension]
-                            or shape=[n_samples, dimension + 1]
+        point : array-like, shape=[n_samples, dim]
+                            or shape=[n_samples, dim + 1]
             Point in hyperbolic space.
         to_point_type : str, {'extrinsic', 'intrinsic', etc}, optional
             Coordinates type.
 
         Returns
         -------
-        point_to : array-like, shape=[n_samples, dimension]
-                               or shape=[n_sample, dimension + 1]
+        point_to : array-like, shape=[n_samples, dim]
+                               or shape=[n_sample, dim + 1]
             Point in hyperbolic space in coordinates given by to_point_type.
         """
         return Hyperbolic.change_coordinates_system(point,
@@ -341,16 +341,16 @@ class Hyperbolic(Manifold):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dimension]
-                            or shape=[n_samples, dimension + 1]
+        point : array-like, shape=[n_samples, dim]
+                            or shape=[n_samples, dim + 1]
             Point in hyperbolic space in coordinates from_point_type.
         from_point_type : str, {'ball', 'extrinsic', 'intrinsic', 'half_plane'}
             Coordinates type.
 
         Returns
         -------
-        point_current : array-like, shape=[n_samples, dimension]
-                                    or shape=[n_sample, dimension + 1]
+        point_current : array-like, shape=[n_samples, dim]
+                                    or shape=[n_sample, dim + 1]
             Point in hyperbolic space.
         """
         return Hyperbolic.change_coordinates_system(point,
@@ -375,7 +375,7 @@ class Hyperbolic(Manifold):
 
         Returns
         -------
-        samples : array-like, shape=[n_samples, dimension + 1]
+        samples : array-like, shape=[n_samples, dim + 1]
             Samples in hyperbolic space.
         """
         size = (n_samples, self.dim)
@@ -419,11 +419,11 @@ class HyperbolicMetric(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec_a : array-like, shape=[n_samples, dimension + 1]
+        tangent_vec_a : array-like, shape=[n_samples, dim + 1]
             First tangent vector at base point.
-        tangent_vec_b : array-like, shape=[n_samples, dimension + 1]
+        tangent_vec_b : array-like, shape=[n_samples, dim + 1]
             Second tangent vector at base point.
-        base_point : array-like, shape=[n_samples, dimension + 1], optional
+        base_point : array-like, shape=[n_samples, dim + 1], optional
             Point in hyperbolic space.
 
         Returns
@@ -444,9 +444,9 @@ class HyperbolicMetric(RiemannianMetric):
 
         Parameters
         ----------
-        vector : array-like, shape=[n_samples, dimension + 1]
+        vector : array-like, shape=[n_samples, dim + 1]
             Vector on the tangent space of the hyperbolic space at base point.
-        base_point : array-like, shape=[n_samples, dimension + 1], optional
+        base_point : array-like, shape=[n_samples, dim + 1], optional
             Point in hyperbolic space in extrinsic coordinates.
 
         Returns
@@ -466,9 +466,9 @@ class HyperbolicMetric(RiemannianMetric):
 
         Parameters
         ----------
-        vector : array-like, shape=[n_samples, dimension + 1]
+        vector : array-like, shape=[n_samples, dim + 1]
             Vector on the tangent space of the hyperbolic space at base point.
-        base_point : array-like, shape=[n_samples, dimension + 1], optional
+        base_point : array-like, shape=[n_samples, dim + 1], optional
             Point in hyperbolic space in extrinsic coordinates.
 
         Returns
@@ -483,11 +483,11 @@ class HyperbolicMetric(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec_a : array-like, shape=[n_samples, dimension + 1]
+        tangent_vec_a : array-like, shape=[n_samples, dim + 1]
             First tangent vector at base point.
-        tangent_vec_b : array-like, shape=[n_samples, dimension + 1]
+        tangent_vec_b : array-like, shape=[n_samples, dim + 1]
             Second tangent vector at base point.
-        base_point : array-like, shape=[n_samples, dimension + 1], optional
+        base_point : array-like, shape=[n_samples, dim + 1], optional
             Point in hyperbolic space.
 
         Returns

--- a/geomstats/geometry/hyperbolic.py
+++ b/geomstats/geometry/hyperbolic.py
@@ -25,7 +25,7 @@ class Hyperbolic(Manifold):
 
     Parameters
     ----------
-    dimension : int
+    dim : int
         Dimension of the hyperbolic space.
     point_type : str, {'extrinsic', 'intrinsic', etc}, optional
         Default coordinates to represent points in hyperbolic space.
@@ -37,12 +37,12 @@ class Hyperbolic(Manifold):
     default_coords_type = 'extrinsic'
     default_point_type = 'vector'
 
-    def __init__(self, dimension, scale=1):
-        super(Hyperbolic, self).__init__(dimension=dimension)
+    def __init__(self, dim, scale=1):
+        super(Hyperbolic, self).__init__(dim=dim)
         self.point_type = Hyperbolic.default_point_type
         self.coords_type = Hyperbolic.default_coords_type
         self.scale = scale
-        self.metric = HyperbolicMetric(self.dimension, self.scale)
+        self.metric = HyperbolicMetric(self.dim, self.scale)
 
     @staticmethod
     def _extrinsic_to_extrinsic_coordinates(point):
@@ -378,7 +378,7 @@ class Hyperbolic(Manifold):
         samples : array-like, shape=[n_samples, dimension + 1]
             Samples in hyperbolic space.
         """
-        size = (n_samples, self.dimension)
+        size = (n_samples, self.dim)
         samples = bound * 2. * (gs.random.rand(*size) - 0.5)
 
         samples = Hyperbolic.change_coordinates_system(
@@ -394,7 +394,7 @@ class HyperbolicMetric(RiemannianMetric):
 
     Parameters
     ----------
-    dimension : int
+    dim : int
         Dimension of the hyperbolic space.
     point_type : str, {'extrinsic', 'intrinsic', etc}, optional
         Default coordinates to represent points in hyperbolic space.
@@ -406,10 +406,10 @@ class HyperbolicMetric(RiemannianMetric):
     default_point_type = 'vector'
     default_coords_type = 'extrinsic'
 
-    def __init__(self, dimension, scale=1):
+    def __init__(self, dim, scale=1):
         super(HyperbolicMetric, self).__init__(
-            dimension=dimension,
-            signature=(dimension, 0, 0))
+            dim=dim,
+            signature=(dim, 0, 0))
         self.point_type = HyperbolicMetric.default_point_type
 
         self.scale = scale

--- a/geomstats/geometry/hyperboloid.py
+++ b/geomstats/geometry/hyperboloid.py
@@ -79,7 +79,7 @@ class Hyperboloid(Hyperbolic, EmbeddedManifold):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dimension]
+        point : array-like, shape=[n_samples, dim]
             Point to be tested.
         tolerance : float, optional
             Tolerance at which to evaluate how close the squared norm
@@ -114,12 +114,12 @@ class Hyperboloid(Hyperbolic, EmbeddedManifold):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dimension + 1]
+        point : array-like, shape=[n_samples, dim + 1]
             Point.
 
         Returns
         -------
-        projected_point : array-like, shape=[n_samples, dimension + 1]
+        projected_point : array-like, shape=[n_samples, dim + 1]
             Point in hyperbolic space in canonical representation
             in extrinsic coordinates.
         """
@@ -151,14 +151,14 @@ class Hyperboloid(Hyperbolic, EmbeddedManifold):
 
         Parameters
         ----------
-        vector : array-like, shape=[n_samples, dimension + 1]
+        vector : array-like, shape=[n_samples, dim + 1]
             Vector in Minkowski space to be projected.
-        base_point : array-like, shape=[n_samples, dimension + 1]
+        base_point : array-like, shape=[n_samples, dim + 1]
             Point in hyperbolic space.
 
         Returns
         -------
-        tangent_vec : array-like, shape=[n_samples, dimension + 1]
+        tangent_vec : array-like, shape=[n_samples, dim + 1]
             Tangent vector at the base point, equal to the projection of
             the vector in Minkowski space.
         """
@@ -242,11 +242,11 @@ class HyperboloidMetric(HyperbolicMetric):
 
         Parameters
         ----------
-        base_point: array-like, shape=[n_samples, dimension+1]
+        base_point: array-like, shape=[n_samples, dim+1]
 
         Returns
         -------
-        inner_prod_mat: array-like, shape=[n_samples, dimension+1, dimension+1]
+        inner_prod_mat: array-like, shape=[n_samples, dim+1, dim+1]
         """
         self.embedding_metric.inner_product_matrix(base_point)
 
@@ -255,11 +255,11 @@ class HyperboloidMetric(HyperbolicMetric):
 
         Parameters
         ----------
-        tangent_vec_a : array-like, shape=[n_samples, dimension + 1]
+        tangent_vec_a : array-like, shape=[n_samples, dim + 1]
             First tangent vector at base point.
-        tangent_vec_b : array-like, shape=[n_samples, dimension + 1]
+        tangent_vec_b : array-like, shape=[n_samples, dim + 1]
             Second tangent vector at base point.
-        base_point : array-like, shape=[n_samples, dimension + 1], optional
+        base_point : array-like, shape=[n_samples, dim + 1], optional
             Point in hyperbolic space.
 
         Returns
@@ -279,9 +279,9 @@ class HyperboloidMetric(HyperbolicMetric):
 
         Parameters
         ----------
-        vector : array-like, shape=[n_samples, dimension + 1]
+        vector : array-like, shape=[n_samples, dim + 1]
             Vector on the tangent space of the hyperbolic space at base point.
-        base_point : array-like, shape=[n_samples, dimension + 1], optional
+        base_point : array-like, shape=[n_samples, dim + 1], optional
             Point in hyperbolic space in extrinsic coordinates.
 
         Returns
@@ -298,14 +298,14 @@ class HyperboloidMetric(HyperbolicMetric):
 
         Parameters
         ----------
-        tangent_vec : array-like, shape=[n_samples, dimension + 1]
+        tangent_vec : array-like, shape=[n_samples, dim + 1]
             Tangent vector at a base point.
-        base_point : array-like, shape=[n_samples, dimension + 1]
+        base_point : array-like, shape=[n_samples, dim + 1]
             Point in hyperbolic space.
 
         Returns
         -------
-        exp : array-like, shape=[n_samples, dimension + 1]
+        exp : array-like, shape=[n_samples, dim + 1]
             Point in hyperbolic space equal to the Riemannian exponential
             of tangent_vec at the base point.
         """
@@ -358,14 +358,14 @@ class HyperboloidMetric(HyperbolicMetric):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dimension + 1]
+        point : array-like, shape=[n_samples, dim + 1]
             Point in hyperbolic space.
-        base_point : array-like, shape=[n_samples, dimension + 1]
+        base_point : array-like, shape=[n_samples, dim + 1]
             Point in hyperbolic space.
 
         Returns
         -------
-        log : array-like, shape=[n_samples, dimension + 1]
+        log : array-like, shape=[n_samples, dim + 1]
             Tangent vector at the base point equal to the Riemannian logarithm
             of point at the base point.
         """
@@ -407,9 +407,9 @@ class HyperboloidMetric(HyperbolicMetric):
 
         Parameters
         ----------
-        point_a : array-like, shape=[n_samples, dimension + 1]
+        point_a : array-like, shape=[n_samples, dim + 1]
             First point in hyperbolic space.
-        point_b : array-like, shape=[n_samples, dimension + 1]
+        point_b : array-like, shape=[n_samples, dim + 1]
             Second point in hyperbolic space.
 
         Returns

--- a/geomstats/geometry/hyperboloid.py
+++ b/geomstats/geometry/hyperboloid.py
@@ -63,13 +63,13 @@ class Hyperboloid(Hyperbolic, EmbeddedManifold):
 
     def __init__(self, dim, coords_type='extrinsic', scale=1):
         self.scale = scale
-        self.dimension = dim
+        self.dim = dim
         self.coords_type = coords_type
         self.point_type = Hyperboloid.default_point_type
         self.embedding_manifold = Minkowski(dim + 1)
         self.embedding_metric = self.embedding_manifold.metric
         self.metric =\
-            HyperboloidMetric(self.dimension, self.coords_type, self.scale)
+            HyperboloidMetric(self.dim, self.coords_type, self.scale)
 
     def belongs(self, point, tolerance=TOLERANCE):
         """Test if a point belongs to the hyperbolic space.
@@ -92,9 +92,9 @@ class Hyperboloid(Hyperbolic, EmbeddedManifold):
             belong to the hyperbolic space.
         """
         point_dim = point.shape[-1]
-        if point_dim is not self.dimension + 1:
+        if point_dim is not self.dim + 1:
             belongs = False
-            if point_dim is self.dimension and self.coords_type == 'intrinsic':
+            if point_dim is self.dim and self.coords_type == 'intrinsic':
                 belongs = True
             if gs.ndim(point) == 2:
                 belongs = gs.tile([belongs], (point.shape[0],))
@@ -182,10 +182,10 @@ class Hyperboloid(Hyperbolic, EmbeddedManifold):
         point_intrinsic : array-like, shape=[n_samples, dim]
             Point in the embedded manifold in intrinsic coordinates.
         """
-        if self.dimension != point_intrinsic.shape[-1]:
+        if self.dim != point_intrinsic.shape[-1]:
             raise NameError("Wrong intrinsic dimension: "
                             + str(point_intrinsic.shape[-1]) + " instead of "
-                            + str(self.dimension))
+                            + str(self.dim))
         return\
             Hyperbolic.change_coordinates_system(point_intrinsic,
                                                  'intrinsic',

--- a/geomstats/geometry/hyperboloid.py
+++ b/geomstats/geometry/hyperboloid.py
@@ -49,7 +49,7 @@ class Hyperboloid(Hyperbolic, EmbeddedManifold):
 
     Parameters
     ----------
-    dimension : int
+    dim : int
         Dimension of the hyperbolic space.
     point_type : str, {'extrinsic', 'intrinsic'}, optional
         Default coordinates to represent points in hyperbolic space.
@@ -61,12 +61,12 @@ class Hyperboloid(Hyperbolic, EmbeddedManifold):
     default_coords_type = 'extrinsic'
     default_point_type = 'vector'
 
-    def __init__(self, dimension, coords_type='extrinsic', scale=1):
+    def __init__(self, dim, coords_type='extrinsic', scale=1):
         self.scale = scale
-        self.dimension = dimension
+        self.dimension = dim
         self.coords_type = coords_type
         self.point_type = Hyperboloid.default_point_type
-        self.embedding_manifold = Minkowski(dimension + 1)
+        self.embedding_manifold = Minkowski(dim + 1)
         self.embedding_metric = self.embedding_manifold.metric
         self.metric =\
             HyperboloidMetric(self.dimension, self.coords_type, self.scale)
@@ -214,7 +214,7 @@ class HyperboloidMetric(HyperbolicMetric):
 
     Parameters
     ----------
-    dimension : int
+    dim : int
         Dimension of the hyperbolic space.
     point_type : str, {'extrinsic', 'intrinsic', etc}, optional
         Default coordinates to represent points in hyperbolic space.
@@ -226,11 +226,11 @@ class HyperboloidMetric(HyperbolicMetric):
     default_point_type = 'vector'
     default_coords_type = 'extrinsic'
 
-    def __init__(self, dimension, coords_type='extrinsic', scale=1):
+    def __init__(self, dim, coords_type='extrinsic', scale=1):
         super(HyperboloidMetric, self).__init__(
-            dimension=dimension,
+            dim=dim,
             scale=scale)
-        self.embedding_metric = MinkowskiMetric(dimension + 1)
+        self.embedding_metric = MinkowskiMetric(dim + 1)
 
         self.coords_type = coords_type
         self.point_type = HyperbolicMetric.default_point_type
@@ -344,7 +344,7 @@ class HyperboloidMetric(HyperbolicMetric):
             gs.einsum('...,...j->...j', coef_1, base_point)
             + gs.einsum('...,...j->...j', coef_2, tangent_vec))
 
-        hyperbolic_space = Hyperboloid(dimension=self.dimension)
+        hyperbolic_space = Hyperboloid(dim=self.dim)
         exp = hyperbolic_space.regularize(exp)
         return exp
 

--- a/geomstats/geometry/hypersphere.py
+++ b/geomstats/geometry/hypersphere.py
@@ -61,7 +61,7 @@ class Hypersphere(EmbeddedManifold):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dimension + 1]
+        point : array-like, shape=[n_samples, dim + 1]
             Points in Euclidean space.
         tolerance : float, optional
             Tolerance at which to evaluate norm == 1 (default: TOLERANCE).
@@ -94,12 +94,12 @@ class Hypersphere(EmbeddedManifold):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dimension + 1]
+        point : array-like, shape=[n_samples, dim + 1]
             Points on the hypersphere.
 
         Returns
         -------
-        projected_point : array-like, shape=[n_samples, dimension + 1]
+        projected_point : array-like, shape=[n_samples, dim + 1]
             Points in canonical representation chosen for the hypersphere.
         """
         if not gs.all(self.belongs(point)):
@@ -113,12 +113,12 @@ class Hypersphere(EmbeddedManifold):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dimension + 1]
+        point : array-like, shape=[n_samples, dim + 1]
             Point in embedding Euclidean space.
 
         Returns
         -------
-        projected_point : array-like, shape=[n_samples, dimension + 1]
+        projected_point : array-like, shape=[n_samples, dim + 1]
             Point projected on the hypersphere.
         """
         norm = self.embedding_metric.norm(point)
@@ -135,15 +135,15 @@ class Hypersphere(EmbeddedManifold):
 
         Parameters
         ----------
-        vector : array-like, shape=[n_samples, dimension + 1]
+        vector : array-like, shape=[n_samples, dim + 1]
             Vector in Euclidean space.
-        base_point : array-like, shape=[n_samples, dimension + 1]
+        base_point : array-like, shape=[n_samples, dim + 1]
             Point on the hypersphere defining the tangent space,
             where the vector will be projected.
 
         Returns
         -------
-        tangent_vec : array-like, shape=[n_samples, dimension + 1]
+        tangent_vec : array-like, shape=[n_samples, dim + 1]
             Tangent vector in the tangent space of the hypersphere
             at the base point.
         """
@@ -164,12 +164,12 @@ class Hypersphere(EmbeddedManifold):
 
         Parameters
         ----------
-        point_spherical : array-like, shape=[n_samples, dimension]
+        point_spherical : array-like, shape=[n_samples, dim]
             Point on the sphere, in spherical coordinates.
 
         Returns
         -------
-        point_extrinsic : array_like, shape=[n_samples, dimension + 1]
+        point_extrinsic : array_like, shape=[n_samples, dim + 1]
             Point on the sphere, in extrinsic coordinates in Euclidean space.
         """
         if self.dim != 2:
@@ -201,14 +201,14 @@ class Hypersphere(EmbeddedManifold):
 
         Parameters
         ----------
-        tangent_vec_spherical : array-like, shape=[n_samples, dimension]
+        tangent_vec_spherical : array-like, shape=[n_samples, dim]
             Tangent vector to the sphere, in spherical coordinates.
-        base_point_spherical : array-like, shape=[n_samples, dimension]
+        base_point_spherical : array-like, shape=[n_samples, dim]
             Point on the sphere, in spherical coordinates.
 
         Returns
         -------
-        tangent_vec_extrinsic : array-like, shape=[n_samples, dimension + 1]
+        tangent_vec_extrinsic : array-like, shape=[n_samples, dim + 1]
             Tangent vector to the sphere, at base point,
             in extrinsic coordinates in Euclidean space.
         """
@@ -241,12 +241,12 @@ class Hypersphere(EmbeddedManifold):
 
         Parameters
         ----------
-        point_intrinsic : array-like, shape=[n_samples, dimension]
+        point_intrinsic : array-like, shape=[n_samples, dim]
             Point on the hypersphere, in intrinsic coordinates.
 
         Returns
         -------
-        point_extrinsic : array-like, shape=[n_samples, dimension + 1]
+        point_extrinsic : array-like, shape=[n_samples, dim + 1]
             Point on the hypersphere, in extrinsic coordinates in
             Euclidean space.
         """
@@ -269,13 +269,13 @@ class Hypersphere(EmbeddedManifold):
 
         Parameters
         ----------
-        point_extrinsic : array-like, shape=[n_samples, dimension + 1]
+        point_extrinsic : array-like, shape=[n_samples, dim + 1]
             Point on the hypersphere, in extrinsic coordinates in
             Euclidean space.
 
         Returns
         -------
-        point_intrinsic : array-like, shape=[n_samples, dimension]
+        point_intrinsic : array-like, shape=[n_samples, dim]
             Point on the hypersphere, in intrinsic coordinates.
         """
         point_intrinsic = point_extrinsic[:, 1:]
@@ -292,7 +292,7 @@ class Hypersphere(EmbeddedManifold):
 
         Returns
         -------
-        samples : array-like, shape=[n_samples, dimension + 1]
+        samples : array-like, shape=[n_samples, dim + 1]
             Points sampled on the hypersphere.
         """
         size = (n_samples, self.dim + 1)
@@ -377,11 +377,11 @@ class HypersphereMetric(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec_a : array-like, shape=[n_samples, dimension + 1]
+        tangent_vec_a : array-like, shape=[n_samples, dim + 1]
             First tangent vector at base point.
-        tangent_vec_b : array-like, shape=[n_samples, dimension + 1]
+        tangent_vec_b : array-like, shape=[n_samples, dim + 1]
             Second tangent vector at base point.
-        base_point : array-like, shape=[n_samples, dimension + 1], optional
+        base_point : array-like, shape=[n_samples, dim + 1], optional
             Point on the hypersphere.
 
         Returns
@@ -402,9 +402,9 @@ class HypersphereMetric(RiemannianMetric):
 
         Parameters
         ----------
-        vector : array-like, shape=[n_samples, dimension + 1]
+        vector : array-like, shape=[n_samples, dim + 1]
             Vector on the tangent space of the hypersphere at base point.
-        base_point : array-like, shape=[n_samples, dimension + 1], optional
+        base_point : array-like, shape=[n_samples, dim + 1], optional
             Point on the hypersphere.
 
         Returns
@@ -421,14 +421,14 @@ class HypersphereMetric(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec : array-like, shape=[n_samples, dimension + 1]
+        tangent_vec : array-like, shape=[n_samples, dim + 1]
             Tangent vector at a base point.
-        base_point : array-like, shape=[n_samples, dimension + 1]
+        base_point : array-like, shape=[n_samples, dim + 1]
             Point on the hypersphere.
 
         Returns
         -------
-        exp : array-like, shape=[n_samples, dimension + 1]
+        exp : array-like, shape=[n_samples, dim + 1]
             Point on the hypersphere equal to the Riemannian exponential
             of tangent_vec at the base point.
         """
@@ -470,14 +470,14 @@ class HypersphereMetric(RiemannianMetric):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dimension + 1]
+        point : array-like, shape=[n_samples, dim + 1]
             Point on the hypersphere.
-        base_point : array-like, shape=[n_samples, dimension + 1]
+        base_point : array-like, shape=[n_samples, dim + 1]
             Point on the hypersphere.
 
         Returns
         -------
-        log : array-like, shape=[n_samples, dimension + 1]
+        log : array-like, shape=[n_samples, dim + 1]
             Tangent vector at the base point equal to the Riemannian logarithm
             of point at the base point.
         """
@@ -542,9 +542,9 @@ class HypersphereMetric(RiemannianMetric):
 
         Parameters
         ----------
-        point_a : array-like, shape=[n_samples, dimension + 1]
+        point_a : array-like, shape=[n_samples, dim + 1]
             First point on the hypersphere.
-        point_b : array-like, shape=[n_samples, dimension + 1]
+        point_b : array-like, shape=[n_samples, dim + 1]
             Second point on the hypersphere.
 
         Returns
@@ -568,9 +568,9 @@ class HypersphereMetric(RiemannianMetric):
 
         Parameters
         ----------
-        point_a : array-like, shape=[n_samples, dimension]
+        point_a : array-like, shape=[n_samples, dim]
             Point on the hypersphere.
-        point_b : array-like, shape=[n_samples, dimension]
+        point_b : array-like, shape=[n_samples, dim]
             Point on the hypersphere.
 
         Returns
@@ -587,17 +587,17 @@ class HypersphereMetric(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec_a : array-like, shape=[n_samples, dimension + 1]
+        tangent_vec_a : array-like, shape=[n_samples, dim + 1]
             Tangent vector at base point to be transported.
-        tangent_vec_b : array-like, shape=[n_samples, dimension + 1]
+        tangent_vec_b : array-like, shape=[n_samples, dim + 1]
             Tangent vector at base point, along which the parallel transport
             is computed.
-        base_point : array-like, shape=[n_samples, dimension + 1]
+        base_point : array-like, shape=[n_samples, dim + 1]
             Point on the hypersphere.
 
         Returns
         -------
-        transported_tangent_vec: array-like, shape=[n_samples, dimension + 1]
+        transported_tangent_vec: array-like, shape=[n_samples, dim + 1]
             Transported tangent vector at exp_(base_point)(tangent_vec_b).
         """
         tangent_vec_a = gs.to_ndarray(tangent_vec_a, to_ndim=2)
@@ -621,7 +621,7 @@ class HypersphereMetric(RiemannianMetric):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dimension]
+        point : array-like, shape=[n_samples, dim]
             Point on hypersphere where the Christoffel symbols are computed.
 
         point_type: str, {'spherical', 'intrinsic', 'extrinsic'}

--- a/geomstats/geometry/hypersphere.py
+++ b/geomstats/geometry/hypersphere.py
@@ -43,16 +43,16 @@ class Hypersphere(EmbeddedManifold):
 
     Parameters
     ----------
-    dimension: int
+    dim: int
         Dimension of the hypersphere.
     """
 
-    def __init__(self, dimension):
+    def __init__(self, dim):
         super(Hypersphere, self).__init__(
-            dimension=dimension,
-            embedding_manifold=Euclidean(dimension + 1))
+            dim=dim,
+            embedding_manifold=Euclidean(dim + 1))
         self.embedding_metric = self.embedding_manifold.metric
-        self.metric = HypersphereMetric(dimension)
+        self.metric = HypersphereMetric(dim)
 
     def belongs(self, point, tolerance=TOLERANCE):
         """Test if a point belongs to the hypersphere.
@@ -73,8 +73,8 @@ class Hypersphere(EmbeddedManifold):
             the hypersphere.
         """
         point_dim = gs.shape(point)[-1]
-        if point_dim != self.dimension + 1:
-            if point_dim is self.dimension:
+        if point_dim != self.dim + 1:
+            if point_dim is self.dim:
                 logging.warning(
                     'Use the extrinsic coordinates to '
                     'represent points on the hypersphere.')
@@ -172,7 +172,7 @@ class Hypersphere(EmbeddedManifold):
         point_extrinsic : array_like, shape=[n_samples, dimension + 1]
             Point on the sphere, in extrinsic coordinates in Euclidean space.
         """
-        if self.dimension != 2:
+        if self.dim != 2:
             raise NotImplementedError(
                 'The conversion from spherical coordinates'
                 ' to extrinsic coordinates is implemented'
@@ -181,7 +181,7 @@ class Hypersphere(EmbeddedManifold):
         theta = point_spherical[:, 0]
         phi = point_spherical[:, 1]
         point_extrinsic = gs.zeros(
-            (point_spherical.shape[0], self.dimension + 1))
+            (point_spherical.shape[0], self.dim + 1))
         point_extrinsic[:, 0] = gs.sin(theta) * gs.cos(phi)
         point_extrinsic[:, 1] = gs.sin(theta) * gs.sin(phi)
         point_extrinsic[:, 2] = gs.cos(theta)
@@ -212,7 +212,7 @@ class Hypersphere(EmbeddedManifold):
             Tangent vector to the sphere, at base point,
             in extrinsic coordinates in Euclidean space.
         """
-        if self.dimension != 2:
+        if self.dim != 2:
             raise NotImplementedError(
                 'The conversion from spherical coordinates'
                 ' to extrinsic coordinates is implemented'
@@ -221,7 +221,7 @@ class Hypersphere(EmbeddedManifold):
         n_samples = base_point_spherical.shape[0]
         theta = base_point_spherical[:, 0]
         phi = base_point_spherical[:, 1]
-        jac = gs.zeros((n_samples, self.dimension + 1, self.dimension))
+        jac = gs.zeros((n_samples, self.dim + 1, self.dim))
         jac[:, 0, 0] = gs.cos(theta) * gs.cos(phi)
         jac[:, 0, 1] = - gs.sin(theta) * gs.sin(phi)
         jac[:, 1, 0] = gs.cos(theta) * gs.sin(phi)
@@ -295,7 +295,7 @@ class Hypersphere(EmbeddedManifold):
         samples : array-like, shape=[n_samples, dimension + 1]
             Points sampled on the hypersphere.
         """
-        size = (n_samples, self.dimension + 1)
+        size = (n_samples, self.dim + 1)
 
         samples = gs.random.normal(size=size)
         while True:
@@ -305,7 +305,7 @@ class Hypersphere(EmbeddedManifold):
             if num_bad_samples == 0:
                 break
             samples[indcs, :] = gs.random.normal(
-                size=(num_bad_samples, self.dimension + 1))
+                size=(num_bad_samples, self.dim + 1))
 
         samples = gs.einsum('..., ...i->...i', 1 / norms, samples)
         if n_samples == 1:
@@ -335,7 +335,7 @@ class Hypersphere(EmbeddedManifold):
             Points sampled on the sphere in extrinsic coordinates
             in Euclidean space of dimension 3.
         """
-        if self.dimension != 2:
+        if self.dim != 2:
             raise NotImplementedError(
                 'Sampling from the von Mises Fisher distribution'
                 'is only implemented in dimension 2.')
@@ -362,15 +362,15 @@ class HypersphereMetric(RiemannianMetric):
 
     Parameters
     ----------
-    dimension : int
+    dim : int
         Dimension of the hypersphere.
     """
 
-    def __init__(self, dimension):
+    def __init__(self, dim):
         super(HypersphereMetric, self).__init__(
-            dimension=dimension,
-            signature=(dimension, 0, 0))
-        self.embedding_metric = EuclideanMetric(dimension + 1)
+            dim=dim,
+            signature=(dim, 0, 0))
+        self.embedding_metric = EuclideanMetric(dim + 1)
 
     def inner_product(self, tangent_vec_a, tangent_vec_b, base_point=None):
         """Compute the inner-product of two tangent vectors at a base point.
@@ -438,7 +438,7 @@ class HypersphereMetric(RiemannianMetric):
         _, extrinsic_dim = base_point.shape
         n_tangent_vecs, _ = tangent_vec.shape
 
-        hypersphere = Hypersphere(dimension=extrinsic_dim - 1)
+        hypersphere = Hypersphere(dim=extrinsic_dim - 1)
         proj_tangent_vec = hypersphere.projection_to_tangent_space(
             tangent_vec, base_point)
         norm_tangent_vec = self.embedding_metric.norm(proj_tangent_vec)
@@ -633,7 +633,7 @@ class HypersphereMetric(RiemannianMetric):
                                          covariant index, 2nd covariant index]
             Christoffel symbols at point.
         """
-        if self.dimension != 2 or point_type != 'spherical':
+        if self.dim != 2 or point_type != 'spherical':
             raise NotImplementedError(
                 'The Christoffel symbols are only implemented'
                 ' for spherical coordinates in the 2-sphere')

--- a/geomstats/geometry/invariant_metric.py
+++ b/geomstats/geometry/invariant_metric.py
@@ -22,7 +22,7 @@ class InvariantMetric(RiemannianMetric):
     ----------
     group : LieGroup
         The group to equip with the invariant metric
-    inner_product_mat_at_identity : array-like, shape=[dimension, dimension]
+    inner_product_mat_at_identity : array-like, shape=[dim, dim]
         The matrix that defines the metric at identity.
     left_or_right : str, {'left', 'right'}
         Wether to use a left or right invariant metric.
@@ -56,14 +56,14 @@ class InvariantMetric(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec_a : array-like, shape=[n_samples, dimension]
+        tangent_vec_a : array-like, shape=[n_samples, dim]
             First tangent vector at identity.
-        tangent_vec_b : array-like, shape=[n_samples, dimension]
+        tangent_vec_b : array-like, shape=[n_samples, dim]
             Second tangent vector at identity.
 
         Returns
         -------
-        inner_prod : array-like, shape=[n_samples, dimension]
+        inner_prod : array-like, shape=[n_samples, dim]
             Inner-product of the two tangent vectors.
         """
         geomstats.error.check_parameter_accepted_values(
@@ -100,16 +100,16 @@ class InvariantMetric(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec_a : array-like, shape=[n_samples, dimension]
+        tangent_vec_a : array-like, shape=[n_samples, dim]
             First tangent vector at base_point.
-        tangent_vec_b : array-like, shape=[n_samples, dimension]
+        tangent_vec_b : array-like, shape=[n_samples, dim]
             Second tangent vector at base_point.
-        base_point : array-like, shape=[n_samples, dimension], optional
+        base_point : array-like, shape=[n_samples, dim], optional
             Point in the group (the default is identity).
 
         Returns
         -------
-        inner_prod : array-like, shape=[n_samples, dimension]
+        inner_prod : array-like, shape=[n_samples, dim]
             Inner-product of the two tangent vectors.
         """
         if base_point is None:
@@ -142,12 +142,12 @@ class InvariantMetric(RiemannianMetric):
 
         Parameters
         ----------
-        base_point : array-like, shape=[n_samples, dimension], optional
+        base_point : array-like, shape=[n_samples, dim], optional
             Point in the group (the default is identity).
 
         Returns
         -------
-        metric_mat : array-like, shape=[n_samples, dimension, dimension]
+        metric_mat : array-like, shape=[n_samples, dim, dim]
             The metric matrix at base_point.
         """
         if self.group.default_point_type == 'matrix':
@@ -185,12 +185,12 @@ class InvariantMetric(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec : array-like, shape=[n_samples, dimension]
+        tangent_vec : array-like, shape=[n_samples, dim]
             Tangent vector at identity.
 
         Returns
         -------
-        exp : array-like, shape=[n_samples, dimension]
+        exp : array-like, shape=[n_samples, dim]
             Point in the group.
         """
         tangent_vec = self.group.regularize_tangent_vec_at_identity(
@@ -210,12 +210,12 @@ class InvariantMetric(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec : array-like, shape=[n_samples, dimension]
+        tangent_vec : array-like, shape=[n_samples, dim]
             Tangent vector at identity.
 
         Returns
         -------
-        exp : array-like, shape=[n_samples, dimension]
+        exp : array-like, shape=[n_samples, dim]
             Point in the group.
         """
         if self.left_or_right == 'left':
@@ -233,14 +233,14 @@ class InvariantMetric(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec : array-like, shape=[n_samples, dimension]
+        tangent_vec : array-like, shape=[n_samples, dim]
             Tangent vector at a base point.
-        base_point : array-like, shape=[n_samples, dimension]
+        base_point : array-like, shape=[n_samples, dim]
             Point in the group.
 
         Returns
         -------
-        exp : array-like, shape=[n_samples, dimension]
+        exp : array-like, shape=[n_samples, dim]
             Point in the group equal to the Riemannian exponential
             of tangent_vec at the base point.
         """
@@ -283,12 +283,12 @@ class InvariantMetric(RiemannianMetric):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dimension]
+        point : array-like, shape=[n_samples, dim]
             Point in the group.
 
         Returns
         -------
-        log : array-like, shape=[n_samples, dimension]
+        log : array-like, shape=[n_samples, dim]
             Tangent vector at the identity equal to the Riemannian logarithm
             of point at the identity.
         """
@@ -306,12 +306,12 @@ class InvariantMetric(RiemannianMetric):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dimension]
+        point : array-like, shape=[n_samples, dim]
             Point in the group.
 
         Returns
         -------
-        log : array-like, shape=[n_samples, dimension]
+        log : array-like, shape=[n_samples, dim]
             Tangent vector at the identity equal to the Riemannian logarithm
             of point at the identity.
         """
@@ -331,15 +331,15 @@ class InvariantMetric(RiemannianMetric):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dimension]
+        point : array-like, shape=[n_samples, dim]
             Point in the group.
-        base_point : array-like, shape=[n_samples, dimension], optional
+        base_point : array-like, shape=[n_samples, dim], optional
             Point in the group, from which to compute the log,
             (the default is identity).
 
         Returns
         -------
-        log : array-like, shape=[n_samples, dimension]
+        log : array-like, shape=[n_samples, dim]
             Tangent vector at the base point equal to the Riemannian logarithm
             of point at the base point.
         """

--- a/geomstats/geometry/invariant_metric.py
+++ b/geomstats/geometry/invariant_metric.py
@@ -34,7 +34,7 @@ class InvariantMetric(RiemannianMetric):
 
         self.group = group
         if inner_product_mat_at_identity is None:
-            inner_product_mat_at_identity = gs.eye(self.group.dimension)
+            inner_product_mat_at_identity = gs.eye(self.group.dim)
 
         geomstats.error.check_parameter_accepted_values(
             left_or_right, 'left_or_right', ['left', 'right'])

--- a/geomstats/geometry/landmarks.py
+++ b/geomstats/geometry/landmarks.py
@@ -22,7 +22,7 @@ class Landmarks(Manifold):
         dimension = None
         if n_landmarks:
             self.dimension = n_landmarks * ambient_manifold.dimension
-        super(Landmarks, self).__init__(dimension=dimension)
+        super(Landmarks, self).__init__(dim=dimension)
         self.ambient_manifold = ambient_manifold
         self.l2_metric = L2Metric(self.ambient_manifold)
         self.n_landmarks = n_landmarks
@@ -49,7 +49,7 @@ class L2Metric(RiemannianMetric):
 
     def __init__(self, ambient_manifold):
         super(L2Metric, self).__init__(
-            dimension=math.inf,
+            dim=math.inf,
             signature=(math.inf, 0, 0))
         self.ambient_manifold = ambient_manifold
         self.ambient_metric = ambient_manifold.metric

--- a/geomstats/geometry/landmarks.py
+++ b/geomstats/geometry/landmarks.py
@@ -21,7 +21,7 @@ class Landmarks(Manifold):
         """
         dimension = None
         if n_landmarks:
-            self.dimension = n_landmarks * ambient_manifold.dimension
+            self.dimension = n_landmarks * ambient_manifold.dim
         super(Landmarks, self).__init__(dim=dimension)
         self.ambient_manifold = ambient_manifold
         self.l2_metric = L2Metric(self.ambient_manifold)

--- a/geomstats/geometry/landmarks.py
+++ b/geomstats/geometry/landmarks.py
@@ -21,7 +21,7 @@ class Landmarks(Manifold):
         """
         dimension = None
         if n_landmarks:
-            self.dimension = n_landmarks * ambient_manifold.dim
+            self.dim = n_landmarks * ambient_manifold.dim
         super(Landmarks, self).__init__(dim=dimension)
         self.ambient_manifold = ambient_manifold
         self.l2_metric = L2Metric(self.ambient_manifold)

--- a/geomstats/geometry/lie_algebra.py
+++ b/geomstats/geometry/lie_algebra.py
@@ -25,7 +25,7 @@ class MatrixLieAlgebra:
             The amount of rows and columns in the matrix representation of the
             Lie algebra
         """
-        geomstats.error.check_integer(dimension, 'dimension')
+        geomstats.error.check_integer(dimension, 'dim')
         geomstats.error.check_integer(n, 'n')
         self.dimension = dimension
         self.n = n
@@ -103,7 +103,7 @@ class MatrixLieAlgebra:
 
         Returns
         -------
-        basis_representation: array-like, shape=[n_sample, dimension]
+        basis_representation: array-like, shape=[n_sample, dim]
         """
         raise NotImplementedError("basis_representation not implemented.")
 
@@ -115,7 +115,7 @@ class MatrixLieAlgebra:
 
         Parameters
         ----------
-        basis_representation: array-like, shape=[n_sample, dimension]
+        basis_representation: array-like, shape=[n_sample, dim]
 
         Returns
         -------

--- a/geomstats/geometry/lie_algebra.py
+++ b/geomstats/geometry/lie_algebra.py
@@ -14,20 +14,20 @@ from ._bch_coefficients import BCH_COEFFICIENTS
 class MatrixLieAlgebra:
     """Class implementing matrix Lie algebra related functions."""
 
-    def __init__(self, dimension, n):
+    def __init__(self, dim, n):
         """Construct the MatrixLieAlgebra object.
 
         Parameters
         ----------
-        dimension: int
+        dim: int
             The dimension of the Lie algebra as a real vector space
         n: int
             The amount of rows and columns in the matrix representation of the
             Lie algebra
         """
-        geomstats.error.check_integer(dimension, 'dim')
+        geomstats.error.check_integer(dim, 'dim')
         geomstats.error.check_integer(n, 'n')
-        self.dimension = dimension
+        self.dim = dim
         self.n = n
         self.basis = None
 

--- a/geomstats/geometry/lie_group.py
+++ b/geomstats/geometry/lie_group.py
@@ -66,7 +66,7 @@ class LieGroup(Manifold):
     and columns of the matrix.
     """
 
-    def __init__(self, dim, point_type='vector'):
+    def __init__(self, dim, default_point_type='vector'):
         Manifold.__init__(self, dim=dim)
 
         self.left_canonical_metric = InvariantMetric(
@@ -82,7 +82,7 @@ class LieGroup(Manifold):
         )
 
         self.metrics = []
-        self.default_point_type = point_type
+        self.default_point_type = default_point_type
 
     def get_identity(self, point_type=None):
         """Get the identity of the group.

--- a/geomstats/geometry/lie_group.py
+++ b/geomstats/geometry/lie_group.py
@@ -13,8 +13,8 @@ def loss(y_pred, y_true, group, metric=None):
 
     Parameters
     ----------
-    y_pred : array-like, shape=[n_samples, {dimension, [n, n]}]
-    y_true : array-like, shape=[n_samples, {dimension, [n, n]}]
+    y_pred : array-like, shape=[n_samples, {dim, [n, n]}]
+    y_true : array-like, shape=[n_samples, {dim, [n, n]}]
         shape has to match y_pred
     group : LieGroup
     metric : RiemannianMetric, optional
@@ -22,7 +22,7 @@ def loss(y_pred, y_true, group, metric=None):
 
     Returns
     -------
-    loss : array-like, shape=[n_samples, {dimension, [n, n]}]
+    loss : array-like, shape=[n_samples, {dim, [n, n]}]
         the squared (geodesic) distance between y_pred and y_true
     """
     if metric is None:
@@ -36,8 +36,8 @@ def grad(y_pred, y_true, group, metric=None):
 
     Parameters
     ----------
-    y_pred : array-like, shape=[n_samples, {dimension, [n, n]}]
-    y_true : array-like, shape=[n_samples, {dimension, [n, n]}]
+    y_pred : array-like, shape=[n_samples, {dim, [n, n]}]
+    y_true : array-like, shape=[n_samples, {dim, [n, n]}]
         shape has to match y_pred
     group : LieGroup
     metric : RiemannianMetric, optional
@@ -45,7 +45,7 @@ def grad(y_pred, y_true, group, metric=None):
 
     Returns
     -------
-    grad : array-like, shape=[n_samples, {dimension, [n, n]}]
+    grad : array-like, shape=[n_samples, {dim, [n, n]}]
         tangent vector at point `y_pred`
     """
     if metric is None:
@@ -94,7 +94,7 @@ class LieGroup(Manifold):
 
         Returns
         -------
-        identity : array-like, shape={[dimension], [n, n]}
+        identity : array-like, shape={[dim], [n, n]}
         """
         raise NotImplementedError(
             'The Lie group identity is not implemented.'
@@ -109,17 +109,17 @@ class LieGroup(Manifold):
 
         Parameters
         ----------
-        point_a : array-like, shape=[n_samples, {dimension, [n, n]}]
+        point_a : array-like, shape=[n_samples, {dim, [n, n]}]
             the left factor in the product
-        point_b : array-like, shape=[n_samples, {dimension, [n, n]}]
+        point_b : array-like, shape=[n_samples, {dim, [n, n]}]
             the right factor in the product
         point_type : str, {'vector', 'matrix'}
             the point_type of the passed point_a and point_b
 
         Returns
         -------
-        composed : array-like, shape=[n_samples, {dimension, [n,n]}]
-            the product of point_a and point_b along the first dimension
+        composed : array-like, shape=[n_samples, {dim, [n,n]}]
+            the product of point_a and point_b along the first dim
         """
         raise NotImplementedError(
             'The Lie group composition is not implemented.'
@@ -130,7 +130,7 @@ class LieGroup(Manifold):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, {dimension, [n,n]}]
+        point : array-like, shape=[n_samples, {dim, [n,n]}]
             the points to be inverted
 
         point_type : str, {'vector', 'matrix'}, optional
@@ -138,7 +138,7 @@ class LieGroup(Manifold):
 
         Returns
         -------
-        inverse : array-like, shape=[n_samples, {dimension, [n,n]}]
+        inverse : array-like, shape=[n_samples, {dim, [n,n]}]
             the inverted point
         """
         raise NotImplementedError('The Lie group inverse is not implemented.')
@@ -152,7 +152,7 @@ class LieGroup(Manifold):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, {dimension, [n,n]]
+        point : array-like, shape=[n_samples, {dim, [n,n]]
             the points to be inverted
 
         left_or_right : str, {'left', 'right'}
@@ -177,14 +177,14 @@ class LieGroup(Manifold):
 
         Parameters
         ----------
-        tangent_vec : array-like, shape=[n_samples, {dimension,[n,n]}]
+        tangent_vec : array-like, shape=[n_samples, {dim,[n,n]}]
             the tangent vector to exponentiate
         point_type : str, {'vector', 'matrix'}
             default: the default point type
 
         Returns
         -------
-        point : array-like, shape=[n_samples, {dimension,[n,n]}]
+        point : array-like, shape=[n_samples, {dim,[n,n]}]
         """
         raise NotImplementedError(
             'The group exponential from the identity is not implemented.'
@@ -195,14 +195,14 @@ class LieGroup(Manifold):
 
         Parameters
         ----------
-        tangent_vec : array-like, shape=[n_samples, {dimension,[n,n]}]
-        base_point : array-like, shape=[n_samples, {dimension,[n,n]}]
+        tangent_vec : array-like, shape=[n_samples, {dim,[n,n]}]
+        base_point : array-like, shape=[n_samples, {dim,[n,n]}]
         point_type : str, {'vector', 'matrix'}
             default: the default point type
 
         Returns
         -------
-        exp : array-like, shape=[n_samples, {dimension,[n,n]}]
+        exp : array-like, shape=[n_samples, {dim,[n,n]}]
             the computed exponential
         """
         if point_type == 'vector':
@@ -233,8 +233,8 @@ class LieGroup(Manifold):
 
         Parameters
         ----------
-        tangent_vec : array-like, shape=[n_samples, {dimension,[n,n]}]
-        base_point : array-like, shape=[n_samples, {dimension,[n,n]}]
+        tangent_vec : array-like, shape=[n_samples, {dim,[n,n]}]
+        base_point : array-like, shape=[n_samples, {dim,[n,n]}]
             default: self.identity
         point_type : str, {'vector', 'matrix'}
             default: the default point type
@@ -242,7 +242,7 @@ class LieGroup(Manifold):
 
         Returns
         -------
-        result : array-like, shape=[n_samples, {dimension,[n,n]}]
+        result : array-like, shape=[n_samples, {dim,[n,n]}]
             The exponentiated tangent vector
         """
         if point_type is None:
@@ -265,13 +265,13 @@ class LieGroup(Manifold):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, {dimension,[n,n]}]
+        point : array-like, shape=[n_samples, {dim,[n,n]}]
         point_type : str, {'vector', 'matrix'}, optional
             defaults to the default point type
 
         Returns
         -------
-        tangent_vec : array-like, shape=[n_samples, {dimension,[n,n]}]
+        tangent_vec : array-like, shape=[n_samples, {dim,[n,n]}]
         """
         raise NotImplementedError(
             'The group logarithm from the identity is not implemented.'
@@ -282,14 +282,14 @@ class LieGroup(Manifold):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, {dimension,[n,n]}]
-        base_point : array-like, shape=[n_samples, {dimension,[n,n]}]
+        point : array-like, shape=[n_samples, {dim,[n,n]}]
+        base_point : array-like, shape=[n_samples, {dim,[n,n]}]
         point_type : str, {'vector', 'matrix'}, optional
             defaults to the default point type
 
         Returns
         -------
-        tangent_vec : array-like, shape=[n_samples, {dimension,[n,n]}]
+        tangent_vec : array-like, shape=[n_samples, {dim,[n,n]}]
         """
         if point_type == 'vector':
             jacobian = self.jacobian_translation(
@@ -317,13 +317,13 @@ class LieGroup(Manifold):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, {dimension,[n,n]}]
-        base_point : array-like, shape=[n_samples, {dimension,[n,n]}]
+        point : array-like, shape=[n_samples, {dim,[n,n]}]
+        base_point : array-like, shape=[n_samples, {dim,[n,n]}]
         point_type : str, {'vector', 'matrix'}
 
         Returns
         -------
-        tangent_vec : array-like, shape=[n_samples, {dimension,[n,n]}]
+        tangent_vec : array-like, shape=[n_samples, {dim,[n,n]}]
         """
         # TODO(ninamiolane): Build a standalone decorator that *only*
         # deals with point_type None and base_point None

--- a/geomstats/geometry/lie_group.py
+++ b/geomstats/geometry/lie_group.py
@@ -66,18 +66,18 @@ class LieGroup(Manifold):
     and columns of the matrix.
     """
 
-    def __init__(self, dimension, point_type='vector'):
-        Manifold.__init__(self, dimension=dimension)
+    def __init__(self, dim, point_type='vector'):
+        Manifold.__init__(self, dim=dim)
 
         self.left_canonical_metric = InvariantMetric(
             group=self,
-            inner_product_mat_at_identity=gs.eye(self.dimension),
+            inner_product_mat_at_identity=gs.eye(self.dim),
             left_or_right='left',
         )
 
         self.right_canonical_metric = InvariantMetric(
             group=self,
-            inner_product_mat_at_identity=gs.eye(self.dimension),
+            inner_product_mat_at_identity=gs.eye(self.dim),
             left_or_right='right',
         )
 

--- a/geomstats/geometry/manifold.py
+++ b/geomstats/geometry/manifold.py
@@ -10,16 +10,23 @@ import geomstats.error
 class Manifold:
     """Class for manifolds."""
 
-    def __init__(self, dimension):
-        geomstats.error.check_integer(dimension, 'dimension')
-        self.dimension = dimension
+    def __init__(
+            self, dim, default_point_type='vector',
+            default_coords_type='intrinsic'):
+        geomstats.error.check_integer(dim, 'dimension')
+        geomstats.error.check_parameter_accepted_values(
+            default_point_type, 'default_point_type', ['vector', 'matrix'])
+
+        self.dim = dim
+        self.default_point_type = default_point_type
+        self.default_coords_type = default_coords_type
 
     def belongs(self, point, point_type=None):
         """Evaluate if a point belongs to the manifold.
 
         Parameters
         ----------
-        points : array-like, shape=[n_samples, dimension]
+        point : array-like, shape=[n_samples, dimension]
                  Input points.
 
         Returns
@@ -33,7 +40,7 @@ class Manifold:
 
         Parameters
         ----------
-        points : array-like, shape=[n_samples, dimension]
+        point : array-like, shape=[n_samples, dimension]
                  Input points.
 
         Returns

--- a/geomstats/geometry/manifold.py
+++ b/geomstats/geometry/manifold.py
@@ -13,7 +13,7 @@ class Manifold:
     def __init__(
             self, dim, default_point_type='vector',
             default_coords_type='intrinsic'):
-        geomstats.error.check_integer(dim, 'dimension')
+        geomstats.error.check_integer(dim, 'dim')
         geomstats.error.check_parameter_accepted_values(
             default_point_type, 'default_point_type', ['vector', 'matrix'])
 
@@ -26,7 +26,7 @@ class Manifold:
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dimension]
+        point : array-like, shape=[n_samples, dim]
                  Input points.
 
         Returns
@@ -40,12 +40,12 @@ class Manifold:
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dimension]
+        point : array-like, shape=[n_samples, dim]
                  Input points.
 
         Returns
         -------
-        regularized_point : array-like, shape=[n_samples, dimension]
+        regularized_point : array-like, shape=[n_samples, dim]
         """
         regularized_point = point
         return regularized_point

--- a/geomstats/geometry/matrices.py
+++ b/geomstats/geometry/matrices.py
@@ -15,7 +15,7 @@ class Matrices(Euclidean):
     """Class for the space of matrices (m, n)."""
 
     def __init__(self, m, n):
-        super(Matrices, self).__init__(dimension=m * n)
+        super(Matrices, self).__init__(dim=m * n)
         geomstats.error.check_integer(n, 'n')
         geomstats.error.check_integer(m, 'm')
         self.m = m
@@ -174,7 +174,7 @@ class MatricesMetric(RiemannianMetric):
     def __init__(self, m, n):
         dimension = m * n
         super(MatricesMetric, self).__init__(
-            dimension=dimension,
+            dim=dimension,
             signature=(dimension, 0, 0))
 
     def inner_product(self, tangent_vec_a, tangent_vec_b, base_point=None):

--- a/geomstats/geometry/minkowski.py
+++ b/geomstats/geometry/minkowski.py
@@ -17,7 +17,7 @@ class Minkowski(Manifold):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dimension]
+        point : array-like, shape=[n_samples, dim]
                 Input points.
 
         Returns
@@ -41,7 +41,7 @@ class Minkowski(Manifold):
 
         Returns
         -------
-        points : array-like, shape=[n_samples, dimension]
+        points : array-like, shape=[n_samples, dim]
                  Sampled points.
         """
         size = (self.dim,)
@@ -68,11 +68,11 @@ class MinkowskiMetric(RiemannianMetric):
 
         Parameters
         ----------
-        base_point: array-like, shape=[n_samples, dimension]
+        base_point: array-like, shape=[n_samples, dim]
 
         Returns
         -------
-        inner_prod_mat: array-like, shape=[n_samples, dimension, dimension]
+        inner_prod_mat: array-like, shape=[n_samples, dim, dim]
         """
         inner_prod_mat = gs.eye(self.dim - 1, self.dim - 1)
         first_row = gs.array([0.] * (self.dim - 1))
@@ -93,15 +93,15 @@ class MinkowskiMetric(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec: array-like, shape=[n_samples, dimension]
-                                 or shape=[1, dimension]
-        base_point: array-like, shape=[n_samples, dimension]
-                                or shape=[1, dimension]
+        tangent_vec: array-like, shape=[n_samples, dim]
+                                 or shape=[1, dim]
+        base_point: array-like, shape=[n_samples, dim]
+                                or shape=[1, dim]
 
         Returns
         -------
-        exp: array-like, shape=[n_samples, dimension]
-                          or shape-[n_samples, dimension]
+        exp: array-like, shape=[n_samples, dim]
+                          or shape-[n_samples, dim]
         """
         exp = base_point + tangent_vec
         return exp
@@ -113,15 +113,15 @@ class MinkowskiMetric(RiemannianMetric):
 
         Parameters
         ----------
-        point: array-like, shape=[n_samples, dimension]
-                           or shape=[1, dimension]
-        base_point: array-like, shape=[n_samples, dimension]
-                                or shape=[1, dimension]
+        point: array-like, shape=[n_samples, dim]
+                           or shape=[1, dim]
+        base_point: array-like, shape=[n_samples, dim]
+                                or shape=[1, dim]
 
         Returns
         -------
-        log: array-like, shape=[n_samples, dimension]
-                          or shape-[n_samples, dimension]
+        log: array-like, shape=[n_samples, dim]
+                          or shape-[n_samples, dim]
         """
         log = point - base_point
         return log

--- a/geomstats/geometry/minkowski.py
+++ b/geomstats/geometry/minkowski.py
@@ -8,9 +8,9 @@ from geomstats.geometry.riemannian_metric import RiemannianMetric
 class Minkowski(Manifold):
     """Class for Minkowski Space."""
 
-    def __init__(self, dimension):
-        super(Minkowski, self).__init__(dimension=dimension)
-        self.metric = MinkowskiMetric(dimension)
+    def __init__(self, dim):
+        super(Minkowski, self).__init__(dim=dim)
+        self.metric = MinkowskiMetric(dim)
 
     def belongs(self, point):
         """Evaluate if a point belongs to the Minkowski space.
@@ -25,7 +25,7 @@ class Minkowski(Manifold):
         belongs : array-like, shape=[n_samples,]
         """
         point_dim = point.shape[-1]
-        belongs = point_dim == self.dimension
+        belongs = point_dim == self.dim
         if gs.ndim(point) == 2:
             belongs = gs.tile([belongs], (point.shape[0],))
 
@@ -44,9 +44,9 @@ class Minkowski(Manifold):
         points : array-like, shape=[n_samples, dimension]
                  Sampled points.
         """
-        size = (self.dimension,)
+        size = (self.dim,)
         if n_samples != 1:
-            size = (n_samples, self.dimension)
+            size = (n_samples, self.dim)
         point = bound * gs.random.rand(*size) * 2 - 1
 
         return point
@@ -58,10 +58,10 @@ class MinkowskiMetric(RiemannianMetric):
     The metric is flat: the inner product is independent of the base point.
     """
 
-    def __init__(self, dimension):
+    def __init__(self, dim):
         super(MinkowskiMetric, self).__init__(
-            dimension=dimension,
-            signature=(dimension - 1, 1, 0))
+            dim=dim,
+            signature=(dim - 1, 1, 0))
 
     def inner_product_matrix(self, base_point=None):
         """Compute the inner product matrix, independent of the base point.
@@ -74,13 +74,13 @@ class MinkowskiMetric(RiemannianMetric):
         -------
         inner_prod_mat: array-like, shape=[n_samples, dimension, dimension]
         """
-        inner_prod_mat = gs.eye(self.dimension - 1, self.dimension - 1)
-        first_row = gs.array([0.] * (self.dimension - 1))
+        inner_prod_mat = gs.eye(self.dim - 1, self.dim - 1)
+        first_row = gs.array([0.] * (self.dim - 1))
         first_row = gs.to_ndarray(first_row, to_ndim=2, axis=1)
         inner_prod_mat = gs.vstack(
             [gs.transpose(first_row), inner_prod_mat])
 
-        first_column = gs.array([-1.] + [0.] * (self.dimension - 1))
+        first_column = gs.array([-1.] + [0.] * (self.dim - 1))
         first_column = gs.to_ndarray(first_column, to_ndim=2, axis=1)
         inner_prod_mat = gs.hstack([first_column, inner_prod_mat])
 

--- a/geomstats/geometry/poincare_ball.py
+++ b/geomstats/geometry/poincare_ball.py
@@ -19,7 +19,7 @@ class PoincareBall(Hyperbolic):
 
     Parameters
     ----------
-    dimension : int
+    dim : int
         Dimension of the hyperbolic space.
     scale : int, optional
         Scale of the hyperbolic space, defined as the set of points
@@ -29,14 +29,14 @@ class PoincareBall(Hyperbolic):
     default_coords_type = 'ball'
     default_point_type = 'vector'
 
-    def __init__(self, dimension, scale=1):
+    def __init__(self, dim, scale=1):
         super(PoincareBall, self).__init__(
-            dimension=dimension,
+            dim=dim,
             scale=scale)
         self.coords_type = PoincareBall.default_coords_type
         self.point_type = PoincareBall.default_point_type
         self.metric =\
-            PoincareBallMetric(self.dimension, self.scale)
+            PoincareBallMetric(self.dim, self.scale)
 
     def belongs(self, point, tolerance=TOLERANCE):
         """Test if a point belongs to the hyperbolic space.
@@ -66,7 +66,7 @@ class PoincareBallMetric(RiemannianMetric):
 
     Parameters
     ----------
-    dimension : int
+    dim : int
         Dimension of the hyperbolic space.
     scale : int, optional
         Scale of the hyperbolic space, defined as the set of points
@@ -76,10 +76,10 @@ class PoincareBallMetric(RiemannianMetric):
     default_point_type = 'vector'
     default_coords_type = 'ball'
 
-    def __init__(self, dimension, scale=1):
+    def __init__(self, dim, scale=1):
         super(PoincareBallMetric, self).__init__(
-            dimension=dimension,
-            signature=(dimension, 0, 0))
+            dim=dim,
+            signature=(dim, 0, 0))
         self.coords_type = PoincareBall.default_coords_type
         self.point_type = PoincareBall.default_point_type
         self.scale = scale
@@ -204,7 +204,7 @@ class PoincareBallMetric(RiemannianMetric):
         point_a = gs.to_ndarray(point_a, to_ndim=2)
         point_b = gs.to_ndarray(point_b, to_ndim=2)
 
-        ball_manifold = PoincareBall(self.dimension, scale=self.scale)
+        ball_manifold = PoincareBall(self.dim, scale=self.scale)
         point_a_belong = ball_manifold.belongs(point_a)
         point_b_belong = ball_manifold.belongs(point_b)
 
@@ -283,7 +283,7 @@ class PoincareBallMetric(RiemannianMetric):
         point : array-like, shape=[n_samples, dimension]
             Retraction point.
         """
-        ball_manifold = PoincareBall(self.dimension, scale=self.scale)
+        ball_manifold = PoincareBall(self.dim, scale=self.scale)
         base_point_belong = ball_manifold.belongs(base_point)
 
         if not gs.all(base_point_belong):
@@ -310,10 +310,10 @@ class PoincareBallMetric(RiemannianMetric):
         inner_prod_mat: array-like, shape=[n_samples, dimension, dimension]
         """
         if base_point is None:
-            base_point = gs.zeros((1, self.dimension))
+            base_point = gs.zeros((1, self.dim))
 
         lambda_base =\
             (2 / (1 - gs.sum(base_point * base_point, axis=-1)))**2
-        identity = gs.eye(self.dimension, self.dimension)
+        identity = gs.eye(self.dim, self.dim)
 
         return gs.einsum('i,jk->ijk', lambda_base, identity)

--- a/geomstats/geometry/poincare_ball.py
+++ b/geomstats/geometry/poincare_ball.py
@@ -46,7 +46,7 @@ class PoincareBall(Hyperbolic):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dimension]
+        point : array-like, shape=[n_samples, dim]
             Point to be tested.
         tolerance : float, optional
             Tolerance at which to evaluate how close the squared norm
@@ -89,14 +89,14 @@ class PoincareBallMetric(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec : array-like, shape=[n_samples, dimension]
+        tangent_vec : array-like, shape=[n_samples, dim]
             Tangent vector at a base point.
-        base_point : array-like, shape=[n_samples, dimension]
+        base_point : array-like, shape=[n_samples, dim]
             Point in hyperbolic space.
 
         Returns
         -------
-        exp : array-like, shape=[n_samples, dimension]
+        exp : array-like, shape=[n_samples, dim]
             Point in hyperbolic space equal to the Riemannian exponential
             of tangent_vec at the base point.
         """
@@ -146,14 +146,14 @@ class PoincareBallMetric(RiemannianMetric):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dimension]
+        point : array-like, shape=[n_samples, dim]
             Point in hyperbolic space.
-        base_point : array-like, shape=[n_samples, dimension]
+        base_point : array-like, shape=[n_samples, dim]
             Point in hyperbolic space.
 
         Returns
         -------
-        log : array-like, shape=[n_samples, dimension]
+        log : array-like, shape=[n_samples, dim]
             Tangent vector at the base point equal to the Riemannian logarithm
             of point at the base point.
         """
@@ -191,9 +191,9 @@ class PoincareBallMetric(RiemannianMetric):
 
         Parameters
         ----------
-        point_a : array-like, shape=[n_samples, dimension]
+        point_a : array-like, shape=[n_samples, dim]
             Point in hyperbolic space.
-        point_b : array-like, shape=[n_samples, dimension]
+        point_b : array-like, shape=[n_samples, dim]
             Point in hyperbolic space.
 
         Returns
@@ -237,9 +237,9 @@ class PoincareBallMetric(RiemannianMetric):
 
         Parameters
         ----------
-        point_a : array-like, shape=[n_samples, dimension]
+        point_a : array-like, shape=[n_samples, dim]
             First point in hyperbolic space.
-        point_b : array-like, shape=[n_samples, dimension]
+        point_b : array-like, shape=[n_samples, dim]
             Second point in hyperbolic space.
 
         Returns
@@ -273,14 +273,14 @@ class PoincareBallMetric(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec : array-like, shape=[n_samples, dimension]
+        tangent_vec : array-like, shape=[n_samples, dim]
             vector in tangent space.
-        base_point : array-like, shape=[n_samples, dimension]
+        base_point : array-like, shape=[n_samples, dim]
             Second point in hyperbolic space.
 
         Returns
         -------
-        point : array-like, shape=[n_samples, dimension]
+        point : array-like, shape=[n_samples, dim]
             Retraction point.
         """
         ball_manifold = PoincareBall(self.dim, scale=self.scale)
@@ -303,11 +303,11 @@ class PoincareBallMetric(RiemannianMetric):
 
         Parameters
         ----------
-        base_point: array-like, shape=[n_samples, dimension]
+        base_point: array-like, shape=[n_samples, dim]
 
         Returns
         -------
-        inner_prod_mat: array-like, shape=[n_samples, dimension, dimension]
+        inner_prod_mat: array-like, shape=[n_samples, dim, dim]
         """
         if base_point is None:
             base_point = gs.zeros((1, self.dim))

--- a/geomstats/geometry/poincare_polydisk.py
+++ b/geomstats/geometry/poincare_polydisk.py
@@ -116,4 +116,3 @@ class PoincarePolydiskMetric(ProductRiemannianMetric):
             list_metrics.append(metric_i)
         super(PoincarePolydiskMetric, self).__init__(
             metrics=list_metrics, default_point_type='matrix')
-        self.default_point_type = 'matrix'

--- a/geomstats/geometry/poincare_polydisk.py
+++ b/geomstats/geometry/poincare_polydisk.py
@@ -105,12 +105,10 @@ class PoincarePolydiskMetric(ProductRiemannianMetric):
     """
 
     default_coords_type = 'extrinsic'
-    default_point_type = 'vector'
 
     def __init__(self, n_disks, coords_type='extrinsic'):
         self.n_disks = n_disks
         self.coords_type = coords_type
-        self.default_point_type = 'matrix'
         list_metrics = []
         for i_disk in range(n_disks):
             scale_i = (n_disks - i_disk) ** 0.5
@@ -118,3 +116,4 @@ class PoincarePolydiskMetric(ProductRiemannianMetric):
             list_metrics.append(metric_i)
         super(PoincarePolydiskMetric, self).__init__(
             metrics=list_metrics, default_point_type='matrix')
+        self.default_point_type = 'matrix'

--- a/geomstats/geometry/poincare_polydisk.py
+++ b/geomstats/geometry/poincare_polydisk.py
@@ -50,11 +50,11 @@ class PoincarePolydisk(ProductManifold):
 
         Parameters
         ----------
-        point_intrinsic : array-like, shape=[n_samples, n_disk, dimension]
+        point_intrinsic : array-like, shape=[n_samples, n_disk, dim]
 
         Returns
         -------
-        point_extrinsic : array-like, shape=[n_samples, n_disks, dimension + 1]
+        point_extrinsic : array-like, shape=[n_samples, n_disks, dim + 1]
         """
         n_disks = point_intrinsic.shape[1]
         point_extrinsic = gs.stack(
@@ -71,12 +71,12 @@ class PoincarePolydisk(ProductManifold):
 
         Parameters
         ----------
-        vector : array-like, shape=[n_samples, n_disks, dimension + 1]
-        base_point : array-like, shape=[n_samples, n_disks, dimension + 1]
+        vector : array-like, shape=[n_samples, n_disks, dim + 1]
+        base_point : array-like, shape=[n_samples, n_disks, dim + 1]
 
         Returns
         -------
-        tangent_vec : array-like, shape=[n_samples, n_disks, dimension + 1]
+        tangent_vec : array-like, shape=[n_samples, n_disks, dim + 1]
         """
         n_disks = base_point.shape[1]
         hyperbolic_space = Hyperboloid(2, self.coords_type)

--- a/geomstats/geometry/product_manifold.py
+++ b/geomstats/geometry/product_manifold.py
@@ -40,16 +40,15 @@ class ProductManifold(Manifold):
         geomstats.error.check_parameter_accepted_values(
             default_point_type, 'default_point_type', ['vector', 'matrix'])
 
-        self.default_point_type = default_point_type
-
+        self.dimensions = [manifold.dim for manifold in manifolds]
+        super(ProductManifold, self).__init__(
+            dim=sum(self.dimensions),
+            default_point_type=default_point_type)
         self.manifolds = manifolds
         self.metric = ProductRiemannianMetric(
             [manifold.metric for manifold in manifolds],
             default_point_type=default_point_type)
-
-        self.dimensions = [manifold.dim for manifold in manifolds]
-        super(ProductManifold, self).__init__(
-            dim=sum(self.dimensions))
+        self.default_point_type = default_point_type
         self.n_jobs = n_jobs
 
     @staticmethod

--- a/geomstats/geometry/product_manifold.py
+++ b/geomstats/geometry/product_manifold.py
@@ -40,9 +40,9 @@ class ProductManifold(Manifold):
         geomstats.error.check_parameter_accepted_values(
             default_point_type, 'default_point_type', ['vector', 'matrix'])
 
-        self.dimensions = [manifold.dim for manifold in manifolds]
+        self.dims = [manifold.dim for manifold in manifolds]
         super(ProductManifold, self).__init__(
-            dim=sum(self.dimensions),
+            dim=sum(self.dims),
             default_point_type=default_point_type)
         self.manifolds = manifolds
         self.metric = ProductRiemannianMetric(
@@ -58,8 +58,8 @@ class ProductManifold(Manifold):
     def _iterate_over_manifolds(
             self, func, args, intrinsic=False):
 
-        cum_index = gs.cumsum(self.dimensions)[:-1] if intrinsic else \
-            gs.cumsum([k + 1 for k in self.dimensions])
+        cum_index = gs.cumsum(self.dims)[:-1] if intrinsic else \
+            gs.cumsum([k + 1 for k in self.dims])
         arguments = {key: gs.split(
             args[key], cum_index, axis=1) for key in args.keys()}
         args_list = [{key: arguments[key][j] for key in args.keys()} for j in

--- a/geomstats/geometry/product_manifold.py
+++ b/geomstats/geometry/product_manifold.py
@@ -49,7 +49,7 @@ class ProductManifold(Manifold):
 
         self.dimensions = [manifold.dimension for manifold in manifolds]
         super(ProductManifold, self).__init__(
-            dimension=sum(self.dimensions))
+            dim=sum(self.dimensions))
         self.n_jobs = n_jobs
 
     @staticmethod

--- a/geomstats/geometry/product_manifold.py
+++ b/geomstats/geometry/product_manifold.py
@@ -23,7 +23,7 @@ class ProductManifold(Manifold):
     This type of representation is called 'vector'.
 
     Alternatively, a point can be represented by an array of shape:
-    [n_samples, n_manifolds, dim] if the n_manifolds have same dim dim.
+    [n_samples, n_manifolds, dim] if the n_manifolds have same dimension dim.
     This type of representation is called `matrix`.
 
     Parameters
@@ -48,7 +48,6 @@ class ProductManifold(Manifold):
         self.metric = ProductRiemannianMetric(
             [manifold.metric for manifold in manifolds],
             default_point_type=default_point_type)
-        self.default_point_type = default_point_type
         self.n_jobs = n_jobs
 
     @staticmethod

--- a/geomstats/geometry/product_manifold.py
+++ b/geomstats/geometry/product_manifold.py
@@ -23,7 +23,7 @@ class ProductManifold(Manifold):
     This type of representation is called 'vector'.
 
     Alternatively, a point can be represented by an array of shape:
-    [n_samples, n_manifolds, dim] if the n_manifolds have same dimension dim.
+    [n_samples, n_manifolds, dim] if the n_manifolds have same dim dim.
     This type of representation is called `matrix`.
 
     Parameters
@@ -47,7 +47,7 @@ class ProductManifold(Manifold):
             [manifold.metric for manifold in manifolds],
             default_point_type=default_point_type)
 
-        self.dimensions = [manifold.dimension for manifold in manifolds]
+        self.dimensions = [manifold.dim for manifold in manifolds]
         super(ProductManifold, self).__init__(
             dim=sum(self.dimensions))
         self.n_jobs = n_jobs
@@ -155,7 +155,7 @@ class ProductManifold(Manifold):
 
         Returns
         -------
-        samples : array-like, shape=[n_samples, dimension + 1]
+        samples : array-like, shape=[n_samples, dim + 1]
             Points sampled on the hypersphere.
         """
         if point_type is None:

--- a/geomstats/geometry/product_riemannian_metric.py
+++ b/geomstats/geometry/product_riemannian_metric.py
@@ -251,7 +251,6 @@ class ProductRiemannianMetric(RiemannianMetric):
 
         if point_type is None:
             point_type = self.default_point_type
-
         if point_type == 'vector':
             point = gs.to_ndarray(point, to_ndim=2)
             base_point = gs.to_ndarray(base_point, to_ndim=2)

--- a/geomstats/geometry/product_riemannian_metric.py
+++ b/geomstats/geometry/product_riemannian_metric.py
@@ -22,22 +22,21 @@ class ProductRiemannianMetric(RiemannianMetric):
 
     def __init__(self, metrics, default_point_type='vector', n_jobs=1):
         self.n_metrics = len(metrics)
-        dimensions = [metric.dim for metric in metrics]
+        dims = [metric.dim for metric in metrics]
         signatures = [metric.signature for metric in metrics]
 
         sig_0 = sum(sig[0] for sig in signatures)
         sig_1 = sum(sig[1] for sig in signatures)
         sig_2 = sum(sig[2] for sig in signatures)
         super(ProductRiemannianMetric, self).__init__(
-            dim=sum(dimensions),
+            dim=sum(dims),
             signature=(sig_0, sig_1, sig_2),
             default_point_type=default_point_type)
 
         self.metrics = metrics
-        self.dimensions = dimensions
+        self.dims = dims
         self.signatures = signatures
         self.n_jobs = n_jobs
-
 
     def inner_product_matrix(self, base_point=None, point_type=None):
         """Compute the matrix of the inner-product.
@@ -70,7 +69,7 @@ class ProductRiemannianMetric(RiemannianMetric):
             len(base_point), self.dim, self.dim])
         cum_dim = 0
         for i in range(self.n_metrics):
-            cum_dim_next = cum_dim + self.dimensions[i]
+            cum_dim_next = cum_dim + self.dims[i]
             if point_type == 'matrix':
                 matrix_next = self.metrics[i].inner_product_matrix(
                     base_point[:, i])
@@ -105,7 +104,7 @@ class ProductRiemannianMetric(RiemannianMetric):
 
         if point.shape[1] == self.dim:
             intrinsic = True
-        elif point.shape[1] == sum(dim + 1 for dim in self.dimensions):
+        elif point.shape[1] == sum(dim + 1 for dim in self.dims):
             intrinsic = False
         else:
             raise ValueError(
@@ -119,8 +118,8 @@ class ProductRiemannianMetric(RiemannianMetric):
     def _iterate_over_metrics(
             self, func, args, intrinsic=False):
 
-        cum_index = gs.cumsum(self.dimensions, axis=0)[:-1] if intrinsic else \
-            gs.cumsum(gs.array([k + 1 for k in self.dimensions]), axis=0)
+        cum_index = gs.cumsum(self.dims, axis=0)[:-1] if intrinsic else \
+            gs.cumsum(gs.array([k + 1 for k in self.dims]), axis=0)
         arguments = {
             key: gs.split(args[key], cum_index, axis=1) for key in args.keys()}
         args_list = [{key: arguments[key][j] for key in args.keys()} for j in

--- a/geomstats/geometry/product_riemannian_metric.py
+++ b/geomstats/geometry/product_riemannian_metric.py
@@ -35,7 +35,7 @@ class ProductRiemannianMetric(RiemannianMetric):
         sig_1 = sum(sig[1] for sig in signatures)
         sig_2 = sum(sig[2] for sig in signatures)
         super(ProductRiemannianMetric, self).__init__(
-            dimension=sum(dimensions),
+            dim=sum(dimensions),
             signature=(sig_0, sig_1, sig_2))
 
     def inner_product_matrix(self, base_point=None, point_type=None):
@@ -66,7 +66,7 @@ class ProductRiemannianMetric(RiemannianMetric):
         base_point = gs.to_ndarray(base_point, to_ndim=3)
 
         matrix = gs.zeros([
-            len(base_point), self.dimension, self.dimension])
+            len(base_point), self.dim, self.dim])
         cum_dim = 0
         for i in range(self.n_metrics):
             cum_dim_next = cum_dim + self.dimensions[i]
@@ -102,7 +102,7 @@ class ProductRiemannianMetric(RiemannianMetric):
             raise ValueError(
                 'Invalid default_point_type: \'vector\' expected.')
 
-        if point.shape[1] == self.dimension:
+        if point.shape[1] == self.dim:
             intrinsic = True
         elif point.shape[1] == sum(dim + 1 for dim in self.dimensions):
             intrinsic = False

--- a/geomstats/geometry/product_riemannian_metric.py
+++ b/geomstats/geometry/product_riemannian_metric.py
@@ -22,7 +22,7 @@ class ProductRiemannianMetric(RiemannianMetric):
 
     def __init__(self, metrics, default_point_type='vector', n_jobs=1):
         self.n_metrics = len(metrics)
-        dimensions = [metric.dimension for metric in metrics]
+        dimensions = [metric.dim for metric in metrics]
         signatures = [metric.signature for metric in metrics]
 
         self.metrics = metrics
@@ -46,16 +46,16 @@ class ProductRiemannianMetric(RiemannianMetric):
 
         Parameters
         ----------
-        base_point : array-like, shape=[n_samples, n_metrics, dimension] or
-            [n_samples, dimension], optional
+        base_point : array-like, shape=[n_samples, n_metrics, dim] or
+            [n_samples, dim], optional
             Point on the manifold at which to compute the inner-product matrix.
         point_type : str, {'vector', 'matrix'}, optional
             Type of representation used for points.
 
         Returns
         -------
-        matrix : array-like, shape=[n_samples, dimension, dimension] or
-        [n_samples, dimension + n_metrics, dimension + n_metrics]
+        matrix : array-like, shape=[n_samples, dim, dim] or
+        [n_samples, dim + n_metrics, dim + n_metrics]
             Matrix of the inner-product at the base point.
 
         """
@@ -90,7 +90,7 @@ class ProductRiemannianMetric(RiemannianMetric):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dimension]
+        point : array-like, shape=[n_samples, dim]
             Point on the product manifold.
 
         Returns
@@ -141,11 +141,11 @@ class ProductRiemannianMetric(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec_a : array-like, shape=[n_samples, dimension + 1]
+        tangent_vec_a : array-like, shape=[n_samples, dim + 1]
             First tangent vector at base point.
-        tangent_vec_b : array-like, shape=[n_samples, dimension + 1]
+        tangent_vec_b : array-like, shape=[n_samples, dim + 1]
             Second tangent vector at base point.
-        base_point : array-like, shape=[n_samples, dimension + 1], optional
+        base_point : array-like, shape=[n_samples, dim + 1], optional
             Point on the manifold.
         point_type : str, {'vector', 'matrix'}, optional
             Type of representation used for points.
@@ -191,16 +191,16 @@ class ProductRiemannianMetric(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec : array-like, shape=[n_samples, dimension]
+        tangent_vec : array-like, shape=[n_samples, dim]
             Tangent vector at a base point.
-        base_point : array-like, shape=[n_samples, dimension]
+        base_point : array-like, shape=[n_samples, dim]
             Point on the manifold.
         point_type : str, {'vector', 'matrix'}, optional
             Type of representation used for points.
 
         Returns
         -------
-        exp : array-like, shape=[n_samples, dimension]
+        exp : array-like, shape=[n_samples, dim]
             Point on the manifold equal to the Riemannian exponential
             of tangent_vec at the base point.
         """
@@ -233,16 +233,16 @@ class ProductRiemannianMetric(RiemannianMetric):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dimension]
+        point : array-like, shape=[n_samples, dim]
             Point on the manifold.
-        base_point : array-like, shape=[n_samples, dimension]
+        base_point : array-like, shape=[n_samples, dim]
             Point on the manifold.
         point_type : str, {'vector', 'matrix'}, optional
             Type of representation used for points.
 
         Returns
         -------
-        log : array-like, shape=[n_samples, dimension]
+        log : array-like, shape=[n_samples, dim]
             Tangent vector at the base point equal to the Riemannian logarithm
             of point at the base point.
         """

--- a/geomstats/geometry/product_riemannian_metric.py
+++ b/geomstats/geometry/product_riemannian_metric.py
@@ -25,18 +25,19 @@ class ProductRiemannianMetric(RiemannianMetric):
         dimensions = [metric.dim for metric in metrics]
         signatures = [metric.signature for metric in metrics]
 
-        self.metrics = metrics
-        self.dimensions = dimensions
-        self.signatures = signatures
-        self.default_point_type = default_point_type
-        self.n_jobs = n_jobs
-
         sig_0 = sum(sig[0] for sig in signatures)
         sig_1 = sum(sig[1] for sig in signatures)
         sig_2 = sum(sig[2] for sig in signatures)
         super(ProductRiemannianMetric, self).__init__(
             dim=sum(dimensions),
-            signature=(sig_0, sig_1, sig_2))
+            signature=(sig_0, sig_1, sig_2),
+            default_point_type=default_point_type)
+
+        self.metrics = metrics
+        self.dimensions = dimensions
+        self.signatures = signatures
+        self.n_jobs = n_jobs
+
 
     def inner_product_matrix(self, base_point=None, point_type=None):
         """Compute the matrix of the inner-product.

--- a/geomstats/geometry/riemannian_metric.py
+++ b/geomstats/geometry/riemannian_metric.py
@@ -55,8 +55,9 @@ def grad(y_pred, y_true, metric):
 class RiemannianMetric(Connection):
     """Class for Riemannian and pseudo-Riemannian metrics."""
 
-    def __init__(self, dim, signature=None):
-        super(RiemannianMetric, self).__init__(dim=dim)
+    def __init__(self, dim, signature=None, default_point_type='vector'):
+        super(RiemannianMetric, self).__init__(
+            dim=dim, default_point_type=default_point_type)
         self.signature = signature
 
     def inner_product_matrix(self, base_point=None):

--- a/geomstats/geometry/riemannian_metric.py
+++ b/geomstats/geometry/riemannian_metric.py
@@ -55,8 +55,8 @@ def grad(y_pred, y_true, metric):
 class RiemannianMetric(Connection):
     """Class for Riemannian and pseudo-Riemannian metrics."""
 
-    def __init__(self, dimension, signature=None):
-        super(RiemannianMetric, self).__init__(dimension=dimension)
+    def __init__(self, dim, signature=None):
+        super(RiemannianMetric, self).__init__(dim=dim)
         self.signature = signature
 
     def inner_product_matrix(self, base_point=None):

--- a/geomstats/geometry/riemannian_metric.py
+++ b/geomstats/geometry/riemannian_metric.py
@@ -64,7 +64,7 @@ class RiemannianMetric(Connection):
 
         Parameters
         ----------
-        base_point : array-like, shape=[n_samples, dimension], optional
+        base_point : array-like, shape=[n_samples, dim], optional
         """
         raise NotImplementedError(
             'The computation of the inner product matrix'
@@ -75,7 +75,7 @@ class RiemannianMetric(Connection):
 
         Parameters
         ----------
-        base_point : array-like, shape=[n_samples, dimension], optional
+        base_point : array-like, shape=[n_samples, dim], optional
         """
         metric_matrix = self.inner_product_matrix(base_point)
         cometric_matrix = gs.linalg.inv(metric_matrix)
@@ -86,7 +86,7 @@ class RiemannianMetric(Connection):
 
         Parameters
         ----------
-        base_point : array-like, shape=[n_samples, dimension], optional
+        base_point : array-like, shape=[n_samples, dim], optional
         """
         metric_derivative = autograd.jacobian(self.inner_product_matrix)
         return metric_derivative(base_point)
@@ -96,12 +96,12 @@ class RiemannianMetric(Connection):
 
         Parameters
         ----------
-        base_point: array-like, shape=[n_samples, dimension]
+        base_point: array-like, shape=[n_samples, dim]
 
         Returns
         -------
         christoffels: array-like,
-                             shape=[n_samples, dimension, dimension, dimension]
+                             shape=[n_samples, dim, dim, dim]
         """
         cometric_mat_at_point = self.inner_product_inverse_matrix(base_point)
         metric_derivative_at_point = self.inner_product_derivative_matrix(
@@ -125,12 +125,12 @@ class RiemannianMetric(Connection):
 
         Parameters
         ----------
-        tangent_vec_a: array-like, shape=[n_samples, dimension]
-                                   or shape=[1, dimension]
-        tangent_vec_b: array-like, shape=[n_samples, dimension]
-                                   or shape=[1, dimension]
-        base_point: array-like, shape=[n_samples, dimension]
-                                or shape=[1, dimension]
+        tangent_vec_a: array-like, shape=[n_samples, dim]
+                                   or shape=[1, dim]
+        tangent_vec_b: array-like, shape=[n_samples, dim]
+                                   or shape=[1, dim]
+        base_point: array-like, shape=[n_samples, dim]
+                                or shape=[1, dim]
 
         Returns
         -------
@@ -155,8 +155,8 @@ class RiemannianMetric(Connection):
 
         Parameters
         ----------
-        vector : array-like, shape=[n_samples, dimension]
-        base_point : array-like, shape=[n_samples, dimension]
+        vector : array-like, shape=[n_samples, dim]
+        base_point : array-like, shape=[n_samples, dim]
 
         Returns
         -------
@@ -176,8 +176,8 @@ class RiemannianMetric(Connection):
 
         Parameters
         ----------
-        vector : array-like, shape=[n_samples, dimension]
-        base_point : array-like, shape=[n_samples, dimension]
+        vector : array-like, shape=[n_samples, dim]
+        base_point : array-like, shape=[n_samples, dim]
 
         Returns
         -------
@@ -192,8 +192,8 @@ class RiemannianMetric(Connection):
 
         Parameters
         ----------
-        point_a : array-like, shape=[n_samples, dimension]
-        point_b : array-like, shape=[n_samples, dimension]
+        point_a : array-like, shape=[n_samples, dim]
+        point_b : array-like, shape=[n_samples, dim]
 
         Returns
         -------
@@ -211,8 +211,8 @@ class RiemannianMetric(Connection):
 
         Parameters
         ----------
-        point_a : array-like, shape=[n_samples, dimension]
-        point_b : array-like, shape=[n_samples, dimension]
+        point_a : array-like, shape=[n_samples, dim]
+        point_b : array-like, shape=[n_samples, dim]
 
         Returns
         -------

--- a/geomstats/geometry/skew_symmetric_matrices.py
+++ b/geomstats/geometry/skew_symmetric_matrices.py
@@ -63,7 +63,7 @@ class SkewSymmetricMatrices(MatrixLieAlgebra):
 
         Returns
         -------
-        basis_representation: array-like, shape=[n_samples, dimension]
+        basis_representation: array-like, shape=[n_samples, dim]
         """
         old_shape = gs.shape(matrix_representation)
         as_vector = gs.reshape(matrix_representation, (old_shape[0], -1))

--- a/geomstats/geometry/spd_matrices.py
+++ b/geomstats/geometry/spd_matrices.py
@@ -351,10 +351,10 @@ class SPDMetricAffine(RiemannianMetric):
           SPD matrices? A principled continuum of metrics" Proc. of GSI, 2019.
           https://arxiv.org/abs/1906.01349
         """
-        dimension = int(n * (n + 1) / 2)
+        dim = int(n * (n + 1) / 2)
         super(SPDMetricAffine, self).__init__(
-            dimension=dimension,
-            signature=(dimension, 0, 0))
+            dim=dim,
+            signature=(dim, 0, 0))
         self.n = n
         self.space = SPDMatrices(n)
         self.power_affine = power_affine

--- a/geomstats/geometry/spd_matrices.py
+++ b/geomstats/geometry/spd_matrices.py
@@ -20,7 +20,7 @@ class SPDMatrices(SymmetricMatrices, EmbeddedManifold):
     def __init__(self, n):
         super(SPDMatrices, self).__init__(
             n=n,
-            dimension=int(n * (n + 1) / 2),
+            dim=int(n * (n + 1) / 2),
             embedding_manifold=GeneralLinear(n=n))
 
     @staticmethod

--- a/geomstats/geometry/spd_matrices.py
+++ b/geomstats/geometry/spd_matrices.py
@@ -613,10 +613,10 @@ class SPDMetricProcrustes(RiemannianMetric):
     """
 
     def __init__(self, n):
-        dimension = int(n * (n + 1) / 2)
+        dim = int(n * (n + 1) / 2)
         super(SPDMetricProcrustes, self).__init__(
-            dimension=dimension,
-            signature=(dimension, 0, 0))
+            dim=dim,
+            signature=(dim, 0, 0))
         self.n = n
         self.space = SPDMatrices(n)
 
@@ -649,10 +649,10 @@ class SPDMetricEuclidean(RiemannianMetric):
     """Class for the Euclidean metric on the SPD manifold."""
 
     def __init__(self, n, power_euclidean=1):
-        dimension = int(n * (n + 1) / 2)
+        dim = int(n * (n + 1) / 2)
         super(SPDMetricEuclidean, self).__init__(
-            dimension=dimension,
-            signature=(dimension, 0, 0))
+            dim=dim,
+            signature=(dim, 0, 0))
         self.n = n
         self.space = SPDMatrices(n)
         self.power_euclidean = power_euclidean
@@ -733,10 +733,10 @@ class SPDMetricLogEuclidean(RiemannianMetric):
     """Class for the Log-Euclidean metric on the SPD manifold."""
 
     def __init__(self, n):
-        dimension = int(n * (n + 1) / 2)
+        dim = int(n * (n + 1) / 2)
         super(SPDMetricLogEuclidean, self).__init__(
-            dimension=dimension,
-            signature=(dimension, 0, 0))
+            dim=dim,
+            signature=(dim, 0, 0))
         self.n = n
         self.space = SPDMatrices(n)
 

--- a/geomstats/geometry/spd_matrices.py
+++ b/geomstats/geometry/spd_matrices.py
@@ -580,17 +580,17 @@ class SPDMetricAffine(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec_a : array-like, shape=[n_samples, dimension + 1]
+        tangent_vec_a : array-like, shape=[n_samples, dim + 1]
             Tangent vector at base point to be transported.
-        tangent_vec_b : array-like, shape=[n_samples, dimension + 1]
+        tangent_vec_b : array-like, shape=[n_samples, dim + 1]
             Tangent vector at base point, initial speed of the geodesic along
             which the parallel transport is computed.
-        base_point : array-like, shape=[n_samples, dimension + 1]
+        base_point : array-like, shape=[n_samples, dim + 1]
             point on the manifold of SPD matrices
 
         Returns
         -------
-        transported_tangent_vec: array-like, shape=[n_samples, dimension + 1]
+        transported_tangent_vec: array-like, shape=[n_samples, dim + 1]
             Transported tangent vector at exp_(base_point)(tangent_vec_b).
         """
         end_point = self.exp(tangent_vec_b, base_point)

--- a/geomstats/geometry/special_euclidean.py
+++ b/geomstats/geometry/special_euclidean.py
@@ -42,7 +42,7 @@ class SpecialEuclidean(LieGroup):
     representation corresponds to homogeneous coordinates.
     """
 
-    def __init__(self, n, point_type=None, epsilon=0.):
+    def __init__(self, n, default_point_type=None, epsilon=0.):
         """Initiate an object of class SpecialEuclidean.
 
         Parameter
@@ -67,12 +67,12 @@ class SpecialEuclidean(LieGroup):
         self.epsilon = epsilon
 
         super(SpecialEuclidean, self).__init__(
-            dim=self.dimension, point_type=point_type)
-        if point_type is None:
+            dim=self.dimension, default_point_type=default_point_type)
+        if default_point_type is None:
             self.default_point_type = 'vector' if n == 3 else 'matrix'
 
         self.rotations = SpecialOrthogonal(
-            n=n, epsilon=epsilon, point_type=point_type)
+            n=n, epsilon=epsilon, default_point_type=default_point_type)
         self.translations = Euclidean(dim=n)
 
     def get_identity(self, point_type=None):

--- a/geomstats/geometry/special_euclidean.py
+++ b/geomstats/geometry/special_euclidean.py
@@ -67,13 +67,13 @@ class SpecialEuclidean(LieGroup):
         self.epsilon = epsilon
 
         super(SpecialEuclidean, self).__init__(
-            dimension=self.dimension, point_type=point_type)
+            dim=self.dimension, point_type=point_type)
         if point_type is None:
             self.default_point_type = 'vector' if n == 3 else 'matrix'
 
         self.rotations = SpecialOrthogonal(
             n=n, epsilon=epsilon, point_type=point_type)
-        self.translations = Euclidean(dimension=n)
+        self.translations = Euclidean(dim=n)
 
     def get_identity(self, point_type=None):
         """Get the identity of the group.
@@ -168,7 +168,7 @@ class SpecialEuclidean(LieGroup):
         """
         if point_type == 'vector':
             rotations = self.rotations
-            dim_rotations = rotations.dimension
+            dim_rotations = rotations.dim
 
             rot_vec = point[:, :dim_rotations]
             regularized_rot_vec = rotations.regularize(
@@ -244,7 +244,7 @@ class SpecialEuclidean(LieGroup):
 
         if point_type == 'vector':
             rotations = self.rotations
-            dim_rotations = rotations.dimension
+            dim_rotations = rotations.dim
 
             rot_tangent_vec = tangent_vec[:, :dim_rotations]
             rot_base_point = base_point[:, :dim_rotations]
@@ -290,8 +290,8 @@ class SpecialEuclidean(LieGroup):
         vec = self.regularize(vec, point_type='vector')
         n_vecs, _ = vec.shape
 
-        rot_vec = vec[:, :self.rotations.dimension]
-        trans_vec = vec[:, self.rotations.dimension:]
+        rot_vec = vec[:, :self.rotations.dim]
+        trans_vec = vec[:, self.rotations.dim:]
 
         rot_mat = self.rotations.matrix_from_rotation_vector(rot_vec)
         trans_vec = gs.reshape(trans_vec, (n_vecs, self.n, 1))
@@ -325,7 +325,7 @@ class SpecialEuclidean(LieGroup):
 
         """
         rotations = self.rotations
-        dim_rotations = rotations.dimension
+        dim_rotations = rotations.dim
 
         point_a = self.regularize(point_a, point_type=point_type)
         point_b = self.regularize(point_b, point_type=point_type)
@@ -386,7 +386,7 @@ class SpecialEuclidean(LieGroup):
         :math:`(R, t)^{-1} = (R^{-1}, R^{-1}.(-t))`
         """
         rotations = self.rotations
-        dim_rotations = rotations.dimension
+        dim_rotations = rotations.dim
 
         point = self.regularize(point)
 
@@ -450,8 +450,8 @@ class SpecialEuclidean(LieGroup):
 
         rotations = self.rotations
         translations = self.translations
-        dim_rotations = rotations.dimension
-        dim_translations = translations.dimension
+        dim_rotations = rotations.dim
+        dim_translations = translations.dim
 
         point = self.regularize(point, point_type=point_type)
 
@@ -513,7 +513,7 @@ class SpecialEuclidean(LieGroup):
         """
         if point_type == 'vector':
             rotations = self.rotations
-            dim_rotations = rotations.dimension
+            dim_rotations = rotations.dim
 
             rot_vec = tangent_vec[:, :dim_rotations]
             rot_vec = self.rotations.regularize(rot_vec, point_type=point_type)
@@ -597,7 +597,7 @@ class SpecialEuclidean(LieGroup):
         point = self.regularize(point, point_type=point_type)
 
         rotations = self.rotations
-        dim_rotations = rotations.dimension
+        dim_rotations = rotations.dim
 
         if point_type == 'vector':
             rot_vec = point[:, :dim_rotations]

--- a/geomstats/geometry/special_euclidean.py
+++ b/geomstats/geometry/special_euclidean.py
@@ -86,7 +86,7 @@ class SpecialEuclidean(LieGroup):
 
         Returns
         -------
-        identity : array-like, shape={[dimension], [n + 1, n + 1]}
+        identity : array-like, shape={[dim], [n + 1, n + 1]}
         """
         if point_type is None:
             point_type = self.default_point_type
@@ -107,7 +107,7 @@ class SpecialEuclidean(LieGroup):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, {dimension, [n + 1, n + 1]}]
+        point : array-like, shape=[n_samples, {dim, [n + 1, n + 1]}]
             the point of which to check whether it belongs to SE(n)
         point_type : str, {'vector', 'matrix'}, optional
             default: self.default_point_type
@@ -157,14 +157,14 @@ class SpecialEuclidean(LieGroup):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, {dimension, [n + 1, n + 1]}]
+        point : array-like, shape=[n_samples, {dim, [n + 1, n + 1]}]
             the point which should be regularized
         point_type : str, {'vector', 'matrix'}, optional
             default: self.default_point_type
 
         Returns
         -------
-        point : array-like, shape=[n_samples, {dimension, [n + 1, n + 1]}]
+        point : array-like, shape=[n_samples, {dim, [n + 1, n + 1]}]
         """
         if point_type == 'vector':
             rotations = self.rotations
@@ -193,7 +193,7 @@ class SpecialEuclidean(LieGroup):
 
         Parameters
         ----------
-        tangent_vec: array-like, shape=[n_samples, {dimension, [n + 1, n + 1]}]
+        tangent_vec: array-like, shape=[n_samples, {dim, [n + 1, n + 1]}]
         metric : RiemannianMetric, optional
         point_type : str, {'vector', 'matrix'}, optional
             default: self.default_point_type
@@ -228,8 +228,8 @@ class SpecialEuclidean(LieGroup):
 
         Parameters
         ----------
-        tangent_vec: array-like, shape=[n_samples, {dimension, [n + 1, n + 1]}]
-        base_point : array-like, shape=[n_samples, {dimension, [n + 1, n + 1]}]
+        tangent_vec: array-like, shape=[n_samples, {dim, [n + 1, n + 1]}]
+        base_point : array-like, shape=[n_samples, {dim, [n + 1, n + 1]}]
         metric : RiemannianMetric, optional
             default: self.left_canonical_metric
         point_type: str, {'vector', 'matrix'}, optional
@@ -281,11 +281,11 @@ class SpecialEuclidean(LieGroup):
 
         Parameters
         ----------
-        vec: array-like, shape=[n_samples, dimension]
+        vec: array-like, shape=[n_samples, dim]
 
         Returns
         -------
-        mat: array-like, shape=[n_samples, {dimension, [n+1, n+1]}]
+        mat: array-like, shape=[n_samples, {dim, [n+1, n+1]}]
         """
         vec = self.regularize(vec, point_type='vector')
         n_vecs, _ = vec.shape
@@ -310,8 +310,8 @@ class SpecialEuclidean(LieGroup):
 
         Parameters
         ----------
-        point_1 : array-like, shape=[n_samples, {dimension, [n + 1, n + 1]}]
-        point_2 : array-like, shape=[n_samples, {dimension, [n + 1, n + 1]}]
+        point_1 : array-like, shape=[n_samples, {dim, [n + 1, n + 1]}]
+        point_2 : array-like, shape=[n_samples, {dim, [n + 1, n + 1]}]
         point_type: str, {'vector', 'matrix'}, optional
             default: self.default_point_type
 
@@ -371,14 +371,14 @@ class SpecialEuclidean(LieGroup):
 
         Parameters
         ----------
-        point: array-like, shape=[n_samples, {dimension, [n + 1, n + 1]}]
+        point: array-like, shape=[n_samples, {dim, [n + 1, n + 1]}]
         point_type: str, {'vector', 'matrix'}, optional
             default: self.default_point_type
 
         Returns
         -------
         inverse_point : array-like,
-            shape=[n_samples, {dimension, [n + 1, n + 1]}]
+            shape=[n_samples, {dim, [n + 1, n + 1]}]
             the inverted point
 
         Notes
@@ -429,7 +429,7 @@ class SpecialEuclidean(LieGroup):
 
         Parameters
         ----------
-        point: array-like, shape=[n_samples, {dimension, [n + 1, n + 1]}]
+        point: array-like, shape=[n_samples, {dim, [n + 1, n + 1]}]
 
         left_or_right: str, {'left', 'right'}, optional
             default: 'left'
@@ -439,7 +439,7 @@ class SpecialEuclidean(LieGroup):
 
         Returns
         -------
-        jacobian : array-like, shape=[n_samples, dimension]
+        jacobian : array-like, shape=[n_samples, dim]
             The jacobian of the left / right translation
         """
         if point_type is None:
@@ -501,13 +501,13 @@ class SpecialEuclidean(LieGroup):
 
         Parameters
         ----------
-        tangent_vec: array-like, shape=[n_samples, {dimension, [n + 1, n + 1]}]
+        tangent_vec: array-like, shape=[n_samples, {dim, [n + 1, n + 1]}]
         point_type: str, {'vector', 'matrix'}, optional
             default: self.default_point_type
 
         Returns
         -------
-        group_exp: array-like, shape=[n_samples, {dimension, [n + 1, n + 1]}]
+        group_exp: array-like, shape=[n_samples, {dim, [n + 1, n + 1]}]
             the group exponential of the tangent vectors calculated
             at the identity
         """
@@ -585,13 +585,13 @@ class SpecialEuclidean(LieGroup):
 
         Parameters
         ----------
-        point: array-like, shape=[n_samples, {dimension, [n + 1, n + 1]}]
+        point: array-like, shape=[n_samples, {dim, [n + 1, n + 1]}]
         point_type: str, {'vector', 'matrix'}, optional
             default: self.default_point_type
 
         Returns
         -------
-        group_log: array-like, shape=[n_samples, {dimension, [n + 1, n + 1]}]
+        group_log: array-like, shape=[n_samples, {dim, [n + 1, n + 1]}]
             the group logarithm in the Lie algbra
         """
         point = self.regularize(point, point_type=point_type)
@@ -681,7 +681,7 @@ class SpecialEuclidean(LieGroup):
         Returns
         -------
         random_point: array-like,
-            shape=[n_samples, {dimension, [n + 1, n + 1]}]
+            shape=[n_samples, {dim, [n + 1, n + 1]}]
             An array of random elements in SE(n) having the given point_type.
         """
         if point_type is None:
@@ -723,7 +723,7 @@ class SpecialEuclidean(LieGroup):
 
         Parameters
         ----------
-        rot_vec : array-like, shape=[n_samples, dimension]
+        rot_vec : array-like, shape=[n_samples, dim]
 
         Returns
         -------

--- a/geomstats/geometry/special_orthogonal.py
+++ b/geomstats/geometry/special_orthogonal.py
@@ -32,14 +32,14 @@ class SpecialOrthogonal(LieGroup, EmbeddedManifold):
     i.e. the Lie group of rotations.
     """
 
-    def __init__(self, n, point_type=None, epsilon=0.):
+    def __init__(self, n, default_point_type=None, epsilon=0.):
         """Initialize an instance of SO(n).
 
         Parameters
         ----------
         n : int
             the dimension of the euclidean space that SO(n) acts upon
-        point_type : str, {'vector', 'matrix'}, optional
+        default_point_type : str, {'vector', 'matrix'}, optional
             if None is given, point_type is set to 'vector for dimension 3
             and matrix otherwise
         epsilon : float, optional
@@ -54,15 +54,16 @@ class SpecialOrthogonal(LieGroup, EmbeddedManifold):
         self.dim = int((n * (n - 1)) / 2)
 
         self.epsilon = epsilon
+        if default_point_type is None:
+            default_point_type = 'vector' if n == 3 else 'matrix'
 
         LieGroup.__init__(self,
-                          dim=self.dim, point_type=point_type)
+                          dim=self.dim, default_point_type=default_point_type)
         EmbeddedManifold.__init__(self,
                                   dim=self.dim,
-                                  embedding_manifold=GeneralLinear(n=n))
+                                  embedding_manifold=GeneralLinear(n=n),
+                                  default_point_type=default_point_type)
         self.bi_invariant_metric = self.left_canonical_metric
-        if point_type is None:
-            self.default_point_type = 'vector' if n == 3 else 'matrix'
 
     def get_identity(self, point_type=None):
         """Get the identity of the group.

--- a/geomstats/geometry/special_orthogonal.py
+++ b/geomstats/geometry/special_orthogonal.py
@@ -51,14 +51,14 @@ class SpecialOrthogonal(LieGroup, EmbeddedManifold):
             raise ValueError('Parameter `n` is required to be an integer > 1.')
 
         self.n = n
-        self.dimension = int((n * (n - 1)) / 2)
+        self.dim = int((n * (n - 1)) / 2)
 
         self.epsilon = epsilon
 
         LieGroup.__init__(self,
-                          dimension=self.dimension, point_type=point_type)
+                          dim=self.dim, point_type=point_type)
         EmbeddedManifold.__init__(self,
-                                  dimension=self.dimension,
+                                  dim=self.dim,
                                   embedding_manifold=GeneralLinear(n=n))
         self.bi_invariant_metric = self.left_canonical_metric
         if point_type is None:
@@ -79,7 +79,7 @@ class SpecialOrthogonal(LieGroup, EmbeddedManifold):
         if point_type is None:
             point_type = self.default_point_type
 
-        identity = gs.zeros(self.dimension)
+        identity = gs.zeros(self.dim)
         if point_type == 'matrix':
             identity = gs.eye(self.n)
         return identity
@@ -106,8 +106,8 @@ class SpecialOrthogonal(LieGroup, EmbeddedManifold):
 
         if point_type == 'vector':
             vec_dim = point.shape[-1]
-            belongs = vec_dim == self.dimension
-            if gs.ndim(point) == 2:
+            belongs = vec_dim == self.dim
+            if point.ndim == 2:
                 belongs = gs.tile([belongs], (point.shape[0],))
             return belongs
 

--- a/geomstats/geometry/special_orthogonal.py
+++ b/geomstats/geometry/special_orthogonal.py
@@ -74,7 +74,7 @@ class SpecialOrthogonal(LieGroup, EmbeddedManifold):
 
         Returns
         -------
-        identity : array-like, shape={[dimension], [n, n]}
+        identity : array-like, shape={[dim], [n, n]}
         """
         if point_type is None:
             point_type = self.default_point_type
@@ -91,7 +91,7 @@ class SpecialOrthogonal(LieGroup, EmbeddedManifold):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, {dimension, [n, n]}]
+        point : array-like, shape=[n_samples, {dim, [n, n]}]
             the point of which to check whether it belongs to SO(n)
         point_type : str, {'vector', 'matrix'}, optional
             default: default_point_type
@@ -136,13 +136,13 @@ class SpecialOrthogonal(LieGroup, EmbeddedManifold):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, {dimension, [n, n]}]
+        point : array-like, shape=[n_samples, {dim, [n, n]}]
         point_type : str, {'vector', 'matrix'}, optional
             default: self.default_point_type
 
         Returns
         -------
-        regularized_point : array-like, shape=[n_samples, {dimension, [n, n]}]
+        regularized_point : array-like, shape=[n_samples, {dim, [n, n]}]
         """
         geomstats.error.check_parameter_accepted_values(
             point_type, 'point_type', ['vector', 'matrix'])
@@ -192,7 +192,7 @@ class SpecialOrthogonal(LieGroup, EmbeddedManifold):
 
         Parameters
         ----------
-        tangent_vec : array-like, shape=[n_samples, {dimension, [n, n]}]
+        tangent_vec : array-like, shape=[n_samples, {dim, [n, n]}]
         metric : RiemannianMetric, optional
             default: self.left_canonical_metric
         point_type : str, {'vector', 'matrix'}, optional
@@ -200,7 +200,7 @@ class SpecialOrthogonal(LieGroup, EmbeddedManifold):
 
         Returns
         -------
-        regularized_vec : array-like, shape=[n_samples, {dimension, [n, n]}]
+        regularized_vec : array-like, shape=[n_samples, {dim, [n, n]}]
         """
         geomstats.error.check_parameter_accepted_values(
             point_type, 'point_type', ['vector', 'matrix'])
@@ -271,9 +271,9 @@ class SpecialOrthogonal(LieGroup, EmbeddedManifold):
 
         Parameters
         ----------
-        tangent_vec : array-like, shape=[n_samples, {dimension, [n, n]}]
+        tangent_vec : array-like, shape=[n_samples, {dim, [n, n]}]
             Tangent vector at base point.
-        base_point : array-like, shape=[n_samples, {dimension, [n, n]}]
+        base_point : array-like, shape=[n_samples, {dim, [n, n]}]
             Point on the manifold.
         metric : RiemannianMetric, optional
             default: self.left_canonical_metric
@@ -283,7 +283,7 @@ class SpecialOrthogonal(LieGroup, EmbeddedManifold):
         Returns
         -------
         regularized_tangent_vec : array-like,
-            shape=[n_samples, {dimension, [n, n]}]
+            shape=[n_samples, {dim, [n, n]}]
         """
         geomstats.error.check_parameter_accepted_values(
             point_type, 'point_type', ['vector', 'matrix'])
@@ -391,7 +391,7 @@ class SpecialOrthogonal(LieGroup, EmbeddedManifold):
 
         Parameters
         ----------
-        vec : array-like, shape=[n_samples, dimension]
+        vec : array-like, shape=[n_samples, dim]
 
         Returns
         -------
@@ -481,11 +481,11 @@ class SpecialOrthogonal(LieGroup, EmbeddedManifold):
 
         Returns
         -------
-        vec : array-like, shape=[n_samples, dimension]
+        vec : array-like, shape=[n_samples, dim]
         """
         n_skew_mats, mat_dim_1, _ = skew_mat.shape
 
-        vec_dim = self.dimension
+        vec_dim = self.dim
         vec = gs.zeros((n_skew_mats, vec_dim))
 
         if self.n == 2:  # SO(2)
@@ -534,7 +534,7 @@ class SpecialOrthogonal(LieGroup, EmbeddedManifold):
 
         Returns
         -------
-        regularized_rot_vec : array-like, shape=[n_samples, dimension]
+        regularized_rot_vec : array-like, shape=[n_samples, dim]
         """
         n_rot_mats, _, _ = rot_mat.shape
 
@@ -583,11 +583,11 @@ class SpecialOrthogonal(LieGroup, EmbeddedManifold):
 
         Parameters
         ----------
-        rot_vec: array-like, shape=[n_samples, dimension]
+        rot_vec: array-like, shape=[n_samples, dim]
 
         Returns
         -------
-        rot_mat: array-like, shape=[n_samples, {dimension, [n, n]}]
+        rot_mat: array-like, shape=[n_samples, {dim, [n, n]}]
         """
         rot_vec = self.regularize(rot_vec, point_type='vector')
 
@@ -619,7 +619,7 @@ class SpecialOrthogonal(LieGroup, EmbeddedManifold):
 
             coef_1 = gs.squeeze(coef_1, axis=1)
             coef_2 = gs.squeeze(coef_2, axis=1)
-            term_1 = (gs.eye(self.dimension)
+            term_1 = (gs.eye(self.dim)
                       + gs.einsum('n,njk->njk', coef_1, skew_rot_vec))
 
             squared_skew_rot_vec = gs.einsum(
@@ -662,7 +662,7 @@ class SpecialOrthogonal(LieGroup, EmbeddedManifold):
 
         Parameters
         ----------
-        rot_vec : array-like, shape=[n_samples, dimension]
+        rot_vec : array-like, shape=[n_samples, dim]
 
         Returns
         -------
@@ -703,7 +703,7 @@ class SpecialOrthogonal(LieGroup, EmbeddedManifold):
 
         Returns
         -------
-        rot_vec : array-like, shape=[n_samples, dimension]
+        rot_vec : array-like, shape=[n_samples, dim]
         """
         if self.n != 3:
             raise ValueError(
@@ -742,7 +742,7 @@ class SpecialOrthogonal(LieGroup, EmbeddedManifold):
 
         Returns
         -------
-        rot_mat : array-like, shape=[n_samples, dimension]
+        rot_mat : array-like, shape=[n_samples, dim]
         """
         if self.n != 3:
             raise ValueError(
@@ -1115,7 +1115,7 @@ class SpecialOrthogonal(LieGroup, EmbeddedManifold):
 
         Returns
         -------
-        rot_vec : array-like, shape=[n_samples, dimension]
+        rot_vec : array-like, shape=[n_samples, dim]
         """
         if self.n != 3:
             raise ValueError(
@@ -1254,7 +1254,7 @@ class SpecialOrthogonal(LieGroup, EmbeddedManifold):
 
         Parameters
         ----------
-        rot_vec : array-like, shape=[n_samples, dimension]
+        rot_vec : array-like, shape=[n_samples, dim]
         extrinsic_or_intrinsic : str, {'extrinsic', 'intrinsic'}, optional
             default: 'extrinsic'
         order : str, {'xyz', 'zyx'}, optional
@@ -1284,14 +1284,14 @@ class SpecialOrthogonal(LieGroup, EmbeddedManifold):
 
         Parameters
         ----------
-        point_1 : array-like, shape=[n_samples, {dimension, [n, n]}]
-        point_2 : array-like, shape=[n_samples, {dimension, [n, n]}]
+        point_1 : array-like, shape=[n_samples, {dim, [n, n]}]
+        point_2 : array-like, shape=[n_samples, {dim, [n, n]}]
         point_type : str, {'vector', 'matrix'}, optional
             default: default_point_type
 
         Returns
         -------
-        point_prod : array-like, shape=[n_samples, {dimension, [n, n]}]
+        point_prod : array-like, shape=[n_samples, {dim, [n, n]}]
         """
         point_a = self.regularize(point_a, point_type=point_type)
         point_b = self.regularize(point_b, point_type=point_type)
@@ -1314,13 +1314,13 @@ class SpecialOrthogonal(LieGroup, EmbeddedManifold):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, {dimension, [n, n]}]
+        point : array-like, shape=[n_samples, {dim, [n, n]}]
         point_type : str, {'vector', 'matrix'}, optional
             default: self.default_point_type
 
         Returns
         -------
-        inv_point : array-like, shape=[n_samples, {dimension, [n, n]}]
+        inv_point : array-like, shape=[n_samples, {dim, [n, n]}]
         """
         if point_type is None:
             point_type = self.default_point_type
@@ -1348,7 +1348,7 @@ class SpecialOrthogonal(LieGroup, EmbeddedManifold):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, {dimension, [n, n]}]
+        point : array-like, shape=[n_samples, {dim, [n, n]}]
         left_or_right : str, {'left', 'right'}, optional
             default: 'left'
         point_type : str, {'vector', 'matrix'}, optional
@@ -1356,7 +1356,7 @@ class SpecialOrthogonal(LieGroup, EmbeddedManifold):
 
         Returns
         -------
-        jacobian : array-like, shape=[n_samples, dimension, dimension]
+        jacobian : array-like, shape=[n_samples, dim, dim]
         """
         geomstats.error.check_parameter_accepted_values(
             left_or_right, 'left_or_right', ['left', 'right'])
@@ -1417,7 +1417,7 @@ class SpecialOrthogonal(LieGroup, EmbeddedManifold):
                     (angle / 2) / gs.tan(angle / 2))
                 coef_2 += mask_else_float * (
                     (1 - coef_1) / angle ** 2)
-                jacobian = gs.zeros((n_points, self.dimension, self.dimension))
+                jacobian = gs.zeros((n_points, self.dim, self.dim))
                 n_points_tensor = gs.array(n_points)
                 for i in range(n_points):
                     # This avoids dividing by 0.
@@ -1430,7 +1430,7 @@ class SpecialOrthogonal(LieGroup, EmbeddedManifold):
                         sign = + 1.
 
                     jacobian_i = (
-                        coef_1[i] * gs.eye(self.dimension)
+                        coef_1[i] * gs.eye(self.dim)
                         + coef_2[i] * gs.outer(point[i], point[i])
                         + sign * self.skew_matrix_from_vector(point[i]) / 2.)
 
@@ -1463,12 +1463,12 @@ class SpecialOrthogonal(LieGroup, EmbeddedManifold):
 
         Returns
         -------
-        point : array-like, shape=[n_samples, {dimension, [n, n]}]
+        point : array-like, shape=[n_samples, {dim, [n, n]}]
         """
         if point_type is None:
             point_type = self.default_point_type
 
-        random_point = gs.random.rand(n_samples, self.dimension) * 2 - 1
+        random_point = gs.random.rand(n_samples, self.dim) * 2 - 1
         random_point = self.regularize(random_point, point_type='vector')
         if point_type == 'matrix':
             random_point = self.matrix_from_rotation_vector(random_point)
@@ -1484,13 +1484,13 @@ class SpecialOrthogonal(LieGroup, EmbeddedManifold):
 
         Parameters
         ----------
-        tangent_vec : array-like, shape=[n_samples, {dimension, [n, n]}]
+        tangent_vec : array-like, shape=[n_samples, {dim, [n, n]}]
         point_type : str, {'vector', 'matrix'}, optional
             default: self.default_point_type
 
         Returns
         -------
-        point : array-like, shape=[n_samples, {dimension, [n, n]}]
+        point : array-like, shape=[n_samples, {dim, [n, n]}]
         """
         if point_type == 'matrix' and self.n > 3:
             return gs.linalg.expm(tangent_vec)
@@ -1506,13 +1506,13 @@ class SpecialOrthogonal(LieGroup, EmbeddedManifold):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, {dimension, [n, n]}]
+        point : array-like, shape=[n_samples, {dim, [n, n]}]
         point_type : str, {'vector', 'matrix'}, optional
             default: self.default_point_type
 
         Returns
         -------
-        tangent_vec : array-like, shape=[n_samples, {dimension, [n, n]}]
+        tangent_vec : array-like, shape=[n_samples, {dim, [n, n]}]
         """
         if point_type == 'vector':
             tangent_vec = self.regularize(point, point_type=point_type)

--- a/geomstats/geometry/stiefel.py
+++ b/geomstats/geometry/stiefel.py
@@ -36,9 +36,9 @@ class Stiefel(EmbeddedManifold):
         if p > n:
             raise ValueError('p needs to be smaller than n.')
 
-        dimension = int(p * n - (p * (p + 1) / 2))
+        dim = int(p * n - (p * (p + 1) / 2))
         super(Stiefel, self).__init__(
-            dimension=dimension,
+            dim=dim,
             embedding_manifold=Matrices(n, p))
 
         self.n = n
@@ -143,10 +143,10 @@ class StiefelCanonicalMetric(RiemannianMetric):
     """
 
     def __init__(self, n, p):
-        dimension = int(p * n - (p * (p + 1) / 2))
+        dim = int(p * n - (p * (p + 1) / 2))
         super(StiefelCanonicalMetric, self).__init__(
-            dimension=dimension,
-            signature=(dimension, 0, 0))
+            dim=dim,
+            signature=(dim, 0, 0))
         self.embedding_metric = EuclideanMetric(n * p)
         self.n = n
         self.p = p

--- a/geomstats/geometry/stiefel.py
+++ b/geomstats/geometry/stiefel.py
@@ -352,7 +352,7 @@ class StiefelCanonicalMetric(RiemannianMetric):
 
         Returns
         -------
-        log : array-like, shape=[n_samples, dimension + 1]
+        log : array-like, shape=[n_samples, dim + 1]
             Tangent vector at the base point equal to the Riemannian logarithm
             of point at the base point.
         """
@@ -450,7 +450,7 @@ class StiefelCanonicalMetric(RiemannianMetric):
 
         Returns
         -------
-        log : array-like, shape=[n_samples, dimension + 1]
+        log : array-like, shape=[n_samples, dim + 1]
             Tangent vector at the base point equal to the lifting
             of point at the base point.
         """

--- a/geomstats/geometry/symmetric_matrices.py
+++ b/geomstats/geometry/symmetric_matrices.py
@@ -17,7 +17,7 @@ class SymmetricMatrices(EmbeddedManifold):
 
     def __init__(self, n, **kwargs):
         super(SymmetricMatrices, self).__init__(
-            dimension=int(n * (n + 1) / 2),
+            dim=int(n * (n + 1) / 2),
             embedding_manifold=Matrices(n, n))
         self.n = n
 

--- a/geomstats/integrator.py
+++ b/geomstats/integrator.py
@@ -12,7 +12,7 @@ def _symplectic_euler_step(state, force, dt):
 
     Parameters
     ----------
-    state : array-like, shape=[2, dimension]
+    state : array-like, shape=[2, dim]
         variables a time t
     force : callable
     dt : float
@@ -20,9 +20,9 @@ def _symplectic_euler_step(state, force, dt):
 
     Returns
     -------
-    point_new : array-like, shape=[dimension]
+    point_new : array-like, shape=[dim]
         first variable at time t + dt
-    vector_new : array-like, shape=[dimension]
+    vector_new : array-like, shape=[dim]
         second variable at time t + dt
     """
     point, vector = state
@@ -36,19 +36,19 @@ def rk4_step(state, force, dt, k1=None):
 
     Parameters
     ----------
-    state : array-like, shape=[2, dimension]
+    state : array-like, shape=[2, dim]
         variables a time t
     force : callable
     dt : float
         time-step
-    k1 : array-like, shape=[dimension]
+    k1 : array-like, shape=[dim]
         initial guess for the slope at time t
 
     Returns
     -------
-    point_new : array-like, shape=[dimension]
+    point_new : array-like, shape=[dim]
         first variable at time t + dt
-    vector_new : array-like, shape=[dimension]
+    vector_new : array-like, shape=[dim]
         second variable at time t + dt
 
     See Also

--- a/geomstats/learning/exponential_barycenter.py
+++ b/geomstats/learning/exponential_barycenter.py
@@ -105,7 +105,7 @@ class ExponentialBarycenter(BaseEstimator):
 
     Attributes
     ----------
-    estimate_ : array-like, shape=[dimension, dimension]
+    estimate_ : array-like, shape=[dim, dim]
     """
 
     def __init__(self, group,

--- a/geomstats/learning/frechet_mean.py
+++ b/geomstats/learning/frechet_mean.py
@@ -21,7 +21,7 @@ def variance(points,
 
     Parameters
     ----------
-    points : array-like, shape=[n_samples, dimension]
+    points : array-like, shape=[n_samples, dim]
 
     weights : array-like, shape=[n_samples, 1], optional
     """
@@ -61,7 +61,7 @@ def linear_mean(points, weights=None):
 
     Parameters
     ----------
-    points : array-like, shape=[n_samples, dimension]
+    points : array-like, shape=[n_samples, dim]
         Points to be averaged.
 
     weights : array-like, shape=[n_samples, 1], optional
@@ -69,7 +69,7 @@ def linear_mean(points, weights=None):
 
     Returns
     -------
-    mean : array-like, shape=[1, dimension]
+    mean : array-like, shape=[1, dim]
         Weighted linear mean of the points.
     """
     if isinstance(points, list):
@@ -206,7 +206,7 @@ def _adaptive_gradient_descent(points,
 
     Parameters
     ----------
-    points : array-like, shape=[n_samples, dimension]
+    points : array-like, shape=[n_samples, dim]
         Points to be averaged.
 
     weights : array-like, shape=[n_samples, 1], optional
@@ -215,7 +215,7 @@ def _adaptive_gradient_descent(points,
     max_iter : int, optional
         Maximum number of iterations for the gradient descent.
 
-    init_point : array-like, shape=[n_init, dimension], optional
+    init_point : array-like, shape=[n_init, dim], optional
         Initial points.
 
     epsilon : float, optional
@@ -223,7 +223,7 @@ def _adaptive_gradient_descent(points,
 
     Returns
     -------
-    current_mean: array-like, shape=[n_samples, dimension]
+    current_mean: array-like, shape=[n_samples, dim]
         Weighted Frechet mean of the points.
     """
     tau_max = 1e6

--- a/geomstats/learning/online_kmeans.py
+++ b/geomstats/learning/online_kmeans.py
@@ -143,7 +143,7 @@ class OnlineKMeans(BaseEstimator, ClusterMixin):
     -------
     >>> from geomstats.geometry.hypersphere import Hypersphere
     >>> from geomstats.learning.onlinekmeans import OnlineKmeans
-    >>> sphere = Hypersphere(dimension=2)
+    >>> sphere = Hypersphere(dim=2)
     >>> metric = sphere.metric
     >>> X = sphere.random_von_mises_fisher(kappa=10, n_samples=50)
     >>> clustering = OnlineKmeans(metric=metric,n_clusters=4).fit(X)

--- a/geomstats/visualization.py
+++ b/geomstats/visualization.py
@@ -11,9 +11,9 @@ from mpl_toolkits.mplot3d import Axes3D  # NOQA
 
 SE3_GROUP = SpecialEuclidean(n=3)
 SO3_GROUP = SpecialOrthogonal(n=3)
-S1 = Hypersphere(dimension=1)
-S2 = Hypersphere(dimension=2)
-H2 = Hyperboloid(dimension=2)
+S1 = Hypersphere(dim=1)
+S2 = Hypersphere(dim=2)
+H2 = Hyperboloid(dim=2)
 
 AX_SCALE = 1.2
 
@@ -410,7 +410,7 @@ def convert_to_trihedron(point, space=None):
     point = gs.to_ndarray(point, to_ndim=2)
     n_points, _ = point.shape
 
-    dim_rotations = SO3_GROUP.dimension
+    dim_rotations = SO3_GROUP.dim
 
     if space == 'SE3_GROUP':
         rot_vec = point[:, :dim_rotations]

--- a/tests/test_agglomerative_hierarchical_clustering.py
+++ b/tests/test_agglomerative_hierarchical_clustering.py
@@ -36,7 +36,7 @@ class TestAgglomerativeHierarchicalClustering(geomstats.tests.TestCase):
         """Test the 'fit' class method using the Euclidean distance."""
         n_clusters = 2
         dimension = 2
-        space = Euclidean(dimension=dimension)
+        space = Euclidean(dim=dimension)
         distance = space.metric.dist
         dataset = gs.array([[1, 2], [1, 4], [1, 0], [4, 2], [4, 4], [4, 0]])
         clustering = AgglomerativeHierarchicalClustering(
@@ -54,7 +54,7 @@ class TestAgglomerativeHierarchicalClustering(geomstats.tests.TestCase):
         """Test the 'fit' class method using the hypersphere distance."""
         n_clusters = 2
         dimension = 2
-        space = Hypersphere(dimension=dimension)
+        space = Hypersphere(dim=dimension)
         distance = space.metric.dist
         dataset = gs.array(
             [[1, 0, 0],

--- a/tests/test_beta_distributions.py
+++ b/tests/test_beta_distributions.py
@@ -14,7 +14,7 @@ class TestBetaMethods(geomstats.tests.TestCase):
         self.beta = BetaDistributions()
         self.metric = BetaMetric()
         self.n_samples = 10
-        self.dimension = self.beta.dimension
+        self.dimension = self.beta.dim
 
     @geomstats.tests.np_and_pytorch_only
     def test_random_uniform_and_belongs(self):

--- a/tests/test_beta_distributions.py
+++ b/tests/test_beta_distributions.py
@@ -14,7 +14,7 @@ class TestBetaMethods(geomstats.tests.TestCase):
         self.beta = BetaDistributions()
         self.metric = BetaMetric()
         self.n_samples = 10
-        self.dimension = self.beta.dim
+        self.dim = self.beta.dim
 
     @geomstats.tests.np_and_pytorch_only
     def test_random_uniform_and_belongs(self):
@@ -35,7 +35,7 @@ class TestBetaMethods(geomstats.tests.TestCase):
         Test that the random uniform method samples points of the right shape
         """
         point = self.beta.random_uniform(self.n_samples)
-        self.assertAllClose(gs.shape(point), (self.n_samples, self.dimension))
+        self.assertAllClose(gs.shape(point), (self.n_samples, self.dim))
 
     @geomstats.tests.np_only
     def test_sample(self):
@@ -107,5 +107,5 @@ class TestBetaMethods(geomstats.tests.TestCase):
         christoffel = self.metric.christoffels(points)
         result = christoffel.shape
         expected = gs.array(
-            [self.n_samples, self.dimension, self.dimension, self.dimension])
+            [self.n_samples, self.dim, self.dim, self.dim])
         self.assertAllClose(result, expected)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -13,8 +13,8 @@ class TestConnectionMethods(geomstats.tests.TestCase):
     def setUp(self):
         warnings.simplefilter('ignore', category=UserWarning)
 
-        self.dimension = 4
-        self.euc_metric = EuclideanMetric(dim=self.dimension)
+        self.dim = 4
+        self.euc_metric = EuclideanMetric(dim=self.dim)
 
         self.connection = Connection(dim=2)
         self.hypersphere = Hypersphere(dim=2)
@@ -23,7 +23,7 @@ class TestConnectionMethods(geomstats.tests.TestCase):
         base_point = gs.array([0., 1., 0., 0.])
 
         result = self.euc_metric.inner_product_matrix(base_point)
-        expected = gs.eye(self.dimension)
+        expected = gs.eye(self.dim)
 
         self.assertAllClose(result, expected)
 
@@ -31,7 +31,7 @@ class TestConnectionMethods(geomstats.tests.TestCase):
         base_point = gs.array([0., 1., 0., 0.])
 
         result = self.euc_metric.inner_product_inverse_matrix(base_point)
-        expected = gs.eye(self.dimension)
+        expected = gs.eye(self.dim)
 
         self.assertAllClose(result, expected)
 
@@ -40,7 +40,7 @@ class TestConnectionMethods(geomstats.tests.TestCase):
         base_point = gs.array([0., 1., 0., 0.])
 
         result = self.euc_metric.inner_product_derivative_matrix(base_point)
-        expected = gs.zeros((self.dimension, ) * 3)
+        expected = gs.zeros((self.dim,) * 3)
 
         self.assertAllClose(result, expected)
 
@@ -49,7 +49,7 @@ class TestConnectionMethods(geomstats.tests.TestCase):
         base_point = gs.array([0., 1., 0., 0.])
 
         result = self.euc_metric.christoffels(base_point)
-        expected = gs.zeros((self.dimension, ) * 3)
+        expected = gs.zeros((self.dim,) * 3)
 
         self.assertAllClose(result, expected)
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -14,10 +14,10 @@ class TestConnectionMethods(geomstats.tests.TestCase):
         warnings.simplefilter('ignore', category=UserWarning)
 
         self.dimension = 4
-        self.euc_metric = EuclideanMetric(dimension=self.dimension)
+        self.euc_metric = EuclideanMetric(dim=self.dimension)
 
-        self.connection = Connection(dimension=2)
-        self.hypersphere = Hypersphere(dimension=2)
+        self.connection = Connection(dim=2)
+        self.hypersphere = Hypersphere(dim=2)
 
     def test_metric_matrix(self):
         base_point = gs.array([0., 1., 0., 0.])

--- a/tests/test_discretized_curves.py
+++ b/tests/test_discretized_curves.py
@@ -13,7 +13,7 @@ from geomstats.geometry.hypersphere import Hypersphere
 class TestDiscretizedCurvesMethods(geomstats.tests.TestCase):
     @geomstats.tests.np_and_pytorch_only
     def setUp(self):
-        s2 = Hypersphere(dimension=2)
+        s2 = Hypersphere(dim=2)
         r3 = s2.embedding_manifold
 
         initial_point = [0., 0., 1.]

--- a/tests/test_exponential_barycenter.py
+++ b/tests/test_exponential_barycenter.py
@@ -11,9 +11,9 @@ from geomstats.learning.frechet_mean import FrechetMean
 class TestExponentialBarycenter(geomstats.tests.TestCase):
 
     def setUp(self):
-        self.se_mat = SpecialEuclidean(n=3, point_type='matrix')
-        self.so_vec = SpecialOrthogonal(n=3, point_type='vector')
-        self.so = SpecialOrthogonal(n=3, point_type='matrix')
+        self.se_mat = SpecialEuclidean(n=3, default_point_type='matrix')
+        self.so_vec = SpecialOrthogonal(n=3, default_point_type='vector')
+        self.so = SpecialOrthogonal(n=3, default_point_type='matrix')
         self.n_samples = 3
 
     @geomstats.tests.np_only
@@ -124,7 +124,9 @@ class TestExponentialBarycenter(geomstats.tests.TestCase):
         point = self.so.random_uniform(self.n_samples)
         estimator = ExponentialBarycenter(self.so, max_iter=32, epsilon=1e-12)
         estimator.fit(point)
-        so_vector = SpecialOrthogonal(3, point_type='vector')
+        result = estimator.estimate_
+        print(self.so.default_point_type)
+        so_vector = SpecialOrthogonal(3, default_point_type='vector')
         frechet_estimator = FrechetMean(
             so_vector.bi_invariant_metric, max_iter=32, epsilon=1e-10,
             point_type='vector')
@@ -132,7 +134,6 @@ class TestExponentialBarycenter(geomstats.tests.TestCase):
         frechet_estimator.fit(vector_point)
         mean = frechet_estimator.estimate_
         expected = so_vector.matrix_from_rotation_vector(mean)[0]
-        result = estimator.estimate_
         self.assertAllClose(result, expected)
 
     @geomstats.tests.np_only
@@ -155,7 +156,7 @@ class TestExponentialBarycenter(geomstats.tests.TestCase):
         self.assertAllClose(result, expected)
 
     def test_linear_mean(self):
-        se_vec = SpecialEuclidean(n=3, point_type='vector')
+        se_vec = SpecialEuclidean(n=3, default_point_type='vector')
         translations = se_vec.translations
         point = translations.random_uniform(self.n_samples)
         estimator = ExponentialBarycenter(translations)

--- a/tests/test_frechet_mean.py
+++ b/tests/test_frechet_mean.py
@@ -18,10 +18,10 @@ class TestFrechetMean(geomstats.tests.TestCase):
     _multiprocess_can_split_ = True
 
     def setUp(self):
-        self.sphere = Hypersphere(dimension=4)
-        self.hyperbolic = Hyperboloid(dimension=3)
-        self.euclidean = Euclidean(dimension=2)
-        self.minkowski = Minkowski(dimension=2)
+        self.sphere = Hypersphere(dim=4)
+        self.hyperbolic = Hyperboloid(dim=3)
+        self.euclidean = Euclidean(dim=2)
+        self.minkowski = Minkowski(dim=2)
 
     @geomstats.tests.np_only
     def test_adaptive_gradient_descent_sphere(self):

--- a/tests/test_hyperbolic.py
+++ b/tests/test_hyperbolic.py
@@ -21,9 +21,9 @@ class TestHyperbolicMethods(geomstats.tests.TestCase):
     def setUp(self):
         gs.random.seed(1234)
         self.dimension = 3
-        self.space = Hyperboloid(dimension=self.dimension)
+        self.space = Hyperboloid(dim=self.dimension)
         self.metric = self.space.metric
-        self.ball_manifold = PoincareBall(dimension=2)
+        self.ball_manifold = PoincareBall(dim=2)
         self.n_samples = 10
 
     def test_random_uniform_and_belongs(self):
@@ -139,7 +139,7 @@ class TestHyperbolicMethods(geomstats.tests.TestCase):
         dim = 5
         n_samples = self.n_samples
 
-        h5 = Hyperboloid(dimension=dim)
+        h5 = Hyperboloid(dim=dim)
         h5_metric = h5.metric
 
         base_point = h5.random_uniform()
@@ -178,7 +178,7 @@ class TestHyperbolicMethods(geomstats.tests.TestCase):
         self.assertAllClose(result, expected)
 
     def test_exp_and_belongs(self):
-        H2 = Hyperboloid(dimension=2)
+        H2 = Hyperboloid(dim=2)
         METRIC = H2.metric
 
         base_point = gs.array([1., 0., 0.])
@@ -445,8 +445,8 @@ class TestHyperbolicMethods(geomstats.tests.TestCase):
             tangent_vec_b,
             base_point)
         scale = 2
-        default_space = Hyperboloid(dimension=self.dimension)
-        scaled_space = Hyperboloid(dimension=self.dimension, scale=2)
+        default_space = Hyperboloid(dim=self.dimension)
+        scaled_space = Hyperboloid(dim=self.dimension, scale=2)
         inner_product_default_metric = \
             default_space.metric.inner_product(
                 tangent_vec_a,
@@ -470,8 +470,8 @@ class TestHyperbolicMethods(geomstats.tests.TestCase):
         tangent_vec = self.space.projection_to_tangent_space(
             tangent_vec, base_point)
         scale = 2
-        default_space = Hyperboloid(dimension=self.dimension)
-        scaled_space = Hyperboloid(dimension=self.dimension, scale=2)
+        default_space = Hyperboloid(dim=self.dimension)
+        scaled_space = Hyperboloid(dim=self.dimension, scale=2)
         squared_norm_default_metric = default_space.metric.squared_norm(
             tangent_vec, base_point)
         squared_norm_scaled_metric = scaled_space.metric.squared_norm(
@@ -487,7 +487,7 @@ class TestHyperbolicMethods(geomstats.tests.TestCase):
         point_a = self.space.from_coordinates(point_a_intrinsic, 'intrinsic')
         point_b = self.space.from_coordinates(point_b_intrinsic, 'intrinsic')
         scale = 2
-        scaled_space = Hyperboloid(dimension=self.dimension, scale=2)
+        scaled_space = Hyperboloid(dim=self.dimension, scale=2)
         distance_default_metric = self.space.metric.dist(point_a, point_b)
         distance_scaled_metric = scaled_space.metric.dist(point_a, point_b)
         result = distance_scaled_metric

--- a/tests/test_hyperbolic_coords.py
+++ b/tests/test_hyperbolic_coords.py
@@ -20,15 +20,15 @@ class TestHyperbolicMethods(geomstats.tests.TestCase):
         self.dimension = 2
 
         self.extrinsic_manifold = Hyperboloid(
-            dimension=self.dimension)
+            dim=self.dimension)
         self.extrinsic_metric = self.extrinsic_manifold.metric
 
         self.ball_manifold = PoincareBall(
-            dimension=self.dimension)
+            dim=self.dimension)
         self.ball_metric = self.ball_manifold.metric
 
         self.intrinsic_manifold = Hyperboloid(
-            dimension=self.dimension, coords_type='intrinsic')
+            dim=self.dimension, coords_type='intrinsic')
         self.intrinsic_metric = self.intrinsic_manifold.metric
 
         self.n_samples = 10

--- a/tests/test_hypersphere.py
+++ b/tests/test_hypersphere.py
@@ -16,7 +16,7 @@ class TestHypersphereMethods(geomstats.tests.TestCase):
         gs.random.seed(1234)
 
         self.dimension = 4
-        self.space = Hypersphere(dimension=self.dimension)
+        self.space = Hypersphere(dim=self.dimension)
         self.metric = self.space.metric
         self.n_samples = 10
 

--- a/tests/test_invariant_metric.py
+++ b/tests/test_invariant_metric.py
@@ -83,7 +83,7 @@ class TestInvariantMetricMethods(geomstats.tests.TestCase):
 
     @geomstats.tests.np_and_tf_only
     def test_inner_product_mat_at_identity_shape(self):
-        dim = self.left_metric.group.dimension
+        dim = self.left_metric.group.dim
 
         result = self.left_metric.inner_product_mat_at_identity
         self.assertAllClose(gs.shape(result), (dim, dim))
@@ -91,12 +91,12 @@ class TestInvariantMetricMethods(geomstats.tests.TestCase):
     @geomstats.tests.np_and_tf_only
     def test_inner_product_matrix_shape(self):
         base_point = None
-        dim = self.left_metric.group.dimension
+        dim = self.left_metric.group.dim
         result = self.left_metric.inner_product_matrix(base_point=base_point)
         self.assertAllClose(gs.shape(result), (dim, dim))
 
         base_point = self.group.identity
-        dim = self.left_metric.group.dimension
+        dim = self.left_metric.group.dim
         result = self.left_metric.inner_product_matrix(base_point=base_point)
         self.assertAllClose(gs.shape(result), (dim, dim))
 

--- a/tests/test_invariant_metric.py
+++ b/tests/test_invariant_metric.py
@@ -22,7 +22,7 @@ class TestInvariantMetricMethods(geomstats.tests.TestCase):
 
         n = 3
         group = SpecialEuclidean(n=n)
-        matrix_group = SpecialOrthogonal(n=n, point_type='matrix')
+        matrix_group = SpecialOrthogonal(n=n, default_point_type='matrix')
 
         # Diagonal left and right invariant metrics
         diag_mat_at_identity = gs.eye(group.dimension)

--- a/tests/test_knn.py
+++ b/tests/test_knn.py
@@ -16,7 +16,7 @@ class TestKNearestNeighborsClassifier(geomstats.tests.TestCase):
         gs.random.seed(1234)
         self.n_neighbors = 3
         self.dimension = 2
-        self.space = Euclidean(dimension=self.dimension)
+        self.space = Euclidean(dim=self.dimension)
         self.distance = self.space.metric.dist
 
     @geomstats.tests.np_only

--- a/tests/test_landmarks.py
+++ b/tests/test_landmarks.py
@@ -11,7 +11,7 @@ from geomstats.geometry.landmarks import Landmarks
 class TestLandmarksMethods(geomstats.tests.TestCase):
     @geomstats.tests.np_and_pytorch_only
     def setUp(self):
-        s2 = Hypersphere(dimension=2)
+        s2 = Hypersphere(dim=2)
         r3 = s2.embedding_manifold
 
         initial_point = [0., 0., 1.]

--- a/tests/test_lie_algebra.py
+++ b/tests/test_lie_algebra.py
@@ -8,19 +8,19 @@ from geomstats.geometry.skew_symmetric_matrices import SkewSymmetricMatrices
 class TestLieAlgebraMethods(geomstats.tests.TestCase):
     def setUp(self):
         self.n = 4
-        self.dimension = int(self.n * (self.n - 1) / 2)
+        self.dim = int(self.n * (self.n - 1) / 2)
         self.algebra = SkewSymmetricMatrices(n=self.n)
 
     def test_dimension(self):
         result = self.algebra.dimension
-        expected = self.dimension
+        expected = self.dim
         self.assertAllClose(result, expected)
 
     @geomstats.tests.np_only
     def test_matrix_representation_and_belongs(self):
         n_samples = 2
-        point = gs.random.rand(n_samples * self.dimension)
-        point = gs.reshape(point, (n_samples, self.dimension))
+        point = gs.random.rand(n_samples * self.dim)
+        point = gs.reshape(point, (n_samples, self.dim))
         mat = self.algebra.matrix_representation(point)
         result = self.algebra.belongs(mat).all()
         expected = True
@@ -29,8 +29,8 @@ class TestLieAlgebraMethods(geomstats.tests.TestCase):
     @geomstats.tests.np_only
     def test_basis_and_matrix_representation(self):
         n_samples = 2
-        expected = gs.random.rand(n_samples * self.dimension)
-        expected = gs.reshape(expected, (n_samples, self.dimension))
+        expected = gs.random.rand(n_samples * self.dim)
+        expected = gs.reshape(expected, (n_samples, self.dim))
         mat = self.algebra.matrix_representation(expected)
         result = self.algebra.basis_representation(mat)
         self.assertAllClose(result, expected)

--- a/tests/test_lie_algebra.py
+++ b/tests/test_lie_algebra.py
@@ -12,7 +12,7 @@ class TestLieAlgebraMethods(geomstats.tests.TestCase):
         self.algebra = SkewSymmetricMatrices(n=self.n)
 
     def test_dimension(self):
-        result = self.algebra.dimension
+        result = self.algebra.dim
         expected = self.dim
         self.assertAllClose(result, expected)
 

--- a/tests/test_lie_group.py
+++ b/tests/test_lie_group.py
@@ -6,10 +6,10 @@ from geomstats.geometry.lie_group import LieGroup
 
 class TestLieGroupMethods(geomstats.tests.TestCase):
     dimension = 4
-    group = LieGroup(dimension=dimension)
+    group = LieGroup(dim=dimension)
 
     def test_dimension(self):
-        result = self.group.dimension
+        result = self.group.dim
         expected = self.dimension
 
         self.assertAllClose(result, expected)

--- a/tests/test_manifold.py
+++ b/tests/test_manifold.py
@@ -13,7 +13,7 @@ class TestManifoldMethods(geomstats.tests.TestCase):
         self.manifold = Manifold(self.dimension)
 
     def test_dimension(self):
-        result = self.manifold.dimension
+        result = self.manifold.dim
         expected = self.dimension
         self.assertAllClose(result, expected)
 

--- a/tests/test_online_kmeans.py
+++ b/tests/test_online_kmeans.py
@@ -14,7 +14,7 @@ class TestOnlineKmeansMethods(geomstats.tests.TestCase):
         gs.random.seed(1234)
 
         self.dimension = 2
-        self.space = Hypersphere(dimension=self.dimension)
+        self.space = Hypersphere(dim=self.dimension)
         self.metric = self.space.metric
         self.data = self.space.random_von_mises_fisher(
             kappa=100, n_samples=50)

--- a/tests/test_pca.py
+++ b/tests/test_pca.py
@@ -114,7 +114,7 @@ class TestTangentPCA(geomstats.tests.TestCase):
 
     @geomstats.tests.np_only
     def test_fit_matrix_se(self):
-        se_mat = SpecialEuclidean(n=3, point_type='matrix')
+        se_mat = SpecialEuclidean(n=3, default_point_type='matrix')
         X = se_mat.random_uniform(self.n_samples)
         estimator = ExponentialBarycenter(se_mat)
         estimator.fit(X)

--- a/tests/test_poincare_polydisk.py
+++ b/tests/test_poincare_polydisk.py
@@ -20,7 +20,7 @@ class TestPoincarePolydiskMethods(geomstats.tests.TestCase):
     def test_dimension(self):
         """Test the dimension."""
         expected = self.n_disks * 2
-        result = self.space.dimension
+        result = self.space.dim
         self.assertAllClose(result, expected)
 
     def test_metric_signature(self):
@@ -35,7 +35,7 @@ class TestPoincarePolydiskMethods(geomstats.tests.TestCase):
         coords_type = 'extrinsic'
         point_a_intrinsic = gs.array([0.01, 0.0])
         point_b_intrinsic = gs.array([0.0, 0.0])
-        hyperbolic_space = Hyperboloid(dimension=2)
+        hyperbolic_space = Hyperboloid(dim=2)
         point_a = hyperbolic_space.from_coordinates(
             point_a_intrinsic, 'intrinsic')
         point_b = hyperbolic_space.from_coordinates(

--- a/tests/test_product_manifold.py
+++ b/tests/test_product_manifold.py
@@ -17,15 +17,15 @@ class TestProductManifoldMethods(geomstats.tests.TestCase):
         gs.random.seed(1234)
 
         self.space_matrix = ProductManifold(
-            manifolds=[Hypersphere(dimension=2), Hyperboloid(dimension=2)],
+            manifolds=[Hypersphere(dim=2), Hyperboloid(dim=2)],
             default_point_type='matrix')
         self.space_vector = ProductManifold(
-            manifolds=[Hypersphere(dimension=2), Hyperboloid(dimension=5)],
+            manifolds=[Hypersphere(dim=2), Hyperboloid(dim=5)],
             default_point_type='vector')
 
     def test_dimension(self):
         expected = 7
-        result = self.space_vector.dimension
+        result = self.space_vector.dim
         self.assertAllClose(result, expected)
 
     @geomstats.tests.np_and_pytorch_only

--- a/tests/test_skew_symmetric_matrices.py
+++ b/tests/test_skew_symmetric_matrices.py
@@ -23,7 +23,7 @@ class TestSkewSymmetricMatrices(geomstats.tests.TestCase):
     def test_basis_has_the_right_dimension(self):
         for n in self.n_seq:
             skew = self.skew[n]
-            self.assertEqual(int(n * (n - 1) / 2), skew.dimension)
+            self.assertEqual(int(n * (n - 1) / 2), skew.dim)
 
     def test_bch_up_to_fourth_order_works(self):
         for n in self.n_seq:

--- a/tests/test_special_euclidean.py
+++ b/tests/test_special_euclidean.py
@@ -112,7 +112,7 @@ class TestSpecialEuclideanMethods(geomstats.tests.TestCase):
             inner_product_mat_at_identity=diag_mat_at_identity,
             left_or_right='right')
 
-        # mat_at_identity = 7 * gs.eye(group.dimension)
+        # mat_at_identity = 7 * gs.eye(group.dim)
 
         # left_metric = InvariantMetric(
         #            group=group,

--- a/tests/test_special_orthogonal.py
+++ b/tests/test_special_orthogonal.py
@@ -70,7 +70,7 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
         canonical_metrics = {n: group.bi_invariant_metric
                              for n, group in so.items()}
 
-        diag_mats = {n: 9 * gs.eye(group.dimension)
+        diag_mats = {n: 9 * gs.eye(group.dim)
                      for n, group in so.items()}
         left_diag_metrics = {
             n: InvariantMetric(
@@ -219,7 +219,7 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
         for n in self.n_seq:
             group = self.so[n]
             result = group.random_uniform(point_type=point_type)
-            self.assertAllClose(gs.shape(result), (group.dimension,))
+            self.assertAllClose(gs.shape(result), (group.dim,))
 
         point_type = 'matrix'
         for n in self.n_seq:
@@ -331,7 +331,7 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
 
                 if point_type == 'vector':
                     self.assertAllClose(
-                        gs.shape(result), (n_samples, group.dimension))
+                        gs.shape(result), (n_samples, group.dim))
                 if point_type == 'matrix':
                     self.assertAllClose(
                         gs.shape(result), (n_samples, n, n))
@@ -2799,7 +2799,7 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
                 result = group.compose(one_point, n_points_a)
                 if point_type == 'vector':
                     self.assertAllClose(
-                        gs.shape(result), (n_samples, group.dimension))
+                        gs.shape(result), (n_samples, group.dim))
                 if point_type == 'matrix':
                     self.assertAllClose(
                         gs.shape(result), (n_samples, n, n))
@@ -2807,7 +2807,7 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
                 result = group.compose(n_points_a, one_point)
                 if point_type == 'vector':
                     self.assertAllClose(
-                        gs.shape(result), (n_samples, group.dimension))
+                        gs.shape(result), (n_samples, group.dim))
                 if point_type == 'matrix':
                     self.assertAllClose(
                         gs.shape(result), (n_samples, n, n))
@@ -2815,7 +2815,7 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
                 result = group.compose(n_points_a, n_points_b)
                 if point_type == 'vector':
                     self.assertAllClose(
-                        gs.shape(result), (n_samples, group.dimension))
+                        gs.shape(result), (n_samples, group.dim))
                 if point_type == 'matrix':
                     self.assertAllClose(
                         gs.shape(result), (n_samples, n, n))
@@ -2830,7 +2830,7 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
 
             if n == 3:
                 self.assertAllClose(
-                    gs.shape(result), (n_samples, group.dimension))
+                    gs.shape(result), (n_samples, group.dim))
             else:
                 self.assertAllClose(
                     gs.shape(result), (n_samples, n, n))
@@ -2866,7 +2866,7 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
                                                left_or_right='left')
         self.assertAllClose(
             gs.shape(jacobians),
-            (n_samples, group.dimension, group.dimension))
+            (n_samples, group.dim, group.dim))
 
     def test_exp(self):
         """
@@ -2923,17 +2923,17 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
             # Test with the 1 base point, and n tangent vecs
             result = metric.exp(n_tangent_vec, one_base_point)
             self.assertAllClose(
-                gs.shape(result), (n_samples, group.dimension))
+                gs.shape(result), (n_samples, group.dim))
 
             # Test with the several base point, and one tangent vec
             result = metric.exp(one_tangent_vec, n_base_point)
             self.assertAllClose(
-                gs.shape(result), (n_samples, group.dimension))
+                gs.shape(result), (n_samples, group.dim))
 
             # Test with the same number n of base point and n tangent vec
             result = metric.exp(n_tangent_vec, n_base_point)
             self.assertAllClose(
-                gs.shape(result), (n_samples, group.dimension))
+                gs.shape(result), (n_samples, group.dim))
 
     def test_log(self):
         """
@@ -2991,17 +2991,17 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
             # Test with the 1 base point, and several different points
             result = metric.log(n_point, one_base_point)
             self.assertAllClose(
-                gs.shape(result), (n_samples, group.dimension))
+                gs.shape(result), (n_samples, group.dim))
 
             # Test with the several base point, and 1 point
             result = metric.log(one_point, n_base_point)
             self.assertAllClose(
-                gs.shape(result), (n_samples, group.dimension))
+                gs.shape(result), (n_samples, group.dim))
 
             # Test with the same number n of base point and point
             result = metric.log(n_point, n_base_point)
             self.assertAllClose(
-                gs.shape(result), (n_samples, group.dimension))
+                gs.shape(result), (n_samples, group.dim))
 
     def test_exp_from_identity_vectorization(self):
         n = 3
@@ -3014,7 +3014,7 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
         result = metric.exp_from_identity(tangent_vecs)
 
         self.assertAllClose(
-            gs.shape(result), (n_samples, group.dimension))
+            gs.shape(result), (n_samples, group.dim))
 
     def test_log_from_identity_vectorization(self):
         n = 3
@@ -3027,7 +3027,7 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
         result = metric.log_from_identity(points)
 
         self.assertAllClose(
-            gs.shape(result), (n_samples, group.dimension))
+            gs.shape(result), (n_samples, group.dim))
 
     def test_exp_then_log_from_identity(self):
         """
@@ -3283,7 +3283,7 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
         result = group.exp_from_identity(tangent_vecs)
 
         self.assertAllClose(
-            gs.shape(result), (n_samples, group.dimension))
+            gs.shape(result), (n_samples, group.dim))
 
     def test_group_log_from_identity_vectorization(self):
         n = 3
@@ -3294,7 +3294,7 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
         result = group.log_from_identity(points)
 
         self.assertAllClose(
-            gs.shape(result), (n_samples, group.dimension))
+            gs.shape(result), (n_samples, group.dim))
 
     def test_group_exp_vectorization(self):
         n = 3
@@ -3307,7 +3307,7 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
         result = group.exp(tangent_vecs, base_point)
 
         self.assertAllClose(
-            gs.shape(result), (n_samples, group.dimension))
+            gs.shape(result), (n_samples, group.dim))
 
         # Test with the same number of base_points and tangent_vecs
         tangent_vecs = group.random_uniform(n_samples=n_samples)
@@ -3315,7 +3315,7 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
         result = group.exp(tangent_vecs, base_points)
 
         self.assertAllClose(
-            gs.shape(result), (n_samples, group.dimension))
+            gs.shape(result), (n_samples, group.dim))
 
         # Test with the several base_points, and 1 tangent_vec
         tangent_vec = group.random_uniform(n_samples=1)
@@ -3323,7 +3323,7 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
         result = group.exp(tangent_vec, base_points)
 
         self.assertAllClose(
-            gs.shape(result), (n_samples, group.dimension))
+            gs.shape(result), (n_samples, group.dim))
 
     def test_group_log_vectorization(self):
         n = 3
@@ -3336,7 +3336,7 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
         result = group.log(points, base_point)
 
         self.assertAllClose(
-            gs.shape(result), (n_samples, group.dimension))
+            gs.shape(result), (n_samples, group.dim))
 
         # Test with the same number of base points and points
         points = group.random_uniform(n_samples=n_samples)
@@ -3344,7 +3344,7 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
         result = group.log(points, base_points)
 
         self.assertAllClose(
-            gs.shape(result), (n_samples, group.dimension))
+            gs.shape(result), (n_samples, group.dim))
 
         # Test with the several base points, and 1 point
         point = group.random_uniform(n_samples=1)
@@ -3352,7 +3352,7 @@ class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
         result = group.log(point, base_points)
 
         self.assertAllClose(
-            gs.shape(result), (n_samples, group.dimension))
+            gs.shape(result), (n_samples, group.dim))
 
     def test_group_exp_then_log_from_identity(self):
         """

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -19,9 +19,9 @@ class TestVisualizationMethods(geomstats.tests.TestCase):
         self.n_samples = 10
         self.SO3_GROUP = SpecialOrthogonal(n=3)
         self.SE3_GROUP = SpecialEuclidean(n=3)
-        self.S1 = Hypersphere(dimension=1)
-        self.S2 = Hypersphere(dimension=2)
-        self.H2 = Hyperbolic(dimension=2)
+        self.S1 = Hypersphere(dim=1)
+        self.S2 = Hypersphere(dim=2)
+        self.H2 = Hyperbolic(dim=2)
 
         plt.figure()
 


### PR DESCRIPTION
This PR addresses issues #376 and partially #472 
In some manifolds `default_coords_type='extrinsic'` doesn't really make sense, or won't very useful. Maybe a method that returns the shape of the points would be more useful?

Let's try to merge quickly otherwise conflicts will come up everywhere!