### PR TITLE
Change docstring convention for shape=

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -457,14 +457,14 @@ Here's a generic docstring template::
 
       Parameters
       ----------
-      my_param_1 : array-like, shape=[n_samples, dimension]
+      my_param_1 : array-like, shape=[..., dim]
          Write a short description of parameter my_param_1.
       my_param_2 : str, {'vector', 'matrix'}
          Write a short description of parameter my_param_2.
 
       Returns
       -------
-      my_result : array-like, shape=[n_samples, dimension, dimension]
+      my_result : array-like, shape=[..., dim, dim]
          Write a short description of the result returned by the method.
 
       Notes
@@ -493,17 +493,17 @@ And here's a filled-in example from the Scikit-Learn project, modified to our sy
 
       Parameters
       ----------
-      X : {array-like, sparse_matrix} of shape=[n_samples, n_features]
+      X : {array-like, sparse_matrix} of shape=[..., n_features]
          New data to transform.
       y : Ignored
          Not used, present here for API consistency by convention.
-      sample_weight : array-like, shape [n_samples,], optional
+      sample_weight : array-like, shape [...,], optional
          The weights for each observation in X. If None, all observations
          are assigned equal weight (default: None).
 
       Returns
       -------
-      labels : array, shape=[n_samples,]
+      labels : array, shape=[...,]
          Index of the cluster each sample belongs to.
       """
       return self.fit(X, sample_weight=sample_weight).labels_
@@ -512,7 +512,7 @@ In general, have the following in mind:
 
    1. Use built-in Python types. (``bool`` instead of ``boolean``)
 
-   2. Use ``[`` for defining shapes: ``array-like, shape=[n_samples,]``
+   2. Use ``[`` for defining shapes: ``array-like, shape=[..., dim]``
 
    3. If a shape can vary, use a list-like notation:
       ``array-like, shape=[dimension[:axis], n, dimension[axis:]]``

--- a/geomstats/geometry/beta_distributions.py
+++ b/geomstats/geometry/beta_distributions.py
@@ -34,13 +34,13 @@ class BetaDistributions(EmbeddedManifold):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, 2]
-            the point of which to check whether it belongs to Beta
+        point : array-like, shape=[..., 2]
+            Point to be checked.
 
         Returns
         -------
-        belongs : array-like, shape=[n_samples, 1]
-            array of booleans indicating whether point belongs the Beta
+        belongs : array-like, shape=[...,]
+            Boolean indicating whether point represents a beta distribution.
         """
         point_dim = point.shape[-1]
         belongs = point_dim == self.dim
@@ -57,12 +57,14 @@ class BetaDistributions(EmbeddedManifold):
         Parameters
         ----------
         n_samples : int, optional
+            Number of samples.
         bound : float, optional
-            scalar to scale samples
+            Side of the square where the beta parameters are sampled.
 
         Returns
         -------
-        samples : array-like, shape=[n_samples, 2]
+        samples : array-like, shape=[..., 2]
+            Sample of points representing beta distributions.
         """
         size = (2,) if n_samples == 1 else (n_samples, 2)
         return bound * gs.random.rand(*size)
@@ -74,14 +76,15 @@ class BetaDistributions(EmbeddedManifold):
 
         Parameters
         ----------
-        point : array-like, shape [n_points, 2]
+        point : array-like, shape=[..., 2]
+            Point representing a beta distribution.
         n_samples : int
-            the number of points to sample with each pair of parameter in
-            point
+            Number of points to sample with each pair of parameters in point.
 
         Returns
         -------
-        samples : array-like, shape=[n_points, n_samples]
+        samples : array-like, shape=[..., n_samples]
+            Sample from beta distributions.
         """
         point = gs.to_ndarray(point, to_ndim=2)
         geomstats.error.check_belongs(
@@ -101,20 +104,21 @@ class BetaDistributions(EmbeddedManifold):
 
         Parameters
         ----------
-        data : array-like, shape=[n_distributions, n_samples]
-            the data to estimate parameters from. Arrays of
+        data : array-like, shape=[..., n_samples]
+            Data to estimate parameters from. Arrays of
             different length may be passed.
         loc : float, optional
-            the location parameter of the distribution to estimate parameters
-            from. It is kept fixed during optimization
+            Location parameter of the distribution to estimate parameters
+            from. It is kept fixed during optimization.
             default: 0
         scale : float, optional
-            the scale parameter of the distribution to estimate parameters
-            from. It is kept fixed during optimization
+            Scale parameter of the distribution to estimate parameters
+            from. It is kept fixed during optimization.
             default: 1
+
         Returns
         -------
-        parameter : array-like, shape=[n_samples, 2]
+        parameter : array-like, shape=[..., 2]
         """
         data = gs.cast(data, gs.float32)
         data = gs.to_ndarray(
@@ -138,12 +142,12 @@ class BetaMetric(RiemannianMetric):
 
         Parameters
         ----------
-        param_a : array-like, shape=[n_samples,]
-        param_b : array-like, shape=[n_samples,]
+        param_a : array-like, shape=[...,]
+        param_b : array-like, shape=[...,]
 
         Returns
         -------
-        metric_det : array-like, shape=[n_samples,]
+        metric_det : array-like, shape=[...,]
         """
         metric_det = gs.polygamma(1, param_a) * gs.polygamma(1, param_b) - \
             gs.polygamma(1, param_a + param_b) * (gs.polygamma(1, param_a) +
@@ -155,11 +159,11 @@ class BetaMetric(RiemannianMetric):
 
         Parameters
         ----------
-        base_point : array-like, shape=[n_samples, 2]
+        base_point : array-like, shape=[..., 2]
 
         Returns
         -------
-        base_point : array-like, shape=[n_samples, 2, 2]
+        base_point : array-like, shape=[..., 2, 2]
         """
         if base_point is None:
             raise ValueError('The metric depends on the base point.')
@@ -182,11 +186,11 @@ class BetaMetric(RiemannianMetric):
 
         Parameters
         ----------
-        base_point : array-like, shape=[n_samples, 2]
+        base_point : array-like, shape=[..., 2]
 
         Returns
         -------
-        christoffels : array-like, shape=[n_samples, 2, 2, 2]
+        christoffels : array-like, shape=[..., 2, 2, 2]
         """
         def coefficients(param_a, param_b):
             metric_det = 2 * self.metric_det(param_a, param_b)
@@ -217,13 +221,13 @@ class BetaMetric(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec : array-like, shape=[n_samples, dim]
-        base_point : array-like, shape=[n_samples, dim]
+        tangent_vec : array-like, shape=[..., dim]
+        base_point : array-like, shape=[..., dim]
         n_steps : int
 
         Returns
         -------
-        exp : array-like, shape=[n_samples, dim]
+        exp : array-like, shape=[..., dim]
         """
         base_point = gs.to_ndarray(base_point, to_ndim=2)
         tangent_vec = gs.to_ndarray(tangent_vec, to_ndim=2)
@@ -251,15 +255,15 @@ class BetaMetric(RiemannianMetric):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dim]
-        base_point : array-like, shape=[n_samples, dim]
+        point : array-like, shape=[..., dim]
+        base_point : array-like, shape=[..., dim]
         n_steps : int
 
         Returns
         -------
-        tangent_vec : array-like, shape=[n_samples, dim]
-            the initial velocity of the geodesic starting at base_point and
-            reaching point at time 1
+        tangent_vec : array-like, shape=[..., dim]
+            Initial velocity of the geodesic starting at base_point and
+            reaching point at time 1.
         """
         stop_time = 1.
         t = gs.linspace(0, stop_time, n_steps)

--- a/geomstats/geometry/connection.py
+++ b/geomstats/geometry/connection.py
@@ -38,12 +38,12 @@ class Connection:
 
         Parameters
         ----------
-        base_point : array-like, shape=[n_samples, dim]
+        base_point : array-like, shape=[..., dim]
             Point on the manifold.
 
         Returns
         -------
-        gamma : array-like, shape=[n_samples, dim, dim, dim]
+        gamma : array-like, shape=[..., dim, dim, dim]
             Values of the christoffel symbols, with the covariant index on
             the first dimension.
         """
@@ -58,11 +58,11 @@ class Connection:
 
         Parameters
         ----------
-        tangent_vec_a : array-like, shape=[n_samples, dim]
+        tangent_vec_a : array-like, shape=[..., dim]
             Tangent vector at base point.
-        tangent_vec_b : array-like, shape=[n_samples, dim]
+        tangent_vec_b : array-like, shape=[..., dim]
             Tangent vector at base point.
-        base_point : array-like, shape=[n_samples, dim]
+        base_point : array-like, shape=[..., dim]
             Point on the manifold.
         """
         raise NotImplementedError(
@@ -73,15 +73,15 @@ class Connection:
 
         Parameters
         ----------
-        velocity : array-like, shape=[n_samples, dim]
+        velocity : array-like, shape=[..., dim]
             Tangent vector at the position.
-        position : array-like, shape=[n_samples, dim]
+        position : array-like, shape=[..., dim]
             Point on the manifold, the position at which to compute the
             geodesic ODE.
 
         Returns
         -------
-        geodesic_ode : array-like, shape=[n_samples, dim]
+        geodesic_ode : array-like, shape=[..., dim]
             Value of the vector field to be integrated at position.
         """
         gamma = self.christoffels(position)
@@ -103,12 +103,12 @@ class Connection:
 
         Parameters
         ----------
-        tangent_vec : array-like, shape=[n_samples, dim]
+        tangent_vec : array-like, shape=[..., dim]
             Tangent vector at the base point.
-        base_point : array-like, shape=[n_samples, dim]
+        base_point : array-like, shape=[..., dim]
             Point on the manifold.
         n_steps : int
-            The number of discrete time steps to take in the integration.
+            Number of discrete time steps to take in the integration.
         step : str, {'euler', 'rk4'}
             The numerical scheme to use for integration.
         point_type : str, {'vector', 'matrix'}
@@ -116,7 +116,7 @@ class Connection:
 
         Returns
         -------
-        exp : array-like, shape=[n_samples, dim]
+        exp : array-like, shape=[..., dim]
             Point on the manifold.
         """
         initial_state = (base_point, tangent_vec)
@@ -134,18 +134,18 @@ class Connection:
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dim]
+        point : array-like, shape=[..., dim]
             Point on the manifold.
-        base_point : array-like, shape=[n_samples, dim]
+        base_point : array-like, shape=[..., dim]
             Point on the manifold.
         n_steps : int
-            The number of discrete time steps to take in the integration.
+            Number of discrete time steps to take in the integration.
         step : str, {'euler', 'rk4'}
-            The numerical scheme to use for integration.
+            Numerical scheme to use for integration.
 
         Returns
         -------
-        tangent_vec : array-like, shape=[n_samples, dim]
+        tangent_vec : array-like, shape=[..., dim]
             Tangent vector at the base point.
         """
         n_samples = geomstats.vectorization.get_n_points(
@@ -182,11 +182,11 @@ class Connection:
 
         Parameters
         ----------
-        base_point : array-like, shape=[n_samples, dim]
+        base_point : array-like, shape=[..., dim]
             Point on the manifold, from which to transport.
-        next_point : array-like, shape=[n_samples, dim]
+        next_point : array-like, shape=[..., dim]
             Point on the manifold, to transport to.
-        base_shoot : array-like, shape=[n_samples, dim]
+        base_shoot : array-like, shape=[..., dim]
             Point on the manifold, end point of the geodesics starting
             from the base point with initial speed to be transported.
         return_geodesics : bool, optional (defaults to False)
@@ -196,14 +196,14 @@ class Connection:
         Returns
         -------
         next_step : dict of array-like and callable with following keys:
-            next_tangent_vec : array-like, shape=[n_samples, dim]
+            next_tangent_vec : array-like, shape=[..., dim]
                 Tangent vector at end point.
-            end_point : array-like, shape=[n_samples, dim]
+            end_point : array-like, shape=[..., dim]
                 Point on the manifold, closes the geodesic parallelogram of the
                 construction.
             geodesics : list of callable, len=3 (only if
             `return_geodesics=True`)
-                The three geodesics of the construction.
+                Three geodesics of the construction.
 
         References
         ----------
@@ -260,11 +260,11 @@ class Connection:
 
         Parameters
         ----------
-        base_point : array-like, shape=[n_samples, dim]
+        base_point : array-like, shape=[..., dim]
             Point on the manifold, from which to transport.
-        next_point : array-like, shape=[n_samples, dim]
+        next_point : array-like, shape=[..., dim]
             Point on the manifold, to transport to.
-        base_shoot : array-like, shape=[n_samples, dim]
+        base_shoot : array-like, shape=[..., dim]
             Point on the manifold, end point of the geodesics starting
             from the base point with initial speed to be transported.
         return_geodesics : bool, optional (defaults to False)
@@ -273,9 +273,9 @@ class Connection:
 
         Returns
         -------
-        transported_tangent_vector : array-like, shape=[n_samples, dim]
+        transported_tangent_vector : array-like, shape=[..., dim]
             Tangent vector at end point.
-        end_point : array-like, shape=[n_samples, dim]
+        end_point : array-like, shape=[..., dim]
             Point on the manifold, closes the geodesic parallelogram of the
             construction.
 
@@ -343,12 +343,12 @@ class Connection:
 
         Parameters
         ----------
-        tangent_vec_a : array-like, shape=[n_samples, dim]
+        tangent_vec_a : array-like, shape=[..., dim]
             Tangent vector at base point to transport.
-        tangent_vec_b : array-like, shape=[n_samples, dim]
+        tangent_vec_b : array-like, shape=[..., dim]
             Tangent vector at base point, initial speed of the geodesic along
             which to transport.
-        base_point : array-like, shape=[n_samples, dim]
+        base_point : array-like, shape=[..., dim]
             Point on the manifold, initial position of the geodesic along
             which to transport.
         n_steps : int
@@ -360,7 +360,7 @@ class Connection:
         Returns
         -------
         ladder : dict of array-like and callable with following keys
-            transported_tangent_vector : array-like, shape=[n_samples, dim]
+            transported_tangent_vector : array-like, shape=[..., dim]
                 Approximation of the parallel transport of tangent vector a.
             trajectory : list of list of callable, len=n_steps
                 List of lists containing the geodesics of the
@@ -410,7 +410,7 @@ class Connection:
 
         Parameters
         ----------
-        base_point: array-like, shape=[n_samples, dim]
+        base_point: array-like, shape=[..., dim]
             Point on the manifold.
         """
         raise NotImplementedError(
@@ -427,12 +427,12 @@ class Connection:
 
         Parameters
         ----------
-        initial_point : array-like, shape=[n_samples, dim]
+        initial_point : array-like, shape=[..., dim]
             Point on the manifold, initial point of the geodesic.
-        end_point : array-like, shape=[n_samples, dim], optional
+        end_point : array-like, shape=[..., dim], optional
             Point on the manifold, end point of the geodesic. If None,
             an initial tangent vector must be given.
-        initial_tangent_vec : array-like, shape=[n_samples, dim],
+        initial_tangent_vec : array-like, shape=[..., dim],
             optional
             Tangent vector at base point, the initial speed of the geodesics.
             If None, an end point must be given and a logarithm is computed.
@@ -511,7 +511,7 @@ class Connection:
 
         Parameters
         ----------
-        base_point: array-like, shape=[n_samples, dim]
+        base_point: array-like, shape=[..., dim]
             Point on the manifold.
         """
         raise NotImplementedError(

--- a/geomstats/geometry/discretized_curves.py
+++ b/geomstats/geometry/discretized_curves.py
@@ -18,7 +18,6 @@ class DiscretizedCurves(Manifold):
     """Space of discretized curves sampled at points in ambient_manifold."""
 
     def __init__(self, ambient_manifold):
-        """Initialize DiscretizedCurves object."""
         super(DiscretizedCurves, self).__init__(dim=math.inf)
         self.ambient_manifold = ambient_manifold
         self.l2_metric = L2Metric(self.ambient_manifold)
@@ -29,7 +28,8 @@ class DiscretizedCurves(Manifold):
 
         Parameters
         ----------
-        point :
+        point : array-like
+            Point representing a discretized curve.
 
         Returns
         -------
@@ -95,7 +95,6 @@ class SRVMetric(RiemannianMetric):
     def pointwise_norm(self, tangent_vec, base_curve):
         """Compute the norm of tangent vector components at base curve.
 
-        TODO: (revise this to refer to action on single elements)
         Compute the norms of the components of a (series of) tangent
         vector(s) at (a) base curve(s).
 
@@ -108,6 +107,7 @@ class SRVMetric(RiemannianMetric):
         -------
         norm :
         """
+        # TODO: Revise this to refer to action on single elements
         sq_norm = self.pointwise_inner_product(tangent_vec_a=tangent_vec,
                                                tangent_vec_b=tangent_vec,
                                                base_curve=base_curve)

--- a/geomstats/geometry/embedded_manifold.py
+++ b/geomstats/geometry/embedded_manifold.py
@@ -26,7 +26,7 @@ class EmbeddedManifold(Manifold):
 
         Parameters
         ----------
-        point_intrinsic : array-like, shape=[n_samples, dim]
+        point_intrinsic : array-like, shape=[..., dim]
             Point in the embedded manifold in intrinsic coordinates.
         """
         raise NotImplementedError(
@@ -37,7 +37,7 @@ class EmbeddedManifold(Manifold):
 
         Parameters
         ----------
-        point_extrinsic : array-like, shape=[n_samples, dim_embedding]
+        point_extrinsic : array-like, shape=[..., dim_embedding]
             Point in the embedded manifold in extrinsic coordinates,
             i. e. in the coordinates of the embedding manifold.
         """
@@ -49,7 +49,7 @@ class EmbeddedManifold(Manifold):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dim_embedding]
+        point : array-like, shape=[..., dim_embedding]
             Point in embedding manifold
         """
         raise NotImplementedError(

--- a/geomstats/geometry/euclidean.py
+++ b/geomstats/geometry/euclidean.py
@@ -21,12 +21,12 @@ class Euclidean(Manifold):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dim]
-                Input points.
+        point : array-like, shape=[..., dim]
+            Point to evaluate.
 
         Returns
         -------
-        belongs : array-like, shape=[n_samples,]
+        belongs : array-like, shape=[...,]
         """
         point_dim = point.shape[-1]
         belongs = point_dim == self.dim
@@ -40,14 +40,14 @@ class Euclidean(Manifold):
 
         Parameters
         ----------
-        n_samples: int, optional
+        n_samples : int, optional
             default: 1
-        bound: float, optional
+        bound : float, optional
             default: 1.0
 
         Returns
         -------
-        point : array-like, shape=[n_samples, dim]
+        point : array-like, shape=[..., dim]
         """
         size = (self.dim,)
         if n_samples != 1:
@@ -75,11 +75,11 @@ class EuclideanMetric(RiemannianMetric):
 
         Parameters
         ----------
-        base_point: array-like, shape=[n_samples, dim]
+        base_point : array-like, shape=[..., dim]
 
         Returns
         -------
-        inner_prod_mat: array-like, shape=[n_samples, dim, dim]
+        inner_prod_mat : array-like, shape=[..., dim, dim]
         """
         mat = gs.eye(self.dim)
         return mat
@@ -91,16 +91,13 @@ class EuclideanMetric(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec: array-like, shape=[n_samples, dim]
-                                 or shape=[1, dim]
+        tangent_vec : array-like, shape=[..., dim]
 
-        base_point: array-like, shape=[n_samples, dim]
-                                or shape=[1, dim]
+        base_point : array-like, shape=[..., dim]
 
         Returns
         -------
-        exp: array-like, shape=[n_samples, dim]
-                          or shape-[n_samples, dim]
+        exp : array-like, shape=[..., dim]
         """
         exp = base_point + tangent_vec
         return exp
@@ -112,16 +109,13 @@ class EuclideanMetric(RiemannianMetric):
 
         Parameters
         ----------
-        point: array-like, shape=[n_samples, dim]
-                           or shape=[1, dim]
+        point: array-like, shape=[..., dim]
 
-        base_point: array-like, shape=[n_samples, dim]
-                                or shape=[1, dim]
+        base_point: array-like, shape=[..., dim]
 
         Returns
         -------
-        log: array-like, shape=[n_samples, dim]
-                          or shape-[n_samples, dim]
+        log: array-like, shape=[..., dim]
         """
         log = point - base_point
         return log

--- a/geomstats/geometry/general_linear.py
+++ b/geomstats/geometry/general_linear.py
@@ -58,8 +58,8 @@ class GeneralLinear(Matrices):
 
         Returns
         -------
-        samples : array-like, shape=[n_samples, n, n]
-            Points sampled on GL(n).
+        samples : array-like, shape=[..., n, n]
+            Point sampled on GL(n).
         """
         samples = gs.random.rand(n_samples, self.n, self.n)
         while True:
@@ -93,18 +93,14 @@ class GeneralLinear(Matrices):
 
         Parameters
         ----------
-        tangent_vec :   array-like, shape=[n_samples, n, n]
-                                    or shape=[n, n]
-        base_point :    array-like, shape=[n_samples, n, n]
-                                    or shape=[n, n]
+        tangent_vec : array-like, shape=[..., n, n]
+        base_point : array-like, shape=[..., n, n]}
             Defaults to identity.
 
         Returns
         -------
-        point :         array-like, shape=[..., n, n]
-                                    or shape=[n, n]
-            The left multiplication of `exp(algebra_mat)` with
-            `base_point`.
+        point : array-like, shape=[..., n, n]
+            Left multiplication of `exp(algebra_mat)` with `base_point`.
         """
         expm = gs.linalg.expm
         if base_point is None:
@@ -122,17 +118,14 @@ class GeneralLinear(Matrices):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, n, n]
-                            or shape=[n, n]
-        base_point : array-like, shape=[n_samples, n, n]
-                                 or shape=[n, n]
+        point : array-like, shape=[..., n, n]
+        base_point : array-like, shape=[..., n, n]
             Defaults to identity.
 
         Returns
         -------
-        tangent_vec : array-like, shape=[n_samples, n, n]
-                                  or shape=[n, n]
-            A matrix such that `exp(tangent_vec, base_point) = point`.
+        tangent_vec : array-like, shape=[..., n, n]
+            Matrix such that `exp(tangent_vec, base_point) = point`.
 
         Notes
         -----

--- a/geomstats/geometry/grassmannian.py
+++ b/geomstats/geometry/grassmannian.py
@@ -51,7 +51,7 @@ class Grassmannian(EmbeddedManifold):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, n, n]
+        point : array-like, shape=[..., n, n]
         tolerance : int
             default: TOLERANCE
 
@@ -90,14 +90,14 @@ class GrassmannianCanonicalMetric(RiemannianMetric):
 
         Parameters
         ----------
-        vector : array-like, shape=[n_samples, n, n]
+        vector : array-like, shape=[..., n, n]
             `vector` is skew-symmetric, in so(n).
-        point : array-like, shape=[n_samples, n, n]
+        point : array-like, shape=[..., n, n]
             `point` is a rank p projector of Gr(n, k).
 
         Returns
         -------
-        exp : array-like, shape=[n_samples, n, n]
+        exp : array-like, shape=[..., n, n]
         """
         expm = gs.linalg.expm
         mul = Matrices.mul
@@ -115,14 +115,14 @@ class GrassmannianCanonicalMetric(RiemannianMetric):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, n, n]
+        point : array-like, shape=[..., n, n]
             Point in the Grassmannian.
-        base_point : array-like, shape=[n_samples, n, n]
+        base_point : array-like, shape=[..., n, n]
             Point in the Grassmannian.
 
         Returns
         -------
-        tangent_vec : array-like, shape=[n_samples, n, n]
+        tangent_vec : array-like, shape=[..., n, n]
             Tangent vector at `base_point`.
 
         References

--- a/geomstats/geometry/hyperbolic.py
+++ b/geomstats/geometry/hyperbolic.py
@@ -55,12 +55,12 @@ class Hyperbolic(Manifold):
 
         Parameters
         ----------
-        point_extrinsic : array-like, shape=[n_samples, dim + 1]
+        point_extrinsic : array-like, shape=[..., dim + 1]
             Point in hyperbolic space in extrinsic coordinates.
 
         Returns
         -------
-        point_intrinsic : array-like, shape=[n_samples, dim]
+        point_intrinsic : array-like, shape=[..., dim]
             Point in hyperbolic space in intrinsic coordinates.
         """
         return point
@@ -76,12 +76,12 @@ class Hyperbolic(Manifold):
 
         Parameters
         ----------
-        point_intrinsic : array-like, shape=[n_samples, dim]
+        point_intrinsic : array-like, shape=[..., dim]
             Point in hyperbolic space in intrinsic coordinates.
 
         Returns
         -------
-        point_extrinsic : array-like, shape=[n_samples, dim + 1]
+        point_extrinsic : array-like, shape=[..., dim + 1]
             Point in hyperbolic space in extrinsic coordinates.
         """
         coord_0 = gs.sqrt(1. + gs.linalg.norm(point_intrinsic, axis=-1) ** 2)
@@ -102,12 +102,12 @@ class Hyperbolic(Manifold):
 
         Parameters
         ----------
-        point_extrinsic : array-like, shape=[n_samples, dim + 1]
+        point_extrinsic : array-like, shape=[..., dim + 1]
             Point in hyperbolic space in extrinsic coordinates.
 
         Returns
         -------
-        point_intrinsic : array-like, shape=[n_samples, dim]
+        point_intrinsic : array-like, shape=[..., dim]
         """
         point_intrinsic = point_extrinsic[..., 1:]
 
@@ -123,12 +123,12 @@ class Hyperbolic(Manifold):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dim + 1]
+        point : array-like, shape=[..., dim + 1]
             Point in hyperbolic space in extrinsic coordinates.
 
         Returns
         -------
-        point_ball : array-like, shape=[n_samples, dim]
+        point_ball : array-like, shape=[..., dim]
             Point in hyperbolic space in Poincare ball coordinates.
         """
         return point[..., 1:] / (1 + point[..., :1])
@@ -144,12 +144,12 @@ class Hyperbolic(Manifold):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dim]
+        point : array-like, shape=[..., dim]
             Point in hyperbolic space in Poincare ball coordinates.
 
         Returns
         -------
-        extrinsic : array-like, shape=[n_samples, dim + 1]
+        extrinsic : array-like, shape=[..., dim + 1]
             Point in hyperbolic space in extrinsic coordinates.
         """
         squared_norm = gs.sum(point**2, -1)
@@ -172,12 +172,12 @@ class Hyperbolic(Manifold):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, 2]
+        point : array-like, shape=[..., 2]
             Point in hyperbolic space in half-plane coordinates.
 
         Returns
         -------
-        extrinsic : array-like, shape=[n_samples, 3]
+        extrinsic : array-like, shape=[..., 3]
             Point in hyperbolic plane in extrinsic coordinates.
         """
         x, y = point[:, 0], point[:, 1]
@@ -201,12 +201,12 @@ class Hyperbolic(Manifold):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, 2]
+        point : array-like, shape=[..., 2]
             Point in the hyperbolic plane in intrinsic coordinates.
 
         Returns
         -------
-        point_half_plane : array-like, shape=[n_samples, 2]
+        point_half_plane : array-like, shape=[..., 2]
             Point in the hyperbolic plane in Poincare upper half-plane
             coordinates.
         """
@@ -246,8 +246,7 @@ class Hyperbolic(Manifold):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dim]
-                            or shape=[n_samples, dim + 1]
+        point : array-like, shape=[..., {dim, dim + 1}]
             Point in hyperbolic space.
         from_coordinates_system : str, {'extrinsic', 'intrinsic', etc}
             Coordinates type.
@@ -256,7 +255,7 @@ class Hyperbolic(Manifold):
 
         Returns
         -------
-        point_to : array-like, shape=[n_samples, dim]
+        point_to : array-like, shape=[..., dim]
                                or shape=[n_sample, dim + 1]
             Point in hyperbolic space in coordinates given by to_point_type.
         """
@@ -295,7 +294,7 @@ class Hyperbolic(Manifold):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dim]
+        point : array-like, shape=[..., dim]
             Point to be tested.
         tolerance : float, optional
             Tolerance at which to evaluate how close the squared norm
