### PR TITLE
Force version of autograd 1.3 (latest) in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-autograd
+autograd==1.3
 joblib==0.14.1
 matplotlib
 numpy>=1.18.1


### PR DESCRIPTION
Testing `tests/test_beta_distributions.py` was failing on my local with a previous version of autograd.