### PR TITLE
Transformer for Frechet Mean

### DIFF
--- a/geomstats/learning/frechet_mean.py
+++ b/geomstats/learning/frechet_mean.py
@@ -388,6 +388,7 @@ class FrechetMean(BaseEstimator, TransformerMixin):
         -------
         X_new : array-like, shape=[n_samples, dim]
         """
+        # TODO(nguis): put this in a dedicated class
         if base_point is None:
             base_point = self.estimate_
 

--- a/geomstats/learning/frechet_mean.py
+++ b/geomstats/learning/frechet_mean.py
@@ -3,11 +3,14 @@
 import logging
 import math
 
-from sklearn.base import BaseEstimator
+from sklearn.base import BaseEstimator, TransformerMixin
 
 import geomstats.backend as gs
 from geomstats.geometry.euclidean import EuclideanMetric
+from geomstats.geometry.matrices import Matrices
 from geomstats.geometry.minkowski import MinkowskiMetric
+from geomstats.geometry.skew_symmetric_matrices import SkewSymmetricMatrices
+from geomstats.geometry.symmetric_matrices import SymmetricMatrices
 
 EPSILON = 1e-4
 
@@ -291,7 +294,7 @@ def _adaptive_gradient_descent(points,
     return gs.to_ndarray(current_mean, to_ndim=2)
 
 
-class FrechetMean(BaseEstimator):
+class FrechetMean(BaseEstimator, TransformerMixin):
     """Empirical Frechet mean.
 
     Parameters
@@ -302,7 +305,7 @@ class FrechetMean(BaseEstimator):
     def __init__(self, metric,
                  max_iter=32,
                  epsilon=EPSILON,
-                 point_type='vector',
+                 point_type=None,
                  method='default',
                  verbose=False):
         self.metric = metric
@@ -311,6 +314,9 @@ class FrechetMean(BaseEstimator):
         self.point_type = point_type
         self.method = method
         self.verbose = verbose