@@ -303,7 +302,7 @@ class Hyperbolic(Manifold):
 
         Returns
         -------
-        belongs : array-like, shape=[n_samples, 1]
+        belongs : array-like, shape=[..., 1]
             Array of booleans indicating whether the corresponding points
             belong to the hyperbolic space.
         """
@@ -317,16 +316,14 @@ class Hyperbolic(Manifold):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dim]
-                            or shape=[n_samples, dim + 1]
+        point : array-like, shape=[..., {dim, dim + 1}]
             Point in hyperbolic space.
         to_point_type : str, {'extrinsic', 'intrinsic', etc}, optional
             Coordinates type.
 
         Returns
         -------
-        point_to : array-like, shape=[n_samples, dim]
-                               or shape=[n_sample, dim + 1]
+        point_to : array-like, shape=[..., {dim, dim + 1}]
             Point in hyperbolic space in coordinates given by to_point_type.
         """
         return Hyperbolic.change_coordinates_system(point,
@@ -341,16 +338,14 @@ class Hyperbolic(Manifold):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dim]
-                            or shape=[n_samples, dim + 1]
+        point : array-like, shape=[..., {dim, dim + 1}]
             Point in hyperbolic space in coordinates from_point_type.
         from_point_type : str, {'ball', 'extrinsic', 'intrinsic', 'half_plane'}
             Coordinates type.
 
         Returns
         -------
-        point_current : array-like, shape=[n_samples, dim]
-                                    or shape=[n_sample, dim + 1]
+        point_current : array-like, shape=[..., {dim, dim + 1}]
             Point in hyperbolic space.
         """
         return Hyperbolic.change_coordinates_system(
@@ -374,7 +369,7 @@ class Hyperbolic(Manifold):
 
         Returns
         -------
-        samples : array-like, shape=[n_samples, dim + 1]
+        samples : array-like, shape=[..., dim + 1]
             Samples in hyperbolic space.
         """
         size = (n_samples, self.dim)
