### PR TITLE
Move FrechetMean transform to a preprocessing module

### DIFF
--- a/geomstats/geometry/spd_matrices.py
+++ b/geomstats/geometry/spd_matrices.py
@@ -354,7 +354,8 @@ class SPDMetricAffine(RiemannianMetric):
         dim = int(n * (n + 1) / 2)
         super(SPDMetricAffine, self).__init__(
             dim=dim,
-            signature=(dim, 0, 0))
+            signature=(dim, 0, 0),
+            default_point_type='matrix')
         self.n = n
         self.space = SPDMatrices(n)
         self.power_affine = power_affine

--- a/geomstats/learning/frechet_mean.py
+++ b/geomstats/learning/frechet_mean.py
@@ -3,16 +3,14 @@
 import logging
 import math
 
-from sklearn.base import BaseEstimator, TransformerMixin
+from sklearn.base import BaseEstimator
 
 import geomstats.backend as gs
 import geomstats.error as error
 import geomstats.vectorization
 from geomstats.geometry.euclidean import EuclideanMetric
-from geomstats.geometry.matrices import Matrices, MatricesMetric
+from geomstats.geometry.matrices import MatricesMetric
 from geomstats.geometry.minkowski import MinkowskiMetric
-from geomstats.geometry.skew_symmetric_matrices import SkewSymmetricMatrices
-from geomstats.geometry.symmetric_matrices import SymmetricMatrices
 
 EPSILON = 1e-4
 
