### PR TITLE
Address issue #399 by removing gs.where in GL.belongs

### DIFF
--- a/geomstats/geometry/general_linear.py
+++ b/geomstats/geometry/general_linear.py
@@ -18,8 +18,8 @@ class GeneralLinear(Matrices):
         _, mat_dim_1, mat_dim_2 = point.shape
         det = gs.linalg.det(point)
         return gs.logical_and(
-            mat_dim_1 == self.n and mat_dim_2 == self.n, gs.where(
-                det != 0., gs.array(True), gs.array(False)))
+            mat_dim_1 == self.n and mat_dim_2 == self.n,
+            det != 0.)
 
     def identity(self):
         """Return the identity matrix."""

--- a/geomstats/geometry/general_linear.py
+++ b/geomstats/geometry/general_linear.py
@@ -14,8 +14,8 @@ class GeneralLinear(Matrices):
 
     def belongs(self, point):
         """Test if a matrix is invertible and of the right size."""
-        point = gs.to_ndarray(point, to_ndim=3)
-        _, mat_dim_1, mat_dim_2 = point.shape
+        point_shape = point.shape
+        mat_dim_1, mat_dim_2 = point_shape[-2], point_shape[-1]
         det = gs.linalg.det(point)
         return gs.logical_and(
             mat_dim_1 == self.n and mat_dim_2 == self.n,

--- a/tests/test_general_linear.py
+++ b/tests/test_general_linear.py
@@ -18,6 +18,15 @@ class TestGeneralLinearMethods(geomstats.tests.TestCase):
 
         warnings.simplefilter('ignore', category=ImportWarning)
 
+    def test_belongs_shape(self):
+        mat = gs.eye(3)
+        result = self.group.belongs(mat)
+        self.assertAllClose(gs.shape(result), ())
+
+        mat = gs.ones((3, 3))
+        result = self.group.belongs(mat)
+        self.assertAllClose(gs.shape(result), ())
+
     def test_belongs(self):
         mat = gs.eye(3)
         result = self.group.belongs(mat)
@@ -28,6 +37,11 @@ class TestGeneralLinearMethods(geomstats.tests.TestCase):
         result = self.group.belongs(mat)
         expected = False
         self.assertAllClose(result, expected)
+
+    def test_belongs_vectorization_shape(self):
+        mats = gs.array([gs.eye(3), gs.ones((3, 3))])
+        result = self.group.belongs(mats)
+        self.assertAllClose(gs.shape(result), (2,))
 
     def test_belongs_vectorization(self):
         mats = gs.array([gs.eye(3), gs.ones((3, 3))])

--- a/tests/test_general_linear.py
+++ b/tests/test_general_linear.py
@@ -19,6 +19,17 @@ class TestGeneralLinearMethods(geomstats.tests.TestCase):
         warnings.simplefilter('ignore', category=ImportWarning)
 
     def test_belongs(self):
+        mat = gs.eye(3)
+        result = self.group.belongs(mat)
+        expected = True
+        self.assertAllClose(result, expected)
+
+        mat = gs.ones((3, 3))
+        result = self.group.belongs(mat)
+        expected = False
+        self.assertAllClose(result, expected)
+
+    def test_belongs_vectorization(self):
         mats = gs.array([gs.eye(3), gs.ones((3, 3))])
         result = self.group.belongs(mats)
         expected = gs.array([True, False])


### PR DESCRIPTION
This addresses issue #399 about the use of `gs.where`.