### PR TITLE
Rename tests' classes: remove `Method`

### DIFF
--- a/geomstats/geometry/special_orthogonal.py
+++ b/geomstats/geometry/special_orthogonal.py
@@ -774,7 +774,7 @@ class SpecialOrthogonal(LieGroup, EmbeddedManifold):
             rot_mat_i = gs.transpose(
                 gs.hstack([column_1, column_2, column_3]))
             rot_mat_i = gs.to_ndarray(rot_mat_i, to_ndim=3)
-            rot_mat += gs.einsum('n,nij->nij', mask_i, rot_mat_i)
+            rot_mat += gs.einsum('...,...ij->...ij', mask_i, rot_mat_i)
 
         return rot_mat
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ matplotlib
 numpy>=1.18.1
 scikit-learn>=0.22.1
 scipy>=1.4.1
-tensorflow==2.0.1; python_version < '3.8'
+tensorflow==2.1.0; python_version < '3.8'
 torch==1.4.0

--- a/tests/test_beta_distributions.py
+++ b/tests/test_beta_distributions.py
@@ -8,7 +8,7 @@ from geomstats.geometry.beta_distributions import BetaDistributions
 from geomstats.geometry.beta_distributions import BetaMetric
 
 
-class TestBetaMethods(geomstats.tests.TestCase):
+class TestBetaDistributions(geomstats.tests.TestCase):
     def setUp(self):
         warnings.simplefilter('ignore', category=UserWarning)
         self.beta = BetaDistributions()

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -9,7 +9,7 @@ from geomstats.geometry.euclidean import EuclideanMetric
 from geomstats.geometry.hypersphere import Hypersphere
 
 
-class TestConnectionMethods(geomstats.tests.TestCase):
+class TestConnection(geomstats.tests.TestCase):
     def setUp(self):
         warnings.simplefilter('ignore', category=UserWarning)
 

--- a/tests/test_discretized_curves.py
+++ b/tests/test_discretized_curves.py
@@ -10,7 +10,7 @@ from geomstats.geometry.discretized_curves import DiscretizedCurves
 from geomstats.geometry.hypersphere import Hypersphere
 
 
-class TestDiscretizedCurvesMethods(geomstats.tests.TestCase):
+class TestDiscretizedCurves(geomstats.tests.TestCase):
     @geomstats.tests.np_and_pytorch_only
     def setUp(self):
         s2 = Hypersphere(dim=2)

--- a/tests/test_euclidean.py
+++ b/tests/test_euclidean.py
@@ -7,7 +7,7 @@ import geomstats.tests
 from geomstats.geometry.euclidean import Euclidean
 
 
-class TestEuclideanMethods(geomstats.tests.TestCase):
+class TestEuclidean(geomstats.tests.TestCase):
     def setUp(self):
         gs.random.seed(1234)
 

--- a/tests/test_general_linear.py
+++ b/tests/test_general_linear.py
@@ -9,7 +9,7 @@ from geomstats.geometry.general_linear import GeneralLinear
 RTOL = 1e-5
 
 
-class TestGeneralLinearMethods(geomstats.tests.TestCase):
+class TestGeneralLinear(geomstats.tests.TestCase):
     def setUp(self):
         gs.random.seed(1234)
         self.n = 3

--- a/tests/test_grassmannian.py
+++ b/tests/test_grassmannian.py
@@ -32,7 +32,7 @@ pi_2 = gs.pi / 2
 pi_4 = gs.pi / 4
 
 
-class TestGrassmannianMethods(geomstats.tests.TestCase):
+class TestGrassmannian(geomstats.tests.TestCase):
     def setUp(self):
         gs.random.seed(1234)
 

--- a/tests/test_hyperbolic.py
+++ b/tests/test_hyperbolic.py
@@ -17,7 +17,7 @@ from geomstats.geometry.poincare_ball import PoincareBall
 RTOL = 1e-6
 
 
-class TestHyperbolicMethods(geomstats.tests.TestCase):
+class TestHyperbolic(geomstats.tests.TestCase):
     def setUp(self):
         gs.random.seed(1234)
         self.dimension = 3

--- a/tests/test_hyperbolic_coords.py
+++ b/tests/test_hyperbolic_coords.py
@@ -14,7 +14,7 @@ from geomstats.geometry.hyperboloid import Hyperboloid
 from geomstats.geometry.poincare_ball import PoincareBall
 
 
-class TestHyperbolicMethods(geomstats.tests.TestCase):
+class TestHyperbolicCoords(geomstats.tests.TestCase):
     def setUp(self):
         gs.random.seed(1234)
         self.dimension = 2

--- a/tests/test_hypersphere.py
+++ b/tests/test_hypersphere.py
@@ -11,7 +11,7 @@ KAPPA_ESTIMATION_TOL = 1e-2
 ONLINE_KMEANS_TOL = 2e-2
 
 