@@ -284,7 +282,7 @@ def _adaptive_gradient_descent(points,
     return current_mean
 
 
-class FrechetMean(BaseEstimator, TransformerMixin):
+class FrechetMean(BaseEstimator):
     """Empirical Frechet mean.
 
     Parameters
@@ -359,88 +357,3 @@ class FrechetMean(BaseEstimator, TransformerMixin):
         self.estimate_ = mean
 
         return self
-
-    def transform(self, X, y=None, base_point=None):
-        """Lift data to a tangent space.
-
-        Compute the logs of all data point and reshapes them to
-        1d vectors if necessary. By default the logs are taken at the mean
-        but any other base point can be passed. Any machine learning
-        algorithm can then be used with the output array.
-
-        Parameters
-        ----------
-        X : array-like, shape=[n_samples, {dim, [n, n]}]
-            Data to transform.
-        y : Ignored (Compliance with scikit-learn interface)
-        base_point : array-like, shape={dim, [n,n]}, optional (mean)
-            Point on the manifold, the returned samples will be tangent
-            vectors at the base point.
-
-        Returns
-        -------
-        X_new : array-like, shape=[n_samples, dim]
-        """
-        # TODO(nguis): put this in a dedicated class
-        if base_point is None:
-            base_point = self.estimate_
-
-            if self.estimate_ is None:
-                raise RuntimeError('fit needs to be called first or a '
-                                   'base_point passed.')
-
-        tangent_vecs = self.metric.log(X, base_point=base_point)
-
-        if self.point_type == 'vector':
-            return tangent_vecs
-
-        if gs.all(Matrices.is_symmetric(tangent_vecs)):
-            X = SymmetricMatrices.vector_from_symmetric_matrix(
-                tangent_vecs)
-        elif gs.all(Matrices.is_skew_symmetric(tangent_vecs)):
-            X = SkewSymmetricMatrices(
-                tangent_vecs.shape[-1]).basis_representation(tangent_vecs)
-        else:
-            X = gs.reshape(tangent_vecs, (len(X), - 1))
-
-        return X
-
-    def inverse_transform(self, X, base_point=None):
-        """Reconstruction of X.
-
-        The reconstruction will match X_original whose transform would be X.
-
-        Parameters
-        ----------
-        X : array-like, shape=[n_samples, dim]
-            New data, where dim is the dimension of the manifold data belong
-            to.
-        base_point : array-like, shape={dim, [n,n]}, optional (mean)
-            Point on the manifold, where the input samples are tangent
-            vectors.
-
-        Returns
-        -------
-        X_original : array-like, shape=[n_samples, {dim, [n, n]}
-            Data lying on the manifold.
-        """
-        if base_point is None:
-            base_point = self.estimate_
-
-            if self.estimate_ is None:
-                raise RuntimeError('fit needs to be called first or a '
-                                   'base_point passed.')
-
-        if self.point_type == 'matrix':
-            if gs.all(Matrices.is_symmetric(base_point)):
-                tangent_vecs = SymmetricMatrices(
-                    base_point.shape[-1]).symmetric_matrix_from_vector(X)
-            elif gs.all(Matrices.is_skew_symmetric(base_point)):
-                tangent_vecs = SkewSymmetricMatrices(
-                    base_point.shape[-1]).matrix_representation(X)
-            else:
-                dim = base_point.shape[-1]
-                tangent_vecs = gs.reshape(X, (len(X), dim, dim))
-        else:
-            tangent_vecs = X
-        return self.metric.exp(tangent_vecs, base_point)

--- a/geomstats/learning/preprocessing.py
+++ b/geomstats/learning/preprocessing.py
@@ -52,8 +52,8 @@ class VectorTransformer(TransformerMixin):
             else:
                 raise ValueError('The input geometry must be either a '
                                  'Manifold equipped with a '
-                                 'RiemannianMetric, or a RiemannianMetric or a '
-                                 'LieGroup')
+                                 'RiemannianMetric, or a RiemannianMetric or a'
+                                 ' LieGroup')
             self.estimator = FrechetMean(metric=self._used_geometry, **kwargs)
         self.point_type = geometry.default_point_type
         self.geometry = geometry

--- a/geomstats/learning/preprocessing.py
+++ b/geomstats/learning/preprocessing.py
@@ -154,12 +154,17 @@ class ToTangentSpace(BaseEstimator, TransformerMixin):
                                    'base_point passed.')
 
         if self.point_type == 'matrix':
-            if gs.all(Matrices.is_symmetric(base_point)):
+            n_base_point = base_point.shape[-1]
+            n_vecs = X.shape[-1]
+            dim_sym = int(n_base_point * (n_base_point + 1) / 2)
+            dim_skew = int(n_base_point * (n_base_point - 1) / 2)
+
+            if gs.all(Matrices.is_symmetric(base_point)) and dim_sym == n_vecs:
                 tangent_vecs = SymmetricMatrices(
                     base_point.shape[-1]).symmetric_matrix_from_vector(X)
-            elif gs.all(Matrices.is_skew_symmetric(base_point)):
+            elif dim_skew == n_vecs:
                 tangent_vecs = SkewSymmetricMatrices(
-                    base_point.shape[-1]).matrix_representation(X)
+                    dim_skew).matrix_representation(X)
             else:
                 dim = base_point.shape[-1]
                 tangent_vecs = gs.reshape(X, (len(X), dim, dim))

--- a/geomstats/learning/preprocessing.py
+++ b/geomstats/learning/preprocessing.py
@@ -14,14 +14,14 @@ from geomstats.learning.frechet_mean import FrechetMean
 EPSILON = 1e-4
 
 
-class VectorTransformer(BaseEstimator, TransformerMixin):
+class ToTangentSpace(BaseEstimator, TransformerMixin):
     """Lift data to a tangent space.
 
     Compute the logs of all data points and reshape them to
     1d vectors if necessary. This means that all the data points, that belong
     to a possibly non-linear manifold are lifted to one of the tangent space of
     the manifold, which is a vector space. By default, the mean of the data
-    is computed (with the FrechetMean or the ExponentialBarycenter estimator
+    is computed (with the FrechetMean or the ExponentialBarycenter estimator,
     as appropriate) and the tangent space at the mean is used. Any other base
     point can be passed. The data points are then represented by the initial
     velocities of the geodesics that lead from base_point to each data point.

--- a/geomstats/learning/preprocessing.py
+++ b/geomstats/learning/preprocessing.py
@@ -1,6 +1,6 @@
 """Transformer for manifold-valued data."""
 
-from sklearn.base import TransformerMixin
+from sklearn.base import BaseEstimator, TransformerMixin
 
 import geomstats.backend as gs
 from geomstats.geometry.lie_group import LieGroup
@@ -14,7 +14,7 @@ from geomstats.learning.frechet_mean import FrechetMean
 EPSILON = 1e-4
 
 
-class VectorTransformer(TransformerMixin):
+class VectorTransformer(BaseEstimator, TransformerMixin):
     """Lift data to a tangent space.
 
     Compute the logs of all data points and reshape them to
@@ -83,7 +83,7 @@ class VectorTransformer(TransformerMixin):
             self.estimator.fit(X, y, weights)
         return self
 
-    def transform(self, X, y=None, base_point=None):
+    def transform(self, X, base_point=None):
         """Lift data to a tangent space.
 
         Compute the logs of all data point and reshapes them to

--- a/geomstats/learning/preprocessing.py
+++ b/geomstats/learning/preprocessing.py
@@ -1,0 +1,168 @@
+"""Transformer for manifold-valued data."""
+
+from sklearn.base import TransformerMixin
+
+import geomstats.backend as gs
+from geomstats.geometry.lie_group import LieGroup
+from geomstats.geometry.matrices import Matrices
+from geomstats.geometry.riemannian_metric import RiemannianMetric
+from geomstats.geometry.skew_symmetric_matrices import SkewSymmetricMatrices
+from geomstats.geometry.symmetric_matrices import SymmetricMatrices
+from geomstats.learning.exponential_barycenter import ExponentialBarycenter
+from geomstats.learning.frechet_mean import FrechetMean
+
+EPSILON = 1e-4
+
+
+class VectorTransformer(TransformerMixin):
+    """Lift data to a tangent space.
+
+    Compute the logs of all data points and reshape them to
+    1d vectors if necessary. This means that all the data points, that belong
+    to a possibly non-linear manifold are lifted to one of the tangent space of
+    the manifold, which is a vector space. By default, the mean of the data
+    is computed (with the FrechetMean or the ExponentialBarycenter estimator
+    as appropriate) and the tangent space at the mean is used. Any other base
+    point can be passed. The data points are then represented by the initial
+    velocities of the geodesics that lead from base_point to each data point.
+    Any machine learning algorithm can then be used with the output array.
+
+    Parameters
+    ----------
+    geometry : {Manifold ,LieGroup or RiemannianMetric}
+        Metric or Lie group to use to compute the log and exp. If a Lie group
+        is passed, its group exp/log will be used, which don't necessarily
+        correspond to a Riemannian metric. To use a `metric` on the Lie group,
+        explicitly pass `geometry=metric`
+    **kwargs : key-word arguments for the FrechetMean/ExponentialBarycenter
+        estimator.
+    """
+
+    def __init__(self, geometry, **kwargs):
+
+        if isinstance(geometry, LieGroup):
+            self._used_geometry = geometry
+            self.estimator = ExponentialBarycenter(
+                group=self._used_geometry, **kwargs)
+        else:
+            if hasattr(geometry, 'metric'):
+                self._used_geometry = geometry.metric
+            elif isinstance(geometry, RiemannianMetric):
+                self._used_geometry = geometry
+            else:
+                raise ValueError('The input geometry must be either a '
+                                 'Manifold equipped with a '
+                                 'RiemannianMetric, or a RiemannianMetric or a '
+                                 'LieGroup')
+            self.estimator = FrechetMean(metric=self._used_geometry, **kwargs)
+        self.point_type = geometry.default_point_type
+        self.geometry = geometry
+
+    def fit(self, X, y=None, weights=None, base_point=None):
+        """Compute the central point at which to take the log.
+
+        This method is only used if `base_point=None` to compute the mean of
+        the input data.
+
+        Parameters
+        ----------
+        X : array-like, shape=[n_samples, {dim, [n, n]}]
+            The training input samples.
+        y : array-like, shape (n_samples,) or (n_samples, n_outputs)
+            Ignored
+        weights : array-like, shape=[n_samples, 1], optional
+        base_point : array-like, shape=[{dim, [n, n]}]
+            Point similar to the input data from which to compute the logs
+
+        Returns
+        -------
+        self : object
+            Returns self.
+        """
+        if base_point is None:
+            self.estimator.fit(X, y, weights)
+        return self
+
+    def transform(self, X, y=None, base_point=None):
+        """Lift data to a tangent space.
+
+        Compute the logs of all data point and reshapes them to
+        1d vectors if necessary. By default the logs are taken at the mean
+        but any other base point can be passed. Any machine learning
+        algorithm can then be used with the output array.
+
+        Parameters
+        ----------
+        X : array-like, shape=[n_samples, {dim, [n, n]}]
+            Data to transform.
+        y : Ignored (Compliance with scikit-learn interface)
+        base_point : array-like, shape={dim, [n,n]}, optional (mean)
+            Point on the manifold, the returned samples will be tangent
+            vectors at the base point.
+
+        Returns
+        -------
+        X_new : array-like, shape=[n_samples, dim]
+        """
+        if base_point is None:
+            base_point = self.estimator.estimate_
+
+            if self.estimator.estimate_ is None:
+                raise RuntimeError('fit needs to be called first or a '
+                                   'base_point passed.')
+
+        tangent_vecs = self._used_geometry.log(X, base_point=base_point)
+
+        if self.point_type == 'vector':
+            return tangent_vecs
+
+        if gs.all(Matrices.is_symmetric(tangent_vecs)):
+            X = SymmetricMatrices.vector_from_symmetric_matrix(
+                tangent_vecs)
+        elif gs.all(Matrices.is_skew_symmetric(tangent_vecs)):
+            X = SkewSymmetricMatrices(
+                tangent_vecs.shape[-1]).basis_representation(tangent_vecs)
+        else:
+            X = gs.reshape(tangent_vecs, (len(X), - 1))
+
+        return X
+
+    def inverse_transform(self, X, base_point=None):
+        """Reconstruction of X.
+
+        The reconstruction will match X_original whose transform would be X.
+
+        Parameters
+        ----------
+        X : array-like, shape=[n_samples, dim]
+            New data, where dim is the dimension of the manifold data belong
+            to.
+        base_point : array-like, shape={dim, [n,n]}, optional (mean)
+            Point on the manifold, where the input samples are tangent
+            vectors.
+
+        Returns
+        -------
+        X_original : array-like, shape=[n_samples, {dim, [n, n]}
+            Data lying on the manifold.
+        """
+        if base_point is None:
+            base_point = self.estimator.estimate_
+
+            if self.estimator.estimate_ is None:
+                raise RuntimeError('fit needs to be called first or a '
+                                   'base_point passed.')
+
+        if self.point_type == 'matrix':
+            if gs.all(Matrices.is_symmetric(base_point)):
+                tangent_vecs = SymmetricMatrices(
+                    base_point.shape[-1]).symmetric_matrix_from_vector(X)
+            elif gs.all(Matrices.is_skew_symmetric(base_point)):
+                tangent_vecs = SkewSymmetricMatrices(
+                    base_point.shape[-1]).matrix_representation(X)
+            else:
+                dim = base_point.shape[-1]
+                tangent_vecs = gs.reshape(X, (len(X), dim, dim))
+        else:
+            tangent_vecs = X
+        return self._used_geometry.exp(tangent_vecs, base_point)

--- a/tests/test_frechet_mean.py
+++ b/tests/test_frechet_mean.py
@@ -224,48 +224,12 @@ class TestFrechetMean(geomstats.tests.TestCase):
         self.assertAllClose(expected, result)
 
     @geomstats.tests.np_and_pytorch_only
-    def test_estimate_transform_sphere(self):
-        point = gs.array([0., 0., 0., 0., 1.])
-        points = gs.array([point, point])
-
-        mean = FrechetMean(metric=self.sphere.metric)
-        mean.fit(X=points)
-        result = mean.transform(points)
-        expected = gs.zeros_like(points)
-        self.assertAllClose(expected, result)
-
-    @geomstats.tests.np_and_pytorch_only
-    def test_estimate_transform_spd(self):
+    def test_estimate_spd(self):
         point = SPDMatrices(3).random_uniform()
         points = gs.array([point, point])
         mean = FrechetMean(metric=SPDMetricAffine(3), point_type='matrix')
         mean.fit(X=points)
-        result = mean.transform(points)
-        expected = gs.zeros((2, 6))
-        self.assertAllClose(expected, result)
-
-    def test_fit_transform_hyperbolic(self):
-        point = gs.array([2., 1., 1., 1.])
-        points = gs.array([point, point])
-        mean = FrechetMean(metric=self.hyperbolic.metric)
-        result = mean.fit_transform(X=points)
-        expected = gs.zeros_like(points)
-        self.assertAllClose(expected, result)
-
-    def test_inverse_transform_hyperbolic(self):
-        points = self.hyperbolic.random_uniform(10)
-        mean = FrechetMean(metric=self.hyperbolic.metric)
-        X = mean.fit_transform(X=points)
-        result = mean.inverse_transform(X)
-        expected = points
-        self.assertAllClose(expected, result)
-
-    @geomstats.tests.np_and_pytorch_only
-    def test_inverse_transform_spd(self):
-        point = SPDMatrices(3).random_uniform(10)
-        mean = FrechetMean(metric=SPDMetricAffine(3), point_type='matrix')
-        X = mean.fit_transform(X=point)
-        result = mean.inverse_transform(X)
+        result = mean.estimate_
         expected = point
         self.assertAllClose(expected, result)
 

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -1,0 +1,99 @@
+"""Unit tests for pre-processing transformers."""
+
+import geomstats.backend as gs
+import geomstats.tests
+from geomstats.geometry.euclidean import Euclidean
+from geomstats.geometry.hyperboloid import Hyperboloid
+from geomstats.geometry.hypersphere import Hypersphere
+from geomstats.geometry.minkowski import Minkowski
+from geomstats.geometry.spd_matrices import SPDMatrices, SPDMetricAffine
+from geomstats.geometry.special_orthogonal import SpecialOrthogonal
+from geomstats.learning.preprocessing import VectorTransformer
+
+
+class TestVectorTransformer(geomstats.tests.TestCase):
+    _multiprocess_can_split_ = True
+
+    def setUp(self):
+        gs.random.seed(123)
+        self.sphere = Hypersphere(dim=4)
+        self.hyperbolic = Hyperboloid(dim=3)
+        self.euclidean = Euclidean(dim=2)
+        self.minkowski = Minkowski(dim=2)
+        self.so3 = SpecialOrthogonal(n=3, point_type='vector')
+        self.so_matrix = SpecialOrthogonal(n=3, point_type='matrix')
+
+    def test_estimate_transform_sphere(self):
+        point = gs.array([0., 0., 0., 0., 1.])
+        points = gs.array([point, point])
+        transformer = VectorTransformer(geometry=self.sphere)
+        transformer.fit(X=points)
+        result = transformer.transform(points)
+        expected = gs.zeros_like(points)
+        self.assertAllClose(expected, result)
+
+    def test_inverse_transform_no_fit_sphere(self):
+        point = self.sphere.random_uniform(3)
+        base_point = point[0]
+        point = point[1:]
+        transformer = VectorTransformer(geometry=self.sphere)
+        X = transformer.transform(point, base_point=base_point)
+        result = transformer.inverse_transform(X, base_point=base_point)
+        expected = point
+        self.assertAllClose(expected, result)
+
+    @geomstats.tests.np_and_tf_only
+    def test_estimate_transform_so_group(self):
+        point = self.so_matrix.random_uniform()
+        points = gs.array([point, point])
+
+        transformer = VectorTransformer(
+            geometry=self.so_matrix)
+        transformer.fit(X=points)
+        result = transformer.transform(points)
+        expected = gs.zeros((2, 6))
+        self.assertAllClose(expected, result)
+
+    def test_estimate_transform_spd(self):
+        point = SPDMatrices(3).random_uniform()
+        points = gs.stack([point, point])
+        transformer = VectorTransformer(geometry=SPDMetricAffine(3))
+        transformer.fit(X=points)
+        result = transformer.transform(points)
+        expected = gs.zeros((2, 6))
+        self.assertAllClose(expected, result)
+
+    def test_fit_transform_hyperbolic(self):
+        point = gs.array([2., 1., 1., 1.])
+        points = gs.array([point, point])
+        transformer = VectorTransformer(geometry=self.hyperbolic.metric)
+        result = transformer.fit_transform(X=points)
+        expected = gs.zeros_like(points)
+        self.assertAllClose(expected, result)
+
+    def test_inverse_transform_hyperbolic(self):
+        points = self.hyperbolic.random_uniform(10)
+        transformer = VectorTransformer(geometry=self.hyperbolic.metric)
+        X = transformer.fit_transform(X=points)
+        result = transformer.inverse_transform(X)
+        expected = points
+        self.assertAllClose(expected, result)
+
+    def test_inverse_transform_spd(self):
+        point = SPDMatrices(3).random_uniform(10)
+        transformer = VectorTransformer(geometry=SPDMetricAffine(3))
+        X = transformer.fit_transform(X=point)
+        result = transformer.inverse_transform(X)
+        expected = point
+        self.assertAllClose(expected, result, atol=1e-4)
+
+    @geomstats.tests.np_only
+    def test_inverse_transform_so(self):
+        # FIXME: einsum vectorization error for invariant_metric log in tf
+        point = self.so_matrix.random_uniform(10)
+        transformer = VectorTransformer(
+            geometry=self.so_matrix.bi_invariant_metric)
+        X = transformer.fit_transform(X=point)
+        result = transformer.inverse_transform(X)
+        expected = point
+        self.assertAllClose(expected, result)

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -47,8 +47,7 @@ class TestToTangentSpace(geomstats.tests.TestCase):
         point = self.so_matrix.random_uniform()
         points = gs.array([point, point])
 
-        transformer = ToTangentSpace(
-            geometry=self.so_matrix)
+        transformer = ToTangentSpace(geometry=self.so_matrix)
         transformer.fit(X=points)
         result = transformer.transform(points)
         expected = gs.zeros((2, 6))
@@ -93,7 +92,8 @@ class TestToTangentSpace(geomstats.tests.TestCase):
         point = self.so_matrix.random_uniform(10)
         transformer = ToTangentSpace(
             geometry=self.so_matrix.bi_invariant_metric)
-        X = transformer.fit_transform(X=point)
-        result = transformer.inverse_transform(X)
+        X = transformer.transform(X=point, base_point=self.so_matrix.identity)
+        result = transformer.inverse_transform(
+            X, base_point=self.so_matrix.identity)
         expected = point
         self.assertAllClose(expected, result)

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -8,10 +8,10 @@ from geomstats.geometry.hypersphere import Hypersphere
 from geomstats.geometry.minkowski import Minkowski
 from geomstats.geometry.spd_matrices import SPDMatrices, SPDMetricAffine
 from geomstats.geometry.special_orthogonal import SpecialOrthogonal
-from geomstats.learning.preprocessing import VectorTransformer
+from geomstats.learning.preprocessing import ToTangentSpace
 
 
-class TestVectorTransformer(geomstats.tests.TestCase):
+class TestToTangentSpace(geomstats.tests.TestCase):
     _multiprocess_can_split_ = True
 
     def setUp(self):
@@ -26,7 +26,7 @@ class TestVectorTransformer(geomstats.tests.TestCase):
     def test_estimate_transform_sphere(self):
         point = gs.array([0., 0., 0., 0., 1.])
         points = gs.array([point, point])
-        transformer = VectorTransformer(geometry=self.sphere)
+        transformer = ToTangentSpace(geometry=self.sphere)
         transformer.fit(X=points)
         result = transformer.transform(points)
         expected = gs.zeros_like(points)
@@ -36,7 +36,7 @@ class TestVectorTransformer(geomstats.tests.TestCase):
         point = self.sphere.random_uniform(3)
         base_point = point[0]
         point = point[1:]
-        transformer = VectorTransformer(geometry=self.sphere)
+        transformer = ToTangentSpace(geometry=self.sphere)
         X = transformer.transform(point, base_point=base_point)
         result = transformer.inverse_transform(X, base_point=base_point)
         expected = point
@@ -47,7 +47,7 @@ class TestVectorTransformer(geomstats.tests.TestCase):
         point = self.so_matrix.random_uniform()
         points = gs.array([point, point])
 
-        transformer = VectorTransformer(
+        transformer = ToTangentSpace(
             geometry=self.so_matrix)
         transformer.fit(X=points)
         result = transformer.transform(points)
@@ -57,7 +57,7 @@ class TestVectorTransformer(geomstats.tests.TestCase):
     def test_estimate_transform_spd(self):
         point = SPDMatrices(3).random_uniform()
         points = gs.stack([point, point])
-        transformer = VectorTransformer(geometry=SPDMetricAffine(3))
+        transformer = ToTangentSpace(geometry=SPDMetricAffine(3))
         transformer.fit(X=points)
         result = transformer.transform(points)
         expected = gs.zeros((2, 6))
@@ -66,14 +66,14 @@ class TestVectorTransformer(geomstats.tests.TestCase):
     def test_fit_transform_hyperbolic(self):
         point = gs.array([2., 1., 1., 1.])
         points = gs.array([point, point])
-        transformer = VectorTransformer(geometry=self.hyperbolic.metric)
+        transformer = ToTangentSpace(geometry=self.hyperbolic.metric)
         result = transformer.fit_transform(X=points)
         expected = gs.zeros_like(points)
         self.assertAllClose(expected, result)
 
     def test_inverse_transform_hyperbolic(self):
         points = self.hyperbolic.random_uniform(10)
-        transformer = VectorTransformer(geometry=self.hyperbolic.metric)
+        transformer = ToTangentSpace(geometry=self.hyperbolic.metric)
         X = transformer.fit_transform(X=points)
         result = transformer.inverse_transform(X)
         expected = points
@@ -81,7 +81,7 @@ class TestVectorTransformer(geomstats.tests.TestCase):
 
     def test_inverse_transform_spd(self):
         point = SPDMatrices(3).random_uniform(10)
-        transformer = VectorTransformer(geometry=SPDMetricAffine(3))
+        transformer = ToTangentSpace(geometry=SPDMetricAffine(3))
         X = transformer.fit_transform(X=point)
         result = transformer.inverse_transform(X)
         expected = point
@@ -91,7 +91,7 @@ class TestVectorTransformer(geomstats.tests.TestCase):
     def test_inverse_transform_so(self):
         # FIXME: einsum vectorization error for invariant_metric log in tf
         point = self.so_matrix.random_uniform(10)
-        transformer = VectorTransformer(
+        transformer = ToTangentSpace(
             geometry=self.so_matrix.bi_invariant_metric)
         X = transformer.fit_transform(X=point)
         result = transformer.inverse_transform(X)


### PR DESCRIPTION
This addresses comments made in the #577 to address #570 in a specific module rather than in FrechetMean, thus leaving the possibility to use any base point and not only the FrechetMean as base_point to lift data points to a tangent space.