### PR TITLE
Adapt random in GeneralLinear and Hypersphere to work with Tensorflow

### DIFF
--- a/geomstats/_backend/numpy/__init__.py
+++ b/geomstats/_backend/numpy/__init__.py
@@ -148,7 +148,7 @@ def assignment(x, values, indices, axis=0):
     x_new = copy(x)
     if not isinstance(indices, list):
         indices = [indices]
-    if not isinstance(values, list):
+    if np.ndim(values) == 0:
         values = [values] * len(indices)
     for nb_index, index in enumerate(indices):
         if not isinstance(index, tuple):

--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -557,7 +557,8 @@ def assignment(x, values, indices, axis=0):
     single_index = not isinstance(indices, list)
     if single_index:
         indices = [indices]
-    if not isinstance(values, list):
+    values = array(values)
+    if values.dim() == 0:
         values = [values] * len(indices)
     for (nb_index, index) in enumerate(indices):
         if not isinstance(index, tuple):

--- a/geomstats/_backend/tensorflow/__init__.py
+++ b/geomstats/_backend/tensorflow/__init__.py
@@ -303,7 +303,7 @@ def assignment_by_sum(x, values, indices, axis=0):
     If a single value is provided, it is assigned at all the indices.
     If a list is given, it must have the same length as indices.
     """
-    if not isinstance(values, list):
+    if tf.rank(values) == 0:
         return _assignment_single_value_by_sum(x, values, indices, axis)
 
     if not isinstance(indices, list):
@@ -388,7 +388,7 @@ def assignment(x, values, indices, axis=0):
     If a single value is provided, it is assigned at all the indices.
     If a list is given, it must have the same length as indices.
     """
-    if not isinstance(values, list):
+    if tf.rank(values) == 0:
         return _assignment_single_value(x, values, indices, axis)
 
     if not isinstance(indices, list):
@@ -513,6 +513,12 @@ def isclose(x, y, rtol=1e-05, atol=1e-08):
 
 def allclose(x, y, rtol=1e-05, atol=1e-08):
     return tf.reduce_all(isclose(x, y, rtol=rtol, atol=atol))
+
+
+def sum(x, axis=None, keepdims=False, name=None):
+    if x.dtype == bool:
+        x = cast(x, int32)
+    return tf.reduce_sum(x, axis, keepdims, name)
 
 
 def eye(n, m=None):

--- a/geomstats/_backend/tensorflow/__init__.py
+++ b/geomstats/_backend/tensorflow/__init__.py
@@ -515,12 +515,6 @@ def allclose(x, y, rtol=1e-05, atol=1e-08):
     return tf.reduce_all(isclose(x, y, rtol=rtol, atol=atol))
 
 
-def sum(x, axis=None, keepdims=False, name=None):
-    if x.dtype == bool:
-        x = cast(x, int32)
-    return tf.reduce_sum(x, axis, keepdims, name)
-
-
 def eye(n, m=None):
     if m is None:
         m = n

--- a/geomstats/geometry/general_linear.py
+++ b/geomstats/geometry/general_linear.py
@@ -68,8 +68,7 @@ class GeneralLinear(Matrices):
             if num_bad_samples == 0:
                 break
             new_samples = gs.random.rand(num_bad_samples, self.n, self.n)
-            samples = self._replace_values(
-                samples, new_samples, indcs, num_bad_samples)
+            samples = self._replace_values(samples, new_samples, indcs)
         if n_samples == 1:
             samples = gs.squeeze(samples, axis=0)
         return samples

--- a/geomstats/geometry/general_linear.py
+++ b/geomstats/geometry/general_linear.py
@@ -1,8 +1,9 @@
 """Module exposing the GeneralLinear group class."""
 
+from itertools import product
+
 import geomstats.backend as gs
 from geomstats.geometry.matrices import Matrices
-from itertools import product
 
 
 class GeneralLinear(Matrices):

--- a/geomstats/geometry/general_linear.py
+++ b/geomstats/geometry/general_linear.py
@@ -36,7 +36,7 @@ class GeneralLinear(Matrices):
         """Return the inverse of a matrix."""
         return gs.linalg.inv(point)
 
