### PR TITLE
Adapt split of tf and pytorch to Numpy's

### DIFF
--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -94,7 +94,7 @@ def empty(shape, dtype=float64):
 
 def split(x, indices_or_sections, axis=0):
     if isinstance(indices_or_sections, int):
-        indices_or_sections = indices_or_sections // x.shape[axis]
+        indices_or_sections = x.shape[axis] // indices_or_sections
         return torch.split(x, indices_or_sections, dim=axis)
     indices_or_sections = _np.array(indices_or_sections)
     intervals_length = indices_or_sections[1:] - indices_or_sections[:-1]
@@ -453,7 +453,7 @@ def ndim(x):
 
 def hsplit(x, indices_or_section):
     if isinstance(indices_or_section, int):
-        indices_or_section = indices_or_section // x.shape[1]
+        indices_or_section = x.shape[1] // indices_or_section
     return torch.split(x, indices_or_section, dim=1)
 
 

--- a/geomstats/_backend/tensorflow/__init__.py
+++ b/geomstats/_backend/tensorflow/__init__.py
@@ -461,6 +461,18 @@ def vectorize(x, pyfunc, multiple_args=False, dtype=None, **kwargs):
     return tf.map_fn(pyfunc, elems=x, dtype=dtype)
 
 
+def split(x, indices_or_sections, axis=0):
+    if isinstance(indices_or_sections, int):
+        return tf.split(x, indices_or_sections, dim=axis)
+    indices_or_sections = _np.array(indices_or_sections)
+    intervals_length = indices_or_sections[1:] - indices_or_sections[:-1]
+    last_interval_length = x.shape[axis] - indices_or_sections[-1]
+    if last_interval_length > 0:
+        intervals_length = _np.append(intervals_length, last_interval_length)
+    intervals_length = _np.insert(intervals_length, 0, indices_or_sections[0])
+    return tf.split(x, num_or_size_splits=tuple(intervals_length), axis=axis)
+
+
 def hsplit(x, n_splits):
     return tf.split(x, num_or_size_splits=n_splits, axis=1)
 

--- a/geomstats/_backend/tensorflow/__init__.py
+++ b/geomstats/_backend/tensorflow/__init__.py
@@ -45,7 +45,6 @@ from tensorflow import (  # NOQA
     sign,
     sin,
     sinh,
-    split,
     sqrt,
     squeeze,
     stack,

--- a/geomstats/_backend/tensorflow/__init__.py
+++ b/geomstats/_backend/tensorflow/__init__.py
@@ -38,7 +38,6 @@ from tensorflow import (  # NOQA
     reduce_max as amax,
     reduce_mean as mean,
     reduce_min as amin,
-    reduce_sum as sum,
     reshape,
     searchsorted,
     shape,
@@ -520,6 +519,12 @@ def eye(n, m=None):
     if m is None:
         m = n
     return tf.eye(num_rows=n, num_columns=m)
+
+
+def sum(x, axis=None, keepdims=False, name=None):
+    if x.dtype == bool:
+        x = cast(x, int32)
+    return tf.reduce_sum(x, axis, keepdims, name)
 
 
 def einsum(equation, *inputs, **kwargs):

--- a/geomstats/geometry/hypersphere.py
+++ b/geomstats/geometry/hypersphere.py
@@ -301,6 +301,7 @@ class Hypersphere(EmbeddedManifold):
         while True:
             norms = gs.linalg.norm(samples, axis=1)
             indcs = gs.isclose(norms, 0.0)
+            indcs = gs.cast(indcs, gs.int32)
             num_bad_samples = gs.sum(indcs)
             if num_bad_samples == 0:
                 break

--- a/geomstats/geometry/hypersphere.py
+++ b/geomstats/geometry/hypersphere.py
@@ -301,7 +301,6 @@ class Hypersphere(EmbeddedManifold):
         while True:
             norms = gs.linalg.norm(samples, axis=1)
             indcs = gs.isclose(norms, 0.0)
-            indcs = gs.cast(indcs, gs.int32)
             num_bad_samples = gs.sum(indcs)
             if num_bad_samples == 0:
                 break

--- a/tests/test_product_manifold.py
+++ b/tests/test_product_manifold.py
@@ -28,7 +28,6 @@ class TestProductManifoldMethods(geomstats.tests.TestCase):
         result = self.space_vector.dim
         self.assertAllClose(result, expected)
 
-    @geomstats.tests.np_and_pytorch_only
     def test_random_and_belongs_matrix(self):
         n_samples = 5
         data = self.space_matrix.random_uniform(n_samples)
@@ -36,7 +35,6 @@ class TestProductManifoldMethods(geomstats.tests.TestCase):
         expected = gs.array([True] * n_samples)
         self.assertAllClose(result, expected)
 
-    @geomstats.tests.np_only
     def test_random_and_belongs_vector(self):
         n_samples = 5
         data = self.space_vector.random_uniform(n_samples)


### PR DESCRIPTION
This PR adresses #567 : `split` functions are defined in Pytorch and Tensorflow to match the behavior of Numpy's one. This is done by inferring the right arguments to pass to them from the arguments that are normallygiven when using Numpy.