### PR TITLE
Move commits of old PR #593 on assignment to a new one post-rebase

### DIFF
--- a/geomstats/_backend/numpy/__init__.py
+++ b/geomstats/_backend/numpy/__init__.py
@@ -118,6 +118,24 @@ def get_mask_i_float(i, n):
     return mask_i_float
 
 
+def _is_boolean(x):
+    if isinstance(x, bool):
+        return True
+    if isinstance(x, (tuple, list)):
+        return _is_boolean(x[0])
+    if isinstance(x, np.ndarray):
+        return x.dtype == bool
+    return False
+
+
+def _is_iterable(x):
+    if isinstance(x, (list, tuple)):
+        return True
+    if isinstance(x, np.ndarray):
+        return ndim(x) > 0
+    return False
+
+
 def assignment(x, values, indices, axis=0):
     """Assign values at given indices of an array.
 
@@ -146,19 +164,20 @@ def assignment(x, values, indices, axis=0):
     If a list is given, it must have the same length as indices.
     """
     x_new = copy(x)
-    if not isinstance(indices, list):
-        indices = [indices]
-    if not isinstance(values, list):
-        values = [values] * len(indices)
-    for nb_index, index in enumerate(indices):
-        if not isinstance(index, tuple):
-            index = (index,)
-        if len(index) < len(shape(x)):
-            for n_axis in range(shape(x)[axis]):
-                extended_index = index[:axis] + (n_axis,) + index[axis:]
-                x_new[extended_index] = values[nb_index]
-        else:
-            x_new[index] = values[nb_index]
+
+    use_vectorization = hasattr(indices, '__len__') and len(indices) < ndim(x)
+    if _is_boolean(x):
+        x_new[indices] = values
+        return x_new
+    zip_indices = _is_iterable(indices) and _is_iterable(indices[0])
+    if zip_indices:
+        indices = tuple(zip(*indices))
+    if not use_vectorization:
+        x_new[indices] = values
+    else:
+        indices = tuple(
+            list(indices[:axis]) + [slice(None)] + list(indices[axis:]))
+        x_new[indices] = values
     return x_new
 
 
@@ -190,19 +209,20 @@ def assignment_by_sum(x, values, indices, axis=0):
     If a list is given, it must have the same length as indices.
     """
     x_new = copy(x)
-    if not isinstance(indices, list):
-        indices = [indices]
-    if not isinstance(values, list):
-        values = [values] * len(indices)
-    for nb_index, index in enumerate(indices):
-        if not isinstance(index, tuple):
-            index = (index,)
-        if len(index) < len(shape(x)):
-            for n_axis in range(shape(x)[axis]):
-                extended_index = index[:axis] + (n_axis,) + index[axis:]
-                x_new[extended_index] += values[nb_index]
-        else:
-            x_new[index] += values[nb_index]
+
+    use_vectorization = hasattr(indices, '__len__') and len(indices) < ndim(x)
+    if _is_boolean(x):
+        x_new[indices] = values
+        return x_new
+    zip_indices = _is_iterable(indices) and _is_iterable(indices[0])
+    if zip_indices:
+        indices = tuple(zip(*indices))
+    if not use_vectorization:
+        x_new[indices] += values
+    else:
+        indices = tuple(
+            list(indices[:axis]) + [slice(None)] + list(indices[axis:]))
+        x_new[indices] += values
     return x_new
 
 

--- a/geomstats/_backend/numpy/__init__.py
+++ b/geomstats/_backend/numpy/__init__.py
@@ -166,7 +166,7 @@ def assignment(x, values, indices, axis=0):
     x_new = copy(x)
 
     use_vectorization = hasattr(indices, '__len__') and len(indices) < ndim(x)
-    if _is_boolean(x):
+    if _is_boolean(indices):
         x_new[indices] = values
         return x_new
     zip_indices = _is_iterable(indices) and _is_iterable(indices[0])
@@ -211,7 +211,7 @@ def assignment_by_sum(x, values, indices, axis=0):
     x_new = copy(x)
 
     use_vectorization = hasattr(indices, '__len__') and len(indices) < ndim(x)
-    if _is_boolean(x):
+    if _is_boolean(indices):
         x_new[indices] = values
         return x_new
     zip_indices = _is_iterable(indices) and _is_iterable(indices[0])

--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -526,6 +526,24 @@ def get_mask_i_float(i, n):
     return mask_i_float
 
 
+def _is_boolean(x):
+    if isinstance(x, bool):
+        return True
+    if isinstance(x, (tuple, list)):
+        return _is_boolean(x[0])
+    if torch.is_tensor(x):
+        return x.dtype in [torch.bool, torch.uint8]
+    return False
+
+
+def _is_iterable(x):
+    if isinstance(x, (list, tuple)):
+        return True
+    if torch.is_tensor(x):
+        return ndim(x) > 0
+    return False
+
+
 def assignment(x, values, indices, axis=0):
     """Assign values at given indices of an array.
 