-class TestHypersphereMethods(geomstats.tests.TestCase):
+class TestHypersphere(geomstats.tests.TestCase):
     def setUp(self):
         gs.random.seed(1234)
 

--- a/tests/test_invariant_metric.py
+++ b/tests/test_invariant_metric.py
@@ -15,7 +15,7 @@ from geomstats.geometry.special_euclidean import SpecialEuclidean
 from geomstats.geometry.special_orthogonal import SpecialOrthogonal
 
 
-class TestInvariantMetricMethods(geomstats.tests.TestCase):
+class TestInvariantMetric(geomstats.tests.TestCase):
     def setUp(self):
         logger = logging.getLogger()
         logger.disabled = True

--- a/tests/test_landmarks.py
+++ b/tests/test_landmarks.py
@@ -8,7 +8,7 @@ from geomstats.geometry.hypersphere import Hypersphere
 from geomstats.geometry.landmarks import Landmarks
 
 
-class TestLandmarksMethods(geomstats.tests.TestCase):
+class TestLandmarks(geomstats.tests.TestCase):
     @geomstats.tests.np_and_pytorch_only
     def setUp(self):
         s2 = Hypersphere(dim=2)

--- a/tests/test_lie_algebra.py
+++ b/tests/test_lie_algebra.py
@@ -5,7 +5,7 @@ import geomstats.tests
 from geomstats.geometry.skew_symmetric_matrices import SkewSymmetricMatrices
 
 
-class TestLieAlgebraMethods(geomstats.tests.TestCase):
+class TestLieAlgebra(geomstats.tests.TestCase):
     def setUp(self):
         self.n = 4
         self.dim = int(self.n * (self.n - 1) / 2)

--- a/tests/test_lie_group.py
+++ b/tests/test_lie_group.py
@@ -4,7 +4,7 @@ import geomstats.tests
 from geomstats.geometry.lie_group import LieGroup
 
 
-class TestLieGroupMethods(geomstats.tests.TestCase):
+class TestLieGroup(geomstats.tests.TestCase):
     dimension = 4
     group = LieGroup(dim=dimension)
 

--- a/tests/test_load_graph.py
+++ b/tests/test_load_graph.py
@@ -4,7 +4,7 @@ import geomstats.tests
 from geomstats.datasets.graph_data_preparation import Graph
 
 
-class TestLoadDefaultGraph(geomstats.tests.TestCase):
+class TestLoadGraph(geomstats.tests.TestCase):
     """Test for loading graph-structured data."""
 
     @geomstats.tests.np_only

--- a/tests/test_manifold.py
+++ b/tests/test_manifold.py
@@ -7,7 +7,7 @@ import geomstats.tests
 from geomstats.geometry.manifold import Manifold
 
 
-class TestManifoldMethods(geomstats.tests.TestCase):
+class TestManifold(geomstats.tests.TestCase):
     def setUp(self):
         self.dimension = 4
         self.manifold = Manifold(self.dimension)

--- a/tests/test_matrices.py
+++ b/tests/test_matrices.py
@@ -7,7 +7,7 @@ import geomstats.tests
 from geomstats.geometry.matrices import Matrices
 
 
-class TestMatricesMethods(geomstats.tests.TestCase):
+class TestMatrices(geomstats.tests.TestCase):
     def setUp(self):
         gs.random.seed(1234)
 

--- a/tests/test_minkowski.py
+++ b/tests/test_minkowski.py
@@ -10,7 +10,7 @@ import geomstats.tests
 from geomstats.geometry.minkowski import Minkowski
 
 
-class TestMinkowskiMethods(geomstats.tests.TestCase):
+class TestMinkowski(geomstats.tests.TestCase):
     def setUp(self):
         gs.random.seed(1234)
 

--- a/tests/test_online_kmeans.py
+++ b/tests/test_online_kmeans.py
@@ -9,7 +9,7 @@ from geomstats.learning.online_kmeans import OnlineKMeans
 TOLERANCE = 1e-3
 
 
-class TestOnlineKmeansMethods(geomstats.tests.TestCase):
+class TestOnlineKmeans(geomstats.tests.TestCase):
     def setUp(self):
         gs.random.seed(1234)
 

--- a/tests/test_poincare_ball.py
+++ b/tests/test_poincare_ball.py
@@ -15,7 +15,7 @@ from geomstats.geometry.hyperboloid import Hyperboloid
 from geomstats.geometry.poincare_ball import PoincareBall
 
 
-class TestPoincareBallMethods(geomstats.tests.TestCase):
+class TestPoincareBall(geomstats.tests.TestCase):
     def setUp(self):
         self.manifold = PoincareBall(2)
         self.metric = self.manifold.metric