-    def _replace_values(self, samples, new_samples, indcs, num_bad_samples):
+    def _replace_values(self, samples, new_samples, indcs):
         replaced_indices = [
             i for i, is_replaced in enumerate(indcs) if is_replaced]
         value_indices = list(

--- a/geomstats/geometry/hypersphere.py
+++ b/geomstats/geometry/hypersphere.py
@@ -283,7 +283,7 @@ class Hypersphere(EmbeddedManifold):
 
         return point_intrinsic
 
-    def _replace_values(self, samples, new_samples, indcs, num_bad_samples):
+    def _replace_values(self, samples, new_samples, indcs):
         replaced_indices = [
             i for i, is_replaced in enumerate(indcs) if is_replaced]
         value_indices = list(product(replaced_indices, range(self.dim + 1)))

--- a/geomstats/geometry/hypersphere.py
+++ b/geomstats/geometry/hypersphere.py
@@ -313,8 +313,7 @@ class Hypersphere(EmbeddedManifold):
                 break
             new_samples = gs.random.normal(
                 size=(num_bad_samples, self.dim + 1))
-            samples = self._replace_values(
-                samples, new_samples, indcs, num_bad_samples)
+            samples = self._replace_values(samples, new_samples, indcs)
 
         samples = gs.einsum('..., ...i->...i', 1 / norms, samples)
         if n_samples == 1:

--- a/geomstats/geometry/hypersphere.py
+++ b/geomstats/geometry/hypersphere.py
@@ -4,9 +4,9 @@ The n-dimensional hypersphere embedded in (n+1)-dimensional
 Euclidean space.
 """
 
-from itertools import product
 import logging
 import math
+from itertools import product
 
 import geomstats.backend as gs
 import geomstats.vectorization

--- a/tests/test_general_linear.py
+++ b/tests/test_general_linear.py
@@ -41,7 +41,7 @@ class TestGeneralLinearMethods(geomstats.tests.TestCase):
         points = gs.ones((3, 3, 3))
         new_points = gs.zeros((2, 3, 3))
         indcs = [True, False, True]
-        update = self.group._replace_values(points, new_points, indcs, 2)
+        update = self.group._replace_values(points, new_points, indcs)
         self.assertAllClose(update, gs.stack(
             [gs.zeros((3, 3)), gs.ones((3, 3)), gs.zeros((3, 3))]))
 

--- a/tests/test_general_linear.py
+++ b/tests/test_general_linear.py
@@ -24,18 +24,17 @@ class TestGeneralLinearMethods(geomstats.tests.TestCase):
         expected = gs.array([True, False])
         self.assertAllClose(result, expected)
 
-    @geomstats.tests.np_and_pytorch_only
     def test_random_and_belongs(self):
         point = self.group.random_uniform()
         result = self.group.belongs(point)
         expected = gs.array([True])
         self.assertAllClose(result, expected)
 
-    @geomstats.tests.np_and_pytorch_only
     def test_random_and_belongs_vectorization(self):
-        point = self.group.random_uniform(n_samples=3)
+        n_samples = 4
+        point = self.group.random_uniform(n_samples)
         result = self.group.belongs(point)
-        expected = gs.array([True, True, True])
+        expected = gs.array([True] * n_samples)
         self.assertAllClose(result, expected)
 
     def test_compose(self):

--- a/tests/test_general_linear.py
+++ b/tests/test_general_linear.py
@@ -37,6 +37,14 @@ class TestGeneralLinearMethods(geomstats.tests.TestCase):
         expected = gs.array([True] * n_samples)
         self.assertAllClose(result, expected)
 
+    def test_replace_values(self):
+        points = gs.ones((3, 3, 3))
+        new_points = gs.zeros((2, 3, 3))
+        indcs = [True, False, True]
+        update = self.group._replace_values(points, new_points, indcs, 2)
+        self.assertAllClose(update, gs.stack(
+            [gs.zeros((3, 3)), gs.ones((3, 3)), gs.zeros((3, 3))]))
+
     def test_compose(self):
         mat1 = gs.array([
             [1., 0.],

--- a/tests/test_hypersphere.py
+++ b/tests/test_hypersphere.py
@@ -27,17 +27,25 @@ class TestHypersphereMethods(geomstats.tests.TestCase):
         on the hypersphere space.
         """
         n_samples = self.n_samples
-        point = self.space.random_uniform(n_samples)
+        point = self.space.random_uniform(n_samples, 1.)
         result = self.space.belongs(point)
         expected = gs.array([True] * n_samples)
 
         self.assertAllClose(expected, result)
 
-    @geomstats.tests.np_and_pytorch_only
+    # @geomstats.tests.np_and_pytorch_only
     def test_random_uniform(self):
         point = self.space.random_uniform()
 
         self.assertAllClose(gs.shape(point), (self.dimension + 1,))
+
+    def test_replace_values(self):
+        points = gs.ones((3, 5))
+        new_points = gs.zeros((2, 5))
+        indcs = [True, False, True]
+        update = self.space._replace_values(points, new_points, indcs, 2)
+        self.assertAllClose(update, gs.stack(
+            [gs.zeros(5), gs.ones(5), gs.zeros(5)]))
 
     def test_projection_and_belongs(self):
         point = gs.array([1., 2., 3., 4., 5.])

--- a/tests/test_hypersphere.py
+++ b/tests/test_hypersphere.py
@@ -41,7 +41,7 @@ class TestHypersphereMethods(geomstats.tests.TestCase):
         points = gs.ones((3, 5))
         new_points = gs.zeros((2, 5))
         indcs = [True, False, True]
-        update = self.space._replace_values(points, new_points, indcs, 2)
+        update = self.space._replace_values(points, new_points, indcs)
         self.assertAllClose(update, gs.stack(
             [gs.zeros(5), gs.ones(5), gs.zeros(5)]))
 

--- a/tests/test_hypersphere.py
+++ b/tests/test_hypersphere.py
@@ -20,7 +20,7 @@ class TestHypersphereMethods(geomstats.tests.TestCase):
         self.metric = self.space.metric
         self.n_samples = 10
 
-    @geomstats.tests.np_and_pytorch_only
+    # @geomstats.tests.np_and_pytorch_only
     def test_random_uniform_and_belongs(self):
         """
         Test that the random uniform method samples

--- a/tests/test_hypersphere.py
+++ b/tests/test_hypersphere.py
@@ -20,7 +20,6 @@ class TestHypersphereMethods(geomstats.tests.TestCase):
         self.metric = self.space.metric
         self.n_samples = 10
 
-    # @geomstats.tests.np_and_pytorch_only
     def test_random_uniform_and_belongs(self):
         """
         Test that the random uniform method samples
@@ -33,7 +32,6 @@ class TestHypersphereMethods(geomstats.tests.TestCase):
 
         self.assertAllClose(expected, result)
 
-    # @geomstats.tests.np_and_pytorch_only
     def test_random_uniform(self):
         point = self.space.random_uniform()
 


### PR DESCRIPTION
This PR adapts the code for limit cases in sampling for GeneralLinear and Hypersphere (i.e., when determinants or norms are too low respectively) to work with Tensorflow. It uses the `assignment` backend function. This might be quite slow, but since it is a fairly rare case it should be fine.

The piece of code used for replacement is factored in an internal function, to be able to test it without resorting to extensive random seed trials.