@@ -554,20 +572,20 @@ def assignment(x, values, indices, axis=0):
     If a list is given, it must have the same length as indices.
     """
     x_new = copy(x)
-    single_index = not isinstance(indices, list)
-    if single_index:
-        indices = [indices]
-    if not isinstance(values, list):
-        values = [values] * len(indices)
-    for (nb_index, index) in enumerate(indices):
-        if not isinstance(index, tuple):
-            index = (index,)
-        if len(index) < len(shape(x)):
-            for n_axis in range(shape(x)[axis]):
-                extended_index = index[:axis] + (n_axis,) + index[axis:]
-                x_new[extended_index] = values[nb_index]
-        else:
-            x_new[index] = values[nb_index]
+
+    use_vectorization = hasattr(indices, '__len__') and len(indices) < ndim(x)
+    if _is_boolean(x):
+        x_new[indices] = values
+        return x_new
+    zip_indices = _is_iterable(indices) and _is_iterable(indices[0])
+    if zip_indices:
+        indices = tuple(zip(*indices))
+    if not use_vectorization:
+        x_new[indices] = values
+    else:
+        indices = tuple(
+            list(indices[:axis]) + [slice(None)] + list(indices[axis:]))
+        x_new[indices] = values
     return x_new
 
 
@@ -599,20 +617,20 @@ def assignment_by_sum(x, values, indices, axis=0):
     If a list is given, it must have the same length as indices.
     """
     x_new = copy(x)
-    single_index = not isinstance(indices, list)
-    if single_index:
-        indices = [indices]
-    if not isinstance(values, list):
-        values = [values] * len(indices)
-    for (nb_index, index) in enumerate(indices):
-        if not isinstance(index, tuple):
-            index = (index,)
-        if len(index) < len(shape(x)):
-            for n_axis in range(shape(x)[axis]):
-                extended_index = index[:axis] + (n_axis,) + index[axis:]
-                x_new[extended_index] += values[nb_index]
-        else:
-            x_new[index] += values[nb_index]
+
+    use_vectorization = hasattr(indices, '__len__') and len(indices) < ndim(x)
+    if _is_boolean(x):
+        x_new[indices] = values
+        return x_new
+    zip_indices = _is_iterable(indices) and _is_iterable(indices[0])
+    if zip_indices:
+        indices = list(zip(*indices))
+    if not use_vectorization:
+        x_new[indices] += values
+    else:
+        indices = tuple(
+            list(indices[:axis]) + [slice(None)] + list(indices[axis:]))
+        x_new[indices] += values
     return x_new
 
 

--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -574,7 +574,7 @@ def assignment(x, values, indices, axis=0):
     x_new = copy(x)
 
     use_vectorization = hasattr(indices, '__len__') and len(indices) < ndim(x)
-    if _is_boolean(x):
+    if _is_boolean(indices):
         x_new[indices] = values
         return x_new
     zip_indices = _is_iterable(indices) and _is_iterable(indices[0])
@@ -619,7 +619,7 @@ def assignment_by_sum(x, values, indices, axis=0):
     x_new = copy(x)
 
     use_vectorization = hasattr(indices, '__len__') and len(indices) < ndim(x)
-    if _is_boolean(x):
+    if _is_boolean(indices):
         x_new[indices] = values
         return x_new
     zip_indices = _is_iterable(indices) and _is_iterable(indices[0])