--- a/tests/test_poincare_polydisk.py
+++ b/tests/test_poincare_polydisk.py
@@ -7,7 +7,7 @@ from geomstats.geometry.hyperboloid import Hyperboloid
 from geomstats.geometry.poincare_polydisk import PoincarePolydisk
 
 
-class TestPoincarePolydiskMethods(geomstats.tests.TestCase):
+class TestPoincarePolydisk(geomstats.tests.TestCase):
     """Class defining the Poincare polydisk tests."""
 
     def setUp(self):

--- a/tests/test_product_manifold.py
+++ b/tests/test_product_manifold.py
@@ -12,7 +12,7 @@ from geomstats.geometry.minkowski import Minkowski
 from geomstats.geometry.product_manifold import ProductManifold
 
 
-class TestProductManifoldMethods(geomstats.tests.TestCase):
+class TestProductManifold(geomstats.tests.TestCase):
     def setUp(self):
         gs.random.seed(1234)
 

--- a/tests/test_riemannian_kmeans.py
+++ b/tests/test_riemannian_kmeans.py
@@ -8,7 +8,7 @@ from geomstats.learning.frechet_mean import FrechetMean
 from geomstats.learning.kmeans import RiemannianKMeans
 
 
-class TestRiemannianKMeansMethods(geomstats.tests.TestCase):
+class TestRiemannianKMeans(geomstats.tests.TestCase):
     _multiprocess_can_split_ = True
 
     @geomstats.tests.np_and_pytorch_only

--- a/tests/test_spd_matrices.py
+++ b/tests/test_spd_matrices.py
@@ -14,7 +14,7 @@ from geomstats.geometry.spd_matrices import (
 )
 
 
-class TestSPDMatricesMethods(geomstats.tests.TestCase):
+class TestSPDMatrices(geomstats.tests.TestCase):
     """Test of SPDMatrices methods."""
 
     def setUp(self):

--- a/tests/test_special_euclidean.py
+++ b/tests/test_special_euclidean.py
@@ -26,7 +26,7 @@ RTOL = 1e-5
 # TODO(nina): Speed up tf tests
 
 
-class TestSpecialEuclideanMethods(geomstats.tests.TestCase):
+class TestSpecialEuclidean(geomstats.tests.TestCase):
     def setUp(self):
         warnings.simplefilter('ignore', category=ImportWarning)
         gs.random.seed(1234)

--- a/tests/test_special_orthogonal.py
+++ b/tests/test_special_orthogonal.py
@@ -19,7 +19,7 @@ ATOL = 1e-5
 # TODO(nina): Speed up tf tests
 
 
-class TestSpecialOrthogonalMethods(geomstats.tests.TestCase):
+class TestSpecialOrthogonal(geomstats.tests.TestCase):
     def setUp(self):
         warnings.simplefilter('ignore', category=ImportWarning)
         warnings.simplefilter('ignore', category=UserWarning)

--- a/tests/test_stiefel.py
+++ b/tests/test_stiefel.py
@@ -17,7 +17,7 @@ r_z = gs.array([[0., -1., 0.], [1., 0., 0.], [0., 0., 0.]])
 point1 = gs.array([[1., 0.], [0., 1.], [0., 0.]])
 
 
-class TestStiefelMethods(geomstats.tests.TestCase):
+class TestStiefel(geomstats.tests.TestCase):
     def setUp(self):
         """
         Tangent vectors constructed following:

--- a/tests/test_symmetric_matrices.py
+++ b/tests/test_symmetric_matrices.py
@@ -8,7 +8,7 @@ import geomstats.tests
 from geomstats.geometry.symmetric_matrices import SymmetricMatrices
 
 
-class TestSymmetricMatricesMethods(geomstats.tests.TestCase):
+class TestSymmetricMatrices(geomstats.tests.TestCase):
     """Test of SymmetricMatrices methods."""
 
     def setUp(self):

--- a/tests/test_vectorization.py
+++ b/tests/test_vectorization.py
@@ -7,7 +7,7 @@ import geomstats.tests
 import geomstats.vectorization
 
 
-class TestVectorizationMethods(geomstats.tests.TestCase):
+class TestVectorization(geomstats.tests.TestCase):
     def setUp(self):
 
         class Obj:

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -14,7 +14,7 @@ from geomstats.geometry.special_euclidean import SpecialEuclidean
 from geomstats.geometry.special_orthogonal import SpecialOrthogonal
 
 
-class TestVisualizationMethods(geomstats.tests.TestCase):
+class TestVisualization(geomstats.tests.TestCase):
     def setUp(self):
         self.n_samples = 10
         self.SO3_GROUP = SpecialOrthogonal(n=3)


### PR DESCRIPTION
This PR follows PR #604. 

It renames the test classes so that they have a consistent naming. It particular, it removes the suffix `Methods` from many classes' names.