@@ -418,16 +413,16 @@ class HyperbolicMetric(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec_a : array-like, shape=[n_samples, dim + 1]
+        tangent_vec_a : array-like, shape=[..., dim + 1]
             First tangent vector at base point.
-        tangent_vec_b : array-like, shape=[n_samples, dim + 1]
+        tangent_vec_b : array-like, shape=[..., dim + 1]
             Second tangent vector at base point.
-        base_point : array-like, shape=[n_samples, dim + 1], optional
+        base_point : array-like, shape=[..., dim + 1], optional
             Point in hyperbolic space.
 
         Returns
         -------
-        inner_prod : array-like, shape=[n_samples, 1]
+        inner_prod : array-like, shape=[..., 1]
             Inner-product of the two tangent vectors.
         """
         inner_prod = self._inner_product(
@@ -443,14 +438,14 @@ class HyperbolicMetric(RiemannianMetric):
 
         Parameters
         ----------
-        vector : array-like, shape=[n_samples, dim + 1]
+        vector : array-like, shape=[..., dim + 1]
             Vector on the tangent space of the hyperbolic space at base point.
-        base_point : array-like, shape=[n_samples, dim + 1], optional
+        base_point : array-like, shape=[..., dim + 1], optional
             Point in hyperbolic space in extrinsic coordinates.
 
         Returns
         -------
-        sq_norm : array-like, shape=[n_samples, 1]
+        sq_norm : array-like, shape=[..., 1]
             Squared norm of the vector.
         """
         sq_norm = self._squared_norm(vector)
@@ -465,14 +460,14 @@ class HyperbolicMetric(RiemannianMetric):
 
         Parameters
         ----------
-        vector : array-like, shape=[n_samples, dim + 1]
+        vector : array-like, shape=[..., dim + 1]
             Vector on the tangent space of the hyperbolic space at base point.
-        base_point : array-like, shape=[n_samples, dim + 1], optional
+        base_point : array-like, shape=[..., dim + 1], optional
             Point in hyperbolic space in extrinsic coordinates.
 
         Returns
         -------
-        sq_norm : array-like, shape=[n_samples, 1]
+        sq_norm : array-like, shape=[..., 1]
             Squared norm of the vector.
         """
         return super().squared_norm(vector, base_point=base_point)
@@ -482,16 +477,16 @@ class HyperbolicMetric(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec_a : array-like, shape=[n_samples, dim + 1]
+        tangent_vec_a : array-like, shape=[..., dim + 1]
             First tangent vector at base point.
-        tangent_vec_b : array-like, shape=[n_samples, dim + 1]
+        tangent_vec_b : array-like, shape=[..., dim + 1]
             Second tangent vector at base point.
-        base_point : array-like, shape=[n_samples, dim + 1], optional
+        base_point : array-like, shape=[..., dim + 1], optional
             Point in hyperbolic space.
 
         Returns
         -------
-        inner_prod : array-like, shape=[n_samples, 1]
+        inner_prod : array-like, shape=[..., 1]
             Inner-product of the two tangent vectors.
         """
         return super().inner_product(tangent_vec_a, tangent_vec_b,

--- a/geomstats/geometry/hyperboloid.py
+++ b/geomstats/geometry/hyperboloid.py
@@ -81,7 +81,7 @@ class Hyperboloid(Hyperbolic, EmbeddedManifold):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dim]
+        point : array-like, shape=[..., dim]
             Point to be tested.
         tolerance : float, optional
             Tolerance at which to evaluate how close the squared norm
@@ -89,7 +89,7 @@ class Hyperboloid(Hyperbolic, EmbeddedManifold):
 
         Returns
         -------
-        belongs : array-like, shape=[n_samples, 1]
+        belongs : array-like, shape=[..., 1]
             Array of booleans indicating whether the corresponding points
             belong to the hyperbolic space.
         """
@@ -116,12 +116,12 @@ class Hyperboloid(Hyperbolic, EmbeddedManifold):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dim + 1]
+        point : array-like, shape=[..., dim + 1]
             Point.
 
         Returns
         -------
-        projected_point : array-like, shape=[n_samples, dim + 1]
+        projected_point : array-like, shape=[..., dim + 1]
             Point in hyperbolic space in canonical representation
             in extrinsic coordinates.
         """
@@ -153,14 +153,14 @@ class Hyperboloid(Hyperbolic, EmbeddedManifold):
 
         Parameters
         ----------
-        vector : array-like, shape=[n_samples, dim + 1]
+        vector : array-like, shape=[..., dim + 1]
             Vector in Minkowski space to be projected.
-        base_point : array-like, shape=[n_samples, dim + 1]
+        base_point : array-like, shape=[..., dim + 1]
             Point in hyperbolic space.
 
         Returns
         -------
-        tangent_vec : array-like, shape=[n_samples, dim + 1]
+        tangent_vec : array-like, shape=[..., dim + 1]
             Tangent vector at the base point, equal to the projection of
             the vector in Minkowski space.
         """
@@ -181,7 +181,7 @@ class Hyperboloid(Hyperbolic, EmbeddedManifold):
 
         Parameters
         ----------
-        point_intrinsic : array-like, shape=[n_samples, dim]
+        point_intrinsic : array-like, shape=[..., dim]
             Point in the embedded manifold in intrinsic coordinates.
         """
         if self.dim != point_intrinsic.shape[-1]:
@@ -198,7 +198,7 @@ class Hyperboloid(Hyperbolic, EmbeddedManifold):
 
         Parameters
         ----------
-        point_extrinsic : array-like, shape=[n_samples, dim_embedding]
+        point_extrinsic : array-like, shape=[..., dim_embedding]
             Point in the embedded manifold in extrinsic coordinates,
             i. e. in the coordinates of the embedding manifold.
         """
@@ -244,11 +244,11 @@ class HyperboloidMetric(HyperbolicMetric):
 
         Parameters
         ----------
-        base_point: array-like, shape=[n_samples, dim+1]
+        base_point: array-like, shape=[..., dim+1]
 
         Returns
         -------
-        inner_prod_mat: array-like, shape=[n_samples, dim+1, dim+1]
+        inner_prod_mat: array-like, shape=[..., dim+1, dim+1]
         """
         self.embedding_metric.inner_product_matrix(base_point)
 
@@ -257,16 +257,16 @@ class HyperboloidMetric(HyperbolicMetric):
 
         Parameters
         ----------
-        tangent_vec_a : array-like, shape=[n_samples, dim + 1]
+        tangent_vec_a : array-like, shape=[..., dim + 1]
             First tangent vector at base point.
-        tangent_vec_b : array-like, shape=[n_samples, dim + 1]
+        tangent_vec_b : array-like, shape=[..., dim + 1]
             Second tangent vector at base point.
-        base_point : array-like, shape=[n_samples, dim + 1], optional
+        base_point : array-like, shape=[..., dim + 1], optional
             Point in hyperbolic space.
 
         Returns
         -------
-        inner_prod : array-like, shape=[n_samples, 1]
+        inner_prod : array-like, shape=[..., 1]
             Inner-product of the two tangent vectors.
         """
         inner_prod = self.embedding_metric.inner_product(
@@ -281,14 +281,14 @@ class HyperboloidMetric(HyperbolicMetric):
 
         Parameters
         ----------
-        vector : array-like, shape=[n_samples, dim + 1]
+        vector : array-like, shape=[..., dim + 1]
             Vector on the tangent space of the hyperbolic space at base point.
-        base_point : array-like, shape=[n_samples, dim + 1], optional
+        base_point : array-like, shape=[..., dim + 1], optional
             Point in hyperbolic space in extrinsic coordinates.
 
         Returns
         -------
-        sq_norm : array-like, shape=[n_samples, 1]
+        sq_norm : array-like, shape=[..., 1]
             Squared norm of the vector.
         """
         sq_norm = self.embedding_metric.squared_norm(vector)
@@ -300,14 +300,14 @@ class HyperboloidMetric(HyperbolicMetric):
 
         Parameters
         ----------
-        tangent_vec : array-like, shape=[n_samples, dim + 1]
+        tangent_vec : array-like, shape=[..., dim + 1]
             Tangent vector at a base point.
-        base_point : array-like, shape=[n_samples, dim + 1]
+        base_point : array-like, shape=[..., dim + 1]
             Point in hyperbolic space.
 
         Returns
         -------
-        exp : array-like, shape=[n_samples, dim + 1]
+        exp : array-like, shape=[..., dim + 1]
             Point in hyperbolic space equal to the Riemannian exponential
             of tangent_vec at the base point.
         """
@@ -360,14 +360,14 @@ class HyperboloidMetric(HyperbolicMetric):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dim + 1]
+        point : array-like, shape=[..., dim + 1]
             Point in hyperbolic space.
-        base_point : array-like, shape=[n_samples, dim + 1]
+        base_point : array-like, shape=[..., dim + 1]
             Point in hyperbolic space.
 
         Returns
         -------
-        log : array-like, shape=[n_samples, dim + 1]
+        log : array-like, shape=[..., dim + 1]
             Tangent vector at the base point equal to the Riemannian logarithm
             of point at the base point.
         """
@@ -409,14 +409,14 @@ class HyperboloidMetric(HyperbolicMetric):
 
         Parameters
         ----------
-        point_a : array-like, shape=[n_samples, dim + 1]
+        point_a : array-like, shape=[..., dim + 1]
             First point in hyperbolic space.
-        point_b : array-like, shape=[n_samples, dim + 1]
+        point_b : array-like, shape=[..., dim + 1]
             Second point in hyperbolic space.
 
         Returns
         -------
-        dist : array-like, shape=[n_samples, 1]
+        dist : array-like, shape=[..., 1]
             Geodesic distance between the two points.
         """
         sq_norm_a = self.embedding_metric.squared_norm(point_a)

--- a/geomstats/geometry/hypersphere.py
+++ b/geomstats/geometry/hypersphere.py
@@ -62,14 +62,14 @@ class Hypersphere(EmbeddedManifold):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dim + 1]
+        point : array-like, shape=[..., dim + 1]
             Points in Euclidean space.
         tolerance : float, optional
             Tolerance at which to evaluate norm == 1 (default: TOLERANCE).
 
         Returns
         -------
-        belongs : array-like, shape=[n_samples, 1]
+        belongs : array-like, shape=[..., 1]
             Array of booleans evaluating if each point belongs to
             the hypersphere.
         """
@@ -95,12 +95,12 @@ class Hypersphere(EmbeddedManifold):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dim + 1]
+        point : array-like, shape=[..., dim + 1]
             Points on the hypersphere.
 
         Returns
         -------
-        projected_point : array-like, shape=[n_samples, dim + 1]
+        projected_point : array-like, shape=[..., dim + 1]
             Points in canonical representation chosen for the hypersphere.
         """
         if not gs.all(self.belongs(point)):
@@ -114,12 +114,12 @@ class Hypersphere(EmbeddedManifold):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dim + 1]
+        point : array-like, shape=[..., dim + 1]
             Point in embedding Euclidean space.
 
         Returns
         -------
-        projected_point : array-like, shape=[n_samples, dim + 1]
+        projected_point : array-like, shape=[..., dim + 1]
             Point projected on the hypersphere.
         """
         norm = self.embedding_metric.norm(point)
@@ -136,15 +136,15 @@ class Hypersphere(EmbeddedManifold):
 
         Parameters
         ----------
-        vector : array-like, shape=[n_samples, dim + 1]
+        vector : array-like, shape=[..., dim + 1]
             Vector in Euclidean space.
-        base_point : array-like, shape=[n_samples, dim + 1]
+        base_point : array-like, shape=[..., dim + 1]
             Point on the hypersphere defining the tangent space,
             where the vector will be projected.
 
         Returns
         -------
-        tangent_vec : array-like, shape=[n_samples, dim + 1]
+        tangent_vec : array-like, shape=[..., dim + 1]
             Tangent vector in the tangent space of the hypersphere
             at the base point.
         """
@@ -165,12 +165,12 @@ class Hypersphere(EmbeddedManifold):
 
         Parameters
         ----------
-        point_spherical : array-like, shape=[n_samples, dim]
+        point_spherical : array-like, shape=[..., dim]
             Point on the sphere, in spherical coordinates.
 
         Returns
         -------
-        point_extrinsic : array_like, shape=[n_samples, dim + 1]
+        point_extrinsic : array_like, shape=[..., dim + 1]
             Point on the sphere, in extrinsic coordinates in Euclidean space.
         """
         if self.dim != 2:
@@ -203,14 +203,14 @@ class Hypersphere(EmbeddedManifold):
 
         Parameters
         ----------
-        tangent_vec_spherical : array-like, shape=[n_samples, dim]
+        tangent_vec_spherical : array-like, shape=[..., dim]
             Tangent vector to the sphere, in spherical coordinates.
-        base_point_spherical : array-like, shape=[n_samples, dim]
+        base_point_spherical : array-like, shape=[..., dim]
             Point on the sphere, in spherical coordinates.
 
         Returns
         -------
-        tangent_vec_extrinsic : array-like, shape=[n_samples, dim + 1]
+        tangent_vec_extrinsic : array-like, shape=[..., dim + 1]
             Tangent vector to the sphere, at base point,
             in extrinsic coordinates in Euclidean space.
         """
@@ -249,12 +249,12 @@ class Hypersphere(EmbeddedManifold):
 
         Parameters
         ----------
-        point_intrinsic : array-like, shape=[n_samples, dim]
+        point_intrinsic : array-like, shape=[..., dim]
             Point on the hypersphere, in intrinsic coordinates.
 
         Returns
         -------
-        point_extrinsic : array-like, shape=[n_samples, dim + 1]
+        point_extrinsic : array-like, shape=[..., dim + 1]
             Point on the hypersphere, in extrinsic coordinates in
             Euclidean space.
         """
@@ -277,13 +277,13 @@ class Hypersphere(EmbeddedManifold):
 
         Parameters
         ----------
-        point_extrinsic : array-like, shape=[n_samples, dim + 1]
+        point_extrinsic : array-like, shape=[..., dim + 1]
             Point on the hypersphere, in extrinsic coordinates in
             Euclidean space.
 
         Returns
         -------
-        point_intrinsic : array-like, shape=[n_samples, dim]
+        point_intrinsic : array-like, shape=[..., dim]
             Point on the hypersphere, in intrinsic coordinates.
         """
         point_intrinsic = point_extrinsic[:, 1:]
@@ -306,7 +306,7 @@ class Hypersphere(EmbeddedManifold):
 
         Returns
         -------
-        samples : array-like, shape=[n_samples, dim + 1]
+        samples : array-like, shape=[..., dim + 1]
             Points sampled on the hypersphere.
         """
         size = (n_samples, self.dim + 1)
@@ -346,7 +346,7 @@ class Hypersphere(EmbeddedManifold):
 
         Returns
         -------
-        point : array-like, shape=[n_samples, 3]
+        point : array-like, shape=[..., 3]
             Points sampled on the sphere in extrinsic coordinates
             in Euclidean space of dimension 3.
         """
@@ -392,16 +392,16 @@ class HypersphereMetric(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec_a : array-like, shape=[n_samples, dim + 1]
+        tangent_vec_a : array-like, shape=[..., dim + 1]
             First tangent vector at base point.
-        tangent_vec_b : array-like, shape=[n_samples, dim + 1]
+        tangent_vec_b : array-like, shape=[..., dim + 1]
             Second tangent vector at base point.
-        base_point : array-like, shape=[n_samples, dim + 1], optional
+        base_point : array-like, shape=[..., dim + 1], optional
             Point on the hypersphere.
 
         Returns
         -------
-        inner_prod : array-like, shape=[n_samples, 1]
+        inner_prod : array-like, shape=[..., 1]
             Inner-product of the two tangent vectors.
         """
         inner_prod = self.embedding_metric.inner_product(
@@ -417,14 +417,14 @@ class HypersphereMetric(RiemannianMetric):
 
         Parameters
         ----------
-        vector : array-like, shape=[n_samples, dim + 1]
+        vector : array-like, shape=[..., dim + 1]
             Vector on the tangent space of the hypersphere at base point.
-        base_point : array-like, shape=[n_samples, dim + 1], optional
+        base_point : array-like, shape=[..., dim + 1], optional
             Point on the hypersphere.
 
         Returns
         -------
-        sq_norm : array-like, shape=[n_samples, 1]
+        sq_norm : array-like, shape=[..., 1]
             Squared norm of the vector.
         """
         sq_norm = self.embedding_metric.squared_norm(vector)
@@ -436,14 +436,14 @@ class HypersphereMetric(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec : array-like, shape=[n_samples, dim + 1]
+        tangent_vec : array-like, shape=[..., dim + 1]
             Tangent vector at a base point.
-        base_point : array-like, shape=[n_samples, dim + 1]
+        base_point : array-like, shape=[..., dim + 1]
             Point on the hypersphere.
 
         Returns
         -------
-        exp : array-like, shape=[n_samples, dim + 1]
+        exp : array-like, shape=[..., dim + 1]
             Point on the hypersphere equal to the Riemannian exponential
             of tangent_vec at the base point.
         """
@@ -499,14 +499,14 @@ class HypersphereMetric(RiemannianMetric):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dim + 1]
+        point : array-like, shape=[..., dim + 1]
             Point on the hypersphere.
-        base_point : array-like, shape=[n_samples, dim + 1]
+        base_point : array-like, shape=[..., dim + 1]
             Point on the hypersphere.
 
         Returns
         -------
-        log : array-like, shape=[n_samples, dim + 1]
+        log : array-like, shape=[..., dim + 1]
             Tangent vector at the base point equal to the Riemannian logarithm
             of point at the base point.
         """
@@ -571,14 +571,14 @@ class HypersphereMetric(RiemannianMetric):
 
         Parameters
         ----------
-        point_a : array-like, shape=[n_samples, dim + 1]
+        point_a : array-like, shape=[..., dim + 1]
             First point on the hypersphere.
-        point_b : array-like, shape=[n_samples, dim + 1]
+        point_b : array-like, shape=[..., dim + 1]
             Second point on the hypersphere.
 
         Returns
         -------
-        dist : array-like, shape=[n_samples, 1]
+        dist : array-like, shape=[..., 1]
             Geodesic distance between the two points.
         """
         norm_a = self.embedding_metric.norm(point_a)
@@ -598,14 +598,14 @@ class HypersphereMetric(RiemannianMetric):
 
         Parameters
         ----------
-        point_a : array-like, shape=[n_samples, dim]
+        point_a : array-like, shape=[..., dim]
             Point on the hypersphere.
-        point_b : array-like, shape=[n_samples, dim]
+        point_b : array-like, shape=[..., dim]
             Point on the hypersphere.
 
         Returns
         -------
-        sq_dist : array-like, shape=[n_samples,]
+        sq_dist : array-like, shape=[...,]
         """
         return self.dist(point_a, point_b) ** 2
 
@@ -618,17 +618,17 @@ class HypersphereMetric(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec_a : array-like, shape=[n_samples, dim + 1]
+        tangent_vec_a : array-like, shape=[..., dim + 1]
             Tangent vector at base point to be transported.
-        tangent_vec_b : array-like, shape=[n_samples, dim + 1]
+        tangent_vec_b : array-like, shape=[..., dim + 1]
             Tangent vector at base point, along which the parallel transport
             is computed.
-        base_point : array-like, shape=[n_samples, dim + 1]
+        base_point : array-like, shape=[..., dim + 1]
             Point on the hypersphere.
 
         Returns
         -------
-        transported_tangent_vec: array-like, shape=[n_samples, dim + 1]
+        transported_tangent_vec: array-like, shape=[..., dim + 1]
             Transported tangent vector at exp_(base_point)(tangent_vec_b).
         """
         tangent_vec_a = gs.to_ndarray(tangent_vec_a, to_ndim=2)
@@ -652,7 +652,7 @@ class HypersphereMetric(RiemannianMetric):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dim]
+        point : array-like, shape=[..., dim]
             Point on hypersphere where the Christoffel symbols are computed.
 
         point_type: str, {'spherical', 'intrinsic', 'extrinsic'}
@@ -660,7 +660,7 @@ class HypersphereMetric(RiemannianMetric):
 
         Returns
         -------