--- a/geomstats/_backend/tensorflow/__init__.py
+++ b/geomstats/_backend/tensorflow/__init__.py
@@ -134,6 +134,16 @@ def any(x, axis=None):
     return tf.math.reduce_any(tf.cast(x, bool), axis=axis)
 
 
+def _is_boolean(x):
+    if isinstance(x, bool):
+        return True
+    if isinstance(x, (tuple, list)):
+        return isinstance(x[0], bool)
+    if tf.is_tensor(x):
+        return x.dtype == bool
+    return False
+
+
 def get_mask_i_float(i, n):
     """Create a 1D array of zeros with one element at one, with floating type.
 
@@ -258,10 +268,18 @@ def _assignment_single_value_by_sum(x, value, indices, axis=0):
         Copy of x where value was added at all indices (and possibly along
         an axis).
     """
+    if _is_boolean(indices):
+        indices = [index for index, val in enumerate(indices) if val]
+
     single_index = not isinstance(indices, list)
+    if tf.is_tensor(indices):
+        single_index = ndim(indices) <= 1 and sum(indices.shape) <= ndim(x)
     if single_index:
         indices = [indices]
+
     if isinstance(indices[0], tuple):
+        use_vectorization = (len(indices[0]) < ndim(x))
+    elif tf.is_tensor(indices[0]) and ndim(indices[0]) >= 1:
         use_vectorization = (len(indices[0]) < ndim(x))
     else:
         use_vectorization = ndim(x) > 1
@@ -303,10 +321,16 @@ def assignment_by_sum(x, values, indices, axis=0):
     If a single value is provided, it is assigned at all the indices.
     If a list is given, it must have the same length as indices.
     """
-    if not isinstance(values, list):
+    if _is_boolean(indices):
+        indices = [index for index, val in enumerate(indices) if val]
+
+    if tf.rank(values) == 0:
         return _assignment_single_value_by_sum(x, values, indices, axis)
 
-    if not isinstance(indices, list):
+    single_index = not isinstance(indices, list)
+    if tf.is_tensor(indices):
+        single_index = ndim(indices) <= 1 and sum(indices.shape) <= ndim(x)
+    if single_index:
         indices = [indices]
 
     if len(values) != len(indices):
@@ -341,10 +365,18 @@ def _assignment_single_value(x, value, indices, axis=0):
         Copy of x where value was assigned at all indices (and possibly
         along an axis).
     """
+    if _is_boolean(indices):
+        indices = [index for index, val in enumerate(indices) if val]
+
     single_index = not isinstance(indices, list)
+    if tf.is_tensor(indices):
+        single_index = ndim(indices) <= 1 and sum(indices.shape) <= ndim(x)
     if single_index:
         indices = [indices]
+
     if isinstance(indices[0], tuple):
+        use_vectorization = (len(indices[0]) < ndim(x))
+    elif tf.is_tensor(indices[0]) and ndim(indices[0]) >= 1:
         use_vectorization = (len(indices[0]) < ndim(x))
     else:
         use_vectorization = ndim(x) > 1
@@ -388,10 +420,16 @@ def assignment(x, values, indices, axis=0):
     If a single value is provided, it is assigned at all the indices.
     If a list is given, it must have the same length as indices.
     """
-    if not isinstance(values, list):
+    if _is_boolean(indices):
+        indices = [index for index, val in enumerate(indices) if val]
+
+    if tf.rank(values) == 0:
         return _assignment_single_value(x, values, indices, axis)
 
-    if not isinstance(indices, list):
+    single_index = not isinstance(indices, list)
+    if tf.is_tensor(indices):
+        single_index = ndim(indices) <= 1 and sum(indices.shape) <= ndim(x)
+    if single_index:
         indices = [indices]
 
     if len(values) != len(indices):

--- a/geomstats/geometry/general_linear.py
+++ b/geomstats/geometry/general_linear.py
@@ -1,5 +1,7 @@
 """Module exposing the GeneralLinear group class."""
 
+from itertools import product
+
 import geomstats.backend as gs
 from geomstats.geometry.matrices import Matrices
 
@@ -35,6 +37,13 @@ class GeneralLinear(Matrices):
         """Return the inverse of a matrix."""
         return gs.linalg.inv(point)
 
+    def _replace_values(self, samples, new_samples, indcs):
+        replaced_indices = [
+            i for i, is_replaced in enumerate(indcs) if is_replaced]
+        value_indices = list(
+            product(replaced_indices, range(self.n), range(self.n)))
+        return gs.assignment(samples, gs.flatten(new_samples), value_indices)
+
     def random_uniform(self, n_samples=1, tol=1e-6):
         """Sample in GL(n) from the uniform distribution.
 
