### PR TITLE
Start to harmonize methods names across manifolds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,9 @@ dmypy.json
 # Idea folder
 .idea/
 
+# VSCode
+.vscode/
+
 # End of https://www.gitignore.io/api/python,jupyternotebooks
 
 # Miscellaneous

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "python.linting.pylintEnabled": false,
+    "python.linting.flake8Enabled": true,
+    "python.linting.enabled": true
+}

--- a/examples/geomstats_in_pymanopt.py
+++ b/examples/geomstats_in_pymanopt.py
@@ -34,7 +34,7 @@ class GeomstatsSphere(Manifold):
             tangent_vector_a, tangent_vector_b, base_point=base_vector)
 
     def proj(self, base_vector, tangent_vector):
-        return self._sphere.projection_to_tangent_space(
+        return self._sphere.to_tangent(
             tangent_vector, base_point=base_vector)
 
     def retr(self, base_vector, tangent_vector):

--- a/examples/geomstats_in_pymanopt.py
+++ b/examples/geomstats_in_pymanopt.py
@@ -1,4 +1,4 @@
-"""This very simple example demonstrates how geometries from geomstats can be
+"""Simple example that demonstrates how geometries from geomstats can be
 used in pymanopt to perform optimization on manifolds. It uses the Riemannian
 steepest descent solver.
 
@@ -90,12 +90,12 @@ if __name__ == '__main__':
         dominant_eigenvector_estimate = -dominant_eigenvector_estimate
 
     logging.info(
-        'l2-norm of dominant eigenvector: {}',
+        'l2-norm of dominant eigenvector: %s',
         gs.linalg.norm(dominant_eigenvector))
     logging.info(
-        'l2-norm of dominant eigenvector estimate: {}',
+        'l2-norm of dominant eigenvector estimate: %s',
         gs.linalg.norm(dominant_eigenvector_estimate))
     error_norm = gs.linalg.norm(
         dominant_eigenvector - dominant_eigenvector_estimate)
-    logging.info('l2-norm of difference vector: {}', error_norm)
+    logging.info('l2-norm of difference vector: %s', error_norm)
     logging.info('solution found: %s', gs.isclose(error_norm, 0.0, atol=1e-3))

--- a/examples/geomstats_in_pymanopt.py
+++ b/examples/geomstats_in_pymanopt.py
@@ -89,11 +89,13 @@ if __name__ == '__main__':
             gs.sign(dominant_eigenvector_estimate[0])):
         dominant_eigenvector_estimate = -dominant_eigenvector_estimate
 
-    logging.info('l2-norm of dominant eigenvector: {}'.format(
-        gs.linalg.norm(dominant_eigenvector)))
-    logging.info('l2-norm of dominant eigenvector estimate: {}'.format(
-        gs.linalg.norm(dominant_eigenvector_estimate)))
+    logging.info(
+        'l2-norm of dominant eigenvector: {}',
+        gs.linalg.norm(dominant_eigenvector))
+    logging.info(
+        'l2-norm of dominant eigenvector estimate: {}',
+        gs.linalg.norm(dominant_eigenvector_estimate))
     error_norm = gs.linalg.norm(
         dominant_eigenvector - dominant_eigenvector_estimate)
-    logging.info('l2-norm of difference vector: {}'.format(error_norm))
-    logging.info('solution found: %s' % gs.isclose(error_norm, 0.0, atol=1e-3))
+    logging.info('l2-norm of difference vector: {}', error_norm)
+    logging.info('solution found: %s', gs.isclose(error_norm, 0.0, atol=1e-3))

