### PR TITLE
Bring back the table of contents in docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,3 +44,13 @@ enabling GPU acceleration.
 
 To learn how to use `geomstats`, visit the page :ref:`first_steps`.
 To contribute to `geomstats` visit the page :ref:`contributing`.
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Getting Started
+
+   index.rst
+   first-steps.rst
+   api-reference.rst
+   examples.rst
+   contributing.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -50,6 +50,6 @@ To contribute to `geomstats` visit the page :ref:`contributing`.
 
    index.rst
    first-steps.rst
-   api-reference.rst
    examples.rst
+   api-reference.rst
    contributing.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,8 +39,7 @@ The code is object-oriented and classes inherit from
 scikit-learn's base classes and mixins.
 
 In both modules, the operations are vectorized for batch computation and provide
-support for different execution backends---namely NumPy, PyTorch, and TensorFlow---
-enabling GPU acceleration.
+support for different execution backends---namely NumPy, PyTorch, and TensorFlow.
 
 To learn how to use `geomstats`, visit the page :ref:`first_steps`.
 To contribute to `geomstats` visit the page :ref:`contributing`.

--- a/tests/test_invariant_metric.py
+++ b/tests/test_invariant_metric.py
@@ -2,6 +2,7 @@
 Unit tests for the invariant metrics on Lie groups.
 """
 
+import logging
 import warnings
 
 import tests.helper as helper
@@ -16,6 +17,9 @@ from geomstats.geometry.special_orthogonal import SpecialOrthogonal
 
 class TestInvariantMetricMethods(geomstats.tests.TestCase):
     def setUp(self):
+        requests_logger = logging.getLogger()
+        requests_logger.setLevel(logging.DEBUG)
+
         warnings.simplefilter('ignore', category=ImportWarning)
 
         gs.random.seed(1234)


### PR DESCRIPTION
Last PR made the table of contents disappear from the doc website. This PR fixes it.