### PR TITLE
Update of tf's assignment

### DIFF
--- a/geomstats/_backend/numpy/__init__.py
+++ b/geomstats/_backend/numpy/__init__.py
@@ -171,9 +171,15 @@ def assignment(x, values, indices, axis=0):
         x_new[indices] = values
         return x_new
     zip_indices = _is_iterable(indices) and _is_iterable(indices[0])
+    len_indices = len(indices) if _is_iterable(indices) else 1
     if zip_indices:
         indices = tuple(zip(*indices))
     if not use_vectorization:
+        if not zip_indices:
+            len_indices = len(indices) if _is_iterable(indices) else 1
+        len_values = len(values) if _is_iterable(values) else 1
+        if len_values > 1 and len_values != len_indices:
+            raise ValueError('Either one value or as many values as indices')
         x_new[indices] = values
     else:
         indices = tuple(
@@ -213,12 +219,16 @@ def assignment_by_sum(x, values, indices, axis=0):
 
     use_vectorization = hasattr(indices, '__len__') and len(indices) < ndim(x)
     if _is_boolean(indices):
-        x_new[indices] = values
+        x_new[indices] += values
         return x_new
     zip_indices = _is_iterable(indices) and _is_iterable(indices[0])
     if zip_indices:
         indices = tuple(zip(*indices))
     if not use_vectorization:
+        len_indices = len(indices) if _is_iterable(indices) else 1
+        len_values = len(values) if _is_iterable(values) else 1
+        if len_values > 1 and len_values != len_indices:
+            raise ValueError('Either one value or as many values as indices')
         x_new[indices] += values
     else:
         indices = tuple(

--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -574,9 +574,15 @@ def assignment(x, values, indices, axis=0):
         x_new[indices] = values
         return x_new
     zip_indices = _is_iterable(indices) and _is_iterable(indices[0])
+    len_indices = len(indices) if _is_iterable(indices) else 1
     if zip_indices:
         indices = tuple(zip(*indices))
     if not use_vectorization:
+        if not zip_indices:
+            len_indices = len(indices) if _is_iterable(indices) else 1
+        len_values = len(values) if _is_iterable(values) else 1
+        if len_values > 1 and len_values != len_indices:
+            raise ValueError('Either one value or as many values as indices')
         x_new[indices] = values
     else:
         indices = tuple(
@@ -613,15 +619,19 @@ def assignment_by_sum(x, values, indices, axis=0):
     If a list is given, it must have the same length as indices.
     """
     x_new = copy(x)
-
+    values = array(values)
     use_vectorization = hasattr(indices, '__len__') and len(indices) < ndim(x)
     if _is_boolean(indices):
-        x_new[indices] = values
+        x_new[indices] += values
         return x_new
     zip_indices = _is_iterable(indices) and _is_iterable(indices[0])
     if zip_indices:
         indices = list(zip(*indices))
     if not use_vectorization:
+        len_indices = len(indices) if _is_iterable(indices) else 1
+        len_values = len(values) if _is_iterable(values) else 1
+        if len_values > 1 and len_values != len_indices:
+            raise ValueError('Either one value or as many values as indices')
         x_new[indices] += values
     else:
         indices = tuple(

--- a/geomstats/_backend/tensorflow/__init__.py
+++ b/geomstats/_backend/tensorflow/__init__.py
@@ -191,7 +191,7 @@ def _mask_from_indices(indices, mask_shape, dtype=float32):
             if hasattr(index, '__iter__'):
                 indices[i_index] = tuple(index)
             else:
-                indices[i_index] = index,
+                indices[i_index] = (index,)
     for index in indices:
         if len(index) != len(mask_shape):
             raise ValueError('Indices must have the same size as shape')

--- a/geomstats/_backend/tensorflow/__init__.py
+++ b/geomstats/_backend/tensorflow/__init__.py
@@ -563,7 +563,8 @@ def hsplit(x, n_splits):
 def flatten(x):
     """Collapses the tensor into 1-D.
 
-    Following https://www.tensorflow.org/api_docs/python/tf/reshape"""
+    Following https://www.tensorflow.org/api_docs/python/tf/reshape
+    """
     return tf.reshape(x, [-1])
 
 

--- a/geomstats/_backend/tensorflow/__init__.py
+++ b/geomstats/_backend/tensorflow/__init__.py
@@ -270,10 +270,6 @@ def _assignment_single_value_by_sum(x, value, indices, axis=0):
         Copy of x where value was added at all indices (and possibly along
         an axis).
     """
-    if _is_boolean(indices):
-        indices = [indices]
-        indices = [index for index, val in enumerate(indices) if val]
-
     single_index = not isinstance(indices, list)
     if tf.is_tensor(indices):
         single_index = ndim(indices) <= 1 and sum(indices.shape) <= ndim(x)
@@ -309,11 +305,13 @@ def assignment_by_sum(x, values, indices, axis=0):
         Initial array.
     values: {float, list(float)}
         Value or list of values to be assigned.
-    indices: {int, tuple, list(int), list(tuple)}
-        Single int or tuple, or list of ints or tuples of indices where value
-        is assigned.
-        If the length of the tuples is shorter than ndim(x), values are
+    indices: {
+    int, tuple(int), array-like({int, tuple, boolean})
+        Single index or array of indices where values are assigned.
+        If the length of the tuples is shorter than ndim(x) by one, values are
         assigned to each copy along axis.
+        If indices is a list of booleans and ndim(x) > 1, values are assigned
+        across all dimensions.
     axis: int, optional
         Axis along which values are assigned, if vectorized.
 
@@ -325,7 +323,18 @@ def assignment_by_sum(x, values, indices, axis=0):
     Notes
     -----
     If a single value is provided, it is assigned at all the indices.
-    If a list is given, it must have the same length as indices.
+    If a single index is provided, and len(indices) == ndim(x) - 1, then values
+    are assigned along axis.
+
+    Examples
+    --------
+    Most examples translate as
+    assignment(x, indices, values) <=> x[indices] = x[indices] + values
+    Some special cases are given by vectorisation.
+    (Beware that copies are always returned).
+    if ndim(x) == 3, assignment(x, 1, (1, 0), 1) <=> x[1, :, 0] += 1
+    if ndim(x) == 2, assignment(x, [1, 2], [(0, 1), (2, 3)]) <=>
+                        x[((0, 2), (1, 3))] += [1, 2]
     """
     if _is_boolean(indices):
         if ndim(array(indices)) > 1:
@@ -344,7 +353,11 @@ def assignment_by_sum(x, values, indices, axis=0):
     if tf.is_tensor(indices):
         single_index = ndim(indices) <= 1 and sum(indices.shape) <= ndim(x)
     if single_index:
-        indices = [indices]
+        if len(values) > 1:
+            indices = [tuple(list(indices[:axis]) + [i] + list(indices[axis:]))
+                       for i in range(x.shape[axis])]
+        else:
+            indices = [indices]
 
     if len(values) != len(indices):
         raise ValueError('Either one value or as many values as indices')
@@ -378,10 +391,6 @@ def _assignment_single_value(x, value, indices, axis=0):
         Copy of x where value was assigned at all indices (and possibly
         along an axis).
     """
-    if _is_boolean(indices):
-        indices = [indices]
-        indices = [index for index, val in enumerate(indices) if val]
-
     single_index = not isinstance(indices, list)
     if tf.is_tensor(indices):
         single_index = ndim(indices) <= 1 and sum(indices.shape) <= ndim(x)
@@ -408,7 +417,7 @@ def _assignment_single_value(x, value, indices, axis=0):
 
 
 def assignment(x, values, indices, axis=0):
-    """Assign values at given indices of an array.
+    """Add values at given indices of an array.
 
     Parameters
     ----------
@@ -416,23 +425,36 @@ def assignment(x, values, indices, axis=0):
         Initial array.
     values: {float, list(float)}
         Value or list of values to be assigned.
-    indices: {int, tuple, list(int), list(tuple)}
-        Single int or tuple, or list of ints or tuples of indices where value
-        is assigned.
-        If the length of the tuples is shorter than ndim(x), values are
+    indices: {
+    int, tuple(int), array-like({int, tuple, boolean})
+        Single index or array of indices where values are assigned.
+        If the length of the tuples is shorter than ndim(x) by one, values are
         assigned to each copy along axis.
+        If indices is a list of booleans and ndim(x) > 1, values are assigned
+        across all dimensions.
     axis: int, optional
         Axis along which values are assigned, if vectorized.
 
     Returns
     -------
     x_new : array-like, shape=[dim]
-        Copy of x with the values assigned at the given indices.
+        Copy of x as the sum of x and the values at the given indices.
 
     Notes
     -----
     If a single value is provided, it is assigned at all the indices.
-    If a list is given, it must have the same length as indices.
+    If a single index is provided, and len(indices) == ndim(x) - 1, then values
+    are assigned along axis.
+
+    Examples
+    --------
+    Most examples translate as
+    assignment(x, indices, values) <=> x[indices] = values
+    Some special cases are given by vectorisation.
+    (Beware that copies are always returned).
+    if ndim(x) == 3, assignment(x, 1, (1, 0), 1) <=> x[1, :, 0] = 1
+    if ndim(x) == 2, assignment(x, [1, 2], [(0, 1), (2, 3)]) <=>
+                        x[((0, 2), (1, 3))] = [1, 2]
     """
     if _is_boolean(indices):
         if ndim(array(indices)) > 1:
@@ -451,7 +473,11 @@ def assignment(x, values, indices, axis=0):
     if tf.is_tensor(indices):
         single_index = ndim(indices) <= 1 and sum(indices.shape) <= ndim(x)
     if single_index:
-        indices = [indices]
+        if len(values) > 1:
+            indices = [tuple(list(indices[:axis]) + [i] + list(indices[axis:]))
+                       for i in range(x.shape[axis])]
+        else:
+            indices = [indices]
 
     if len(values) != len(indices):
         raise ValueError('Either one value or as many values as indices')

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -521,7 +521,37 @@ class TestBackends(geomstats.tests.TestCase):
             gs_result, 4 * gs_array[~gs_mask], ~gs_mask)
         self.assertAllCloseToNp(gs_result, np_result)
 
+        np_array = _np.array([
+            [22., 55.],
+            [33., 88.],
+            [77., 99.]])
+        gs_array = gs.array([
+            [22., 55.],
+            [33., 88.],
+            [77., 99.]])
+        np_mask = _np.array([[False, False],
+                            [False, True],
+                            [True, True]])
+        gs_mask = gs.array([[False, False],
+                            [False, True],
+                            [True, True,]])
+
+        np_array[np_mask] = _np.zeros_like(np_array[np_mask])
+        np_array[~np_mask] = 4 * np_array[~np_mask]
+        np_result = np_array
+
+        values_mask = gs.zeros_like(gs_array[gs_mask])
+        gs_result = gs.assignment(
+            gs_array, values_mask, gs_mask)
+        gs_result = gs.assignment(
+            gs_result, 4 * gs_array[~gs_mask], ~gs_mask)
+        self.assertAllCloseToNp(gs_result, np_result)
+
     def test_assignment(self):
+        gs_array_1 = gs.ones(3)
+        self.assertRaises(
+            ValueError, gs.assignment, gs_array_1, [.1, 2., 1.], [0, 1])
+
         np_array_1 = _np.ones(3)
         gs_array_1 = gs.ones_like(gs.array(np_array_1))
 
@@ -558,6 +588,11 @@ class TestBackends(geomstats.tests.TestCase):
         gs_result = gs.assignment(gs_array_4, 1, (0, 1), axis=1)
         self.assertAllCloseToNp(gs_result, np_array_4)
 
+        gs_array_4_arr = gs.zeros_like(gs.array(np_array_4))
+
+        gs_result = gs.assignment(gs_array_4_arr, 1, gs.array((0, 1)), axis=1)
+        self.assertAllCloseToNp(gs_result, np_array_4)
+
         np_array_4_list = _np.zeros((3, 3, 2))
         gs_array_4_list = gs.zeros_like(gs.array(np_array_4_list))
 
@@ -566,12 +601,20 @@ class TestBackends(geomstats.tests.TestCase):
         self.assertAllCloseToNp(gs_result, np_array_4_list)
 
     def test_assignment_by_sum(self):
+        gs_array_1 = gs.ones(3)
+        self.assertRaises(
+            ValueError, gs.assignment_by_sum, gs_array_1, [.1, 2., 1.], [0, 1])
+
         np_array_1 = _np.ones(3)
         gs_array_1 = gs.ones_like(gs.array(np_array_1))
 
         np_array_1[2] += 1.5
         gs_result = gs.assignment_by_sum(gs_array_1, 1.5, 2)
         self.assertAllCloseToNp(gs_result, np_array_1)
+
+        gs_result_list = gs.assignment_by_sum(gs_array_1, [2., 1.5], [0, 2])
+        np_array_1[0] += 2.
+        self.assertAllCloseToNp(gs_result_list, np_array_1)
 
         np_array_1_list = _np.ones(3)
         gs_array_1_list = gs.ones_like(gs.array(np_array_1_list))
@@ -622,3 +665,29 @@ class TestBackends(geomstats.tests.TestCase):
         gs_array = gs.assignment_by_sum(
             gs_array, - gs.sin(theta) * gs.sin(phi), (0, 1), axis=1)
         self.assertAllCloseToNp(gs_array, np_array)
+
+        np_array = _np.array([
+            [22., 55.],
+            [33., 88.],
+            [77., 99.]])
+        gs_array = gs.array([
+            [22., 55.],
+            [33., 88.],
+            [77., 99.]])
+        np_mask = _np.array([[False, False],
+                             [False, True],
+                             [True, True]])
+        gs_mask = gs.array([[False, False],
+                            [False, True],
+                            [True, True, ]])
+
+        np_array[np_mask] += _np.zeros_like(np_array[np_mask])
+        np_array[~np_mask] += 4 * np_array[~np_mask]
+        np_result = np_array
+
+        values_mask = gs.zeros_like(gs_array[gs_mask])
+        gs_result = gs.assignment_by_sum(
+            gs_array, values_mask, gs_mask)
+        gs_result = gs.assignment_by_sum(
+            gs_result, 4 * gs_array[~gs_mask], ~gs_mask)
+        self.assertAllCloseToNp(gs_result, np_result)

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -621,6 +621,4 @@ class TestBackends(geomstats.tests.TestCase):
             gs_array, gs.cos(theta) * gs.cos(phi), (0, 0), axis=1)
         gs_array = gs.assignment_by_sum(
             gs_array, - gs.sin(theta) * gs.sin(phi), (0, 1), axis=1)
-        print(np_array)
-        print(gs_array)
         self.assertAllCloseToNp(gs_array, np_array)

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -534,7 +534,7 @@ class TestBackends(geomstats.tests.TestCase):
                             [True, True]])
         gs_mask = gs.array([[False, False],
                             [False, True],
-                            [True, True,]])
+                            [True, True]])
 
         np_array[np_mask] = _np.zeros_like(np_array[np_mask])
         np_array[~np_mask] = 4 * np_array[~np_mask]

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -679,7 +679,7 @@ class TestBackends(geomstats.tests.TestCase):
                              [True, True]])
         gs_mask = gs.array([[False, False],
                             [False, True],
-                            [True, True, ]])
+                            [True, True]])
 
         np_array[np_mask] += _np.zeros_like(np_array[np_mask])
         np_array[~np_mask] += 4 * np_array[~np_mask]

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -329,6 +329,20 @@ class TestBackends(geomstats.tests.TestCase):
 
         self.assertAllCloseToNp(gs_array, np_array)
 
+        n_samples = 3
+        theta = _np.random.rand(5)
+        phi = _np.random.rand(5)
+        np_array = _np.zeros((n_samples, 5, 4))
+        gs_array = gs.array(np_array)
+        np_array[0, :, 0] = gs.cos(theta) * gs.cos(phi)
+        np_array[0, :, 1] = - gs.sin(theta) * gs.sin(phi)
+        gs_array = gs.assignment(
+            gs_array, gs.cos(theta) * gs.cos(phi), (0, 0), axis=1)
+        gs_array = gs.assignment(
+            gs_array, - gs.sin(theta) * gs.sin(phi), (0, 1), axis=1)
+
+        self.assertAllCloseToNp(gs_array, np_array)
+
     def test_assignment_with_booleans_single_index(self):
         np_array = _np.array([[2., 5.]])
         gs_array = gs.array([[2., 5.]])
@@ -595,3 +609,18 @@ class TestBackends(geomstats.tests.TestCase):
         gs_result = gs.assignment_by_sum(
             gs_array_4_list, 1, [(0, 1), (1, 1)], axis=1)
         self.assertAllCloseToNp(gs_result, np_array_4_list)
+
+        n_samples = 3
+        theta = _np.random.rand(5)
+        phi = _np.random.rand(5)
+        np_array = _np.ones((n_samples, 5, 4))
+        gs_array = gs.array(np_array)
+        np_array[0, :, 0] += _np.cos(theta) * _np.cos(phi)
+        np_array[0, :, 1] -= _np.sin(theta) * _np.sin(phi)
+        gs_array = gs.assignment_by_sum(
+            gs_array, gs.cos(theta) * gs.cos(phi), (0, 0), axis=1)
+        gs_array = gs.assignment_by_sum(
+            gs_array, - gs.sin(theta) * gs.sin(phi), (0, 1), axis=1)
+        print(np_array)
+        print(gs_array)
+        self.assertAllCloseToNp(gs_array, np_array)


### PR DESCRIPTION
This PR adds a new use case to tf's `assignment` and the sum version (which was already accessible for numpy and pytorch): vectorization with non-constant values. This simply means that , if `ndim(x) == 3`:
`x = gs.assignment(x, [1, 2, 3], (0, 0), axis=2) <=> x[0, 0, :] = [1, 2, 3]`.

The docstring of assignment is also updated to try and cover its use cases.