@@ -58,7 +67,8 @@ class GeneralLinear(Matrices):
             num_bad_samples = gs.sum(indcs)
             if num_bad_samples == 0:
                 break
-            samples[indcs, :] = gs.random.rand(num_bad_samples, self.n, self.n)
+            new_samples = gs.random.rand(num_bad_samples, self.n, self.n)
+            samples = self._replace_values(samples, new_samples, indcs)
         if n_samples == 1:
             samples = gs.squeeze(samples, axis=0)
         return samples

--- a/tests/test_general_linear.py
+++ b/tests/test_general_linear.py
@@ -52,7 +52,7 @@ class TestGeneralLinear(geomstats.tests.TestCase):
     def test_random_and_belongs(self):
         point = self.group.random_uniform()
         result = self.group.belongs(point)
-        expected = [True]
+        expected = True
         self.assertAllClose(result, expected)
 
     def test_random_and_belongs_vectorization(self):

--- a/tests/test_general_linear.py
+++ b/tests/test_general_linear.py
@@ -49,19 +49,26 @@ class TestGeneralLinear(geomstats.tests.TestCase):
         expected = gs.array([True, False])
         self.assertAllClose(result, expected)
 
-    @geomstats.tests.np_and_pytorch_only
     def test_random_and_belongs(self):
         point = self.group.random_uniform()
         result = self.group.belongs(point)
-        expected = True
+        expected = [True]
         self.assertAllClose(result, expected)
 
-    @geomstats.tests.np_and_pytorch_only
     def test_random_and_belongs_vectorization(self):
-        point = self.group.random_uniform(n_samples=3)
+        n_samples = 4
+        point = self.group.random_uniform(n_samples)
         result = self.group.belongs(point)
-        expected = gs.array([True, True, True])
+        expected = gs.array([True] * n_samples)
         self.assertAllClose(result, expected)
+
+    def test_replace_values(self):
+        points = gs.ones((3, 3, 3))
+        new_points = gs.zeros((2, 3, 3))
+        indcs = [True, False, True]
+        update = self.group._replace_values(points, new_points, indcs)
+        self.assertAllClose(update, gs.stack(
+            [gs.zeros((3, 3)), gs.ones((3, 3)), gs.zeros((3, 3))]))
 
     def test_compose(self):
         mat1 = gs.array([

--- a/tests/test_hypersphere.py
+++ b/tests/test_hypersphere.py
@@ -37,6 +37,14 @@ class TestHypersphere(geomstats.tests.TestCase):
 
         self.assertAllClose(gs.shape(point), (self.dimension + 1,))
 
+    def test_replace_values(self):
+        points = gs.ones((3, 5))
+        new_points = gs.zeros((2, 5))
+        indcs = [True, False, True]
+        update = self.space._replace_values(points, new_points, indcs)
+        self.assertAllClose(update, gs.stack(
+            [gs.zeros(5), gs.ones(5), gs.zeros(5)]))
+
     def test_projection_and_belongs(self):
         point = gs.array([1., 2., 3., 4., 5.])
         proj = self.space.projection(point)


### PR DESCRIPTION
This PR allows gs.assignment to work with booleans (and indices given as tensors) in tf.

It is a follow-up on #583 and #593 

gs.assignment was heavily refactored to take into account arrays and booleans. For numpy and pytorch, I tried to take as much advantage as possible of their slicing opportunities, to keep the cost low (although I don't guarantee anything).

I defined more general check functions, to see if an object is some kind of boolean (mostly a native one or an array of bools), and if it is iterable (list, tuple, array of dim > 0). Maybe it will be useful for other functions too.

Some lines are left untested, I will add the corresponding tests later.