+
+        if point_type is None:
+            self.point_type = metric.default_point_type
 
     def fit(self, X, y=None, weights=None):
         """Compute the empirical Frechet mean.
@@ -355,3 +361,84 @@ class FrechetMean(BaseEstimator):
         self.estimate_ = mean
 
         return self
+
+    def transform(self, X, y=None, base_point=None):
+        """Lift data to a tangent space.
+
+        Compute the logs of all data point and reshapes them to
+        1d vectors if necessary. By default the logs are taken at the mean
+        but any other base point can be passed. Any machine learning
+        algorithm can then be used with the output array.
+
+        Parameters
+        ----------
+        X : array-like, shape=[n_samples, {dim, [n, n]}]
+            Data to transform.
+        y : Ignored (Compliance with scikit-learn interface)
+        base_point : array-like, shape={dim, [n,n]}, optional (mean)
+            Point on the manifold, the returned samples will be tangent
+            vectors at the base point.
+
+        Returns
+        -------
+        X_new : array-like, shape=[n_samples, dim]
+        """
+        if base_point is None:
+            base_point = self.estimate_
+
+        if self.estimate_ is None:
+            raise RuntimeError('fit needs to be called first or a base_point '
+                               'passed.')
+
+        tangent_vecs = self.metric.log(X, base_point=base_point)
+
+        if self.point_type == 'vector':
+            return tangent_vecs
+
+        if gs.all(Matrices.is_symmetric(tangent_vecs)):
+            X = SymmetricMatrices.vector_from_symmetric_matrix(
+                tangent_vecs)
+        elif gs.all(Matrices.is_skew_symmetric(tangent_vecs)):
+            X = SkewSymmetricMatrices.basis_representation(tangent_vecs)
+        else:
+            X = gs.reshape(tangent_vecs, (len(X), - 1))
+
+        return X
+
+    def inverse_transform(self, X, base_point=None):
+        """Reconstruction of X.
+
+        The reconstruction will match X_original whose transform would be X.
+
+        Parameters
+        ----------
+        X : array-like, shape=[n_samples, dim]
+            New data, where dim is the dimension of the manifold they belong to.
+        base_point : array-like, shape={dim, [n,n]}, optional (mean)
+            Point on the manifold, where the input samples are tangent
+            vectors.
+
+        Returns
+        -------
+        X_original : array-like, shape=[n_samples, {dim, [n, n]}
+            Data lying on the manifold.
+        """
+        if base_point is None:
+            base_point = self.estimate_
+
+        if self.estimate_ is None:
+            raise RuntimeError('fit needs to be called first or a base_point '
+                               'passed.')
+
+        if self.point_type == 'matrix':
+            if gs.all(Matrices.is_symmetric(base_point)):
+                tangent_vecs = SymmetricMatrices(
+                    base_point.shape[-1]).symmetric_matrix_from_vector(X)
+            elif gs.all(Matrices.is_skew_symmetric(base_point)):
+                tangent_vecs = SkewSymmetricMatrices.matrix_representation(X)
+            else:
+                dim = base_point.shape[-1]
+                tangent_vecs = gs.reshape(X, (len(X), dim, dim))
+        else:
+            tangent_vecs = X
+        return self.metric.exp(tangent_vecs, base_point)

--- a/geomstats/learning/frechet_mean.py
+++ b/geomstats/learning/frechet_mean.py
@@ -6,6 +6,7 @@ import math
 from sklearn.base import BaseEstimator, TransformerMixin
 
 import geomstats.backend as gs
+import geomstats.error as error
 from geomstats.geometry.euclidean import EuclideanMetric
 from geomstats.geometry.matrices import Matrices
 from geomstats.geometry.minkowski import MinkowskiMetric
@@ -308,6 +309,9 @@ class FrechetMean(BaseEstimator, TransformerMixin):
                  point_type='vector',
                  method='default',
                  verbose=False):
+        error.check_parameter_accepted_values(
+            point_type, 'point_type', ['vector', 'matrix'])
+
         self.metric = metric
         self.max_iter = max_iter
         self.epsilon = epsilon
@@ -400,7 +404,8 @@ class FrechetMean(BaseEstimator, TransformerMixin):
             X = SymmetricMatrices.vector_from_symmetric_matrix(
                 tangent_vecs)
         elif gs.all(Matrices.is_skew_symmetric(tangent_vecs)):
-            X = SkewSymmetricMatrices.basis_representation(tangent_vecs)
+            X = SkewSymmetricMatrices(
+                tangent_vecs.shape[-1]).basis_representation(tangent_vecs)
         else:
             X = gs.reshape(tangent_vecs, (len(X), - 1))
 
@@ -437,7 +442,8 @@ class FrechetMean(BaseEstimator, TransformerMixin):
                 tangent_vecs = SymmetricMatrices(
                     base_point.shape[-1]).symmetric_matrix_from_vector(X)
             elif gs.all(Matrices.is_skew_symmetric(base_point)):
-                tangent_vecs = SkewSymmetricMatrices.matrix_representation(X)
+                tangent_vecs = SkewSymmetricMatrices(
+                    base_point.shape[-1]).matrix_representation(X)
             else:
                 dim = base_point.shape[-1]
                 tangent_vecs = gs.reshape(X, (len(X), dim, dim))

--- a/geomstats/learning/frechet_mean.py
+++ b/geomstats/learning/frechet_mean.py
@@ -414,7 +414,8 @@ class FrechetMean(BaseEstimator, TransformerMixin):
         Parameters
         ----------
         X : array-like, shape=[n_samples, dim]
-            New data, where dim is the dimension of the manifold they belong to.
+            New data, where dim is the dimension of the manifold data belong
+            to.
         base_point : array-like, shape={dim, [n,n]}, optional (mean)
             Point on the manifold, where the input samples are tangent
             vectors.

--- a/geomstats/learning/frechet_mean.py
+++ b/geomstats/learning/frechet_mean.py
@@ -305,7 +305,7 @@ class FrechetMean(BaseEstimator, TransformerMixin):
     def __init__(self, metric,
                  max_iter=32,
                  epsilon=EPSILON,
-                 point_type=None,
+                 point_type='vector',
                  method='default',
                  verbose=False):
         self.metric = metric
@@ -314,6 +314,7 @@ class FrechetMean(BaseEstimator, TransformerMixin):
         self.point_type = point_type
         self.method = method
         self.verbose = verbose
+        self.estimate_ = None
 
         if point_type is None:
             self.point_type = metric.default_point_type
@@ -386,9 +387,9 @@ class FrechetMean(BaseEstimator, TransformerMixin):
         if base_point is None:
             base_point = self.estimate_
 
-        if self.estimate_ is None:
-            raise RuntimeError('fit needs to be called first or a base_point '
-                               'passed.')
+            if self.estimate_ is None:
+                raise RuntimeError('fit needs to be called first or a '
+                                   'base_point passed.')
 
         tangent_vecs = self.metric.log(X, base_point=base_point)
 
@@ -426,9 +427,9 @@ class FrechetMean(BaseEstimator, TransformerMixin):
         if base_point is None:
             base_point = self.estimate_
 
-        if self.estimate_ is None:
-            raise RuntimeError('fit needs to be called first or a base_point '
-                               'passed.')
+            if self.estimate_ is None:
+                raise RuntimeError('fit needs to be called first or a '
+                                   'base_point passed.')
 
         if self.point_type == 'matrix':
             if gs.all(Matrices.is_symmetric(base_point)):


### PR DESCRIPTION
Add `transform, fit_transform, inverse_transform` to the Frechet Mean estimator, addressing #570.
The next step will be to refactor these methods in the PCA estimator to use the ones in Frechet Mean, and do the same for exponential barycenter