--- a/examples/gradient_descent_s2.py
+++ b/examples/gradient_descent_s2.py
@@ -47,7 +47,7 @@ def gradient_descent(start,
     for i in range(max_iter):
         x_prev = x
         euclidean_grad = - lr * grad(x)
-        tangent_vec = manifold.projection_to_tangent_space(
+        tangent_vec = manifold.to_tangent(
             vector=euclidean_grad, base_point=x)
         x = manifold.metric.exp(base_point=x, tangent_vec=tangent_vec)
         if (gs.abs(loss(x, use_gs=True) - loss(x_prev, use_gs=True))

--- a/examples/plot_geodesics_h2.py
+++ b/examples/plot_geodesics_h2.py
@@ -55,7 +55,7 @@ def main():
     """Plot the geodesics."""
     initial_point = gs.array([np.sqrt(2), 1., 0.])
     end_point = H2.from_coordinates([1.5, 1.5], 'intrinsic')
-    initial_tangent_vec = H2.projection_to_tangent_space(
+    initial_tangent_vec = H2.to_tangent(
         vector=gs.array([3.5, 0.6, 0.8]),
         base_point=initial_point)
 

--- a/examples/plot_geodesics_s2.py
+++ b/examples/plot_geodesics_s2.py
@@ -16,7 +16,7 @@ METRIC = SPHERE2.metric
 def main():
     """Plot a geodesic on the sphere."""
     initial_point = np.array([1., 0., 0.])
-    initial_tangent_vec = SPHERE2.projection_to_tangent_space(
+    initial_tangent_vec = SPHERE2.to_tangent(
         vector=np.array([1., 2., 0.8]), base_point=initial_point)
     geodesic = METRIC.geodesic(
         initial_point=initial_point,

--- a/examples/plot_pole_ladder_s2.py
+++ b/examples/plot_pole_ladder_s2.py
@@ -26,11 +26,11 @@ def main():
     """Compute pole ladder and plot the construction."""
     base_point = SPACE.random_uniform(1)
     tangent_vec_b = SPACE.random_uniform(1)
-    tangent_vec_b = SPACE.projection_to_tangent_space(
+    tangent_vec_b = SPACE.to_tangent(
         tangent_vec_b, base_point)
     tangent_vec_b *= N_STEPS / 2
     tangent_vec_a = SPACE.random_uniform(1)
-    tangent_vec_a = SPACE.projection_to_tangent_space(
+    tangent_vec_a = SPACE.to_tangent(
         tangent_vec_a, base_point) * N_STEPS / 4
 
     ladder = METRIC.ladder_parallel_transport(

--- a/geomstats/_backend/pytorch/linalg.py
+++ b/geomstats/_backend/pytorch/linalg.py
@@ -50,7 +50,7 @@ def det(*args, **kwargs):
     return torch.from_numpy(np.array(np.linalg.det(*args, **kwargs)))
 
 
-def norm(x, ord=2, axis=None, keepdims=False):
+def norm(x, ord=2, axis=None):
     if axis is None:
         return torch.norm(x, p=ord)
     return torch.norm(x, p=ord, dim=axis)

--- a/geomstats/geometry/beta_distributions.py
+++ b/geomstats/geometry/beta_distributions.py
@@ -128,7 +128,7 @@ class BetaMetric(RiemannianMetric):
     """Class for the Fisher information metric on beta distributions."""
 
     def __init__(self):
-        super(RiemannianMetric, self).__init__(dim=2)
+        super(BetaMetric, self).__init__(dim=2)
 
     @staticmethod
     def metric_det(param_a, param_b):

--- a/geomstats/geometry/beta_distributions.py
+++ b/geomstats/geometry/beta_distributions.py
@@ -248,7 +248,7 @@ class BetaMetric(RiemannianMetric):
         for point, vec in zip(base_point, tangent_vec):
             initial_state = gs.hstack([point, vec])
             geodesic = odeint(
-                ivp, initial_state, times, tuple(), rtol=1e-6)
+                ivp, initial_state, times, (), rtol=1e-6)
             exp.append(geodesic[-1, :2])
         return exp[0] if len(base_point) == 1 else gs.stack(exp)
 

--- a/geomstats/geometry/beta_distributions.py
+++ b/geomstats/geometry/beta_distributions.py
@@ -25,7 +25,7 @@ class BetaDistributions(EmbeddedManifold):
         super(BetaDistributions, self).__init__(
             dim=2, embedding_manifold=Euclidean(dim=2))
 
-    def belongs(self, point, point_type=None):
+    def belongs(self, point):
         """Evaluate if a point belongs to the manifold of beta distributions.
 
         The statistical manifold of beta distributions is the upper right

--- a/geomstats/geometry/embedded_manifold.py
+++ b/geomstats/geometry/embedded_manifold.py
@@ -54,34 +54,3 @@ class EmbeddedManifold(Manifold):
         """
         raise NotImplementedError(
             'projection is not implemented.')
-
-    def is_tangent(self, vector, base_point=None):
-        """Check whether the vector is tangent at base_point.
-
-        Parameters
-        ----------
-        vector : array-like, shape=[n_samples, dim_embedding]
-            Vector at the tangent space of the embedding manifold.
-        base_point : array-like, shape=[n_samples, dim_embedding]
-            Point on the embedded manifold, in extrinsic coordinates.
-
-        Returns
-        -------
-        is_tangent : bool
-            Boolean denoting if vector is a tangent vector at the base point.
-        """
-        raise NotImplementedError(
-            'is_tangent is not implemented.')
-
-    def to_tangent(self, vector, base_point):
-        """Project a vector to a tangent space of the embedded manifold.
-
-        Parameters
-        ----------
-        vector : array-like, shape=[n_samples, dim_embedding]
-            Vector at the tangent space of the embedding manifold.
-        base_point : array-like, shape=[n_samples, dim_embedding]
-            Point on the embedded manifold, in extrinsic coordinates.
-        """
-        raise NotImplementedError(
-            'to_tangent is not implemented.')

--- a/geomstats/geometry/embedded_manifold.py
+++ b/geomstats/geometry/embedded_manifold.py
@@ -55,7 +55,7 @@ class EmbeddedManifold(Manifold):
         raise NotImplementedError(
             'projection is not implemented.')
 
-    def is_tangent(self, vector, base_point=None, atol=ATOL):
+    def is_tangent(self, vector, base_point=None):
         """Check whether the vector is tangent at base_point.
 
         Parameters

--- a/geomstats/geometry/embedded_manifold.py
+++ b/geomstats/geometry/embedded_manifold.py
@@ -55,7 +55,25 @@ class EmbeddedManifold(Manifold):
         raise NotImplementedError(
             'projection is not implemented.')
 
-    def projection_to_tangent_space(self, vector, base_point):
+    def is_tangent(self, vector, base_point=None, atol=ATOL):
+        """Check whether the vector is tangent at base_point.
+
+        Parameters
+        ----------
+        vector : array-like, shape=[n_samples, dim_embedding]
+            Vector at the tangent space of the embedding manifold.
+        base_point : array-like, shape=[n_samples, dim_embedding]
+            Point on the embedded manifold, in extrinsic coordinates.
+
+        Returns
+        -------
+        is_tangent : bool
+            Boolean denoting if vector is a tangent vector at the base point.
+        """
+        raise NotImplementedError(
+            'is_tangent is not implemented.')
+
+    def to_tangent(self, vector, base_point):
         """Project a vector to a tangent space of the embedded manifold.
 
         Parameters
@@ -66,4 +84,4 @@ class EmbeddedManifold(Manifold):
             Point on the embedded manifold, in extrinsic coordinates.
         """
         raise NotImplementedError(
-            'projection_to_tangent_space is not implemented.')
+            'to_tangent is not implemented.')

--- a/geomstats/geometry/hyperbolic.py
+++ b/geomstats/geometry/hyperbolic.py
@@ -156,8 +156,8 @@ class Hyperbolic(Manifold):
         denominator = 1 - squared_norm
         t = gs.to_ndarray((1 + squared_norm) / denominator, to_ndim=2, axis=1)
         expanded_denominator = gs.expand_dims(denominator, -1)
-        expanded_denominator = gs.repeat(
-            expanded_denominator, point.shape[-1], -1)
+        expanded_denominator = gs.tile(
+            expanded_denominator, (1, point.shape[-1]))
         intrinsic = (2 * point) / expanded_denominator
         return gs.concatenate([t, intrinsic], -1)
 

--- a/geomstats/geometry/hyperboloid.py
+++ b/geomstats/geometry/hyperboloid.py
@@ -143,7 +143,7 @@ class Hyperboloid(Hyperbolic, EmbeddedManifold):
         return projected_point
 
     @geomstats.vectorization.decorator(['else', 'vector', 'vector'])
-    def projection_to_tangent_space(self, vector, base_point):
+    def to_tangent(self, vector, base_point):
         """Project a vector to a tangent space of the hyperbolic space.
 
         Project a vector in Minkowski space on the tangent space

--- a/geomstats/geometry/hypersphere.py
+++ b/geomstats/geometry/hypersphere.py
@@ -225,13 +225,16 @@ class Hypersphere(EmbeddedManifold):
         phi = base_point_spherical[:, 1]
         jac = gs.zeros((n_samples, self.dim + 1, self.dim))
 
-        jac = gs.assignment(
-            jac, gs.cos(theta) * gs.cos(phi), (0, 0), axis=0)
-        jac[:, 0, 0] = gs.cos(theta) * gs.cos(phi)
-        jac[:, 0, 1] = - gs.sin(theta) * gs.sin(phi)
-        jac[:, 1, 0] = gs.cos(theta) * gs.sin(phi)
-        jac[:, 1, 1] = gs.sin(theta) * gs.cos(phi)
-        jac[:, 2, 0] = - gs.sin(theta)
+        zeros = gs.zeros(n_samples)
+
+        jac = gs.concatenate([gs.array([[
+            [gs.cos(theta[i]) * gs.cos(phi[i]),
+             - gs.sin(theta[i]) * gs.sin(phi[i])],
+            [gs.cos(theta[i]) * gs.sin(phi[i]),
+             gs.sin(theta[i]) * gs.cos(phi[i])],
+            [- gs.sin(theta[i]),
+             zeros[i]]]]) for i in range(n_samples)], axis=0)
+
         tangent_vec_extrinsic = gs.einsum(
             '...ij,...j->...i', jac, tangent_vec_spherical)
 

--- a/geomstats/geometry/hypersphere.py
+++ b/geomstats/geometry/hypersphere.py
@@ -225,8 +225,8 @@ class Hypersphere(EmbeddedManifold):
         phi = base_point_spherical[:, 1]
         jac = gs.zeros((n_samples, self.dim + 1, self.dim))
 
-        #jac = gs.assignment(
-        #    jac, gs.cos(theta) * gs.cos(phi), (0, 0), axis=0)
+        jac = gs.assignment(
+            jac, gs.cos(theta) * gs.cos(phi), (0, 0), axis=0)
         jac[:, 0, 0] = gs.cos(theta) * gs.cos(phi)
         jac[:, 0, 1] = - gs.sin(theta) * gs.sin(phi)
         jac[:, 1, 0] = gs.cos(theta) * gs.sin(phi)

--- a/geomstats/geometry/hypersphere.py
+++ b/geomstats/geometry/hypersphere.py
@@ -128,7 +128,7 @@ class Hypersphere(EmbeddedManifold):
         return projected_point
 
     @geomstats.vectorization.decorator(['else', 'vector', 'vector'])
-    def projection_to_tangent_space(self, vector, base_point):
+    def to_tangent(self, vector, base_point):
         """Project a vector to the tangent space.
 
         Project a vector in Euclidean space
@@ -454,7 +454,7 @@ class HypersphereMetric(RiemannianMetric):
         n_tangent_vecs, _ = tangent_vec.shape
 
         hypersphere = Hypersphere(dim=extrinsic_dim - 1)
-        proj_tangent_vec = hypersphere.projection_to_tangent_space(
+        proj_tangent_vec = hypersphere.to_tangent(
             tangent_vec, base_point)
         norm_tangent_vec = self.embedding_metric.norm(proj_tangent_vec)
         norm_tangent_vec = gs.to_ndarray(norm_tangent_vec, to_ndim=1)

--- a/geomstats/geometry/hypersphere.py
+++ b/geomstats/geometry/hypersphere.py
@@ -181,11 +181,12 @@ class Hypersphere(EmbeddedManifold):
 
         theta = point_spherical[:, 0]
         phi = point_spherical[:, 1]
-        point_extrinsic = gs.zeros(
-            (point_spherical.shape[0], self.dim + 1))
-        point_extrinsic[:, 0] = gs.sin(theta) * gs.cos(phi)
-        point_extrinsic[:, 1] = gs.sin(theta) * gs.sin(phi)
-        point_extrinsic[:, 2] = gs.cos(theta)
+
+        point_extrinsic = gs.stack(
+            [gs.sin(theta) * gs.cos(phi),
+             gs.sin(theta) * gs.sin(phi),
+             gs.cos(theta)],
+            axis=1)
         if not gs.all(self.belongs(point_extrinsic)):
             raise ValueError('Points do not belong to the manifold.')
 
@@ -223,13 +224,16 @@ class Hypersphere(EmbeddedManifold):
         theta = base_point_spherical[:, 0]
         phi = base_point_spherical[:, 1]
         jac = gs.zeros((n_samples, self.dim + 1, self.dim))
+
+        #jac = gs.assignment(
+        #    jac, gs.cos(theta) * gs.cos(phi), (0, 0), axis=0)
         jac[:, 0, 0] = gs.cos(theta) * gs.cos(phi)
         jac[:, 0, 1] = - gs.sin(theta) * gs.sin(phi)
         jac[:, 1, 0] = gs.cos(theta) * gs.sin(phi)
         jac[:, 1, 1] = gs.sin(theta) * gs.cos(phi)
         jac[:, 2, 0] = - gs.sin(theta)
         tangent_vec_extrinsic = gs.einsum(
-            'nij,nj->ni', jac, tangent_vec_spherical)
+            '...ij,...j->...i', jac, tangent_vec_spherical)
 
         return tangent_vec_extrinsic
 

--- a/geomstats/geometry/lie_group.py
+++ b/geomstats/geometry/lie_group.py
@@ -357,16 +357,29 @@ class LieGroup(Manifold):
             'The Lie Algebra belongs method is not implemented'
         )
 
-    def is_tangent(self, tangent_vec, base_point=None, atol=ATOL):
-        """Check whether the vector is tangent at base_point."""
+    def is_tangent(self, vector, base_point=None, atol=ATOL):
+        """Check whether the vector is tangent at base_point.
+
+        Parameters
+        ----------
+        vector : array-like, shape=[n_samples, dim_embedding]
+            Vector.
+        base_point : array-like, shape=[n_samples, dim_embedding]
+            Point in the Lie group.
+
+        Returns
+        -------
+        is_tangent : bool
+            Boolean denoting if vector is a tangent vector at the base point.
+        """
         if base_point is None:
             base_point = self.identity
 
         if gs.allclose(base_point, self.identity):
-            tangent_vec_at_id = tangent_vec
+            tangent_vec_at_id = vector
         else:
             tangent_vec_at_id = self.compose(
-                self.inverse(base_point), tangent_vec)
+                self.inverse(base_point), vector)
         is_tangent = self._is_in_lie_algebra(tangent_vec_at_id, atol)
         return is_tangent
 

--- a/geomstats/geometry/manifold.py
+++ b/geomstats/geometry/manifold.py
@@ -35,6 +35,25 @@ class Manifold:
         """
         raise NotImplementedError('belongs is not implemented.')
 
+
+    def is_tangent(self, vector, base_point=None):
+        """Check whether the vector is tangent at base_point.
+
+        Parameters
+        ----------
+        vector : array-like, shape=[n_samples, dim_embedding]
+            Vector.
+        base_point : array-like, shape=[n_samples, dim_embedding]
+            Point on the manifold.
+
+        Returns
+        -------
+        is_tangent : bool
+            Boolean denoting if vector is a tangent vector at the base point.
+        """
+        raise NotImplementedError(
+            'is_tangent is not implemented.')
+
     def regularize(self, point):
         """Regularize a point to the canonical representation for the manifold.
 

--- a/geomstats/geometry/manifold.py
+++ b/geomstats/geometry/manifold.py
@@ -7,6 +7,9 @@ Euclidean space near each point.
 import geomstats.error
 
 
+ATOL = 1e-6
+
+
 class Manifold:
     """Class for manifolds."""
 
@@ -35,7 +38,7 @@ class Manifold:
         """
         raise NotImplementedError('belongs is not implemented.')
 
-    def is_tangent(self, vector, base_point=None):
+    def is_tangent(self, vector, base_point=None, atol=ATOL):
         """Check whether the vector is tangent at base_point.
 
         Parameters

--- a/geomstats/geometry/manifold.py
+++ b/geomstats/geometry/manifold.py
@@ -35,7 +35,6 @@ class Manifold:
         """
         raise NotImplementedError('belongs is not implemented.')
 
-
     def is_tangent(self, vector, base_point=None):
         """Check whether the vector is tangent at base_point.
 

--- a/geomstats/geometry/manifold.py
+++ b/geomstats/geometry/manifold.py
@@ -40,9 +40,9 @@ class Manifold:
 
         Parameters
         ----------
-        vector : array-like, shape=[n_samples, dim_embedding]
+        vector : array-like, shape=[n_samples, dim]
             Vector.
-        base_point : array-like, shape=[n_samples, dim_embedding]
+        base_point : array-like, shape=[n_samples, dim]
             Point on the manifold.
 
         Returns
@@ -52,6 +52,24 @@ class Manifold:
         """
         raise NotImplementedError(
             'is_tangent is not implemented.')
+
+    def to_tangent(self, vector, base_point):
+        """Project a vector to a tangent space of the manifold.
+
+        Parameters
+        ----------
+        vector : array-like, shape=[n_samples, dim]
+            Vector.
+        base_point : array-like, shape=[n_samples, dim]
+            Point on the manifold.
+
+        Returns
+        -------
+        tangent_vec : array-like, shape=[n_samples, dim]
+            Tangent vector at base point.
+        """
+        raise NotImplementedError(
+            'to_tangent is not implemented.')
 
     def regularize(self, point):
         """Regularize a point to the canonical representation for the manifold.

--- a/geomstats/geometry/manifold.py
+++ b/geomstats/geometry/manifold.py
@@ -56,7 +56,7 @@ class Manifold:
         raise NotImplementedError(
             'is_tangent is not implemented.')
 
-    def to_tangent(self, vector, base_point):
+    def to_tangent(self, vector, base_point=None):
         """Project a vector to a tangent space of the manifold.
 
         Parameters

--- a/geomstats/geometry/matrices.py
+++ b/geomstats/geometry/matrices.py
@@ -137,7 +137,7 @@ class Matrices(Manifold):
         return cls.equal(mat, - cls.transpose(mat), atol)
 
     @classmethod
-    def make_symmetric(cls, mat):
+    def to_symmetric(cls, mat):
         """Make a matrix symmetric, by averaging with its transpose.
 
         Parameters

--- a/geomstats/geometry/matrices.py
+++ b/geomstats/geometry/matrices.py
@@ -151,7 +151,7 @@ class Matrices(Manifold):
         return 1 / 2 * (mat + cls.transpose(mat))
 
     @classmethod
-    def make_skew_symmetric(cls, mat):
+    def to_skew_symmetric(cls, mat):
         """
         Make a matrix skew-symmetric, by averaging with minus its transpose.
 

--- a/geomstats/geometry/poincare_polydisk.py
+++ b/geomstats/geometry/poincare_polydisk.py
@@ -81,7 +81,7 @@ class PoincarePolydisk(ProductManifold):
         """
         n_disks = base_point.shape[1]
         hyperbolic_space = Hyperboloid(2, self.coords_type)
-        tangent_vec = gs.stack([hyperbolic_space.projection_to_tangent_space(
+        tangent_vec = gs.stack([hyperbolic_space.to_tangent(
             vector=vector[:, i_disk, :],
             base_point=base_point[:, i_disk, :])
             for i_disk in range(n_disks)], axis=1)

--- a/geomstats/geometry/spd_matrices.py
+++ b/geomstats/geometry/spd_matrices.py
@@ -440,7 +440,7 @@ class SPDMetricAffine(RiemannianMetric):
             '...ij,...jk->...ik', inv_sqrt_base_point, tangent_vec)
         tangent_vec_at_id = gs.einsum(
             '...ij,...jk->...ik', tangent_vec_at_id, inv_sqrt_base_point)
-        tangent_vec_at_id = GeneralLinear.make_symmetric(tangent_vec_at_id)
+        tangent_vec_at_id = GeneralLinear.to_symmetric(tangent_vec_at_id)
         exp_from_id = SymmetricMatrices.expm(tangent_vec_at_id)
 
         exp = gs.einsum(
@@ -505,7 +505,7 @@ class SPDMetricAffine(RiemannianMetric):
             '...ij,...jk->...ik', inv_sqrt_base_point, point)
         point_near_id = gs.einsum(
             '...ij,...jk->...ik', point_near_id, inv_sqrt_base_point)
-        point_near_id = GeneralLinear.make_symmetric(point_near_id)
+        point_near_id = GeneralLinear.to_symmetric(point_near_id)
         log_at_id = SPDMatrices.logm(point_near_id)
 
         log = gs.einsum(

--- a/geomstats/geometry/special_euclidean.py
+++ b/geomstats/geometry/special_euclidean.py
@@ -35,7 +35,7 @@ TAYLOR_COEFFS_2_AT_0 = [+ 1. / 6., 0.,
                         - 1. / 362880.]
 
 
-class _SpecialEuclideanMatrix(GeneralLinear, LieGroup):
+class _SpecialEuclideanMatrices(GeneralLinear, LieGroup):
     """Class for special orthogonal groups.
 
     Parameters
@@ -45,7 +45,7 @@ class _SpecialEuclideanMatrix(GeneralLinear, LieGroup):
     """
 
     def __init__(self, n):
-        super(_SpecialEuclideanMatrix, self).__init__(
+        super(_SpecialEuclideanMatrices, self).__init__(
             dim=int((n * (n - 1)) / 2), default_point_type='matrix', n=n + 1)
         self.rotations = SpecialOrthogonal(n=n)
         self.translations = Euclidean(dim=n)
@@ -151,7 +151,7 @@ class _SpecialEuclideanMatrix(GeneralLinear, LieGroup):
         return random_point
 
 
-class _SpecialEuclidean3Vector(LieGroup):
+class _SpecialEuclidean3Vectors(LieGroup):
     """Class for the special euclidean group in 3d, SE(3).
 
     i.e. the Lie group of rigid transformations. Elements of SE(3) can either
@@ -168,7 +168,7 @@ class _SpecialEuclidean3Vector(LieGroup):
     """
 
     def __init__(self, epsilon=0.):
-        super(_SpecialEuclidean3Vector, self).__init__(
+        super(_SpecialEuclidean3Vectors, self).__init__(
             dim=6, default_point_type='vector')
 
         self.n = 3
@@ -707,7 +707,7 @@ class _SpecialEuclidean3Vector(LieGroup):
         return exponential_mat
 
 
-class SpecialEuclidean(_SpecialEuclidean3Vector, _SpecialEuclideanMatrix):
+class SpecialEuclidean(_SpecialEuclidean3Vectors, _SpecialEuclideanMatrices):
     r"""Class for the special euclidean groups.
 
     Parameters
@@ -728,9 +728,9 @@ class SpecialEuclidean(_SpecialEuclidean3Vector, _SpecialEuclideanMatrix):
         Select the object to instantiate depending on the point_type.
         """
         if n == 3 and point_type == 'vector':
-            return _SpecialEuclidean3Vector(epsilon)
+            return _SpecialEuclidean3Vectors(epsilon)
         if n != 3 and point_type == 'vector':
             raise NotImplementedError(
                 'SE(n) is only implemented in matrix representation'
                 ' when n != 3.')
-        return _SpecialEuclideanMatrix(n)
+        return _SpecialEuclideanMatrices(n)

--- a/geomstats/geometry/special_orthogonal.py
+++ b/geomstats/geometry/special_orthogonal.py
@@ -1375,7 +1375,8 @@ class _SpecialOrthogonal3Vectors(LieGroup):
         return LieGroup.log(self, point, base_point)
 
 
-class SpecialOrthogonal(_SpecialOrthogonal3Vectors, _SpecialOrthogonalMatrices):
+class SpecialOrthogonal(
+        _SpecialOrthogonal3Vectors, _SpecialOrthogonalMatrices):
     r"""Class for the special orthogonal groups.
 
     Parameters

--- a/geomstats/geometry/special_orthogonal.py
+++ b/geomstats/geometry/special_orthogonal.py
@@ -27,7 +27,7 @@ TAYLOR_COEFFS_1_AT_PI = [0., - gs.pi / 4.,
                          - 1. / 480.]
 
 
-class _SpecialOrthogonalMatrix(GeneralLinear, LieGroup):
+class _SpecialOrthogonalMatrices(GeneralLinear, LieGroup):
     """Class for special orthogonal groups in matrix representation.
 
     Parameters
@@ -37,7 +37,7 @@ class _SpecialOrthogonalMatrix(GeneralLinear, LieGroup):
     """
 
     def __init__(self, n):
-        super(_SpecialOrthogonalMatrix, self).__init__(
+        super(_SpecialOrthogonalMatrices, self).__init__(
             dim=int((n * (n - 1)) / 2), default_point_type='matrix', n=n)
         self.lie_algebra = SkewSymmetricMatrices(n=n)
         self.bi_invariant_metric = BiInvariantMetric(group=self)
@@ -58,7 +58,7 @@ class _SpecialOrthogonalMatrix(GeneralLinear, LieGroup):
     @classmethod
     def _to_lie_algebra(cls, tangent_vec):
         """Project vector onto skew-symmetric matrices."""
-        return cls.make_skew_symmetric(tangent_vec)
+        return cls.to_skew_symmetric(tangent_vec)
 
     def random_uniform(self, n_samples=1, tol=1e-6):
         """Sample in SO(n) from the uniform distribution.
@@ -82,7 +82,7 @@ class _SpecialOrthogonalMatrix(GeneralLinear, LieGroup):
         return self.exp(skew)
 
 
-class _SpecialOrthogonal3Vector(LieGroup):
+class _SpecialOrthogonal3Vectors(LieGroup):
     """Class for the special orthogonal group SO(3) in vector representation.
 
     i.e. the Lie group of rotations. This class is specific to the vector
@@ -1375,7 +1375,7 @@ class _SpecialOrthogonal3Vector(LieGroup):
         return LieGroup.log(self, point, base_point)
 
 
-class SpecialOrthogonal(_SpecialOrthogonal3Vector, _SpecialOrthogonalMatrix):
+class SpecialOrthogonal(_SpecialOrthogonal3Vectors, _SpecialOrthogonalMatrices):
     r"""Class for the special orthogonal groups.
 
     Parameters
@@ -1396,9 +1396,9 @@ class SpecialOrthogonal(_SpecialOrthogonal3Vector, _SpecialOrthogonalMatrix):
         Select the object to instantiate depending on the point_type.
         """
         if n == 3 and point_type == 'vector':
-            return _SpecialOrthogonal3Vector(epsilon)
+            return _SpecialOrthogonal3Vectors(epsilon)
         if n != 3 and point_type == 'vector':
             raise NotImplementedError(
                 'SO(n) is only implemented in matrix representation'
                 ' when n != 3.')
-        return _SpecialOrthogonalMatrix(n)
+        return _SpecialOrthogonalMatrices(n)

--- a/geomstats/geometry/symmetric_matrices.py
+++ b/geomstats/geometry/symmetric_matrices.py
@@ -44,7 +44,7 @@ class SymmetricMatrices(EmbeddedManifold):
         """Convert the symmetric part of a symmetric matrix into a vector."""
         if not gs.all(Matrices.is_symmetric(mat)):
             logging.warning('non-symmetric matrix encountered.')
-        mat = Matrices.make_symmetric(mat)
+        mat = Matrices.to_symmetric(mat)
         _, dim, _ = mat.shape
         indices_i, indices_j = gs.triu_indices(dim)
         vec = []
@@ -70,7 +70,7 @@ class SymmetricMatrices(EmbeddedManifold):
         vec = gs.cast(vec, dtype)
         upper_triangular = gs.stack([
             gs.array_from_sparse(indices, data, shape) for data in vec])
-        mat = Matrices.make_symmetric(upper_triangular) * mask
+        mat = Matrices.to_symmetric(upper_triangular) * mask
         return mat
 
     @classmethod

--- a/geomstats/geometry/symmetric_matrices.py
+++ b/geomstats/geometry/symmetric_matrices.py
@@ -40,7 +40,7 @@ class SymmetricMatrices(EmbeddedManifold):
 
     @staticmethod
     @geomstats.vectorization.decorator(['matrix'])
-    def vector_from_symmetric_matrix(mat):
+    def to_vector(mat):
         """Convert the symmetric part of a symmetric matrix into a vector."""
         if not gs.all(Matrices.is_symmetric(mat)):
             logging.warning('non-symmetric matrix encountered.')
@@ -56,7 +56,7 @@ class SymmetricMatrices(EmbeddedManifold):
 
     @staticmethod
     @geomstats.vectorization.decorator(['vector', 'else'])
-    def symmetric_matrix_from_vector(vec, dtype=gs.float32):
+    def from_vector(vec, dtype=gs.float32):
         """Convert a vector into a symmetric matrix."""
         vec_dim = vec.shape[-1]
         mat_dim = (gs.sqrt(8. * vec_dim + 1) - 1) / 2

--- a/geomstats/learning/pca.py
+++ b/geomstats/learning/pca.py
@@ -174,7 +174,7 @@ class TangentPCA(_BasePCA):
         tangent_vecs = self.metric.log(X, base_point=self.base_point_fit)
         if self.point_type == 'matrix':
             if Matrices.is_symmetric(tangent_vecs).all():
-                X = SymmetricMatrices.vector_from_symmetric_matrix(
+                X = SymmetricMatrices.to_vector(
                     tangent_vecs)
             else:
                 X = gs.reshape(tangent_vecs, (len(X), - 1))
@@ -205,7 +205,7 @@ class TangentPCA(_BasePCA):
             if Matrices.is_symmetric(self.base_point_fit).all():
                 scores = SymmetricMatrices(
                     self.base_point_fit.shape[-1]
-                ).symmetric_matrix_from_vector(scores)
+                ).from_vector(scores)
             else:
                 dim = self.base_point_fit.shape[-1]
                 scores = gs.reshape(scores, (len(scores), dim, dim))
@@ -239,7 +239,7 @@ class TangentPCA(_BasePCA):
 
         if self.point_type == 'matrix':
             if Matrices.is_symmetric(tangent_vecs).all():
-                X = SymmetricMatrices.vector_from_symmetric_matrix(
+                X = SymmetricMatrices.to_vector(
                     tangent_vecs)
             else:
                 X = gs.reshape(tangent_vecs, (len(X), - 1))

--- a/geomstats/learning/preprocessing.py
+++ b/geomstats/learning/preprocessing.py
@@ -117,7 +117,7 @@ class ToTangentSpace(BaseEstimator, TransformerMixin):
             return tangent_vecs
 
         if gs.all(Matrices.is_symmetric(tangent_vecs)):
-            X = SymmetricMatrices.vector_from_symmetric_matrix(
+            X = SymmetricMatrices.to_vector(
                 tangent_vecs)
         elif gs.all(Matrices.is_skew_symmetric(tangent_vecs)):
             X = SkewSymmetricMatrices(
@@ -161,7 +161,7 @@ class ToTangentSpace(BaseEstimator, TransformerMixin):
 
             if gs.all(Matrices.is_symmetric(base_point)) and dim_sym == n_vecs:
                 tangent_vecs = SymmetricMatrices(
-                    base_point.shape[-1]).symmetric_matrix_from_vector(X)
+                    base_point.shape[-1]).from_vector(X)
             elif dim_skew == n_vecs:
                 tangent_vecs = SkewSymmetricMatrices(
                     dim_skew).matrix_representation(X)

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -327,24 +327,6 @@ class TestBackends(geomstats.tests.TestCase):
         gs_array = gs.assignment(
             gs_array, 44., (0, 1), axis=0)
 
-        print(np_array)
-        print(gs_array)
-        self.assertAllCloseToNp(gs_array, np_array)
-
-        np_array = _np.zeros((2, 3, 3))
-        gs_array = gs.zeros((2, 3, 3))
-
-        indices =
-
-        np_array[:, 0, 1] = _np.array([44., 22.])
-
-        gs_array = gs.assignment(
-            gs_array,
-            gs.array([44., 22.]),
-            (0, 1), axis=0)
-
-        print(np_array)
-        print(gs_array)
         self.assertAllCloseToNp(gs_array, np_array)
 
     def test_assignment_with_booleans_single_index(self):

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -318,6 +318,35 @@ class TestBackends(geomstats.tests.TestCase):
         gs_result = gs.einsum('...,...i->...i', array_1, array_2)
         self.assertAllCloseToNp(gs_result, np_result)
 
+    def test_assignment_with_matrices(self):
+        np_array = _np.zeros((2, 3, 3))
+        gs_array = gs.zeros((2, 3, 3))
+
+        np_array[:, 0, 1] = 44.
+
+        gs_array = gs.assignment(
+            gs_array, 44., (0, 1), axis=0)
+
+        print(np_array)
+        print(gs_array)
+        self.assertAllCloseToNp(gs_array, np_array)
+
+        np_array = _np.zeros((2, 3, 3))
+        gs_array = gs.zeros((2, 3, 3))
+
+        indices =
+
+        np_array[:, 0, 1] = _np.array([44., 22.])
+
+        gs_array = gs.assignment(
+            gs_array,
+            gs.array([44., 22.]),
+            (0, 1), axis=0)
+
+        print(np_array)
+        print(gs_array)
+        self.assertAllCloseToNp(gs_array, np_array)
+
     def test_assignment_with_booleans_single_index(self):
         np_array = _np.array([[2., 5.]])
         gs_array = gs.array([[2., 5.]])

--- a/tests/test_beta_distributions.py
+++ b/tests/test_beta_distributions.py
@@ -18,7 +18,8 @@ class TestBetaDistributions(geomstats.tests.TestCase):
 
     @geomstats.tests.np_and_pytorch_only
     def test_random_uniform_and_belongs(self):
-        """
+        """Test random_uniform and belongs.
+
         Test that the random uniform method samples
         on the beta distribution space.
         """
@@ -31,7 +32,8 @@ class TestBetaDistributions(geomstats.tests.TestCase):
 
     @geomstats.tests.np_and_pytorch_only
     def test_random_uniform(self):
-        """
+        """Test random_uniform.
+
         Test that the random uniform method samples points of the right shape
         """
         point = self.beta.random_uniform(self.n_samples)
@@ -39,7 +41,8 @@ class TestBetaDistributions(geomstats.tests.TestCase):
 
     @geomstats.tests.np_only
     def test_sample(self):
-        """
+        """Test samples.
+
         Test that the sample method samples variates from beta distributions
         with the specified parameters, using the law of large numbers
         """
@@ -54,7 +57,8 @@ class TestBetaDistributions(geomstats.tests.TestCase):
 
     @geomstats.tests.np_only
     def test_maximum_likelihood_fit(self):
-        """
+        """Test maximum likelihood.
+
         Test that the maximum likelihood fit method recovers
         parameters of beta distribution.
         """
@@ -83,7 +87,8 @@ class TestBetaDistributions(geomstats.tests.TestCase):
 
     @geomstats.tests.np_only
     def test_log_and_exp(self):
-        """
+        """Test Log and Exp.
+
         Test that the Riemannian exponential
         and the Riemannian logarithm are inverse.
 
@@ -99,7 +104,8 @@ class TestBetaDistributions(geomstats.tests.TestCase):
         self.assertAllClose(result, expected, rtol=1e-2)
 
     def test_christoffels_vectorization(self):
-        """
+        """Test Christoffel synbols.
+
         Check vectorization of Christoffel symbols in
         spherical coordinates on the 2-sphere.
         """

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -60,9 +60,9 @@ class TestConnection(geomstats.tests.TestCase):
             n_steps = 1 if step == 'pole' else 100
             tol = 1e-6 if step == 'pole' else 1e-1
             base_point = self.hypersphere.random_uniform(n_samples)
-            tan_vec_a = self.hypersphere.projection_to_tangent_space(
+            tan_vec_a = self.hypersphere.to_tangent(
                 gs.random.rand(n_samples, 3), base_point)
-            tan_vec_b = self.hypersphere.projection_to_tangent_space(
+            tan_vec_b = self.hypersphere.to_tangent(
                 gs.random.rand(n_samples, 3), base_point)
             expected = self.hypersphere.metric.parallel_transport(
                 tan_vec_a, tan_vec_b, base_point)
@@ -80,9 +80,9 @@ class TestConnection(geomstats.tests.TestCase):
             rtol = 1e-6 if step == 'pole' else 1e-1
             atol = 1e-6 if step == 'pole' else 1e-2
             base_point = self.hypersphere.random_uniform(n_samples)
-            tan_vec_a = self.hypersphere.projection_to_tangent_space(
+            tan_vec_a = self.hypersphere.to_tangent(
                 gs.random.rand(n_samples, 3), base_point)
-            tan_vec_b = self.hypersphere.projection_to_tangent_space(
+            tan_vec_b = self.hypersphere.to_tangent(
                 gs.random.rand(n_samples, 3), base_point)
             expected = self.hypersphere.metric.parallel_transport(
                 tan_vec_a, tan_vec_b, base_point)

--- a/tests/test_discretized_curves.py
+++ b/tests/test_discretized_curves.py
@@ -1,6 +1,4 @@
-"""
-Unit tests for parameterized manifolds.
-"""
+"""Unit tests for parameterized manifolds."""
 
 import tests.helper as helper
 

--- a/tests/test_discretized_curves.py
+++ b/tests/test_discretized_curves.py
@@ -57,9 +57,7 @@ class TestDiscretizedCurves(geomstats.tests.TestCase):
 
     @geomstats.tests.np_only
     def test_l2_metric_log_and_squared_norm_and_dist(self):
-        """
-        Test that squared norm of logarithm is squared dist.
-        """
+        """Test that squared norm of logarithm is squared dist."""
         tangent_vec = self.l2_metric_s2.log(
             landmarks=self.curve_b, base_landmarks=self.curve_a)
         log_ab = tangent_vec
@@ -72,9 +70,7 @@ class TestDiscretizedCurves(geomstats.tests.TestCase):
 
     @geomstats.tests.np_only
     def test_l2_metric_log_and_exp(self):
-        """
-        Test that exp and log are inverse maps.
-        """
+        """Test that exp and log are inverse maps."""
         tangent_vec = self.l2_metric_s2.log(
             landmarks=self.curve_b, base_landmarks=self.curve_a)
         result = self.l2_metric_s2.exp(tangent_vec=tangent_vec,
@@ -85,9 +81,7 @@ class TestDiscretizedCurves(geomstats.tests.TestCase):
 
     @geomstats.tests.np_only
     def test_l2_metric_inner_product_vectorization(self):
-        """
-        Test the vectorization inner_product.
-        """
+        """Test the vectorization inner_product."""
         n_samples = self.n_discretized_curves
         curves_ab = self.l2_metric_s2.geodesic(self.curve_a, self.curve_b)
         curves_bc = self.l2_metric_s2.geodesic(self.curve_b, self.curve_c)
@@ -104,9 +98,7 @@ class TestDiscretizedCurves(geomstats.tests.TestCase):
 
     @geomstats.tests.np_only
     def test_l2_metric_dist_vectorization(self):
-        """
-        Test the vectorization of dist.
-        """
+        """Test the vectorization of dist."""
         n_samples = self.n_discretized_curves
         curves_ab = self.l2_metric_s2.geodesic(self.curve_a, self.curve_b)
         curves_bc = self.l2_metric_s2.geodesic(self.curve_b, self.curve_c)
@@ -119,9 +111,7 @@ class TestDiscretizedCurves(geomstats.tests.TestCase):
 
     @geomstats.tests.np_only
     def test_l2_metric_exp_vectorization(self):
-        """
-        Test the vectorization of exp.
-        """
+        """Test the vectorization of exp."""
         curves_ab = self.l2_metric_s2.geodesic(self.curve_a, self.curve_b)
         curves_bc = self.l2_metric_s2.geodesic(self.curve_b, self.curve_c)
         curves_ab = curves_ab(self.times)
@@ -137,9 +127,7 @@ class TestDiscretizedCurves(geomstats.tests.TestCase):
 
     @geomstats.tests.np_only
     def test_l2_metric_log_vectorization(self):
-        """
-        Test the vectorization of log.
-        """
+        """Test the vectorization of log."""
         curves_ab = self.l2_metric_s2.geodesic(self.curve_a, self.curve_b)
         curves_bc = self.l2_metric_s2.geodesic(self.curve_b, self.curve_c)
         curves_ab = curves_ab(self.times)
@@ -153,9 +141,7 @@ class TestDiscretizedCurves(geomstats.tests.TestCase):
 
     @geomstats.tests.np_only
     def test_l2_metric_geodesic(self):
-        """
-        Test the geodesic method of L2Metric.
-        """
+        """Test the geodesic method of L2Metric."""
         curves_ab = self.l2_metric_s2.geodesic(self.curve_a, self.curve_b)
         curves_bc = self.l2_metric_s2.geodesic(self.curve_b, self.curve_c)
         curves_ab = curves_ab(self.times)
@@ -194,8 +180,8 @@ class TestDiscretizedCurves(geomstats.tests.TestCase):
 
     @geomstats.tests.np_only
     def test_square_root_velocity_and_inverse(self):
-        """
-        Test of square_root_velocity and its inverse.
+        """Test of square_root_velocity and its inverse.
+
         N.B: Here curves_ab are seen as curves in R3 and not S2.
         """
         curves_ab = self.l2_metric_s2.geodesic(self.curve_a, self.curve_b)
@@ -212,8 +198,8 @@ class TestDiscretizedCurves(geomstats.tests.TestCase):
 
     @geomstats.tests.np_only
     def test_srv_metric_exp_and_log(self):
-        """
-        Test that exp and log are inverse maps and vectorized.
+        """Test that exp and log are inverse maps and vectorized.
+
         N.B: Here curves_ab and curves_bc are seen as curves in R3 and not S2.
         """
         curves_ab = self.l2_metric_s2.geodesic(self.curve_a, self.curve_b)
@@ -231,8 +217,8 @@ class TestDiscretizedCurves(geomstats.tests.TestCase):
 
     @geomstats.tests.np_only
     def test_srv_metric_geodesic(self):
-        """
-        Test that the geodesic between two curves in a Euclidean space
+        """Test that the geodesic between two curves in a Euclidean space.
+
         for the srv metric is the L2 geodesic betweeen the curves srvs.
         N.B: Here curve_a and curve_b are seen as curves in R3 and not S2.
         """
@@ -259,8 +245,8 @@ class TestDiscretizedCurves(geomstats.tests.TestCase):
 
     @geomstats.tests.np_only
     def test_srv_metric_dist_and_geod(self):
-        """
-        Test that the length of the geodesic gives the distance.
+        """Test that the length of the geodesic gives the distance.
+
         N.B: Here curve_a and curve_b are seen as curves in R3 and not S2.
         """
         geod = self.srv_metric_r3.geodesic(initial_curve=self.curve_a,

--- a/tests/test_euclidean.py
+++ b/tests/test_euclidean.py
@@ -1,6 +1,4 @@
-"""
-Unit tests for the Euclidean space.
-"""
+"""Unit tests for the Euclidean space."""
 
 import geomstats.backend as gs
 import geomstats.tests

--- a/tests/test_grassmannian.py
+++ b/tests/test_grassmannian.py
@@ -1,6 +1,4 @@
-"""
-Unit tests for the Grassmannian.
-"""
+"""Unit tests for the Grassmannian."""
 
 import geomstats.backend as gs
 import geomstats.tests

--- a/tests/test_hyperbolic.py
+++ b/tests/test_hyperbolic.py
@@ -42,7 +42,7 @@ class TestHyperbolic(geomstats.tests.TestCase):
         base_point = gs.array([1., 0., 0., 0.])
         self.assertTrue(self.space.belongs(base_point))
 
-        tangent_vec = self.space.projection_to_tangent_space(
+        tangent_vec = self.space.to_tangent(
             vector=gs.array([1., 2., 1., 3.]),
             base_point=base_point)
 
@@ -51,7 +51,7 @@ class TestHyperbolic(geomstats.tests.TestCase):
 
         self.assertAllClose(result, expected)
 
-        result = self.space.projection_to_tangent_space(
+        result = self.space.to_tangent(
             vector=gs.array([1., 2., 1., 3.]),
             base_point=base_point)
         expected = tangent_vec
@@ -182,7 +182,7 @@ class TestHyperbolic(geomstats.tests.TestCase):
         base_point = gs.array([1., 0., 0.])
         self.assertTrue(H2.belongs(base_point))
 
-        tangent_vec = H2.projection_to_tangent_space(
+        tangent_vec = H2.to_tangent(
             vector=gs.array([1., 2., 1.]),
             base_point=base_point)
         exp = METRIC.exp(tangent_vec=tangent_vec,
@@ -203,12 +203,12 @@ class TestHyperbolic(geomstats.tests.TestCase):
             [5.0, math.sqrt(8), math.sqrt(8), math.sqrt(8)],
             [1.0, 0.0, 0.0, 0.0]])
 
-        one_tangent_vec = self.space.projection_to_tangent_space(
+        one_tangent_vec = self.space.to_tangent(
             one_vec, base_point=one_base_point)
         result = self.metric.exp(one_tangent_vec, one_base_point)
         self.assertAllClose(gs.shape(result), (dim,))
 
-        n_tangent_vecs = self.space.projection_to_tangent_space(
+        n_tangent_vecs = self.space.to_tangent(
             n_vecs, base_point=one_base_point)
         result = self.metric.exp(n_tangent_vecs, one_base_point)
         self.assertAllClose(gs.shape(result), (n_samples, dim))
@@ -221,7 +221,7 @@ class TestHyperbolic(geomstats.tests.TestCase):
         expected = helper.to_vector(gs.array(expected))
         self.assertAllClose(result, expected)
 
-        one_tangent_vec = self.space.projection_to_tangent_space(
+        one_tangent_vec = self.space.to_tangent(
             one_vec, base_point=n_base_points)
         result = self.metric.exp(one_tangent_vec, n_base_points)
         self.assertAllClose(gs.shape(result), (n_samples, dim))
@@ -234,7 +234,7 @@ class TestHyperbolic(geomstats.tests.TestCase):
         expected = helper.to_vector(gs.array(expected))
         self.assertAllClose(result, expected)
 
-        n_tangent_vecs = self.space.projection_to_tangent_space(
+        n_tangent_vecs = self.space.to_tangent(
             n_vecs, base_point=n_base_points)
         result = self.metric.exp(n_tangent_vecs, n_base_points)
         self.assertAllClose(gs.shape(result), (n_samples, dim))
@@ -282,11 +282,11 @@ class TestHyperbolic(geomstats.tests.TestCase):
         base_point = gs.array(
             [1.16563816, 0.36381045, -0.47000603, 0.07381469])
 
-        tangent_vec_a = self.space.projection_to_tangent_space(
+        tangent_vec_a = self.space.to_tangent(
             vector=gs.array([10., 200., 1., 1.]),
             base_point=base_point)
 
-        tangent_vec_b = self.space.projection_to_tangent_space(
+        tangent_vec_b = self.space.to_tangent(
             vector=gs.array([11., 20., -21., 0.]),
             base_point=base_point)
 
@@ -359,7 +359,7 @@ class TestHyperbolic(geomstats.tests.TestCase):
         # General case
         base_point = gs.array([4.0, 1., 3.0, math.sqrt(5)])
         vector = gs.array([2.0, 1.0, 1.0, 1.0])
-        vector = self.space.projection_to_tangent_space(
+        vector = self.space.to_tangent(
             vector=vector,
             base_point=base_point)
         exp = self.metric.exp(tangent_vec=vector, base_point=base_point)
@@ -379,7 +379,7 @@ class TestHyperbolic(geomstats.tests.TestCase):
     def test_exp_and_dist_and_projection_to_tangent_space(self):
         base_point = gs.array([4.0, 1., 3.0, math.sqrt(5)])
         vector = gs.array([0.001, 0., -.00001, -.00003])
-        tangent_vec = self.space.projection_to_tangent_space(
+        tangent_vec = self.space.to_tangent(
             vector=vector,
             base_point=base_point)
         exp = self.metric.exp(
@@ -398,7 +398,7 @@ class TestHyperbolic(geomstats.tests.TestCase):
         n_geodesic_points = 100
         vector = gs.array([1., 0., 0., 0.])
 
-        initial_tangent_vec = self.space.projection_to_tangent_space(
+        initial_tangent_vec = self.space.to_tangent(
             vector=vector,
             base_point=initial_point)
         geodesic = self.metric.geodesic(
@@ -426,7 +426,7 @@ class TestHyperbolic(geomstats.tests.TestCase):
 
         exp = self.metric.exp(tangent_vec=vector, base_point=base_point)
         result = self.metric.log(point=exp, base_point=base_point)
-        expected = self.space.projection_to_tangent_space(
+        expected = self.space.to_tangent(
             vector=vector,
             base_point=base_point)
 
@@ -438,10 +438,10 @@ class TestHyperbolic(geomstats.tests.TestCase):
             base_point_intrinsic, 'intrinsic')
         tangent_vec_a = gs.array([1., 2., 3., 4.])
         tangent_vec_b = gs.array([5., 6., 7., 8.])
-        tangent_vec_a = self.space.projection_to_tangent_space(
+        tangent_vec_a = self.space.to_tangent(
             tangent_vec_a,
             base_point)
-        tangent_vec_b = self.space.projection_to_tangent_space(
+        tangent_vec_b = self.space.to_tangent(
             tangent_vec_b,
             base_point)
         scale = 2
@@ -466,7 +466,7 @@ class TestHyperbolic(geomstats.tests.TestCase):
         base_point = self.space.from_coordinates(
             base_point_intrinsic, 'intrinsic')
         tangent_vec = gs.array([1., 2., 3., 4.])
-        tangent_vec = self.space.projection_to_tangent_space(
+        tangent_vec = self.space.to_tangent(
             tangent_vec, base_point)
         scale = 2
         default_space = Hyperboloid(dim=self.dimension)

--- a/tests/test_hyperbolic_coords.py
+++ b/tests/test_hyperbolic_coords.py
@@ -33,7 +33,6 @@ class TestHyperbolicCoords(geomstats.tests.TestCase):
 
         self.n_samples = 10
 
-    @geomstats.tests.np_and_pytorch_only
     def test_extrinsic_ball_extrinsic(self):
         x_in = gs.array([0.5, 7])
         x = self.intrinsic_manifold.to_coordinates(
@@ -42,13 +41,11 @@ class TestHyperbolicCoords(geomstats.tests.TestCase):
         x2 = self.ball_manifold.to_coordinates(x_b, to_coords_type='extrinsic')
         self.assertAllClose(x, x2, atol=1e-8)
 
-    @geomstats.tests.np_and_pytorch_only
     def test_belongs_intrinsic(self):
         x_in = gs.array([0.5, 7])
         is_in = self.intrinsic_manifold.belongs(x_in)
         self.assertTrue(is_in)
 
-    @geomstats.tests.np_and_pytorch_only
     def test_belongs_extrinsic(self):
         x_true = self.intrinsic_manifold.to_coordinates(
             gs.array([0.5, 7]), 'extrinsic')
@@ -58,7 +55,6 @@ class TestHyperbolicCoords(geomstats.tests.TestCase):
         is_out = self.extrinsic_manifold.belongs(x_false)
         self.assertFalse(is_out)
 
-    @geomstats.tests.np_and_pytorch_only
     def test_belongs_ball(self):
         x_true = gs.array([0.5, 0.5])
         x_false = gs.array([0.8, 0.8])
@@ -67,7 +63,6 @@ class TestHyperbolicCoords(geomstats.tests.TestCase):
         is_out = self.ball_manifold.belongs(x_false)
         self.assertFalse(is_out)
 
-    @geomstats.tests.np_and_pytorch_only
     def test_extrinsic_half_plane_extrinsic(self):
         x_in = gs.array([0.5, 7])
         x = self.intrinsic_manifold.to_coordinates(
@@ -79,7 +74,6 @@ class TestHyperbolicCoords(geomstats.tests.TestCase):
             x_up, 'half-plane', 'extrinsic')
         self.assertAllClose(x, x2, atol=1e-8)
 
-    @geomstats.tests.np_and_pytorch_only
     def test_intrinsic_extrinsic_intrinsic(self):
         x_intr = gs.array([0.5, 7])
         x_extr = self.intrinsic_manifold.to_coordinates(
@@ -88,14 +82,12 @@ class TestHyperbolicCoords(geomstats.tests.TestCase):
             x_extr, to_coords_type='intrinsic')
         self.assertAllClose(x_intr, x_intr2, atol=1e-8)
 
-    @geomstats.tests.np_and_pytorch_only
     def test_ball_extrinsic_ball(self):
         x = gs.array([0.5, 0.2])
         x_e = self.ball_manifold.to_coordinates(x, to_coords_type='extrinsic')
         x2 = self.extrinsic_manifold.to_coordinates(x_e, to_coords_type='ball')
         self.assertAllClose(x, x2, atol=1e-10)
 
-    @geomstats.tests.np_and_pytorch_only
     def test_distance_ball_extrinsic_from_ball(self):
         x_ball = gs.array([0.7, 0.2])
         y_ball = gs.array([0.2, 0.2])
@@ -108,7 +100,6 @@ class TestHyperbolicCoords(geomstats.tests.TestCase):
 
         self.assertAllClose(dst_ball, dst_extr)
 
-    @geomstats.tests.np_and_pytorch_only
     def test_distance_ball_extrinsic_from_extr(self):
         x_int = gs.array([10, 0.2])
         y_int = gs.array([1, 6.])
@@ -125,7 +116,6 @@ class TestHyperbolicCoords(geomstats.tests.TestCase):
 
         self.assertAllClose(dst_ball, dst_extr)
 
-    @geomstats.tests.np_and_pytorch_only
     def test_distance_ball_extrinsic_from_extr_4_dim(self):
         x_int = gs.array([10, 0.2, 3, 4])
         y_int = gs.array([1, 6, 2., 1])
@@ -173,7 +163,6 @@ class TestHyperbolicCoords(geomstats.tests.TestCase):
         #     x_ball_log_exp, from_point_type='ball')
         # self.assertAllClose(x_extr_a, x_extr_b, atol=1e-4)
 
-    @geomstats.tests.np_only
     def test_log_exp_ball(self):
         x = gs.array([0.1, 0.2])
         y = gs.array([0.2, 0.5])
@@ -182,7 +171,6 @@ class TestHyperbolicCoords(geomstats.tests.TestCase):
         exp = self.ball_metric.exp(tangent_vec=log, base_point=x)
         self.assertAllClose(exp, y, atol=1e-1)
 
-    @geomstats.tests.np_only
     def test_log_exp_ball_vectorization(self):
         x = gs.array([0.1, 0.2])
         y = gs.array([[0.2, 0.5], [0.1, 0.7]])
@@ -191,7 +179,6 @@ class TestHyperbolicCoords(geomstats.tests.TestCase):
         exp = self.ball_metric.exp(log, x)
         self.assertAllClose(exp, y, atol=1e-1)
 
-    @geomstats.tests.np_only
     def test_log_exp_ball_null_tangent(self):
         x = gs.array([[0.1, 0.2], [0.1, 0.2]])
         tangent_vec = gs.array([[0.0, 0.0], [0.0, 0.0]])

--- a/tests/test_hyperbolic_coords.py
+++ b/tests/test_hyperbolic_coords.py
@@ -143,25 +143,25 @@ class TestHyperbolicCoords(geomstats.tests.TestCase):
     def test_log_exp_ball_extrinsic_from_extr(self):
         """Compare log exp in different parameterizations."""
         # TODO(Hazaatiti): Fix this test
-        # x_int = gs.array([[4., 0.2]])
-        # y_int = gs.array([[3., 3]])
-        # x_extr = self.intrinsic_manifold.to_coordinates(
-        #     x_int, to_point_type='extrinsic')
-        # y_extr = self.intrinsic_manifold.to_coordinates(
-        #     y_int, to_point_type='extrinsic')
-        # x_ball = self.extrinsic_manifold.to_coordinates(
-        #     x_extr, to_point_type='ball')
-        # y_ball = self.extrinsic_manifold.to_coordinates(
-        #     y_extr, to_point_type='ball')
+        x_int = gs.array([4., 0.2])
+        y_int = gs.array([3., 3])
+        x_extr = self.intrinsic_manifold.to_coordinates(
+            x_int, to_coords_type='extrinsic')
+        y_extr = self.intrinsic_manifold.to_coordinates(
+            y_int, to_coords_type='extrinsic')
+        x_ball = self.extrinsic_manifold.to_coordinates(
+            x_extr, to_coords_type='ball')
+        y_ball = self.extrinsic_manifold.to_coordinates(
+            y_extr, to_coords_type='ball')
 
-        # x_ball_log_exp = self.ball_metric.exp(
-        #     self.ball_metric.log(y_ball, x_ball), x_ball)
+        x_ball_log_exp = self.ball_metric.exp(
+            self.ball_metric.log(y_ball, x_ball), x_ball)
 
-        # x_extr_a = self.extrinsic_metric.exp(
-        #     self.extrinsic_metric.log(y_extr, x_extr), x_extr)
-        # x_extr_b = self.extrinsic_manifold.from_coordinates(
-        #     x_ball_log_exp, from_point_type='ball')
-        # self.assertAllClose(x_extr_a, x_extr_b, atol=1e-4)
+        x_extr_a = self.extrinsic_metric.exp(
+            self.extrinsic_metric.log(y_extr, x_extr), x_extr)
+        x_extr_b = self.extrinsic_manifold.from_coordinates(
+            x_ball_log_exp, from_coords_type='ball')
+        self.assertAllClose(x_extr_a, x_extr_b, atol=1e-4)
 
     def test_log_exp_ball(self):
         x = gs.array([0.1, 0.2])

--- a/tests/test_hyperbolic_coords.py
+++ b/tests/test_hyperbolic_coords.py
@@ -139,10 +139,8 @@ class TestHyperbolicCoords(geomstats.tests.TestCase):
 
         self.assertAllClose(dst_ball, dst_extr)
 
-    @geomstats.tests.np_and_pytorch_only
     def test_log_exp_ball_extrinsic_from_extr(self):
         """Compare log exp in different parameterizations."""
-        # TODO(Hazaatiti): Fix this test
         x_int = gs.array([4., 0.2])
         y_int = gs.array([3., 3])
         x_extr = self.intrinsic_manifold.to_coordinates(

--- a/tests/test_hypersphere.py
+++ b/tests/test_hypersphere.py
@@ -562,9 +562,7 @@ class TestHypersphere(geomstats.tests.TestCase):
         self.assertAllClose(expected, result)
 
     def test_closest_neighbor_index(self):
-        """
-        Check that the closest neighbor is one of neighbors.
-        """
+        """Check that the closest neighbor is one of neighbors."""
         n_samples = 10
         points = self.space.random_uniform(n_samples=n_samples)
         point = points[0, :]

--- a/tests/test_hypersphere.py
+++ b/tests/test_hypersphere.py
@@ -444,7 +444,6 @@ class TestHypersphere(geomstats.tests.TestCase):
 
         self.assertAllClose(result, expected)
 
-    @geomstats.tests.np_and_pytorch_only
     def test_geodesic_and_belongs(self):
         n_geodesic_points = 100
         initial_point = self.space.random_uniform()
@@ -556,7 +555,6 @@ class TestHypersphere(geomstats.tests.TestCase):
         expected = gs.pi
         self.assertAllClose(expected, result)
 
-    @geomstats.tests.np_and_pytorch_only
     def test_closest_neighbor_index(self):
         """
         Check that the closest neighbor is one of neighbors.
@@ -572,7 +570,6 @@ class TestHypersphere(geomstats.tests.TestCase):
         result = test > 0
         self.assertTrue(result)
 
-    @geomstats.tests.np_and_pytorch_only
     def test_sample_von_mises_fisher(self):
         """
         Check that the maximum likelihood estimates of the mean and
@@ -596,7 +593,7 @@ class TestHypersphere(geomstats.tests.TestCase):
             gs.allclose(result, expected, atol=MEAN_ESTIMATION_TOL)
         )
         # check concentration parameter for dispersed distribution
-        kappa = 1
+        kappa = 1.
         points = sphere.random_von_mises_fisher(kappa, n_points)
         sum_points = gs.sum(points, axis=0)
         mean_norm = gs.linalg.norm(sum_points) / n_points
@@ -612,10 +609,9 @@ class TestHypersphere(geomstats.tests.TestCase):
             denominator = 1. - ratio**2 - (p - 1.) * ratio / kappa_estimate
             mean_norm = gs.cast(mean_norm, gs.float64)
             kappa_estimate = kappa_estimate - (ratio - mean_norm) / denominator
-        expected = kappa
         result = kappa_estimate
-        self.assertTrue(
-            gs.allclose(result, expected, atol=KAPPA_ESTIMATION_TOL))
+        expected = kappa
+        self.assertAllClose(result, expected, atol=KAPPA_ESTIMATION_TOL)
 
     @geomstats.tests.np_and_pytorch_only
     def test_spherical_to_extrinsic(self):

--- a/tests/test_hypersphere.py
+++ b/tests/test_hypersphere.py
@@ -158,7 +158,7 @@ class TestHypersphere(geomstats.tests.TestCase):
 
         one_vec = self.space.random_uniform()
         one_base_point = self.space.random_uniform()
-        one_tangent_vec = self.space.projection_to_tangent_space(
+        one_tangent_vec = self.space.to_tangent(
             one_vec, base_point=one_base_point)
 
         result = self.metric.exp(one_tangent_vec, one_base_point)
@@ -185,19 +185,19 @@ class TestHypersphere(geomstats.tests.TestCase):
         n_vecs = self.space.random_uniform(n_samples=n_samples)
         n_base_points = self.space.random_uniform(n_samples=n_samples)
 
-        n_tangent_vecs = self.space.projection_to_tangent_space(
+        n_tangent_vecs = self.space.to_tangent(
             n_vecs, base_point=one_base_point)
         result = self.metric.exp(n_tangent_vecs, one_base_point)
 
         self.assertAllClose(gs.shape(result), (n_samples, dim))
 
-        one_tangent_vec = self.space.projection_to_tangent_space(
+        one_tangent_vec = self.space.to_tangent(
             one_vec, base_point=n_base_points)
         result = self.metric.exp(one_tangent_vec, n_base_points)
 
         self.assertAllClose(gs.shape(result), (n_samples, dim))
 
-        n_tangent_vecs = self.space.projection_to_tangent_space(
+        n_tangent_vecs = self.space.to_tangent(
             n_vecs, base_point=n_base_points)
         result = self.metric.exp(n_tangent_vecs, n_base_points)
 
@@ -264,7 +264,7 @@ class TestHypersphere(geomstats.tests.TestCase):
         base_point = gs.array([0., -3., 0., 3., 4.])
         base_point = base_point / gs.linalg.norm(base_point)
         vector = gs.array([9., 5., 0., 0., -1.])
-        vector = self.space.projection_to_tangent_space(
+        vector = self.space.to_tangent(
             vector=vector, base_point=base_point)
 
         # exp = self.metric.exp(tangent_vec=vector, base_point=base_point)
@@ -291,12 +291,12 @@ class TestHypersphere(geomstats.tests.TestCase):
         base_point = gs.array([10., -2., -.5, 34., 3.])
         base_point = base_point / gs.linalg.norm(base_point)
         vector = 1e-10 * gs.array([.06, -51., 6., 5., 3.])
-        vector = self.space.projection_to_tangent_space(
+        vector = self.space.to_tangent(
             vector=vector, base_point=base_point)
 
         exp = self.metric.exp(tangent_vec=vector, base_point=base_point)
         result = self.metric.log(point=exp, base_point=base_point)
-        expected = self.space.projection_to_tangent_space(
+        expected = self.space.to_tangent(
             vector=vector, base_point=base_point)
 
         self.assertAllClose(result, expected, atol=1e-8)
@@ -417,7 +417,7 @@ class TestHypersphere(geomstats.tests.TestCase):
         base_point = gs.array([16., -2., -2.5, 84., 3.])
         base_point = base_point / gs.linalg.norm(base_point)
         vector = gs.array([9., 0., -1., -2., 1.])
-        tangent_vec = self.space.projection_to_tangent_space(
+        tangent_vec = self.space.to_tangent(
             vector=vector, base_point=base_point)
 
         exp = self.metric.exp(
@@ -439,7 +439,7 @@ class TestHypersphere(geomstats.tests.TestCase):
             [[9., 0., -1., -2., 1.],
              [9., 0., -1., -2., 1]])
 
-        tangent_vec = self.space.projection_to_tangent_space(
+        tangent_vec = self.space.to_tangent(
             vector=vector, base_point=base_point)
 
         exp = self.metric.exp(
@@ -454,7 +454,7 @@ class TestHypersphere(geomstats.tests.TestCase):
         n_geodesic_points = 100
         initial_point = self.space.random_uniform()
         vector = gs.array([2., 0., -1., -2., 1.])
-        initial_tangent_vec = self.space.projection_to_tangent_space(
+        initial_tangent_vec = self.space.to_tangent(
             vector=vector, base_point=initial_point)
         geodesic = self.metric.geodesic(
             initial_point=initial_point,

--- a/tests/test_hypersphere.py
+++ b/tests/test_hypersphere.py
@@ -637,7 +637,6 @@ class TestHypersphere(geomstats.tests.TestCase):
              [gs.sqrt(2.) / 4., gs.sqrt(2.) / 4., gs.sqrt(3.) / 2.]])
         self.assertAllClose(result, expected)
 
-    #@geomstats.tests.np_and_pytorch_only
     def test_tangent_spherical_to_extrinsic(self):
         """
         Check vectorization of conversion from spherical

--- a/tests/test_hypersphere.py
+++ b/tests/test_hypersphere.py
@@ -21,7 +21,8 @@ class TestHypersphere(geomstats.tests.TestCase):
         self.n_samples = 10
 
     def test_random_uniform_and_belongs(self):
-        """
+        """Test random uniform and belongs.
+
         Test that the random uniform method samples
         on the hypersphere space.
         """
@@ -76,7 +77,8 @@ class TestHypersphere(geomstats.tests.TestCase):
         self.assertAllClose(result, expected)
 
     def test_intrinsic_and_extrinsic_coords_vectorization(self):
-        """
+        """Test change of coordinates.
+
         Test that the composition of
         intrinsic_to_extrinsic_coords and
         extrinsic_to_intrinsic_coords
@@ -102,7 +104,8 @@ class TestHypersphere(geomstats.tests.TestCase):
         self.assertAllClose(result, expected)
 
     def test_log_and_exp_general_case(self):
-        """
+        """Test Log and Exp.
+
         Test that the Riemannian exponential
         and the Riemannian logarithm are inverse.
 
@@ -125,7 +128,8 @@ class TestHypersphere(geomstats.tests.TestCase):
         self.assertAllClose(result, expected, atol=1e-6)
 
     def test_log_and_exp_edge_case(self):
-        """
+        """Test Log and Exp.
+
         Test that the Riemannian exponential
         and the Riemannian logarithm are inverse.
 
@@ -242,7 +246,8 @@ class TestHypersphere(geomstats.tests.TestCase):
         self.assertAllClose(gs.shape(result), (n_samples, dim))
 
     def test_exp_and_log_and_projection_to_tangent_space_general_case(self):
-        """
+        """Test Log and Exp.
+
         Test that the Riemannian exponential
         and the Riemannian logarithm are inverse.
 
@@ -271,7 +276,8 @@ class TestHypersphere(geomstats.tests.TestCase):
         expected = expected / norm_expected * regularized_norm_expected
 
     def test_exp_and_log_and_projection_to_tangent_space_edge_case(self):
-        """
+        """Test Log and Exp.
+
         Test that the Riemannian exponential
         and the Riemannian logarithm are inverse.
 

--- a/tests/test_hypersphere.py
+++ b/tests/test_hypersphere.py
@@ -613,7 +613,6 @@ class TestHypersphere(geomstats.tests.TestCase):
         expected = kappa
         self.assertAllClose(result, expected, atol=KAPPA_ESTIMATION_TOL)
 
-    @geomstats.tests.np_and_pytorch_only
     def test_spherical_to_extrinsic(self):
         """
         Check vectorization of conversion from spherical
@@ -627,7 +626,6 @@ class TestHypersphere(geomstats.tests.TestCase):
         expected = gs.array([1., 0., 0.])
         self.assertAllClose(result, expected)
 
-    @geomstats.tests.np_and_pytorch_only
     def test_spherical_to_extrinsic_vectorization(self):
         dim = 2
         sphere = Hypersphere(dim)
@@ -636,7 +634,7 @@ class TestHypersphere(geomstats.tests.TestCase):
         result = sphere.spherical_to_extrinsic(points_spherical)
         expected = gs.array(
             [[1., 0., 0.],
-             [gs.sqrt(2) / 4, gs.sqrt(2) / 4, gs.sqrt(3) / 2]])
+             [gs.sqrt(2.) / 4., gs.sqrt(2.) / 4., gs.sqrt(3.) / 2.]])
         self.assertAllClose(result, expected)
 
     @geomstats.tests.np_and_pytorch_only

--- a/tests/test_hypersphere.py
+++ b/tests/test_hypersphere.py
@@ -637,7 +637,7 @@ class TestHypersphere(geomstats.tests.TestCase):
              [gs.sqrt(2.) / 4., gs.sqrt(2.) / 4., gs.sqrt(3.) / 2.]])
         self.assertAllClose(result, expected)
 
-    @geomstats.tests.np_and_pytorch_only
+    #@geomstats.tests.np_and_pytorch_only
     def test_tangent_spherical_to_extrinsic(self):
         """
         Check vectorization of conversion from spherical

--- a/tests/test_integrator.py
+++ b/tests/test_integrator.py
@@ -14,7 +14,7 @@ class TestIntegrator(geomstats.tests.TestCase):
         self.euclidean = Euclidean(self.dimension)
         self.matrices = Matrices(self.dimension, self.dimension)
         self.intercept = self.euclidean.random_uniform(1)
-        self.slope = Matrices.make_symmetric(self.matrices.random_uniform(1))
+        self.slope = Matrices.to_symmetric(self.matrices.random_uniform(1))
 
     def function_linear(self, point, vector):
         return - gs.dot(self.slope, vector)

--- a/tests/test_invariant_metric.py
+++ b/tests/test_invariant_metric.py
@@ -1,6 +1,4 @@
-"""
-Unit tests for the invariant metrics on Lie groups.
-"""
+"""Unit tests for the invariant metrics on Lie groups."""
 
 import logging
 import warnings

--- a/tests/test_landmarks.py
+++ b/tests/test_landmarks.py
@@ -63,9 +63,7 @@ class TestLandmarks(geomstats.tests.TestCase):
 
     @geomstats.tests.np_only
     def test_l2_metric_log_and_squared_norm_and_dist(self):
-        """
-        Test that squared norm of logarithm is squared dist.
-        """
+        """Test that squared norm of logarithm is squared dist."""
         tangent_vec = self.l2_metric_s2.log(
             landmarks=self.landmarks_b, base_landmarks=self.landmarks_a)
         log_ab = tangent_vec
@@ -78,9 +76,7 @@ class TestLandmarks(geomstats.tests.TestCase):
 
     @geomstats.tests.np_only
     def test_l2_metric_log_and_exp(self):
-        """
-        Test that exp and log are inverse maps.
-        """
+        """Test that exp and log are inverse maps."""
         tangent_vec = self.l2_metric_s2.log(
             landmarks=self.landmarks_b, base_landmarks=self.landmarks_a)
         result = self.l2_metric_s2.exp(
@@ -92,9 +88,7 @@ class TestLandmarks(geomstats.tests.TestCase):
 
     @geomstats.tests.np_only
     def test_l2_metric_inner_product_vectorization(self):
-        """
-        Test the vectorization inner_product.
-        """
+        """Test the vectorization inner_product."""
         n_samples = self.n_landmark_sets
         landmarks_ab = self.l2_metric_s2.geodesic(
             self.landmarks_a, self.landmarks_b)
@@ -113,9 +107,7 @@ class TestLandmarks(geomstats.tests.TestCase):
 
     @geomstats.tests.np_only
     def test_l2_metric_dist_vectorization(self):
-        """
-        Test the vectorization of dist.
-        """
+        """Test the vectorization of dist."""
         n_samples = self.n_landmark_sets
         landmarks_ab = self.l2_metric_s2.geodesic(
             self.landmarks_a, self.landmarks_b)
@@ -130,9 +122,7 @@ class TestLandmarks(geomstats.tests.TestCase):
 
     @geomstats.tests.np_and_tf_only
     def test_l2_metric_exp_vectorization(self):
-        """
-        Test the vectorization of exp.
-        """
+        """Test the vectorization of exp."""
         landmarks_ab = self.l2_metric_s2.geodesic(
             self.landmarks_a, self.landmarks_b)
         landmarks_bc = self.l2_metric_s2.geodesic(
@@ -149,9 +139,7 @@ class TestLandmarks(geomstats.tests.TestCase):
 
     @geomstats.tests.np_only
     def test_l2_metric_log_vectorization(self):
-        """
-        Test the vectorization of log.
-        """
+        """Test the vectorization of log."""
         landmarks_ab = self.l2_metric_s2.geodesic(
             self.landmarks_a, self.landmarks_b)
         landmarks_bc = self.l2_metric_s2.geodesic(
@@ -167,9 +155,7 @@ class TestLandmarks(geomstats.tests.TestCase):
 
     @geomstats.tests.np_only
     def test_l2_metric_geodesic(self):
-        """
-        Test the geodesic method of L2Metric.
-        """
+        """Test the geodesic method of L2Metric."""
         landmarks_ab = self.l2_metric_s2.geodesic(
             self.landmarks_a, self.landmarks_b)
         landmarks_bc = self.l2_metric_s2.geodesic(

--- a/tests/test_landmarks.py
+++ b/tests/test_landmarks.py
@@ -1,6 +1,4 @@
-"""
-Unit tests for landmarks space.
-"""
+"""Unit tests for landmarks space."""
 
 import geomstats.backend as gs
 import geomstats.tests

--- a/tests/test_manifold.py
+++ b/tests/test_manifold.py
@@ -1,6 +1,4 @@
-"""
-Unit tests for manifolds.
-"""
+"""Unit tests for manifolds."""
 
 import geomstats.backend as gs
 import geomstats.tests

--- a/tests/test_matrices.py
+++ b/tests/test_matrices.py
@@ -112,14 +112,14 @@ class TestMatrices(geomstats.tests.TestCase):
     def test_make_symmetric(self):
         sym_mat = gs.array([[1., 2.],
                             [2., 1.]])
-        result = self.space.make_symmetric(sym_mat)
+        result = self.space.to_symmetric(sym_mat)
         expected = sym_mat
         self.assertAllClose(result, expected)
 
         mat = gs.array([[1., 2., 3.],
                         [0., 0., 0.],
                         [3., 1., 1.]])
-        result = self.space.make_symmetric(mat)
+        result = self.space.to_symmetric(mat)
         expected = gs.array([[1., 1., 3.],
                              [1., 0., 0.5],
                              [3., 0.5, 1.]])
@@ -128,7 +128,7 @@ class TestMatrices(geomstats.tests.TestCase):
         mat = gs.array([[1e100, 1e-100, 1e100],
                         [1e100, 1e-100, 1e100],
                         [1e-100, 1e-100, 1e100]])
-        result = self.space.make_symmetric(mat)
+        result = self.space.to_symmetric(mat)
 
         res = 0.5 * (1e100 + 1e-100)
 
@@ -145,7 +145,7 @@ class TestMatrices(geomstats.tests.TestCase):
             [[5., 6.],
              [4., 9.]]])
 
-        sym_points = self.space.make_symmetric(points)
+        sym_points = self.space.to_symmetric(points)
         result = gs.all(self.space.is_symmetric(sym_points))
         expected = True
         self.assertAllClose(result, expected)

--- a/tests/test_matrices.py
+++ b/tests/test_matrices.py
@@ -1,6 +1,4 @@
-"""
-Unit tests for the manifold of matrices.
-"""
+"""Unit tests for the manifold of matrices."""
 
 import geomstats.backend as gs
 import geomstats.tests

--- a/tests/test_minkowski.py
+++ b/tests/test_minkowski.py
@@ -1,6 +1,5 @@
-"""
-Unit tests for Minkowski space.
-"""
+"""Unit tests for Minkowski space."""
+
 import math
 
 import numpy as np

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -60,7 +60,7 @@ class TestToTangentSpace(geomstats.tests.TestCase):
         transformer.fit(X=points)
         result = transformer.transform(points)
         expected = gs.zeros((2, 6))
-        self.assertAllClose(expected, result)
+        self.assertAllClose(expected, result, atol=1e-5)
 
     def test_fit_transform_hyperbolic(self):
         point = gs.array([2., 1., 1., 1.])

--- a/tests/test_product_manifold.py
+++ b/tests/test_product_manifold.py
@@ -1,6 +1,4 @@
-"""
-Unit tests for ProductManifold.
-"""
+"""Unit tests for ProductManifold."""
 
 
 import geomstats.backend as gs

--- a/tests/test_skew_symmetric_matrices.py
+++ b/tests/test_skew_symmetric_matrices.py
@@ -1,6 +1,5 @@
-"""
-Unit tests for the skew symmetric matrices
-"""
+"""Unit tests for the skew symmetric matrices."""
+
 import geomstats.backend as gs
 import geomstats.tests
 from geomstats.geometry.skew_symmetric_matrices import SkewSymmetricMatrices

--- a/tests/test_spd_matrices.py
+++ b/tests/test_spd_matrices.py
@@ -69,15 +69,15 @@ class TestSPDMatrices(geomstats.tests.TestCase):
         sym_mat_1 = gs.array([[1., 0.6, -3.],
                               [0.6, 7., 0.],
                               [-3., 0., 8.]])
-        vector_1 = self.space.vector_from_symmetric_matrix(sym_mat_1)
-        result_1 = self.space.symmetric_matrix_from_vector(vector_1)
+        vector_1 = self.space.to_vector(sym_mat_1)
+        result_1 = self.space.from_vector(vector_1)
         expected_1 = sym_mat_1
 
         self.assertTrue(gs.allclose(result_1, expected_1))
 
         vector_2 = gs.array([1., 2., 3., 4., 5., 6.])
-        sym_mat_2 = self.space.symmetric_matrix_from_vector(vector_2)
-        result_2 = self.space.vector_from_symmetric_matrix(sym_mat_2)
+        sym_mat_2 = self.space.from_vector(vector_2)
+        result_2 = self.space.to_vector(sym_mat_2)
         expected_2 = vector_2
 
         self.assertTrue(gs.allclose(result_2, expected_2))
@@ -86,15 +86,15 @@ class TestSPDMatrices(geomstats.tests.TestCase):
         """Test of vectorization."""
         n_samples = self.n_samples
         vector = gs.random.rand(n_samples, 6)
-        sym_mat = self.space.symmetric_matrix_from_vector(vector)
-        result = self.space.vector_from_symmetric_matrix(sym_mat)
+        sym_mat = self.space.from_vector(vector)
+        result = self.space.to_vector(sym_mat)
         expected = vector
 
         self.assertTrue(gs.allclose(result, expected))
 
         sym_mat = self.space.random_uniform(n_samples)
-        vector = self.space.vector_from_symmetric_matrix(sym_mat)
-        result = self.space.symmetric_matrix_from_vector(vector)
+        vector = self.space.to_vector(sym_mat)
+        result = self.space.from_vector(vector)
         expected = sym_mat
 
         self.assertTrue(gs.allclose(result, expected))

--- a/tests/test_special_euclidean3.py
+++ b/tests/test_special_euclidean3.py
@@ -1,5 +1,4 @@
-"""
-Unit tests for special euclidean group SE(n).
+"""Unit tests for special euclidean group SE(n).
 
 Note: Only the *canonical* left- and right- invariant
 metrics on SE(3) are tested here. Other invariant

--- a/tests/test_special_orthogonal.py
+++ b/tests/test_special_orthogonal.py
@@ -1,6 +1,4 @@
-"""
-Unit tests for special orthogonal group SO(n).
-"""
+"""Unit tests for special orthogonal group SO(n)."""
 
 import geomstats.backend as gs
 import geomstats.tests

--- a/tests/test_stiefel.py
+++ b/tests/test_stiefel.py
@@ -1,6 +1,4 @@
-"""
-Unit tests for Stiefel manifolds.
-"""
+"""Unit tests for Stiefel manifolds."""
 
 import warnings
 

--- a/tests/test_symmetric_matrices.py
+++ b/tests/test_symmetric_matrices.py
@@ -82,15 +82,15 @@ class TestSymmetricMatrices(geomstats.tests.TestCase):
         sym_mat_1 = gs.array([[1., 0.6, -3.],
                               [0.6, 7., 0.],
                               [-3., 0., 8.]])
-        vector_1 = self.space.vector_from_symmetric_matrix(sym_mat_1)
-        result_1 = self.space.symmetric_matrix_from_vector(vector_1)
+        vector_1 = self.space.to_vector(sym_mat_1)
+        result_1 = self.space.from_vector(vector_1)
         expected_1 = sym_mat_1
 
         self.assertTrue(gs.allclose(result_1, expected_1))
 
         vector_2 = gs.array([1, 2, 3, 4, 5, 6])
-        sym_mat_2 = self.space.symmetric_matrix_from_vector(vector_2)
-        result_2 = self.space.vector_from_symmetric_matrix(sym_mat_2)
+        sym_mat_2 = self.space.from_vector(vector_2)
+        result_2 = self.space.to_vector(sym_mat_2)
         expected_2 = vector_2
 
         self.assertTrue(gs.allclose(result_2, expected_2))
@@ -100,20 +100,20 @@ class TestSymmetricMatrices(geomstats.tests.TestCase):
         """Test of vectorization."""
         n_samples = 5
         vector = gs.random.rand(n_samples, 6)
-        sym_mat = self.space.symmetric_matrix_from_vector(vector)
-        result = self.space.vector_from_symmetric_matrix(sym_mat)
+        sym_mat = self.space.from_vector(vector)
+        result = self.space.to_vector(sym_mat)
         expected = vector
 
         self.assertTrue(gs.allclose(result, expected))
 
-        vector = self.space.vector_from_symmetric_matrix(sym_mat)
-        result = self.space.symmetric_matrix_from_vector(vector)
+        vector = self.space.to_vector(sym_mat)
+        result = self.space.from_vector(vector)
         expected = sym_mat
 
         self.assertTrue(gs.allclose(result, expected))
 
     def test_symmetric_matrix_from_vector(self):
         vector_2 = gs.array([1, 2, 3, 4, 5, 6])
-        result = self.space.symmetric_matrix_from_vector(vector_2)
+        result = self.space.from_vector(vector_2)
         expected = gs.array([[1., 2., 3.], [2., 4., 5.], [3., 5., 6.]])
         self.assertAllClose(result, expected)

--- a/tests/test_vectorization.py
+++ b/tests/test_vectorization.py
@@ -15,21 +15,21 @@ class TestVectorization(geomstats.tests.TestCase):
                 self.default_point_type = 'vector'
 
         @geomstats.vectorization.decorator(['vector', 'vector'])
-        def foo(tangent_vec_a, tangent_vec_b):
+        def func(tangent_vec_a, tangent_vec_b):
             result = gs.einsum(
                 '...i,...i->...i', tangent_vec_a, tangent_vec_b)
             result = helper.to_vector(result)
             return result
 
         @geomstats.vectorization.decorator(['vector', 'vector'])
-        def foo_scalar_output(tangent_vec_a, tangent_vec_b):
+        def func_scalar_output(tangent_vec_a, tangent_vec_b):
             result = gs.einsum(
                 '...i,...i->...', tangent_vec_a, tangent_vec_b)
             result = helper.to_scalar(result)
             return result
 
         @geomstats.vectorization.decorator(['vector', 'vector', 'scalar'])
-        def foo_scalar_input_output(tangent_vec_a, tangent_vec_b, in_scalar):
+        def func_scalar_input_output(tangent_vec_a, tangent_vec_b, in_scalar):
             aux = gs.einsum(
                 'ni,ni->n', tangent_vec_a, tangent_vec_b)
             result = gs.einsum('n,nk->n', aux, in_scalar)
@@ -37,7 +37,7 @@ class TestVectorization(geomstats.tests.TestCase):
             return result
 
         @geomstats.vectorization.decorator(['vector', 'vector', 'scalar'])
-        def foo_optional_input(tangent_vec_a, tangent_vec_b, in_scalar=None):
+        def func_optional_input(tangent_vec_a, tangent_vec_b, in_scalar=None):
             if in_scalar is None:
                 in_scalar = gs.array([[1]])
             aux = gs.einsum(
@@ -48,7 +48,7 @@ class TestVectorization(geomstats.tests.TestCase):
 
         @geomstats.vectorization.decorator(
             ['else', 'vector', 'else', 'vector', 'scalar'])
-        def foo_else(else_a, tangent_vec_a, else_b, tangent_vec_b):
+        def func_else(else_a, tangent_vec_a, else_b, tangent_vec_b):
             result = (else_a + else_b) * gs.einsum(
                 'ni,ni->n', tangent_vec_a, tangent_vec_b)
             result = helper.to_scalar(result)
@@ -109,11 +109,11 @@ class TestVectorization(geomstats.tests.TestCase):
             result = gs.array([[5.]] * n_samples)
             return result
 
-        self.foo = foo
-        self.foo_scalar_output = foo_scalar_output
-        self.foo_scalar_input_output = foo_scalar_input_output
-        self.foo_optional_input = foo_optional_input
-        self.foo_else = foo_else
+        self.func = func
+        self.func_scalar_output = func_scalar_output
+        self.func_scalar_input_output = func_scalar_input_output
+        self.func_optional_input = func_optional_input
+        self.func_else = func_else
         self.is_scalar_vectorized = is_scalar_vectorized
         self.is_vector_vectorized = is_vector_vectorized
         self.is_matrix_vectorized = is_matrix_vectorized
@@ -129,7 +129,7 @@ class TestVectorization(geomstats.tests.TestCase):
     def test_decorator_with_squeeze_dim0(self):
         vec_a = gs.array([1, 2, 3])
         vec_b = gs.array([0, 1, 0])
-        result = self.foo(vec_a, vec_b)
+        result = self.func(vec_a, vec_b)
         expected = gs.array([0, 2, 0])
 
         self.assertAllClose(result.shape, expected.shape)
@@ -138,7 +138,7 @@ class TestVectorization(geomstats.tests.TestCase):
     def test_decorator_with_squeeze_dim0_with_kwargs(self):
         vec_a = gs.array([1, 2, 3])
         vec_b = gs.array([0, 1, 0])
-        result = self.foo(tangent_vec_a=vec_a, tangent_vec_b=vec_b)
+        result = self.func(tangent_vec_a=vec_a, tangent_vec_b=vec_b)
         expected = gs.array([0, 2, 0])
 
         self.assertAllClose(result.shape, expected.shape)
@@ -147,7 +147,7 @@ class TestVectorization(geomstats.tests.TestCase):
     def test_decorator_without_squeeze_dim0(self):
         vec_a = gs.array([[1, 2, 3]])
         vec_b = gs.array([0, 1, 0])
-        result = self.foo(vec_a, vec_b)
+        result = self.func(vec_a, vec_b)
         expected = gs.array([[0, 2, 0]])
 
         self.assertAllClose(result.shape, expected.shape)
@@ -156,7 +156,7 @@ class TestVectorization(geomstats.tests.TestCase):
     def test_decorator_without_squeeze_dim0_with_kwargs(self):
         vec_a = gs.array([[1, 2, 3]])
         vec_b = gs.array([0, 1, 0])
-        result = self.foo(tangent_vec_a=vec_a, tangent_vec_b=vec_b)
+        result = self.func(tangent_vec_a=vec_a, tangent_vec_b=vec_b)
         expected = gs.array([[0, 2, 0]])
 
         self.assertAllClose(result.shape, expected.shape)
@@ -165,7 +165,7 @@ class TestVectorization(geomstats.tests.TestCase):
     def test_decorator_vectorization(self):
         vec_a = gs.array([[1, 2, 3], [1, 2, 3]])
         vec_b = gs.array([0, 1, 0])
-        result = self.foo(vec_a, vec_b)
+        result = self.func(vec_a, vec_b)
         expected = gs.array([[0, 2, 0], [0, 2, 0]])
 
         self.assertAllClose(result.shape, expected.shape)
@@ -174,7 +174,7 @@ class TestVectorization(geomstats.tests.TestCase):
     def test_decorator_vectorization_with_kwargs(self):
         vec_a = gs.array([[1, 2, 3], [1, 2, 3]])
         vec_b = gs.array([0, 1, 0])
-        result = self.foo(tangent_vec_a=vec_a, tangent_vec_b=vec_b)
+        result = self.func(tangent_vec_a=vec_a, tangent_vec_b=vec_b)
         expected = gs.array([[0, 2, 0], [0, 2, 0]])
 
         self.assertAllClose(result.shape, expected.shape)
@@ -183,7 +183,7 @@ class TestVectorization(geomstats.tests.TestCase):
     def test_decorator_scalar_with_squeeze_dim1(self):
         vec_a = gs.array([1, 2, 3])
         vec_b = gs.array([0, 1, 0])
-        result = self.foo_scalar_output(vec_a, vec_b)
+        result = self.func_scalar_output(vec_a, vec_b)
         expected = 2
 
         self.assertAllClose(result, expected)
@@ -191,7 +191,7 @@ class TestVectorization(geomstats.tests.TestCase):
     def test_decorator_scalar_with_squeeze_dim1_with_kwargs(self):
         vec_a = gs.array([1, 2, 3])
         vec_b = gs.array([0, 1, 0])
-        result = self.foo_scalar_output(
+        result = self.func_scalar_output(
             tangent_vec_a=vec_a, tangent_vec_b=vec_b)
         expected = 2
 
@@ -201,7 +201,7 @@ class TestVectorization(geomstats.tests.TestCase):
         vec_a = gs.array([1, 2, 3])
         vec_b = gs.array([0, 1, 0])
         scalar = 4
-        result = self.foo_scalar_input_output(vec_a, vec_b, scalar)
+        result = self.func_scalar_input_output(vec_a, vec_b, scalar)
         expected = 8
 
         self.assertAllClose(result, expected)
@@ -210,7 +210,7 @@ class TestVectorization(geomstats.tests.TestCase):
         vec_a = gs.array([1, 2, 3])
         vec_b = gs.array([0, 1, 0])
         scalar = 4
-        result = self.foo_scalar_input_output(
+        result = self.func_scalar_input_output(
             tangent_vec_a=vec_a, tangent_vec_b=vec_b, in_scalar=scalar)
         expected = 8
 
@@ -219,7 +219,7 @@ class TestVectorization(geomstats.tests.TestCase):
     def test_decorator_scalar_output_vectorization(self):
         vec_a = gs.array([[1, 2, 3], [1, 2, 3]])
         vec_b = gs.array([0, 1, 0])
-        result = self.foo_scalar_output(vec_a, vec_b)
+        result = self.func_scalar_output(vec_a, vec_b)
         expected = gs.array([2, 2])
 
         self.assertAllClose(result.shape, expected.shape)
@@ -228,7 +228,7 @@ class TestVectorization(geomstats.tests.TestCase):
     def test_decorator_scalar_output_vectorization_with_kwargs(self):
         vec_a = gs.array([[1, 2, 3], [1, 2, 3]])
         vec_b = gs.array([0, 1, 0])
-        result = self.foo_scalar_output(
+        result = self.func_scalar_output(
             tangent_vec_a=vec_a, tangent_vec_b=vec_b)
         expected = gs.array([2, 2])
 
@@ -238,7 +238,7 @@ class TestVectorization(geomstats.tests.TestCase):
     def test_decorator_optional_input(self):
         vec_a = gs.array([1, 2, 3])
         vec_b = gs.array([0, 1, 0])
-        result = self.foo_optional_input(vec_a, vec_b)
+        result = self.func_optional_input(vec_a, vec_b)
         expected = 2
 
         self.assertAllClose(result, expected)
@@ -246,7 +246,7 @@ class TestVectorization(geomstats.tests.TestCase):
     def test_decorator_optional_input_with_kwargs(self):
         vec_a = gs.array([1, 2, 3])
         vec_b = gs.array([0, 1, 0])
-        result = self.foo_optional_input(
+        result = self.func_optional_input(
             tangent_vec_a=vec_a, tangent_vec_b=vec_b, in_scalar=3)
         expected = 6
 
@@ -255,7 +255,7 @@ class TestVectorization(geomstats.tests.TestCase):
     def test_decorator_optional_input_with_optional_kwargs(self):
         vec_a = gs.array([1, 2, 3])
         vec_b = gs.array([0, 1, 0])
-        result = self.foo_optional_input(
+        result = self.func_optional_input(
             tangent_vec_a=vec_a, tangent_vec_b=vec_b)
         expected = 2
 
@@ -266,7 +266,7 @@ class TestVectorization(geomstats.tests.TestCase):
         vec_b = gs.array([0, 1, 0])
         else_a = 1
         else_b = 1
-        result = self.foo_else(else_a, vec_a, else_b, vec_b)
+        result = self.func_else(else_a, vec_a, else_b, vec_b)
         expected = 4
 
         self.assertAllClose(result, expected)
@@ -276,7 +276,7 @@ class TestVectorization(geomstats.tests.TestCase):
         vec_b = gs.array([0, 1, 0])
         else_a = 1
         else_b = 1
-        result = self.foo_else(
+        result = self.func_else(
             else_a=else_a, tangent_vec_a=vec_a,
             else_b=else_b, tangent_vec_b=vec_b)
         expected = 4

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -1,6 +1,4 @@
-"""
-Unit tests for visualization.
-"""
+"""Unit tests for visualization."""
 
 import matplotlib
 matplotlib.use('Agg')  # NOQA


### PR DESCRIPTION
This PR changes:
- symmetric_matrix_from_vector -> from_vector
- symmetric_matrix_to_vector -> to_vector
- projection_to_tangent_space -> to_tangent
- make_skew_symmetric -> to_skew_symmetric
- make_symmetric -> to_symmetric
- _SpecialEuclideanMatrix -> _SpecialEuclideanMatrices
- _SpecialOrthogonalMatrix -> _SpecialOrthogonalMatrices
- _SpecialEuclidean3Vector -> _SpecialEuclidean3Vectors
- _SpecialOrthogonal3Vector -> _SpecialOrthogonal3Vectors

and:
- adds to_tangent, is_tangent as abstract methods of Manifold,
- adds some docstrings.

@opeltre @stefanheyder @nguigs , following issue #412 