-        christoffel : array-like, shape=[n_samples, contravariant index, 1st
+        christoffel : array-like, shape=[..., contravariant index, 1st
                                          covariant index, 2nd covariant index]
             Christoffel symbols at point.
         """

--- a/geomstats/geometry/invariant_metric.py
+++ b/geomstats/geometry/invariant_metric.py
@@ -57,14 +57,14 @@ class InvariantMetric(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec_a : array-like, shape=[n_samples, dim]
+        tangent_vec_a : array-like, shape=[..., dim]
             First tangent vector at identity.
-        tangent_vec_b : array-like, shape=[n_samples, dim]
+        tangent_vec_b : array-like, shape=[..., dim]
             Second tangent vector at identity.
 
         Returns
         -------
-        inner_prod : array-like, shape=[n_samples, dim]
+        inner_prod : array-like, shape=[..., dim]
             Inner-product of the two tangent vectors.
         """
         geomstats.error.check_parameter_accepted_values(
@@ -100,16 +100,16 @@ class InvariantMetric(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec_a : array-like, shape=[n_samples, dim]
+        tangent_vec_a : array-like, shape=[..., dim]
             First tangent vector at base_point.
-        tangent_vec_b : array-like, shape=[n_samples, dim]
+        tangent_vec_b : array-like, shape=[..., dim]
             Second tangent vector at base_point.
-        base_point : array-like, shape=[n_samples, dim], optional
+        base_point : array-like, shape=[..., dim], optional
             Point in the group (the default is identity).
 
         Returns
         -------
-        inner_prod : array-like, shape=[n_samples, dim]
+        inner_prod : array-like, shape=[..., dim]
             Inner-product of the two tangent vectors.
         """
         if base_point is None:
@@ -142,12 +142,12 @@ class InvariantMetric(RiemannianMetric):
 
         Parameters
         ----------
-        base_point : array-like, shape=[n_samples, dim], optional
+        base_point : array-like, shape=[..., dim], optional
             Point in the group (the default is identity).
 
         Returns
         -------
-        metric_mat : array-like, shape=[n_samples, dim, dim]
+        metric_mat : array-like, shape=[..., dim, dim]
             The metric matrix at base_point.
         """
         if self.group.default_point_type == 'matrix':
@@ -185,12 +185,12 @@ class InvariantMetric(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec : array-like, shape=[n_samples, dim]
+        tangent_vec : array-like, shape=[..., dim]
             Tangent vector at identity.
 
         Returns
         -------
-        exp : array-like, shape=[n_samples, dim]
+        exp : array-like, shape=[..., dim]
             Point in the group.
         """
         tangent_vec = self.group.regularize_tangent_vec_at_identity(
@@ -210,12 +210,12 @@ class InvariantMetric(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec : array-like, shape=[n_samples, dim]
+        tangent_vec : array-like, shape=[..., dim]
             Tangent vector at identity.
 
         Returns
         -------
-        exp : array-like, shape=[n_samples, dim]
+        exp : array-like, shape=[..., dim]
             Point in the group.
         """
         if self.left_or_right == 'left':
@@ -233,14 +233,14 @@ class InvariantMetric(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec : array-like, shape=[n_samples, dim]
+        tangent_vec : array-like, shape=[..., dim]
             Tangent vector at a base point.
-        base_point : array-like, shape=[n_samples, dim]
+        base_point : array-like, shape=[..., dim]
             Point in the group.
 
         Returns
         -------
-        exp : array-like, shape=[n_samples, dim]
+        exp : array-like, shape=[..., dim]
             Point in the group equal to the Riemannian exponential
             of tangent_vec at the base point.
         """
@@ -285,12 +285,12 @@ class InvariantMetric(RiemannianMetric):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dim]
+        point : array-like, shape=[..., dim]
             Point in the group.
 
         Returns
         -------
-        log : array-like, shape=[n_samples, dim]
+        log : array-like, shape=[..., dim]
             Tangent vector at the identity equal to the Riemannian logarithm
             of point at the identity.
         """
@@ -308,12 +308,12 @@ class InvariantMetric(RiemannianMetric):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dim]
+        point : array-like, shape=[..., dim]
             Point in the group.
 
         Returns
         -------
-        log : array-like, shape=[n_samples, dim]
+        log : array-like, shape=[..., dim]
             Tangent vector at the identity equal to the Riemannian logarithm
             of point at the identity.
         """
@@ -333,15 +333,15 @@ class InvariantMetric(RiemannianMetric):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dim]
+        point : array-like, shape=[..., dim]
             Point in the group.
-        base_point : array-like, shape=[n_samples, dim], optional
+        base_point : array-like, shape=[..., dim], optional
             Point in the group, from which to compute the log,
             (the default is identity).
 
         Returns
         -------
-        log : array-like, shape=[n_samples, dim]
+        log : array-like, shape=[..., dim]
             Tangent vector at the base point equal to the Riemannian logarithm
             of point at the base point.
         """
@@ -404,12 +404,12 @@ class BiInvariantMetric(InvariantMetric):
 
         Parameters
         ----------
-        tangent_vec : array-like, shape=[n_samples, {dim, [n, n]}]
+        tangent_vec : array-like, shape=[..., {dim, [n, n]}]
             Tangent vector at identity.
 
         Returns
         -------
-        exp : array-like, shape=[n_samples, {dim, [n, n]}]
+        exp : array-like, shape=[..., {dim, [n, n]}]
             Point in the group.
         """
         return self.group.exp(tangent_vec)
@@ -421,12 +421,12 @@ class BiInvariantMetric(InvariantMetric):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, {dim, [n, n]}]
+        point : array-like, shape=[..., {dim, [n, n]}]
             Point in the group.
 
         Returns
         -------
-        log : array-like, shape=[n_samples, {dim, [n, n]}]
+        log : array-like, shape=[..., {dim, [n, n]}]
             Tangent vector at the identity equal to the Riemannian logarithm
             of point at the identity.
         """

--- a/geomstats/geometry/lie_algebra.py
+++ b/geomstats/geometry/lie_algebra.py
@@ -12,19 +12,18 @@ from ._bch_coefficients import BCH_COEFFICIENTS
 
 
 class MatrixLieAlgebra:
-    """Class implementing matrix Lie algebra related functions."""
+    """Class implementing matrix Lie algebra related functions.
+
+    Parameters
+    ----------
+    dim : int
+        Dimension of the Lie algebra as a real vector space.
+    n : int
+        Amount of rows and columns in the matrix representation of the
+        Lie algebra.
+    """
 
     def __init__(self, dim, n):
-        """Construct the MatrixLieAlgebra object.
-
-        Parameters
-        ----------
-        dim: int
-            The dimension of the Lie algebra as a real vector space
-        n: int
-            The amount of rows and columns in the matrix representation of the
-            Lie algebra
-        """
         geomstats.error.check_integer(dim, 'dim')
         geomstats.error.check_integer(n, 'n')
         self.dim = dim
@@ -40,12 +39,12 @@ class MatrixLieAlgebra:
 
         Parameters
         ----------
-        matrix_a: array-like, shape=[n_sample, n, n]
-        matrix_b: array-like, shape=[n_sample, n, n]
+        matrix_a : array-like, shape=[..., n, n]
+        matrix_b : array-like, shape=[..., n, n]
 
         Returns
         -------
-        bracket: shape=[n_sample, n, n]
+        bracket : shape=[..., n, n]
         """
         return gs.matmul(matrix_a, matrix_b) - gs.matmul(matrix_b, matrix_a)
 
@@ -63,7 +62,7 @@ class MatrixLieAlgebra:
 
         Parameters
         ----------
-        matrix_a, matrix_b : array-like, shape=[n_sample, n, n]
+        matrix_a, matrix_b : array-like, shape=[..., n, n]
         order : int
             The order to which the approximation is calculated. Note that this
             is NOT the same as using only e_i with i < order.
@@ -100,11 +99,11 @@ class MatrixLieAlgebra:
 
         Parameters
         ----------
-        matrix_representation: array-like, shape=[n_sample, n, n]
+        matrix_representation : array-like, shape=[..., n, n]
 
         Returns
         -------
-        basis_representation: array-like, shape=[n_sample, dim]
+        basis_representation : array-like, shape=[..., dim]
         """
         raise NotImplementedError("basis_representation not implemented.")
 
@@ -116,11 +115,11 @@ class MatrixLieAlgebra:
 
         Parameters
         ----------
-        basis_representation: array-like, shape=[n_sample, dim]
+        basis_representation : array-like, shape=[..., dim]
 
         Returns
         -------
-        matrix_representation: array-like, shape=[n_sample, n, n]
+        matrix_representation : array-like, shape=[..., n, n]
         """
         basis_representation = gs.to_ndarray(basis_representation, to_ndim=2)
 

--- a/geomstats/geometry/lie_group.py
+++ b/geomstats/geometry/lie_group.py
@@ -16,8 +16,8 @@ def loss(y_pred, y_true, group, metric=None):
 
     Parameters
     ----------
-    y_pred : array-like, shape=[n_samples, {dim, [n, n]}]
-    y_true : array-like, shape=[n_samples, {dim, [n, n]}]
+    y_pred : array-like, shape=[..., {dim, [n, n]}]
+    y_true : array-like, shape=[..., {dim, [n, n]}]
         shape has to match y_pred
     group : LieGroup
     metric : RiemannianMetric, optional
@@ -25,7 +25,7 @@ def loss(y_pred, y_true, group, metric=None):
 
     Returns
     -------
-    loss : array-like, shape=[n_samples, {dim, [n, n]}]
+    loss : array-like, shape=[..., {dim, [n, n]}]
         the squared (geodesic) distance between y_pred and y_true
     """
     if metric is None:
@@ -39,8 +39,8 @@ def grad(y_pred, y_true, group, metric=None):
 
     Parameters
     ----------
-    y_pred : array-like, shape=[n_samples, {dim, [n, n]}]
-    y_true : array-like, shape=[n_samples, {dim, [n, n]}]
+    y_pred : array-like, shape=[..., {dim, [n, n]}]
+    y_true : array-like, shape=[..., {dim, [n, n]}]
         shape has to match y_pred
     group : LieGroup
     metric : RiemannianMetric, optional
@@ -48,7 +48,7 @@ def grad(y_pred, y_true, group, metric=None):
 
     Returns
     -------
-    grad : array-like, shape=[n_samples, {dim, [n, n]}]
+    grad : array-like, shape=[..., {dim, [n, n]}]
         tangent vector at point `y_pred`
     """
     if metric is None:
@@ -63,9 +63,9 @@ class LieGroup(Manifold):
     In this class, point_type ('vector' or 'matrix') will be used to describe
     the format of the points on the Lie group.
     If point_type is 'vector', the format of the inputs is
-    [n_samples, dimension], where dimension is the dimension of the Lie group.
+    [..., dimension], where dimension is the dimension of the Lie group.
     If point_type is 'matrix' the format of the inputs is
-    [n_samples, n, n] where n is the parameter of GL(n) e.g. the amount of rows
+    [..., n, n] where n is the parameter of GL(n) e.g. the amount of rows
     and columns of the matrix.
     """
 
@@ -112,14 +112,14 @@ class LieGroup(Manifold):
 
         Parameters
         ----------
-        point_a : array-like, shape=[n_samples, {dim, [n, n]}]
+        point_a : array-like, shape=[..., {dim, [n, n]}]
             the left factor in the product
-        point_b : array-like, shape=[n_samples, {dim, [n, n]}]
+        point_b : array-like, shape=[..., {dim, [n, n]}]
             the right factor in the product
 
         Returns
         -------
-        composed : array-like, shape=[n_samples, {dim, [n,n]}]
+        composed : array-like, shape=[..., {dim, [n, n]}]
             the product of point_a and point_b along the first dim
         """
         raise NotImplementedError(
@@ -132,12 +132,12 @@ class LieGroup(Manifold):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, {dim, [n,n]}]
+        point : array-like, shape=[..., {dim, [n, n]}]
             the points to be inverted
 
         Returns
         -------
-        inverse : array-like, shape=[n_samples, {dim, [n,n]}]
+        inverse : array-like, shape=[..., {dim, [n, n]}]
             the inverted point
         """
         raise NotImplementedError('The Lie group inverse is not implemented.')
@@ -150,7 +150,7 @@ class LieGroup(Manifold):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, {dim, [n,n]]
+        point : array-like, shape=[..., {dim, [n, n]]
             the points to be inverted
         left_or_right : str, {'left', 'right'}
             indicate whether to calculate the differential of left or right
@@ -173,12 +173,12 @@ class LieGroup(Manifold):
 
         Parameters
         ----------
-        tangent_vec : array-like, shape=[n_samples, {dim,[n,n]}]
+        tangent_vec : array-like, shape=[..., {dim, [n, n]}]
             the tangent vector to exponentiate
 
         Returns
         -------
-        point : array-like, shape=[n_samples, {dim,[n,n]}]
+        point : array-like, shape=[..., {dim, [n, n]}]
         """
         raise NotImplementedError(
             'The group exponential from the identity is not implemented.'
@@ -189,12 +189,12 @@ class LieGroup(Manifold):
 
         Parameters
         ----------
-        tangent_vec : array-like, shape=[n_samples, {dim,[n,n]}]
-        base_point : array-like, shape=[n_samples, {dim,[n,n]}]
+        tangent_vec : array-like, shape=[..., {dim, [n, n]}]
+        base_point : array-like, shape=[..., {dim, [n, n]}]
 
         Returns
         -------
-        exp : array-like, shape=[n_samples, {dim,[n,n]}]
+        exp : array-like, shape=[..., {dim, [n, n]}]
             the computed exponential
         """
         if self.default_point_type == 'vector':
@@ -220,13 +220,13 @@ class LieGroup(Manifold):
 
         Parameters
         ----------
-        tangent_vec : array-like, shape=[n_samples, {dim,[n,n]}]
-        base_point : array-like, shape=[n_samples, {dim,[n,n]}]
+        tangent_vec : array-like, shape=[..., {dim, [n, n]}]
+        base_point : array-like, shape=[..., {dim, [n, n]}]
             default: self.identity
 
         Returns
         -------
-        result : array-like, shape=[n_samples, {dim,[n,n]}]
+        result : array-like, shape=[..., {dim, [n, n]}]
             The exponentiated tangent vector
         """
         identity = self.get_identity()
@@ -247,11 +247,11 @@ class LieGroup(Manifold):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, {dim,[n,n]}]
+        point : array-like, shape=[..., {dim, [n, n]}]
 
         Returns
         -------
-        tangent_vec : array-like, shape=[n_samples, {dim,[n,n]}]
+        tangent_vec : array-like, shape=[..., {dim, [n, n]}]
         """
         raise NotImplementedError(
             'The group logarithm from the identity is not implemented.'
@@ -262,12 +262,12 @@ class LieGroup(Manifold):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, {dim,[n,n]}]
-        base_point : array-like, shape=[n_samples, {dim,[n,n]}]
+        point : array-like, shape=[..., {dim, [n, n]}]
+        base_point : array-like, shape=[..., {dim, [n, n]}]
 
         Returns
         -------
-        tangent_vec : array-like, shape=[n_samples, {dim,[n,n]}]
+        tangent_vec : array-like, shape=[..., {dim, [n, n]}]
         """
         if self.default_point_type == 'vector':
             jacobian = self.jacobian_translation(
@@ -290,12 +290,12 @@ class LieGroup(Manifold):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, {dim,[n,n]}]
-        base_point : array-like, shape=[n_samples, {dim,[n,n]}]
+        point : array-like, shape=[..., {dim, [n, n]}]
+        base_point : array-like, shape=[..., {dim, [n, n]}]
 
         Returns
         -------
-        tangent_vec : array-like, shape=[n_samples, {dim,[n,n]}]
+        tangent_vec : array-like, shape=[..., {dim, [n, n]}]
         """
         # TODO(ninamiolane): Build a standalone decorator that *only*
         # deals with point_type None and base_point None
@@ -327,13 +327,13 @@ class LieGroup(Manifold):
 
         Parameters
         ----------
-        tangent_vector_a : shape=[n_samples, n, n]
-        tangent_vector_b : shape=[n_samples, n, n]
-        base_point : array-like, shape=[n_samples, n, n]
+        tangent_vector_a : shape=[..., n, n]
+        tangent_vector_b : shape=[..., n, n]
+        base_point : array-like, shape=[..., n, n]
 
         Returns
         -------
-        bracket : array-like, shape=[n_samples, n, n]
+        bracket : array-like, shape=[..., n, n]
         """
         if base_point is None:
             base_point = self.get_identity(point_type=self.default_point_type)
@@ -362,9 +362,9 @@ class LieGroup(Manifold):
 
         Parameters
         ----------
-        vector : array-like, shape=[n_samples, dim_embedding]
+        vector : array-like, shape=[..., dim_embedding]
             Vector.
-        base_point : array-like, shape=[n_samples, dim_embedding]
+        base_point : array-like, shape=[..., dim_embedding]
             Point in the Lie group.
 
         Returns
@@ -394,14 +394,14 @@ class LieGroup(Manifold):
 
         Parameters
         ----------
-        vector : array-like, shape=[n_samples, {dim, [n, n]}]
+        vector : array-like, shape=[..., {dim, [n, n]}]
             Vector to project. Its shape must match the shape of base_point.
-        base_point : array-like, shape=[n_samples, {dim, [n, n]}], optional
+        base_point : array-like, shape=[..., {dim, [n, n]}], optional
             Point of the group.
 
         Returns
         -------
-        tangent_vec : array-like, shape=[n_samples, n, n]
+        tangent_vec : array-like, shape=[..., n, n]
         """
         if base_point is None:
             return self._to_lie_algebra(vector)

--- a/geomstats/geometry/manifold.py
+++ b/geomstats/geometry/manifold.py
@@ -29,12 +29,12 @@ class Manifold:
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dim]
+        point : array-like, shape=[..., dim]
                  Input points.
 
         Returns
         -------
-        belongs : array-like, shape=[n_samples, 1]
+        belongs : array-like, shape=[...,]
         """
         raise NotImplementedError('belongs is not implemented.')
 
@@ -43,9 +43,9 @@ class Manifold:
 
         Parameters
         ----------
-        vector : array-like, shape=[n_samples, dim]
+        vector : array-like, shape=[..., dim]
             Vector.
-        base_point : array-like, shape=[n_samples, dim]
+        base_point : array-like, shape=[..., dim]
             Point on the manifold.
 
         Returns
@@ -61,14 +61,14 @@ class Manifold:
 
         Parameters
         ----------
-        vector : array-like, shape=[n_samples, dim]
+        vector : array-like, shape=[..., dim]
             Vector.
-        base_point : array-like, shape=[n_samples, dim]
+        base_point : array-like, shape=[..., dim]
             Point on the manifold.
 
         Returns
         -------
-        tangent_vec : array-like, shape=[n_samples, dim]
+        tangent_vec : array-like, shape=[..., dim]
             Tangent vector at base point.
         """
         raise NotImplementedError(
@@ -79,12 +79,12 @@ class Manifold:
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dim]
+        point : array-like, shape=[..., dim]
                  Input points.
 
         Returns
         -------
-        regularized_point : array-like, shape=[n_samples, dim]
+        regularized_point : array-like, shape=[..., dim]
         """
         regularized_point = point
         return regularized_point

--- a/geomstats/geometry/matrices.py
+++ b/geomstats/geometry/matrices.py
@@ -28,7 +28,7 @@ class Matrices(Manifold):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, (m,n)]
+        point : array-like, shape=[..., m, n]
 
         Returns
         -------
@@ -44,13 +44,13 @@ class Matrices(Manifold):
 
         Parameters
         ----------
-        mat_a : array-like, shape=[n_samples, dim1, dim2]
-        mat_b : array-like, shape=[n_samples, dim2, dim3]
+        mat_a : array-like, shape=[..., dim1, dim2]
+        mat_b : array-like, shape=[..., dim2, dim3]
         atol
 
         Returns
         -------
-        eq : array-like boolean, shape=[n_samples]
+        eq : array-like boolean, shape=[...,]
         """
         is_vectorized = \
             (gs.ndim(gs.array(mat_a)) == 3) or (gs.ndim(gs.array(mat_b)) == 3)
@@ -63,14 +63,14 @@ class Matrices(Manifold):
 
         Parameters
         ----------
-        a1 : array-like, shape=[n_samples, dim_1, dim_2]
-        a2 : array-like, shape=[n_samples, dim_2, dim_3]
+        a1 : array-like, shape=[..., dim_1, dim_2]
+        a2 : array-like, shape=[..., dim_2, dim_3]
         ...
-        an : array-like, shape=[n_samples, dim_n-1, dim_n]
+        an : array-like, shape=[..., dim_n-1, dim_n]
 
         Returns
         -------
-        mul : array-like, shape=[n_samples, dim_1, dim_n]
+        mul : array-like, shape=[..., dim_1, dim_n]
         """
         return reduce(gs.matmul, args)
 
@@ -80,12 +80,12 @@ class Matrices(Manifold):
 
         Parameters
         ----------
-        mat_a : array-like, shape=[n_samples, dim, dim]
-        mat_b : array-like, shape=[n_samples, dim, dim]
+        mat_a : array-like, shape=[..., dim, dim]
+        mat_b : array-like, shape=[..., dim, dim]
 
         Returns
         -------
-        mat_c : array-like, shape=[n_samples, dim, dim]
+        mat_c : array-like, shape=[..., dim, dim]
         """
         return cls.mul(mat_a, mat_b) - cls.mul(mat_b, mat_a)
 
@@ -95,11 +95,11 @@ class Matrices(Manifold):
 
         Parameters
         ----------
-        mat : array-like, shape=[n_samples, dim, dim]
+        mat : array-like, shape=[..., dim, dim]
 
         Returns
         -------
-        transpose : array-like, shape=[n_samples, dim, dim]
+        transpose : array-like, shape=[..., dim, dim]
         """
         is_vectorized = (gs.ndim(gs.array(mat)) == 3)
         axes = (0, 2, 1) if is_vectorized else (1, 0)
@@ -111,12 +111,12 @@ class Matrices(Manifold):
 
         Parameters
         ----------
-        mat : array-like, shape=[n_samples, n, n]
+        mat : array-like, shape=[..., n, n]
         atol : float, absolute tolerance. defaults to TOLERANCE
 
         Returns
         -------
-        is_sym : array-like boolean, shape=[n_samples]
+        is_sym : array-like boolean, shape=[...,]
         """
         return cls.equal(mat, cls.transpose(mat), atol)
 
@@ -127,12 +127,12 @@ class Matrices(Manifold):
 
         Parameters
         ----------
-        mat : array-like, shape=[n_samples, n, n]
+        mat : array-like, shape=[..., n, n]
         atol : float, absolute tolerance. defaults to TOLERANCE
 
         Returns
         -------
-        is_skew_sym : array-like boolean, shape=[n_samples]
+        is_skew_sym : array-like boolean, shape=[...,]
         """
         return cls.equal(mat, - cls.transpose(mat), atol)
 
@@ -142,11 +142,11 @@ class Matrices(Manifold):
 
         Parameters
         ----------
-        mat : array-like, shape=[n_samples, n, n]
+        mat : array-like, shape=[..., n, n]
 
         Returns
         -------
-        sym : array-like, shape=[n_samples, n, n]
+        sym : array-like, shape=[..., n, n]
         """
         return 1 / 2 * (mat + cls.transpose(mat))
 
@@ -157,11 +157,11 @@ class Matrices(Manifold):
 
         Parameters
         ----------
-        mat : array-like, shape=[n_samples, n, n]
+        mat : array-like, shape=[..., n, n]
 
         Returns
         -------
-        skew_sym : array-like, shape=[n_samples, n, n]
+        skew_sym : array-like, shape=[..., n, n]
         """
         return 1 / 2 * (mat - cls.transpose(mat))
 
@@ -191,12 +191,12 @@ class Matrices(Manifold):
 
         Parameters
         ----------
-        mat_1 : array-like, shape=[n_samples, n, n]
-        mat_2 : array-like, shape=[n_samples, n, n]
+        mat_1 : array-like, shape=[..., n, n]
+        mat_2 : array-like, shape=[..., n, n]
 
         Returns
         -------
-        cong : array-like, shape=[n_samples, n, n]
+        cong : array-like, shape=[..., n, n]
         """
         return cls.mul(mat_2, mat_1, cls.transpose(mat_2))
 
@@ -215,14 +215,14 @@ class MatricesMetric(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec_a : array-like, shape=[n_samples, m, n]
-        tangent_vec_b : array-like, shape=[n_samples, m, n]
-        base_point : array-like, shape=[n_samples, m, n], optional
-
+        tangent_vec_a : array-like, shape=[..., m, n]
+        tangent_vec_b : array-like, shape=[..., m, n]
+        base_point : array-like, shape=[..., m, n], optional
 
         Returns
         -------
-        inner_prod : the Frobenius inner product of a and b
+        inner_prod : array-like, shape=[...,]
+            Frobenius inner product of tangent_vec_a and tangent_vec_b.
         """
         inner_prod = gs.einsum(
             '...ij,...ij->...', tangent_vec_a, tangent_vec_b)

--- a/geomstats/geometry/minkowski.py
+++ b/geomstats/geometry/minkowski.py
@@ -17,12 +17,12 @@ class Minkowski(Manifold):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dim]
-                Input points.
+        point : array-like, shape=[..., dim]
+            Input points.
 
         Returns
         -------
-        belongs : array-like, shape=[n_samples,]
+        belongs : array-like, shape=[...,]
         """
         point_dim = point.shape[-1]
         belongs = point_dim == self.dim
@@ -41,8 +41,8 @@ class Minkowski(Manifold):
 
         Returns
         -------
-        points : array-like, shape=[n_samples, dim]
-                 Sampled points.
+        points : array-like, shape=[..., dim]
+            Sampled points.
         """
         size = (self.dim,)
         if n_samples != 1:
@@ -68,11 +68,11 @@ class MinkowskiMetric(RiemannianMetric):
 
         Parameters
         ----------
-        base_point: array-like, shape=[n_samples, dim]
+        base_point : array-like, shape=[..., dim]
 
         Returns
         -------
-        inner_prod_mat: array-like, shape=[n_samples, dim, dim]
+        inner_prod_mat : array-like, shape=[..., dim, dim]
         """
         inner_prod_mat = gs.eye(self.dim - 1, self.dim - 1)
         first_row = gs.array([0.] * (self.dim - 1))
@@ -93,15 +93,12 @@ class MinkowskiMetric(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec: array-like, shape=[n_samples, dim]
-                                 or shape=[1, dim]
-        base_point: array-like, shape=[n_samples, dim]
-                                or shape=[1, dim]
+        tangent_vec : array-like, shape=[..., dim]
+        base_point : array-like, shape=[..., dim]
 
         Returns
         -------
-        exp: array-like, shape=[n_samples, dim]
-                          or shape-[n_samples, dim]
+        exp : array-like, shape=[..., dim]
         """
         exp = base_point + tangent_vec
         return exp
@@ -113,15 +110,12 @@ class MinkowskiMetric(RiemannianMetric):
 
         Parameters
         ----------
-        point: array-like, shape=[n_samples, dim]
-                           or shape=[1, dim]
-        base_point: array-like, shape=[n_samples, dim]
-                                or shape=[1, dim]
+        point : array-like, shape=[..., dim]
+        base_point : array-like, shape=[..., dim]
 
         Returns
         -------
-        log: array-like, shape=[n_samples, dim]
-                          or shape-[n_samples, dim]
+        log : array-like, shape=[..., dim]
         """
         log = point - base_point
         return log

--- a/geomstats/geometry/poincare_ball.py
+++ b/geomstats/geometry/poincare_ball.py
@@ -46,7 +46,7 @@ class PoincareBall(Hyperbolic):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dim]
+        point : array-like, shape=[..., dim]
             Point to be tested.
         tolerance : float, optional
             Tolerance at which to evaluate how close the squared norm
@@ -54,7 +54,7 @@ class PoincareBall(Hyperbolic):
 
         Returns
         -------
-        belongs : array-like, shape=[n_samples, 1]
+        belongs : array-like, shape=[...,]
             Array of booleans indicating whether the corresponding points
             belong to the hyperbolic space.
         """
@@ -90,14 +90,14 @@ class PoincareBallMetric(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec : array-like, shape=[n_samples, dim]
+        tangent_vec : array-like, shape=[..., dim]
             Tangent vector at a base point.
-        base_point : array-like, shape=[n_samples, dim]
+        base_point : array-like, shape=[..., dim]
             Point in hyperbolic space.
 
         Returns
         -------
-        exp : array-like, shape=[n_samples, dim]
+        exp : array-like, shape=[..., dim]
             Point in hyperbolic space equal to the Riemannian exponential
             of tangent_vec at the base point.
         """
@@ -137,14 +137,14 @@ class PoincareBallMetric(RiemannianMetric):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dim]
+        point : array-like, shape=[..., dim]
             Point in hyperbolic space.
-        base_point : array-like, shape=[n_samples, dim]
+        base_point : array-like, shape=[..., dim]
             Point in hyperbolic space.
 
         Returns
         -------
-        log : array-like, shape=[n_samples, dim]
+        log : array-like, shape=[..., dim]
             Tangent vector at the base point equal to the Riemannian logarithm
             of point at the base point.
         """
@@ -188,14 +188,14 @@ class PoincareBallMetric(RiemannianMetric):
 
         Parameters
         ----------
-        point_a : array-like, shape=[n_samples, dim]
+        point_a : array-like, shape=[..., dim]
             Point in hyperbolic space.
-        point_b : array-like, shape=[n_samples, dim]
+        point_b : array-like, shape=[..., dim]
             Point in hyperbolic space.
 
         Returns
         -------
-        mobius_add : array-like, shape=[n_samples, 1]
+        mobius_add : array-like, shape=[...,]
             Result of the Mobius addition.
         """
         ball_manifold = PoincareBall(self.dim, scale=self.scale)
@@ -229,14 +229,14 @@ class PoincareBallMetric(RiemannianMetric):
 
         Parameters
         ----------
-        point_a : array-like, shape=[n_samples, dim]
+        point_a : array-like, shape=[..., dim]
             First point in hyperbolic space.
-        point_b : array-like, shape=[n_samples, dim]
+        point_b : array-like, shape=[..., dim]
             Second point in hyperbolic space.
 
         Returns
         -------
-        dist : array-like, shape=[n_samples, 1]
+        dist : array-like, shape=[...,]
             Geodesic distance between the two points.
         """
         point_a_norm = gs.clip(gs.sum(point_a ** 2, -1), 0., 1 - EPSILON)
@@ -263,14 +263,14 @@ class PoincareBallMetric(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec : array-like, shape=[n_samples, dim]
+        tangent_vec : array-like, shape=[..., dim]
             vector in tangent space.
-        base_point : array-like, shape=[n_samples, dim]
+        base_point : array-like, shape=[..., dim]
             Second point in hyperbolic space.
 
         Returns
         -------
-        point : array-like, shape=[n_samples, dim]
+        point : array-like, shape=[..., dim]
             Retraction point.
         """
         ball_manifold = PoincareBall(self.dim, scale=self.scale)
@@ -291,11 +291,11 @@ class PoincareBallMetric(RiemannianMetric):
 
         Parameters
         ----------
-        base_point: array-like, shape=[n_samples, dim]
+        base_point : array-like, shape=[..., dim]
 
         Returns
         -------
-        inner_prod_mat: array-like, shape=[n_samples, dim, dim]
+        inner_prod_mat : array-like, shape=[..., dim, dim]
         """
         if base_point is None:
             base_point = gs.zeros((1, self.dim))

--- a/geomstats/geometry/poincare_polydisk.py
+++ b/geomstats/geometry/poincare_polydisk.py
@@ -51,11 +51,11 @@ class PoincarePolydisk(ProductManifold):
 
         Parameters
         ----------
-        point_intrinsic : array-like, shape=[n_samples, n_disk, dim]
+        point_intrinsic : array-like, shape=[..., n_disk, dim]
 
         Returns
         -------
-        point_extrinsic : array-like, shape=[n_samples, n_disks, dim + 1]
+        point_extrinsic : array-like, shape=[..., n_disks, dim + 1]
         """
         n_disks = point_intrinsic.shape[1]
         point_extrinsic = gs.stack(
@@ -72,12 +72,12 @@ class PoincarePolydisk(ProductManifold):
 
         Parameters
         ----------
-        vector : array-like, shape=[n_samples, n_disks, dim + 1]
-        base_point : array-like, shape=[n_samples, n_disks, dim + 1]
+        vector : array-like, shape=[..., n_disks, dim + 1]
+        base_point : array-like, shape=[..., n_disks, dim + 1]
 
         Returns
         -------
-        tangent_vec : array-like, shape=[n_samples, n_disks, dim + 1]
+        tangent_vec : array-like, shape=[..., n_disks, dim + 1]
         """
         n_disks = base_point.shape[1]
         hyperbolic_space = Hyperboloid(2, self.coords_type)

--- a/geomstats/geometry/product_manifold.py
+++ b/geomstats/geometry/product_manifold.py
@@ -18,12 +18,12 @@ class ProductManifold(Manifold):
     same dimension, but the list of manifolds needs to be provided.
 
     By default, a point is represented by an array of shape:
-    [n_samples, dim_1 + ... + dim_n_manifolds]
+    [..., dim_1 + ... + dim_n_manifolds]
     where n_manifolds is the number of manifolds in the product.
     This type of representation is called 'vector'.
 
     Alternatively, a point can be represented by an array of shape:
-    [n_samples, n_manifolds, dim] if the n_manifolds have same dimension dim.
+    [..., n_manifolds, dim] if the n_manifolds have same dimension dim.
     This type of representation is called `matrix`.
 
     Parameters
@@ -76,15 +76,14 @@ class ProductManifold(Manifold):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dim]
-                           or shape=[n_samples, dim_2, dim_2]
+        point : array-like, shape=[..., {dim, [dim_2, dim_2]}]
             Point.
         point_type : str, {'vector', 'matrix'}
             Representation of point.
 
         Returns
         -------
-        belongs : array-like, shape=[n_samples, 1]
+        belongs : array-like, shape=[..., 1]
             Array of booleans evaluating if the corresponding points
             belong to the manifold.
         """
@@ -112,16 +111,14 @@ class ProductManifold(Manifold):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dim]
-                           or shape=[n_samples, dim_2, dim_2]
+        point : array-like, shape=[..., {dim, [dim_2, dim_2]}]
             Point to be regularized.
         point_type : str, {'vector', 'matrix'}
             Representation of point.
 
         Returns
         -------
-        regularized_point : array-like, shape=[n_samples, dim]
-                            or shape=[n_samples, dim_2, dim_2]
+        regularized_point : array-like, shape=[..., {dim, [dim_2, dim_2]}]
             Point in the manifold's canonical representation.
         """
         if point_type is None:
@@ -153,7 +150,7 @@ class ProductManifold(Manifold):
 
         Returns
         -------
-        samples : array-like, shape=[n_samples, dim + 1]
+        samples : array-like, shape=[..., dim + 1]
             Points sampled on the hypersphere.
         """
         if point_type is None:

--- a/geomstats/geometry/product_riemannian_metric.py
+++ b/geomstats/geometry/product_riemannian_metric.py
@@ -46,16 +46,16 @@ class ProductRiemannianMetric(RiemannianMetric):
 
         Parameters
         ----------
-        base_point : array-like, shape=[n_samples, n_metrics, dim] or
-            [n_samples, dim], optional
+        base_point : array-like, shape=[..., n_metrics, dim] or
+            [..., dim], optional
             Point on the manifold at which to compute the inner-product matrix.
         point_type : str, {'vector', 'matrix'}, optional
             Type of representation used for points.
 
         Returns
         -------
-        matrix : array-like, shape=[n_samples, dim, dim] or
-        [n_samples, dim + n_metrics, dim + n_metrics]
+        matrix : array-like, shape=[..., dim, dim] or
+        [..., dim + n_metrics, dim + n_metrics]
             Matrix of the inner-product at the base point.
 
         """
@@ -90,7 +90,7 @@ class ProductRiemannianMetric(RiemannianMetric):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dim]
+        point : array-like, shape=[..., dim]
             Point on the product manifold.
 
         Returns
@@ -141,18 +141,18 @@ class ProductRiemannianMetric(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec_a : array-like, shape=[n_samples, dim + 1]
+        tangent_vec_a : array-like, shape=[..., dim + 1]
             First tangent vector at base point.
-        tangent_vec_b : array-like, shape=[n_samples, dim + 1]
+        tangent_vec_b : array-like, shape=[..., dim + 1]
             Second tangent vector at base point.
-        base_point : array-like, shape=[n_samples, dim + 1], optional
+        base_point : array-like, shape=[..., dim + 1], optional
             Point on the manifold.
         point_type : str, {'vector', 'matrix'}, optional
             Type of representation used for points.
 
         Returns
         -------
-        inner_prod : array-like, shape=[n_samples, 1]
+        inner_prod : array-like, shape=[..., 1]
             Inner-product of the two tangent vectors.
         """
         if base_point is None:
@@ -197,16 +197,16 @@ class ProductRiemannianMetric(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec : array-like, shape=[n_samples, dim]
+        tangent_vec : array-like, shape=[..., dim]
             Tangent vector at a base point.
-        base_point : array-like, shape=[n_samples, dim]
+        base_point : array-like, shape=[..., dim]
             Point on the manifold.
         point_type : str, {'vector', 'matrix'}, optional
             Type of representation used for points.
 
         Returns
         -------
-        exp : array-like, shape=[n_samples, dim]
+        exp : array-like, shape=[..., dim]
             Point on the manifold equal to the Riemannian exponential
             of tangent_vec at the base point.
         """
@@ -239,16 +239,16 @@ class ProductRiemannianMetric(RiemannianMetric):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, dim]
+        point : array-like, shape=[..., dim]
             Point on the manifold.
-        base_point : array-like, shape=[n_samples, dim]
+        base_point : array-like, shape=[..., dim]
             Point on the manifold.
         point_type : str, {'vector', 'matrix'}, optional
             Type of representation used for points.
 
         Returns
         -------
-        log : array-like, shape=[n_samples, dim]
+        log : array-like, shape=[..., dim]
             Tangent vector at the base point equal to the Riemannian logarithm
             of point at the base point.
         """

--- a/geomstats/geometry/riemannian_metric.py
+++ b/geomstats/geometry/riemannian_metric.py
@@ -65,7 +65,7 @@ class RiemannianMetric(Connection):
 
         Parameters
         ----------
-        base_point : array-like, shape=[n_samples, dim], optional
+        base_point : array-like, shape=[..., dim], optional
         """
         raise NotImplementedError(
             'The computation of the inner product matrix'
@@ -76,7 +76,7 @@ class RiemannianMetric(Connection):
 
         Parameters
         ----------
-        base_point : array-like, shape=[n_samples, dim], optional
+        base_point : array-like, shape=[..., dim], optional
         """
         metric_matrix = self.inner_product_matrix(base_point)
         cometric_matrix = gs.linalg.inv(metric_matrix)
@@ -87,7 +87,7 @@ class RiemannianMetric(Connection):
 
         Parameters
         ----------
-        base_point : array-like, shape=[n_samples, dim], optional
+        base_point : array-like, shape=[..., dim], optional
         """
         metric_derivative = autograd.jacobian(self.inner_product_matrix)
         return metric_derivative(base_point)
@@ -97,12 +97,11 @@ class RiemannianMetric(Connection):
 
         Parameters
         ----------
-        base_point: array-like, shape=[n_samples, dim]
+        base_point: array-like, shape=[..., dim]
 
         Returns
         -------
-        christoffels: array-like,
-                             shape=[n_samples, dim, dim, dim]
+        christoffels: array-like, shape=[..., dim, dim, dim]
         """
         cometric_mat_at_point = self.inner_product_inverse_matrix(base_point)
         metric_derivative_at_point = self.inner_product_derivative_matrix(
@@ -126,16 +125,13 @@ class RiemannianMetric(Connection):
 
         Parameters
         ----------
-        tangent_vec_a: array-like, shape=[n_samples, dim]
-                                   or shape=[1, dim]
-        tangent_vec_b: array-like, shape=[n_samples, dim]
-                                   or shape=[1, dim]
-        base_point: array-like, shape=[n_samples, dim]
-                                or shape=[1, dim]
+        tangent_vec_a: array-like, shape=[..., dim]
+        tangent_vec_b: array-like, shape=[..., dim]
+        base_point: array-like, shape=[..., dim]
 
         Returns
         -------
-        inner_product : array-like, shape=[n_samples,]
+        inner_product : array-like, shape=[...,]
         """
         inner_prod_mat = self.inner_product_matrix(base_point)
         inner_prod_mat = gs.to_ndarray(inner_prod_mat, to_ndim=3)
@@ -156,12 +152,12 @@ class RiemannianMetric(Connection):
 
         Parameters
         ----------
-        vector : array-like, shape=[n_samples, dim]
-        base_point : array-like, shape=[n_samples, dim]
+        vector : array-like, shape=[..., dim]
+        base_point : array-like, shape=[..., dim]
 
         Returns
         -------
-        sq_norm : array-like, shape=[n_samples,]
+        sq_norm : array-like, shape=[...,]
         """
         sq_norm = self.inner_product(vector, vector, base_point)
         return sq_norm
@@ -177,12 +173,12 @@ class RiemannianMetric(Connection):
 
         Parameters
         ----------
-        vector : array-like, shape=[n_samples, dim]
-        base_point : array-like, shape=[n_samples, dim]
+        vector : array-like, shape=[..., dim]
+        base_point : array-like, shape=[..., dim]
 
         Returns
         -------
-        norm : array-like, shape=[n_samples,]
+        norm : array-like, shape=[...,]
         """
         sq_norm = self.squared_norm(vector, base_point)
         norm = gs.sqrt(sq_norm)
@@ -193,12 +189,12 @@ class RiemannianMetric(Connection):
 
         Parameters
         ----------
-        point_a : array-like, shape=[n_samples, dim]
-        point_b : array-like, shape=[n_samples, dim]
+        point_a : array-like, shape=[..., dim]
+        point_b : array-like, shape=[..., dim]
 
         Returns
         -------
-        sq_dist : array-like, shape=[n_samples,]
+        sq_dist : array-like, shape=[...,]
         """
         log = self.log(point=point_b, base_point=point_a)
 
@@ -213,12 +209,12 @@ class RiemannianMetric(Connection):
 
         Parameters
         ----------
-        point_a : array-like, shape=[n_samples, dim]
-        point_b : array-like, shape=[n_samples, dim]
+        point_a : array-like, shape=[..., dim]
+        point_b : array-like, shape=[..., dim]
 
         Returns
         -------
-        dist : array-like, shape=[n_samples,]
+        dist : array-like, shape=[...,]
         """
         sq_dist = self.squared_dist(point_a, point_b)
         dist = gs.sqrt(sq_dist)

--- a/geomstats/geometry/skew_symmetric_matrices.py
+++ b/geomstats/geometry/skew_symmetric_matrices.py
@@ -13,16 +13,15 @@ TOLERANCE = 1e-8
 
 
 class SkewSymmetricMatrices(MatrixLieAlgebra):
-    """Class for skew-symmetric matrices."""
+    """Class for skew-symmetric matrices.
+
+    Parameters
+    ----------
+    n : int
+        The number of rows and columns.
+    """
 
     def __init__(self, n):
-        """Instantiate the class.
-
-        Parameters
-        ----------
-        n: int
-            The number of rows and columns.
-        """
         dimension = int(n * (n - 1) / 2)
         super(SkewSymmetricMatrices, self).__init__(dimension, n)
 
@@ -40,7 +39,7 @@ class SkewSymmetricMatrices(MatrixLieAlgebra):
 
         Parameters
         ----------
-        mat : array-like, shape=[n_samples, n, n]
+        mat : array-like, shape=[..., n, n]
             The square matrix to check.
         atol : float
             Tolerance for the equality evaluation.
@@ -59,11 +58,11 @@ class SkewSymmetricMatrices(MatrixLieAlgebra):
 
         Parameters
         ----------
-        matrix_representation: array-like, shape=[n_samples, n, n]
+        matrix_representation : array-like, shape=[..., n, n]
 
         Returns
         -------
-        basis_representation: array-like, shape=[n_samples, dim]
+        basis_representation : array-like, shape=[..., dim]
         """
         old_shape = gs.shape(matrix_representation)
         as_vector = gs.reshape(matrix_representation, (old_shape[0], -1))

--- a/geomstats/geometry/spd_matrices.py
+++ b/geomstats/geometry/spd_matrices.py
@@ -73,18 +73,18 @@ class SPDMatrices(SymmetricMatrices, EmbeddedManifold):
         ----------
         power : float
             Power function to differentiate.
-        tangent_vec : array_like, shape=[n_samples, n, n]
-            Tangent vectors.
-        base_point : array_like, shape=[n_samples, n, n]
-            Base points.
+        tangent_vec : array_like, shape=[..., n, n]
+            Tangent vector.
+        base_point : array_like, shape=[..., n, n]
+            Base point.
 
         Returns
         -------
-        eigvectors : array-like, shape=[n_samples, n, n]
-        transp_eigvectors : array-like, shape=[n_samples, n, n]
-        numerator : array-like, shape=[n_samples, n, n]
-        denominator : array-like, shape=[n_samples, n, n]
-        temp_result : array-like, shape=[n_samples, n, n]
+        eigvectors : array-like, shape=[..., n, n]
+        transp_eigvectors : array-like, shape=[..., n, n]
+        numerator : array-like, shape=[..., n, n]
+        denominator : array-like, shape=[..., n, n]
+        temp_result : array-like, shape=[..., n, n]
         """
         n_tangent_vecs, _, _ = tangent_vec.shape
         n_base_points, _, n = base_point.shape
@@ -155,14 +155,14 @@ class SPDMatrices(SymmetricMatrices, EmbeddedManifold):
         Parameters
         ----------
         power : int
-        tangent_vec : array_like, shape=[n_samples, n, n]
-            Tangent vectors.
-        base_point : array_like, shape=[n_samples, n, n]
-            Base points.
+        tangent_vec : array_like, shape=[..., n, n]
+            Tangent vector.
+        base_point : array_like, shape=[..., n, n]
+            Base point.
 
         Returns
         -------
-        differential_power : array-like, shape=[n_samples, n, n]
+        differential_power : array-like, shape=[..., n, n]
         """
         eigvectors, transp_eigvectors, numerator, denominator, temp_result =\
             cls.aux_differential_power(power, tangent_vec, base_point)
@@ -184,14 +184,14 @@ class SPDMatrices(SymmetricMatrices, EmbeddedManifold):
         Parameters
         ----------
         power : int
-        tangent_vec : array_like, shape=[n_samples, n, n]
-            Tangent vectors.
-        base_point : array_like, shape=[n_samples, n, n]
-            Base points.
+        tangent_vec : array_like, shape=[..., n, n]
+            Tangent vector.
+        base_point : array_like, shape=[..., n, n]
+            Base point.
 
         Returns
         -------
-        inverse_differential_power : array-like, shape=[n_samples, n, n]
+        inverse_differential_power : array-like, shape=[..., n, n]
         """
         eigvectors, transp_eigvectors, numerator, denominator, temp_result =\
             cls.aux_differential_power(power, tangent_vec, base_point)
@@ -211,14 +211,14 @@ class SPDMatrices(SymmetricMatrices, EmbeddedManifold):
 
         Parameters
         ----------
-        tangent_vec : array_like, shape=[n_samples, n, n]
-            Tangent vectors.
-        base_point : array_like, shape=[n_samples, n, n]
-            Base points.
+        tangent_vec : array_like, shape=[..., n, n]
+            Tangent vector.
+        base_point : array_like, shape=[..., n, n]
+            Base point.
 
         Returns
         -------
-        differential_log : array-like, shape=[n_samples, n, n]
+        differential_log : array-like, shape=[..., n, n]
         """
         eigvectors, transp_eigvectors, numerator, denominator, temp_result =\
             cls.aux_differential_power(0, tangent_vec, base_point)
@@ -239,14 +239,14 @@ class SPDMatrices(SymmetricMatrices, EmbeddedManifold):
 
         Parameters
         ----------
-        tangent_vec : array_like, shape=[n_samples, n, n]
-            Tangent vectors.
-        base_point : array_like, shape=[n_samples, n, n]
-            Base points.
+        tangent_vec : array_like, shape=[..., n, n]
+            Tangent vector.
+        base_point : array_like, shape=[..., n, n]
+            Base point.
 
         Returns
         -------
-        inverse_differential_log : array-like, shape=[n_samples, n, n]
+        inverse_differential_log : array-like, shape=[..., n, n]
         """
         eigvectors, transp_eigvectors, numerator, denominator, temp_result =\
             cls.aux_differential_power(0, tangent_vec, base_point)
@@ -266,14 +266,14 @@ class SPDMatrices(SymmetricMatrices, EmbeddedManifold):
 
         Parameters
         ----------
-        tangent_vec : array_like, shape=[n_samples, n, n]
-            Tangent vectors.
-        base_point : array_like, shape=[n_samples, n, n]
-            Base points.
+        tangent_vec : array_like, shape=[..., n, n]
+            Tangent vector.
+        base_point : array_like, shape=[..., n, n]
+            Base point.
 
         Returns
         -------
-        differential_exp : array-like, shape=[n_samples, n, n]
+        differential_exp : array-like, shape=[..., n, n]
         """
         eigvectors, transp_eigvectors, numerator, denominator, temp_result = \
             cls.aux_differential_power(math.inf, tangent_vec, base_point)
@@ -294,14 +294,14 @@ class SPDMatrices(SymmetricMatrices, EmbeddedManifold):
 
         Parameters
         ----------
-        tangent_vec : array_like, shape=[n_samples, n, n]
-            Tangent vectors.
-        base_point : array_like, shape=[n_samples, n, n]
-            Base points.
+        tangent_vec : array_like, shape=[..., n, n]
+            Tangent vector.
+        base_point : array_like, shape=[..., n, n]
+            Base point.
 
         Returns
         -------
-        inverse_differential_exp : array-like, shape=[n_samples, n, n]
+        inverse_differential_exp : array-like, shape=[..., n, n]
         """
         eigvectors, transp_eigvectors, numerator, denominator, temp_result = \
             cls.aux_differential_power(math.inf, tangent_vec, base_point)
@@ -318,12 +318,12 @@ class SPDMatrices(SymmetricMatrices, EmbeddedManifold):
 
         Parameters
         ----------
-        x : array_like, shape=[n_samples, n, n]
+        x : array_like, shape=[..., n, n]
             Symmetric matrix.
 
         Returns
         -------
-        log : array_like, shape=[n_samples, n, n]
+        log : array_like, shape=[..., n, n]
             Logarithm of x.
         """
         return cls.apply_func_to_eigvals(x, gs.log, check_positive=True)
@@ -365,13 +365,13 @@ class SPDMetricAffine(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec_a : array-like, shape=[n_samples, n, n]
-        tangent_vec_b : array-like, shape=[n_samples, n, n]
-        inv_base_point : array-like, shape=[n_samples, n, n]
+        tangent_vec_a : array-like, shape=[..., n, n]
+        tangent_vec_b : array-like, shape=[..., n, n]
+        inv_base_point : array-like, shape=[..., n, n]
 
         Returns
         -------
-        inner_product : array-like, shape=[n_samples, n, n]
+        inner_product : array-like, shape=[..., n, n]
         """
         aux_a = gs.einsum(
             '...ij,...jk->...ik', inv_base_point, tangent_vec_a)
@@ -390,13 +390,13 @@ class SPDMetricAffine(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec_a : array-like, shape=[n_samples, n, n]
-        tangent_vec_b : array-like, shape=[n_samples, n, n]
-        base_point : array-like, shape=[n_samples, n, n]
+        tangent_vec_a : array-like, shape=[..., n, n]
+        tangent_vec_b : array-like, shape=[..., n, n]
+        base_point : array-like, shape=[..., n, n]
 
         Returns
         -------
-        inner_product : array-like, shape=[n_samples, n, n]
+        inner_product : array-like, shape=[..., n, n]
         """
         power_affine = self.power_affine
         spd_space = self.space
@@ -427,7 +427,7 @@ class SPDMetricAffine(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec : array-like, shape=[n_samples, n, n]
+        tangent_vec : array-like, shape=[..., n, n]
         sqrt_base_point
         inv_sqrt_base_point
 
@@ -457,12 +457,12 @@ class SPDMetricAffine(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec : array-like, shape=[n_samples, n, n]
-        base_point : array-like, shape=[n_samples, n, n]
+        tangent_vec : array-like, shape=[..., n, n]
+        base_point : array-like, shape=[..., n, n]
 
         Returns
         -------
-        exp : array-like, shape=[n_samples, n, n]
+        exp : array-like, shape=[..., n, n]
         """
         power_affine = self.power_affine
 
@@ -522,12 +522,12 @@ class SPDMetricAffine(RiemannianMetric):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, n, n]
-        base_point : array-like, shape=[n_samples, n, n]
+        point : array-like, shape=[..., n, n]
+        base_point : array-like, shape=[..., n, n]
 
         Returns
         -------
-        log : array-like, shape=[n_samples, n, n]
+        log : array-like, shape=[..., n, n]
         """
         power_affine = self.power_affine
 
@@ -580,17 +580,17 @@ class SPDMetricAffine(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec_a : array-like, shape=[n_samples, dim + 1]
+        tangent_vec_a : array-like, shape=[..., dim + 1]
             Tangent vector at base point to be transported.
-        tangent_vec_b : array-like, shape=[n_samples, dim + 1]
+        tangent_vec_b : array-like, shape=[..., dim + 1]
             Tangent vector at base point, initial speed of the geodesic along
             which the parallel transport is computed.
-        base_point : array-like, shape=[n_samples, dim + 1]
+        base_point : array-like, shape=[..., dim + 1]
             point on the manifold of SPD matrices
 
         Returns
         -------
-        transported_tangent_vec: array-like, shape=[n_samples, dim + 1]
+        transported_tangent_vec: array-like, shape=[..., dim + 1]
             Transported tangent vector at exp_(base_point)(tangent_vec_b).
         """
         end_point = self.exp(tangent_vec_b, base_point)
@@ -628,9 +628,9 @@ class SPDMetricProcrustes(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec_a : array-like, shape=[n_samples, n, n]
-        tangent_vec_b : array-like, shape=[n_samples, n, n]
-        base_point : array-like, shape=[n_samples, n, n]
+        tangent_vec_a : array-like, shape=[..., n, n]
+        tangent_vec_b : array-like, shape=[..., n, n]
+        base_point : array-like, shape=[..., n, n]
 
         Returns
         -------
@@ -665,9 +665,9 @@ class SPDMetricEuclidean(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec_a : array-like, shape=[n_samples, n, n]
-        tangent_vec_b : array-like, shape=[n_samples, n, n]
-        base_point : array-like, shape=[n_samples, n, n]
+        tangent_vec_a : array-like, shape=[..., n, n]
+        tangent_vec_b : array-like, shape=[..., n, n]
+        base_point : array-like, shape=[..., n, n]
 
         Returns
         -------
@@ -704,12 +704,12 @@ class SPDMetricEuclidean(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec : array-like, shape=[n_samples, n, n]
-        base_point : array-like, shape=[n_samples, n, n]
+        tangent_vec : array-like, shape=[..., n, n]
+        base_point : array-like, shape=[..., n, n]
 
         Returns
         -------
-        exp_domain : array-like, shape=[n_samples, 2]
+        exp_domain : array-like, shape=[..., 2]
         """
         invsqrt_base_point = gs.linalg.powerm(base_point, -.5)
 
@@ -748,9 +748,9 @@ class SPDMetricLogEuclidean(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec_a : array-like, shape=[n_samples, n, n]
-        tangent_vec_b : array-like, shape=[n_samples, n, n]
-        base_point : array-like, shape=[n_samples, n, n]
+        tangent_vec_a : array-like, shape=[..., n, n]
+        tangent_vec_b : array-like, shape=[..., n, n]
+        base_point : array-like, shape=[..., n, n]
 
         Returns
         -------
@@ -778,12 +778,12 @@ class SPDMetricLogEuclidean(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec : array-like, shape=[n_samples, n, n]
-        base_point : array-like, shape=[n_samples, n, n]
+        tangent_vec : array-like, shape=[..., n, n]
+        base_point : array-like, shape=[..., n, n]
 
         Returns
         -------
-        exp : array-like, shape=[n_samples, n, n]
+        exp : array-like, shape=[..., n, n]
         """
         log_base_point = self.space.logm(base_point)
         dlog_tangent_vec = self.space.differential_log(tangent_vec, base_point)
@@ -800,12 +800,12 @@ class SPDMetricLogEuclidean(RiemannianMetric):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, n, n]
-        base_point : array-like, shape=[n_samples, n, n]
+        point : array-like, shape=[..., n, n]
+        base_point : array-like, shape=[..., n, n]
 
         Returns
         -------
-        log : array-like, shape=[n_samples, n, n]
+        log : array-like, shape=[..., n, n]
         """
         log_base_point = SPDMatrices.logm(base_point)
         log_point = SPDMatrices.logm(point)
@@ -819,8 +819,8 @@ class SPDMetricLogEuclidean(RiemannianMetric):
 
         Parameters
         ----------
-        initial_point : array-like, shape=[n_samples, n, n]
-        initial_tangent_vec : array-like, shape=[n_samples, n, n]
+        initial_point : array-like, shape=[..., n, n]
+        initial_tangent_vec : array-like, shape=[..., n, n]
 
         Returns
         -------

--- a/geomstats/geometry/special_euclidean.py
+++ b/geomstats/geometry/special_euclidean.py
@@ -61,13 +61,13 @@ class _SpecialEuclideanMatrices(GeneralLinear, LieGroup):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, n, n],
-            The point for which to check whether it belongs to the group.
+        point : array-like, shape=[..., n, n],
+            Point to be checked.
 
         Returns
         -------
-        belongs : array-like, shape=[n_samples,]
-            Boolean array
+        belongs : array-like, shape=[...,]
+            Boolean denoting if point belongs to the group.
         """
         point_dim1, point_dim2 = point.shape[-2:]
         belongs = (point_dim1 == point_dim2 == self.n + 1)
@@ -129,7 +129,7 @@ class _SpecialEuclideanMatrices(GeneralLinear, LieGroup):
 
         Returns
         -------
-        samples : array-like, shape=[n_samples, n + 1, n + 1]
+        samples : array-like, shape=[..., n + 1, n + 1]
             Points sampled on the SE(n).
         """
         random_translation = self.translations.random_uniform(n_samples)
@@ -207,12 +207,12 @@ class _SpecialEuclidean3Vectors(LieGroup):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, 3]
+        point : array-like, shape=[..., 3]
             The point of which to check whether it belongs to SE(3).
 
         Returns
         -------
-        belongs : array-like, shape=[n_samples, 1]
+        belongs : array-like, shape=[..., 1]
             Boolean indicating whether point belongs to SE(3).
         """
         point_dim = point.shape[-1]
@@ -228,12 +228,12 @@ class _SpecialEuclidean3Vectors(LieGroup):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, 3]
+        point : array-like, shape=[..., 3]
             The point to regularize.
 
         Returns
         -------
-        point : array-like, shape=[n_samples, 3]
+        point : array-like, shape=[..., 3]
         """
         rotations = self.rotations
         dim_rotations = rotations.dim
@@ -255,7 +255,7 @@ class _SpecialEuclidean3Vectors(LieGroup):
 
         Parameters
         ----------
-        tangent_vec: array-like, shape=[n_samples, 3]
+        tangent_vec: array-like, shape=[..., 3]
         metric : RiemannianMetric, optional
 
         Returns
@@ -271,8 +271,8 @@ class _SpecialEuclidean3Vectors(LieGroup):
 
         Parameters
         ----------
-        tangent_vec: array-like, shape=[n_samples, 3]
-        base_point : array-like, shape=[n_samples, 3]
+        tangent_vec: array-like, shape=[..., 3]
+        base_point : array-like, shape=[..., 3]
         metric : RiemannianMetric, optional
             default: self.left_canonical_metric
 
@@ -310,11 +310,11 @@ class _SpecialEuclidean3Vectors(LieGroup):
 
         Parameters
         ----------
-        vec: array-like, shape=[n_samples, 3]
+        vec: array-like, shape=[..., 3]
 
         Returns
         -------
-        mat: array-like, shape=[n_samples, n+1, n+1]
+        mat: array-like, shape=[..., n+1, n+1]
         """
         vec = self.regularize(vec)
         n_vecs, _ = vec.shape
@@ -339,9 +339,9 @@ class _SpecialEuclidean3Vectors(LieGroup):
 
         Parameters
         ----------
-        point_a : array-like, shape=[n_samples, 3]
+        point_a : array-like, shape=[..., 3]
             Point of the group.
-        point_b : array-like, shape=[n_samples, 3]
+        point_b : array-like, shape=[..., 3]
             Point of the group.
 
         Equation
@@ -386,11 +386,11 @@ class _SpecialEuclidean3Vectors(LieGroup):
 
         Parameters
         ----------
-        point: array-like, shape=[n_samples, 3]
+        point: array-like, shape=[..., 3]
 
         Returns
         -------
-        inverse_point : array-like, shape=[n_samples, 3]
+        inverse_point : array-like, shape=[..., 3]
             The inverted point.
 
         Notes
@@ -428,13 +428,13 @@ class _SpecialEuclidean3Vectors(LieGroup):
 
         Parameters
         ----------
-        point: array-like, shape=[n_samples, 3]
+        point: array-like, shape=[..., 3]
         left_or_right: str, {'left', 'right'}, optional
             Whether to compute the jacobian of the left or right translation.
 
         Returns
         -------
-        jacobian : array-like, shape=[n_samples, 3]
+        jacobian : array-like, shape=[..., 3]
             The jacobian of the left / right translation.
         """
         if left_or_right not in ('left', 'right'):
@@ -485,11 +485,11 @@ class _SpecialEuclidean3Vectors(LieGroup):
 
         Parameters
         ----------
-        tangent_vec: array-like, shape=[n_samples, 3]
+        tangent_vec: array-like, shape=[..., 3]
 
         Returns
         -------
-        group_exp: array-like, shape=[n_samples, 3]
+        group_exp: array-like, shape=[..., 3]
             The group exponential of the tangent vectors calculated
             at the identity.
         """
@@ -560,11 +560,11 @@ class _SpecialEuclidean3Vectors(LieGroup):
 
         Parameters
         ----------
-        point: array-like, shape=[n_samples, 3]
+        point: array-like, shape=[..., 3]
 
         Returns
         -------
-        group_log: array-like, shape=[n_samples, 3]
+        group_log: array-like, shape=[..., 3]
             the group logarithm in the Lie algbra
         """
         point = self.regularize(point)
@@ -639,12 +639,12 @@ class _SpecialEuclidean3Vectors(LieGroup):
 
         Parameters
         ----------
-        n_samples: int, optional
-            default: 1
+        n_samples : int, optional
+            default : 1
 
         Returns
         -------
-        random_point: array-like, shape=[n_samples, 3]
+        random_point : array-like, shape=[..., 3]
             An array of random elements in SE(3) having the given.
         """
         random_translation = self.translations.random_uniform(n_samples)
@@ -656,7 +656,7 @@ class _SpecialEuclidean3Vectors(LieGroup):
 
         Parameters
         ----------
-        rot_vec : array-like, shape=[n_samples, 3]
+        rot_vec : array-like, shape=[..., 3]
 
         Returns
         -------

--- a/geomstats/geometry/special_orthogonal.py
+++ b/geomstats/geometry/special_orthogonal.py
@@ -67,11 +67,11 @@ class _SpecialOrthogonalMatrices(GeneralLinear, LieGroup):
         ----------
         n_samples : int, optional (1)
             Number of samples.
-        tol :  unused
+        tol : unused
 
         Returns
         -------
-        samples : array-like, shape=[n_samples, n, n]
+        samples : array-like, shape=[..., n, n]
             Points sampled on the SO(n).
         """
         if n_samples == 1:
@@ -111,7 +111,7 @@ class _SpecialOrthogonal3Vectors(LieGroup):
         Parameters
         ----------
         point_type : str,
-            The point_type of the returned value. Unused here.
+            Point_type of the returned value. Unused here.
 
         Returns
         -------
@@ -129,13 +129,13 @@ class _SpecialOrthogonal3Vectors(LieGroup):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, 3]
-            The point to check whether it belongs to SO(3).
+        point : array-like, shape=[..., 3]
+            Point to check whether it belongs to SO(3).
 
         Returns
         -------
-        belongs : array-like, shape=[n_samples,]
-            Array of booleans indicating whether point belongs to SO(3).
+        belongs : array-like, shape=[...,]
+            Boolean indicating whether point belongs to SO(3).
         """
         vec_dim = point.shape[-1]
         belongs = vec_dim == self.dim
@@ -156,11 +156,11 @@ class _SpecialOrthogonal3Vectors(LieGroup):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples,3]
+        point : array-like, shape=[...,3]
 
         Returns
         -------
-        regularized_point : array-like, shape=[n_samples, 3]
+        regularized_point : array-like, shape=[..., 3]
         """
         regularized_point = point
         angle = gs.linalg.norm(regularized_point, axis=-1)
@@ -203,13 +203,13 @@ class _SpecialOrthogonal3Vectors(LieGroup):
 
         Parameters
         ----------
-        tangent_vec : array-like, shape=[n_samples, 3]]
+        tangent_vec : array-like, shape=[..., 3]]
         metric : RiemannianMetric, optional
             default: self.left_canonical_metric
 
         Returns
         -------
-        regularized_vec : array-like, shape=[n_samples, 3]]
+        regularized_vec : array-like, shape=[..., 3]]
         """
         if metric is None:
             metric = self.left_canonical_metric
@@ -262,9 +262,9 @@ class _SpecialOrthogonal3Vectors(LieGroup):
 
         Parameters
         ----------
-        tangent_vec : array-like, shape=[n_samples,3]
+        tangent_vec : array-like, shape=[...,3]
             Tangent vector at base point.
-        base_point : array-like, shape=[n_samples, 3]
+        base_point : array-like, shape=[..., 3]
             Point on the manifold.
         metric : RiemannianMetric, optional
             default: self.left_canonical_metric
@@ -272,7 +272,7 @@ class _SpecialOrthogonal3Vectors(LieGroup):
         Returns
         -------
         regularized_tangent_vec : array-like,
-            shape=[n_samples, 3]
+            shape=[..., 3]
         """
         if metric is None:
             metric = self.left_canonical_metric
@@ -306,11 +306,11 @@ class _SpecialOrthogonal3Vectors(LieGroup):
 
         Parameters
         ----------
-        mat : array-like, shape=[n_samples, n, n]
+        mat : array-like, shape=[..., n, n]
 
         Returns
         -------
-        rot_mat : array-like, shape=[n_samples, n, n]
+        rot_mat : array-like, shape=[..., n, n]
         """
         mat = point
         n_mats, n, _ = mat.shape
@@ -358,11 +358,11 @@ class _SpecialOrthogonal3Vectors(LieGroup):
 
         Parameters
         ----------
-        vec : array-like, shape=[n_samples, dim]
+        vec : array-like, shape=[..., dim]
 
         Returns
         -------
-        skew_mat : array-like, shape=[n_samples, n, n]
+        skew_mat : array-like, shape=[..., n, n]
         """
         n_vecs, vec_dim = gs.shape(vec)
 
@@ -440,11 +440,11 @@ class _SpecialOrthogonal3Vectors(LieGroup):
 
         Parameters
         ----------
-        skew_mat : array-like, shape=[n_samples, n, n]
+        skew_mat : array-like, shape=[..., n, n]
 
         Returns
         -------
-        vec : array-like, shape=[n_samples, dim]
+        vec : array-like, shape=[..., dim]
         """
         n_skew_mats, _, _ = skew_mat.shape
 
@@ -485,11 +485,11 @@ class _SpecialOrthogonal3Vectors(LieGroup):
 
         Parameters
         ----------
-        rot_mat : array-like, shape=[n_samples, n, n]
+        rot_mat : array-like, shape=[..., n, n]
 
         Returns
         -------
-        regularized_rot_vec : array-like, shape=[n_samples, 3]
+        regularized_rot_vec : array-like, shape=[..., 3]
         """
         n_rot_mats, _, _ = rot_mat.shape
 
@@ -533,11 +533,11 @@ class _SpecialOrthogonal3Vectors(LieGroup):
 
         Parameters
         ----------
-        rot_vec: array-like, shape=[n_samples, 3]
+        rot_vec: array-like, shape=[..., 3]
 
         Returns
         -------
-        rot_mat: array-like, shape=[n_samples, 3]
+        rot_mat: array-like, shape=[..., 3]
         """
         rot_vec = self.regularize(rot_vec)
 
@@ -584,11 +584,11 @@ class _SpecialOrthogonal3Vectors(LieGroup):
 
         Parameters
         ----------
-        rot_mat : array-like, shape=[n_samples, 3, 3]
+        rot_mat : array-like, shape=[..., 3, 3]
 
         Returns
         -------
-        quaternion : array-like, shape=[n_samples, 4]
+        quaternion : array-like, shape=[..., 4]
         """
         rot_vec = self.rotation_vector_from_matrix(rot_mat)
         quaternion = self.quaternion_from_rotation_vector(rot_vec)
@@ -601,11 +601,11 @@ class _SpecialOrthogonal3Vectors(LieGroup):
 
         Parameters
         ----------
-        rot_vec : array-like, shape=[n_samples, 3]
+        rot_vec : array-like, shape=[..., 3]
 
         Returns
         -------
-        quaternion : array-like, shape=[n_samples, 4]
+        quaternion : array-like, shape=[..., 4]
         """
         rot_vec = self.regularize(rot_vec)
 
@@ -634,11 +634,11 @@ class _SpecialOrthogonal3Vectors(LieGroup):
 
         Parameters
         ----------
-        quaternion : array-like, shape=[n_samples, 4]
+        quaternion : array-like, shape=[..., 4]
 
         Returns
         -------
-        rot_vec : array-like, shape=[n_samples, 3]
+        rot_vec : array-like, shape=[..., 3]
         """
         cos_half_angle = quaternion[:, 0]
         cos_half_angle = gs.clip(cos_half_angle, -1, 1)
@@ -668,11 +668,11 @@ class _SpecialOrthogonal3Vectors(LieGroup):
 
         Parameters
         ----------
-        quaternion : array-like, shape=[n_samples, 4]
+        quaternion : array-like, shape=[..., 4]
 
         Returns
         -------
-        rot_mat : array-like, shape=[n_samples, 3]
+        rot_mat : array-like, shape=[..., 3]
         """
         n_quaternions, _ = quaternion.shape
 
@@ -719,11 +719,11 @@ class _SpecialOrthogonal3Vectors(LieGroup):
 
         Parameters
         ----------
-        tait_bryan_angles : array-like, shape=[n_samples, 3]
+        tait_bryan_angles : array-like, shape=[..., 3]
 
         Returns
         -------
-        rot_mat : array-like, shape=[n_samples, 3, 3]
+        rot_mat : array-like, shape=[..., 3, 3]
         """
         n_tait_bryan_angles, _ = tait_bryan_angles.shape
 
@@ -773,11 +773,11 @@ class _SpecialOrthogonal3Vectors(LieGroup):
 
         Parameters
         ----------
-        tait_bryan_angles : array-like, shape=[n_samples, 3]
+        tait_bryan_angles : array-like, shape=[..., 3]
 
         Returns
         -------
-        rot_mat : array-like, shape=[n_samples, n, n]
+        rot_mat : array-like, shape=[..., n, n]
         """
         n_tait_bryan_angles, _ = tait_bryan_angles.shape
 
@@ -834,7 +834,7 @@ class _SpecialOrthogonal3Vectors(LieGroup):
 
         Parameters
         ----------
-        tait_bryan_angles : array-like, shape=[n_samples, 3]
+        tait_bryan_angles : array-like, shape=[..., 3]
         extrinsic_or_intrinsic : str, {'extrensic', 'intrinsic'} optional
             default: 'extrinsic'
         order : str, {'xyz', 'zyx'}, optional
@@ -842,7 +842,7 @@ class _SpecialOrthogonal3Vectors(LieGroup):
 
         Returns
         -------
-        rot_mat : array-like, shape=[n_samples, n, n]
+        rot_mat : array-like, shape=[..., n, n]
         """
         geomstats.error.check_parameter_accepted_values(
             extrinsic_or_intrinsic,
@@ -905,7 +905,7 @@ class _SpecialOrthogonal3Vectors(LieGroup):
 
         Parameters
         ----------
-        rot_mat : array-like, shape=[n_samples, n, n]
+        rot_mat : array-like, shape=[..., n, n]
         extrinsic_or_intrinsic : str, {'extrinsic', 'intrinsic'}, optional
             default: 'extrinsic'
         order : str, {'xyz', 'zyx'}, optional
@@ -913,7 +913,7 @@ class _SpecialOrthogonal3Vectors(LieGroup):
 
         Returns
         -------
-        tait_bryan_angles : array-like, shape=[n_samples, 3]
+        tait_bryan_angles : array-like, shape=[..., 3]
         """
         quaternion = self.quaternion_from_matrix(rot_mat)
         tait_bryan_angles = self.tait_bryan_angles_from_quaternion(
@@ -933,11 +933,11 @@ class _SpecialOrthogonal3Vectors(LieGroup):
 
         Parameters
         ----------
-        tait_bryan_angles : array-like, shape=[n_samples, 3]
+        tait_bryan_angles : array-like, shape=[..., 3]
 
         Returns
         -------
-        quaternion : array-like, shape=[n_samples, 4]
+        quaternion : array-like, shape=[..., 4]
         """
         matrix = self.matrix_from_tait_bryan_angles(
             tait_bryan_angles,
@@ -954,7 +954,7 @@ class _SpecialOrthogonal3Vectors(LieGroup):
 
         Parameters
         ----------
-        tait_bryan_angles : array-like, shape=[n_samples, 3]
+        tait_bryan_angles : array-like, shape=[..., 3]
         extrinsic_or_intrinsic : str, {'extrinsic', 'intrinsic'}, optional
             default: 'extrinsic'
         order : str, {'xyz', 'zyx'}, optional
@@ -962,7 +962,7 @@ class _SpecialOrthogonal3Vectors(LieGroup):
 
         Returns
         -------
-        quat : array-like, shape=[n_samples, 4]
+        quat : array-like, shape=[..., 4]
         """
         extrinsic_zyx = (extrinsic_or_intrinsic == 'extrinsic'
                          and order == 'zyx')
@@ -1012,7 +1012,7 @@ class _SpecialOrthogonal3Vectors(LieGroup):
 
         Parameters
         ----------
-        tait_bryan_angles : array-like, shape=[n_samples, 3]
+        tait_bryan_angles : array-like, shape=[..., 3]
         extrinsic_or_intrinsic : str, {'extrinsic', 'intrinsic'}, optional
             default: 'extrinsic'
         order : str, {'xyz', 'zyx'}, optional
@@ -1020,7 +1020,7 @@ class _SpecialOrthogonal3Vectors(LieGroup):
 
         Returns
         -------
-        rot_vec : array-like, shape=[n_samples, 3]
+        rot_vec : array-like, shape=[..., 3]
         """
         quaternion = self.quaternion_from_tait_bryan_angles(
             tait_bryan_angles,
@@ -1038,11 +1038,11 @@ class _SpecialOrthogonal3Vectors(LieGroup):
 
         Parameters
         ----------
-        quaternion : array-like, shape=[n_samples, 4]
+        quaternion : array-like, shape=[..., 4]
 
         Returns
         -------
-        tait_bryan_angles : array-like, shape=[n_samples, 3]
+        tait_bryan_angles : array-like, shape=[..., 3]
         """
         w, x, y, z = gs.hsplit(quaternion, 4)
         angle_1 = gs.arctan2(y * z + w * x,
@@ -1061,11 +1061,11 @@ class _SpecialOrthogonal3Vectors(LieGroup):
 
         Parameters
         ----------
-        quaternion : array-like, shape=[n_samples, 4]
+        quaternion : array-like, shape=[..., 4]
 
         Returns
         -------
-        tait_bryan_angles : array-like, shape=[n_samples, 3]
+        tait_bryan_angles : array-like, shape=[..., 3]
         """
         w, x, y, z = gs.hsplit(quaternion, 4)
 
@@ -1086,7 +1086,7 @@ class _SpecialOrthogonal3Vectors(LieGroup):
 
         Parameters
         ----------
-        quaternion : array-like, shape=[n_samples, 4]
+        quaternion : array-like, shape=[..., 4]
         extrinsic_or_intrinsic : str, {'extrinsic', 'intrinsic'}, optional
             default: 'extrinsic'
         order : str, {'xyz', 'zyx'}, optional
@@ -1094,7 +1094,7 @@ class _SpecialOrthogonal3Vectors(LieGroup):
 
         Returns
         -------
-        tait_bryan : array-like, shape=[n_samples, 3]
+        tait_bryan : array-like, shape=[..., 3]
         """
         extrinsic_zyx = (extrinsic_or_intrinsic == 'extrinsic'
                          and order == 'zyx')
@@ -1138,7 +1138,7 @@ class _SpecialOrthogonal3Vectors(LieGroup):
 
         Parameters
         ----------
-        rot_vec : array-like, shape=[n_samples, 3]
+        rot_vec : array-like, shape=[..., 3]
         extrinsic_or_intrinsic : str, {'extrinsic', 'intrinsic'}, optional
             default: 'extrinsic'
         order : str, {'xyz', 'zyx'}, optional
@@ -1146,7 +1146,7 @@ class _SpecialOrthogonal3Vectors(LieGroup):
 
         Returns
         -------
-        tait_bryan_angles : array-like, shape=[n_samples, 3]
+        tait_bryan_angles : array-like, shape=[..., 3]
         """
         quaternion = self.quaternion_from_rotation_vector(rot_vec)
         tait_bryan_angles = self.tait_bryan_angles_from_quaternion(
@@ -1161,12 +1161,12 @@ class _SpecialOrthogonal3Vectors(LieGroup):
 
         Parameters
         ----------
-        point_a : array-like, shape=[n_samples, 3]
-        point_b : array-like, shape=[n_samples, 3]
+        point_a : array-like, shape=[..., 3]
+        point_b : array-like, shape=[..., 3]
 
         Returns
         -------
-        point_prod : array-like, shape=[n_samples, 3]
+        point_prod : array-like, shape=[..., 3]
         """
         point_a = self.regularize(point_a)
         point_b = self.regularize(point_b)
@@ -1185,11 +1185,11 @@ class _SpecialOrthogonal3Vectors(LieGroup):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, 3]
+        point : array-like, shape=[..., 3]
 
         Returns
         -------
-        inv_point : array-like, shape=[n_samples, 3]
+        inv_point : array-like, shape=[..., 3]
         """
         return -self.regularize(point)
 
@@ -1204,7 +1204,7 @@ class _SpecialOrthogonal3Vectors(LieGroup):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, 3]
+        point : array-like, shape=[..., 3]
         left_or_right : str, {'left', 'right'}, optional
             default: 'left'
         point_type : str, {'vector', 'matrix'}, optional
@@ -1212,7 +1212,7 @@ class _SpecialOrthogonal3Vectors(LieGroup):
 
         Returns
         -------
-        jacobian : array-like, shape=[n_samples, 3, 3]
+        jacobian : array-like, shape=[..., 3, 3]
         """
         geomstats.error.check_parameter_accepted_values(
             left_or_right, 'left_or_right', ['left', 'right'])
@@ -1299,7 +1299,7 @@ class _SpecialOrthogonal3Vectors(LieGroup):
 
         Returns
         -------
-        point : array-like, shape=[n_samples, 3]
+        point : array-like, shape=[..., 3]
         """
         random_point = gs.random.rand(n_samples, self.dim) * 2 - 1
         random_point = self.regularize(random_point)
@@ -1319,13 +1319,13 @@ class _SpecialOrthogonal3Vectors(LieGroup):
 
         Parameters
         ----------
-        tangent_vec : array-like, shape=[n_samples, 3]
+        tangent_vec : array-like, shape=[..., 3]
         point_type : str, {'vector', 'matrix'}, optional
             default: self.default_point_type
 
         Returns
         -------
-        point : array-like, shape=[n_samples, 3]
+        point : array-like, shape=[..., 3]
         """
         return tangent_vec
 
@@ -1340,11 +1340,11 @@ class _SpecialOrthogonal3Vectors(LieGroup):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, 3]
+        point : array-like, shape=[..., 3]
 
         Returns
         -------
-        tangent_vec : array-like, shape=[n_samples, {dimension, [n, n]}]
+        tangent_vec : array-like, shape=[..., {dimension, [n, n]}]
         """
         return self.regularize(point)
 
@@ -1358,13 +1358,13 @@ class _SpecialOrthogonal3Vectors(LieGroup):
 
         Parameters
         ----------
-        tangent_vector_a : shape=[n_samples, n, n]
-        tangent_vector_b : shape=[n_samples, n, n]
-        base_point : array-like, shape=[n_samples, n, n]
+        tangent_vector_a : shape=[..., n, n]
+        tangent_vector_b : shape=[..., n, n]
+        base_point : array-like, shape=[..., n, n]
 
         Returns
         -------
-        bracket : array-like, shape=[n_samples, n, n]
+        bracket : array-like, shape=[..., n, n]
         """
         return gs.cross(tangent_vector_a, tangent_vector_b)
 

--- a/geomstats/geometry/stiefel.py
+++ b/geomstats/geometry/stiefel.py
@@ -54,14 +54,14 @@ class Stiefel(EmbeddedManifold):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, n, p]
+        point : array-like, shape=[..., n, p]
             Point.
         tolerance : float, optional
             Tolerance at which to evaluate.
 
         Returns
         -------
-        belongs : array-like, shape=[n_samples, 1]
+        belongs : array-like, shape=[..., 1]
             Array of booleans evaluating if the corresponding points
             belong to the Stiefel manifold.
         """
@@ -91,11 +91,11 @@ class Stiefel(EmbeddedManifold):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, n, p]
+        point : array-like, shape=[..., n, p]
 
         Returns
         -------
-        projector : array-like, shape=[n_samples, n, n]
+        projector : array-like, shape=[..., n, n]
         """
         return Matrices.mul(point, Matrices.transpose(point))
 
@@ -113,7 +113,7 @@ class Stiefel(EmbeddedManifold):
 
         Returns
         -------
-        samples : array-like, shape=[n_samples, n, p]
+        samples : array-like, shape=[..., n, p]
             Samples on the Stiefel manifold.
         """
         n, p = self.n, self.p
@@ -174,16 +174,16 @@ class StiefelCanonicalMetric(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec_a : array-like, shape=[n_samples, n, p]
+        tangent_vec_a : array-like, shape=[..., n, p]
             First tangent vector at base point.
-        tangent_vec_b : array-like, shape=[n_samples, n, p]
+        tangent_vec_b : array-like, shape=[..., n, p]
             Second tangent vector at base point.
-        base_point : array-like, shape=[n_samples, n, p]
+        base_point : array-like, shape=[..., n, p]
             Point in the Stiefel manifold.
 
         Returns
         -------
-        inner_prod : array-like, shape=[n_samples, 1]
+        inner_prod : array-like, shape=[..., 1]
             Inner-product of the two tangent vectors.
         """
         base_point_transpose = gs.transpose(base_point, axes=(0, 2, 1))
@@ -202,14 +202,14 @@ class StiefelCanonicalMetric(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec : array-like, shape=[n_samples, n, p]
+        tangent_vec : array-like, shape=[..., n, p]
             Tangent vector at a base point.
-        base_point : array-like, shape=[n_samples, n, p]
+        base_point : array-like, shape=[..., n, p]
             Point in the Stiefel manifold.
 
         Returns
         -------
-        exp : array-like, shape=[n_samples, n, p]
+        exp : array-like, shape=[..., n, p]
             Point in the Stiefel manifold equal to the Riemannian exponential
             of tangent_vec at the base point.
         """
@@ -266,8 +266,8 @@ class StiefelCanonicalMetric(RiemannianMetric):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, n, p]
-        base_point : array-like, shape=[n_samples, n, p]
+        point : array-like, shape=[..., n, p]
+        base_point : array-like, shape=[..., n, p]
         matrix_m : array-like
 
         Returns
@@ -345,14 +345,14 @@ class StiefelCanonicalMetric(RiemannianMetric):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, n, p]
+        point : array-like, shape=[..., n, p]
             Point in the Stiefel manifold.
-        base_point : array-like, shape=[n_samples, n, p]
+        base_point : array-like, shape=[..., n, p]
             Point in the Stiefel manifold.
 
         Returns
         -------
-        log : array-like, shape=[n_samples, dim + 1]
+        log : array-like, shape=[..., dim + 1]
             Tangent vector at the base point equal to the Riemannian logarithm
             of point at the base point.
         """
@@ -404,14 +404,14 @@ class StiefelCanonicalMetric(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec : array-like, shape=[n_samples, n, p]
+        tangent_vec : array-like, shape=[..., n, p]
             Tangent vector at a base point.
-        base_point : array-like, shape=[n_samples, n, p]
+        base_point : array-like, shape=[..., n, p]
             Point in the Stiefel manifold.
 
         Returns
         -------
-        exp : array-like, shape=[n_samples, n, p]
+        exp : array-like, shape=[..., n, p]
             Point in the Stiefel manifold equal to the retraction
             of tangent_vec at the base point.
         """
@@ -443,14 +443,14 @@ class StiefelCanonicalMetric(RiemannianMetric):
 
         Parameters
         ----------
-        point : array-like, shape=[n_samples, n, p]
+        point : array-like, shape=[..., n, p]
             Point in the Stiefel manifold.
-        base_point : array-like, shape=[n_samples, n, p]
+        base_point : array-like, shape=[..., n, p]
             Point in the Stiefel manifold.
 
         Returns
         -------
-        log : array-like, shape=[n_samples, dim + 1]
+        log : array-like, shape=[..., dim + 1]
             Tangent vector at the base point equal to the lifting
             of point at the base point.
         """

--- a/geomstats/geometry/symmetric_matrices.py
+++ b/geomstats/geometry/symmetric_matrices.py
@@ -82,12 +82,12 @@ class SymmetricMatrices(EmbeddedManifold):
 
         Parameters
         ----------
-        x : array_like, shape=[n_samples, n, n]
+        x : array_like, shape=[..., n, n]
             Symmetric matrix.
 
         Returns
         -------
-        exponential : array_like, shape=[n_samples, n, n]
+        exponential : array_like, shape=[..., n, n]
             Exponential of x.
         """
         return cls.apply_func_to_eigvals(x, gs.exp)
@@ -99,14 +99,14 @@ class SymmetricMatrices(EmbeddedManifold):
 
         Parameters
         ----------
-        x : array_like, shape=[n_samples, n, n]
+        x : array_like, shape=[..., n, n]
             Symmetric matrix with non-negative eigenvalues.
         power : float
             The power at which x will be raised.
 
         Returns
         -------
-        powerm : array_like, shape=[n_samples, n, n]
+        powerm : array_like, shape=[..., n, n]
             Matrix power of x.
         """
         def _power(eigvals):
@@ -120,14 +120,14 @@ class SymmetricMatrices(EmbeddedManifold):
 
         Parameters
         ----------
-        x : array_like, shape=[n_samples, n, n]
+        x : array_like, shape=[..., n, n]
             Symmetric matrix.
         function : callable
             Function to apply to eigenvalues.
 
         Returns
         -------
-        x : array_like, shape=[n_samples, n, n]
+        x : array_like, shape=[..., n, n]
             Symmetric matrix.
         """
         eigvals, eigvecs = gs.linalg.eigh(x)


### PR DESCRIPTION
This PR suggests changing the way we indicate shape of array-like inputs in docstrings.

Instead of:
```
tangent_vec : array-like, shape=[n_samples, dim] or shape=[dim,]
```
we use:
```
tangent_vec : array-like, shape=[..., dim]
```

In addition, this allows avoiding ambiguities in the BetaDistribution manifold, where `n_points` and `n_samples` notations were conflicting.

However, using `[...,` instead of `[n_samples,` could be slightly less explicit for users looking at the documentation. What do you think? @nguigs @stefanheyder @cshewmake2 