### PR TITLE
Clean geomstats.errors

### DIFF
--- a/geomstats/errors.py
+++ b/geomstats/errors.py
@@ -5,6 +5,9 @@ import math
 import geomstats.backend as gs
 
 
+TOL = 1e-6
+
+
 def check_integer(n, n_name):
     """Raise an error if n is not a > 0 integer.
 
@@ -23,7 +26,7 @@ def check_integer(n, n_name):
                 ' got {}.'.format(n_name, n))
 
 
-def check_belongs(point, manifold):
+def check_belongs(point, manifold, tol=TOL):
     """Raise an error if point does not belong to the input manifold.
 
     Parameters
@@ -35,7 +38,7 @@ def check_belongs(point, manifold):
     manifold_name : string
         Name of the manifold for the error message.
     """
-    if not gs.all(manifold.belongs(point)):
+    if not gs.all(manifold.belongs(point, tol)):
         raise RuntimeError(
             'Some points do not belong to manifold \'%s\' of dimension %d.'
             % (type(manifold).__name__, manifold.dim))

--- a/geomstats/errors.py
+++ b/geomstats/errors.py
@@ -23,7 +23,7 @@ def check_integer(n, n_name):
                 ' got {}.'.format(n_name, n))
 
 
-def check_belongs(point, manifold, manifold_name):
+def check_belongs(point, manifold):
     """Raise an error if point does not belong to the input manifold.
 
     Parameters
@@ -37,7 +37,8 @@ def check_belongs(point, manifold, manifold_name):
     """
     if not gs.all(manifold.belongs(point)):
         raise RuntimeError(
-            'Some points do not belong to manifold \'%s\'.' % manifold_name)
+            'Some points do not belong to manifold \'%s\'.'
+            % type(manifold).__name__)
 
 
 def check_parameter_accepted_values(param, param_name, accepted_values):

--- a/geomstats/errors.py
+++ b/geomstats/errors.py
@@ -5,9 +5,6 @@ import math
 import geomstats.backend as gs
 
 
-TOL = 1e-6
-
-
 def check_integer(n, n_name):
     """Raise an error if n is not a > 0 integer.
 
@@ -26,7 +23,7 @@ def check_integer(n, n_name):
                 ' got {}.'.format(n_name, n))
 
 
-def check_belongs(point, manifold, tol=TOL):
+def check_belongs(point, manifold, **kwargs):
     """Raise an error if point does not belong to the input manifold.
 
     Parameters
@@ -38,7 +35,7 @@ def check_belongs(point, manifold, tol=TOL):
     manifold_name : string
         Name of the manifold for the error message.
     """
-    if not gs.all(manifold.belongs(point, tol)):
+    if not gs.all(manifold.belongs(point, **kwargs)):
         raise RuntimeError(
             'Some points do not belong to manifold \'%s\' of dimension %d.'
             % (type(manifold).__name__, manifold.dim))

--- a/geomstats/errors.py
+++ b/geomstats/errors.py
@@ -37,8 +37,8 @@ def check_belongs(point, manifold):
     """
     if not gs.all(manifold.belongs(point)):
         raise RuntimeError(
-            'Some points do not belong to manifold \'%s\'.'
-            % type(manifold).__name__)
+            'Some points do not belong to manifold \'%s\' of dimension %d.'
+            % (type(manifold).__name__, manifold.dim))
 
 
 def check_parameter_accepted_values(param, param_name, accepted_values):

--- a/geomstats/geometry/beta_distributions.py
+++ b/geomstats/geometry/beta_distributions.py
@@ -5,7 +5,7 @@ from scipy.integrate import solve_bvp
 from scipy.stats import beta
 
 import geomstats.backend as gs
-import geomstats.error
+import geomstats.errors
 from geomstats.geometry.embedded_manifold import EmbeddedManifold
 from geomstats.geometry.euclidean import Euclidean
 from geomstats.geometry.riemannian_metric import RiemannianMetric
@@ -83,9 +83,8 @@ class BetaDistributions(EmbeddedManifold):
         -------
         samples : array-like, shape=[n_points, n_samples]
         """
+        geomstats.errors.check_belongs(point, self)
         point = gs.to_ndarray(point, to_ndim=2)
-        geomstats.error.check_belongs(
-            point, self, 'beta_distributions')
         samples = []
         for param_a, param_b in point:
             samples.append(gs.array(

--- a/geomstats/geometry/connection.py
+++ b/geomstats/geometry/connection.py
@@ -4,7 +4,7 @@ import autograd
 from scipy.optimize import minimize
 
 import geomstats.backend as gs
-import geomstats.error
+import geomstats.errors
 import geomstats.vectorization
 from geomstats.integrator import integrate
 
@@ -25,8 +25,8 @@ class Connection:
     def __init__(
             self, dim, default_point_type='vector',
             default_coords_type='intrinsic'):
-        geomstats.error.check_integer(dim, 'dim')
-        geomstats.error.check_parameter_accepted_values(
+        geomstats.errors.check_integer(dim, 'dim')
+        geomstats.errors.check_parameter_accepted_values(
             default_point_type, 'default_point_type', ['vector', 'matrix'])
 
         self.dim = dim

--- a/geomstats/geometry/grassmannian.py
+++ b/geomstats/geometry/grassmannian.py
@@ -1,7 +1,7 @@
 """Module exposing `Grassmannian` and `GrassmannianMetric` classes."""
 
 import geomstats.backend as gs
-import geomstats.error
+import geomstats.errors
 from geomstats.geometry.embedded_manifold import EmbeddedManifold
 from geomstats.geometry.euclidean import EuclideanMetric
 from geomstats.geometry.general_linear import GeneralLinear
@@ -23,8 +23,8 @@ class Grassmannian(EmbeddedManifold):
     """
 
     def __init__(self, n, k):
-        geomstats.error.check_integer(k, 'k')
-        geomstats.error.check_integer(n, 'n')
+        geomstats.errors.check_integer(k, 'k')
+        geomstats.errors.check_integer(n, 'n')
         if k > n:
             raise ValueError(
                 'k <= n is required: k-dimensional subspaces in n dimensions.')
@@ -71,8 +71,8 @@ class GrassmannianCanonicalMetric(RiemannianMetric):
     """
 
     def __init__(self, n, p):
-        geomstats.error.check_integer(p, 'p')
-        geomstats.error.check_integer(n, 'n')
+        geomstats.errors.check_integer(p, 'p')
+        geomstats.errors.check_integer(n, 'n')
         if p > n:
             raise ValueError('p <= n is required.')
 

--- a/geomstats/geometry/invariant_metric.py
+++ b/geomstats/geometry/invariant_metric.py
@@ -3,7 +3,7 @@
 import logging
 
 import geomstats.backend as gs
-import geomstats.error
+import geomstats.errors
 from geomstats.geometry.general_linear import GeneralLinear
 from geomstats.geometry.matrices import Matrices
 from geomstats.geometry.riemannian_metric import RiemannianMetric
@@ -37,7 +37,7 @@ class InvariantMetric(RiemannianMetric):
         if inner_product_mat_at_identity is None:
             inner_product_mat_at_identity = gs.eye(self.group.dim)
 
-        geomstats.error.check_parameter_accepted_values(
+        geomstats.errors.check_parameter_accepted_values(
             left_or_right, 'left_or_right', ['left', 'right'])
 
         eigenvalues = gs.linalg.eigvalsh(inner_product_mat_at_identity)
@@ -67,7 +67,7 @@ class InvariantMetric(RiemannianMetric):
         inner_prod : array-like, shape=[n_samples, dim]
             Inner-product of the two tangent vectors.
         """
-        geomstats.error.check_parameter_accepted_values(
+        geomstats.errors.check_parameter_accepted_values(
             self.group.default_point_type,
             'default_point_type',
             ['vector', 'matrix'])

--- a/geomstats/geometry/lie_algebra.py
+++ b/geomstats/geometry/lie_algebra.py
@@ -7,7 +7,7 @@ in that base. This base will be provided in child classes
 (e.g. SkewSymmetricMatrices).
 """
 import geomstats.backend as gs
-import geomstats.error
+import geomstats.errors
 from ._bch_coefficients import BCH_COEFFICIENTS
 
 
@@ -25,8 +25,8 @@ class MatrixLieAlgebra:
             The amount of rows and columns in the matrix representation of the
             Lie algebra
         """
-        geomstats.error.check_integer(dim, 'dim')
-        geomstats.error.check_integer(n, 'n')
+        geomstats.errors.check_integer(dim, 'dim')
+        geomstats.errors.check_integer(n, 'n')
         self.dim = dim
         self.n = n
         self.basis = None

--- a/geomstats/geometry/lie_algebra.py
+++ b/geomstats/geometry/lie_algebra.py
@@ -24,8 +24,8 @@ class MatrixLieAlgebra:
     """
 
     def __init__(self, dim, n):
-        geomstats.error.check_integer(dim, 'dim')
-        geomstats.error.check_integer(n, 'n')
+        geomstats.errors.check_integer(dim, 'dim')
+        geomstats.errors.check_integer(n, 'n')
         self.dim = dim
         self.n = n
         self.basis = None

--- a/geomstats/geometry/manifold.py
+++ b/geomstats/geometry/manifold.py
@@ -4,7 +4,7 @@ In other words, a topological space that locally resembles
 Euclidean space near each point.
 """
 
-import geomstats.error
+import geomstats.errors
 
 
 ATOL = 1e-6
@@ -16,8 +16,8 @@ class Manifold:
     def __init__(
             self, dim, default_point_type='vector',
             default_coords_type='intrinsic'):
-        geomstats.error.check_integer(dim, 'dim')
-        geomstats.error.check_parameter_accepted_values(
+        geomstats.errors.check_integer(dim, 'dim')
+        geomstats.errors.check_parameter_accepted_values(
             default_point_type, 'default_point_type', ['vector', 'matrix'])
 
         self.dim = dim

--- a/geomstats/geometry/matrices.py
+++ b/geomstats/geometry/matrices.py
@@ -3,7 +3,7 @@
 from functools import reduce
 
 import geomstats.backend as gs
-import geomstats.error
+import geomstats.errors
 from geomstats.geometry.manifold import Manifold
 from geomstats.geometry.riemannian_metric import RiemannianMetric
 
@@ -16,8 +16,8 @@ class Matrices(Manifold):
 
     def __init__(self, m, n):
         super(Matrices, self).__init__(dim=m * n)
-        geomstats.error.check_integer(n, 'n')
-        geomstats.error.check_integer(m, 'm')
+        geomstats.errors.check_integer(n, 'n')
+        geomstats.errors.check_integer(m, 'm')
         self.m = m
         self.n = n
         self.default_point_type = 'matrix'

--- a/geomstats/geometry/product_manifold.py
+++ b/geomstats/geometry/product_manifold.py
@@ -3,7 +3,7 @@
 import joblib
 
 import geomstats.backend as gs
-import geomstats.error
+import geomstats.errors
 import geomstats.vectorization
 from geomstats.geometry.manifold import Manifold
 from geomstats.geometry.product_riemannian_metric import \
@@ -37,7 +37,7 @@ class ProductManifold(Manifold):
     # FIXME(nguigs): This only works for 1d points
 
     def __init__(self, manifolds, default_point_type='vector', n_jobs=1):
-        geomstats.error.check_parameter_accepted_values(
+        geomstats.errors.check_parameter_accepted_values(
             default_point_type, 'default_point_type', ['vector', 'matrix'])
 
         self.dims = [manifold.dim for manifold in manifolds]
@@ -126,7 +126,7 @@ class ProductManifold(Manifold):
         """
         if point_type is None:
             point_type = self.default_point_type
-        geomstats.error.check_parameter_accepted_values(
+        geomstats.errors.check_parameter_accepted_values(
             point_type, 'point_type', ['vector', 'matrix'])
 
         if point_type == 'vector':
@@ -158,7 +158,7 @@ class ProductManifold(Manifold):
         """
         if point_type is None:
             point_type = self.default_point_type
-        geomstats.error.check_parameter_accepted_values(
+        geomstats.errors.check_parameter_accepted_values(
             point_type, 'point_type', ['vector', 'matrix'])
 
         if point_type == 'vector':

--- a/geomstats/geometry/special_euclidean.py
+++ b/geomstats/geometry/special_euclidean.py
@@ -61,7 +61,7 @@ class _SpecialEuclideanMatrices(GeneralLinear, LieGroup):
 
         Parameters
         ----------
-        point : array-like, shape=[..., n, n],
+        point : array-like, shape=[..., n, n].
             Point to be checked.
 
         Returns

--- a/geomstats/geometry/special_orthogonal.py
+++ b/geomstats/geometry/special_orthogonal.py
@@ -1,7 +1,7 @@
 """Exposes the `SpecialOrthogonal` group class."""
 
 import geomstats.backend as gs
-import geomstats.error
+import geomstats.errors
 import geomstats.vectorization
 from geomstats import algebra_utils
 from geomstats.geometry.general_linear import GeneralLinear
@@ -844,11 +844,11 @@ class _SpecialOrthogonal3Vectors(LieGroup):
         -------
         rot_mat : array-like, shape=[n_samples, n, n]
         """
-        geomstats.error.check_parameter_accepted_values(
+        geomstats.errors.check_parameter_accepted_values(
             extrinsic_or_intrinsic,
             'extrinsic_or_intrinsic',
             ['extrinsic', 'intrinsic'])
-        geomstats.error.check_parameter_accepted_values(
+        geomstats.errors.check_parameter_accepted_values(
             order,
             'order',
             ['xyz', 'zyx'])
@@ -1214,7 +1214,7 @@ class _SpecialOrthogonal3Vectors(LieGroup):
         -------
         jacobian : array-like, shape=[n_samples, 3, 3]
         """
-        geomstats.error.check_parameter_accepted_values(
+        geomstats.errors.check_parameter_accepted_values(
             left_or_right, 'left_or_right', ['left', 'right'])
 
         point = self.regularize(point)

--- a/geomstats/geometry/stiefel.py
+++ b/geomstats/geometry/stiefel.py
@@ -4,7 +4,7 @@ A set of all orthonormal p-frames in n-dimensional space, where p <= n
 """
 
 import geomstats.backend as gs
-import geomstats.error
+import geomstats.errors
 import geomstats.vectorization
 from geomstats import algebra_utils
 from geomstats.geometry.embedded_manifold import EmbeddedManifold
@@ -31,8 +31,8 @@ class Stiefel(EmbeddedManifold):
     """
 
     def __init__(self, n, p):
-        geomstats.error.check_integer(n, 'n')
-        geomstats.error.check_integer(p, 'p')
+        geomstats.errors.check_integer(n, 'n')
+        geomstats.errors.check_integer(p, 'p')
         if p > n:
             raise ValueError('p needs to be smaller than n.')
 

--- a/geomstats/learning/frechet_mean.py
+++ b/geomstats/learning/frechet_mean.py
@@ -6,7 +6,7 @@ import math
 from sklearn.base import BaseEstimator
 
 import geomstats.backend as gs
-import geomstats.error as error
+import geomstats.errors as error
 import geomstats.vectorization
 from geomstats.geometry.euclidean import EuclideanMetric
 from geomstats.geometry.matrices import MatricesMetric

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -654,8 +654,8 @@ class TestBackends(geomstats.tests.TestCase):
         self.assertAllCloseToNp(gs_result, np_array_4_list)
 
         n_samples = 3
-        theta = _np.random.rand(5)
-        phi = _np.random.rand(5)
+        theta = _np.array([0.1, 0.2, 0.3, 0.4, 5.5])
+        phi = _np.array([0.11, 0.22, 0.33, 0.44, -.55])
         np_array = _np.ones((n_samples, 5, 4))
         gs_array = gs.array(np_array)
         np_array[0, :, 0] += _np.cos(theta) * _np.cos(phi)

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -653,20 +653,24 @@ class TestBackends(geomstats.tests.TestCase):
             gs_array_4_list, 1, [(0, 1), (1, 1)], axis=1)
         self.assertAllCloseToNp(gs_result, np_array_4_list)
 
-        # TODO(pchauchat): Fix this test
-        # n_samples = 3
-        # theta = _np.array([0.1, 0.2, 0.3, 0.4, 5.5])
-        # phi = _np.array([0.11, 0.22, 0.33, 0.44, -.55])
-        # np_array = _np.ones((n_samples, 5, 4))
-        # gs_array = gs.array(np_array)
-        # np_array[0, :, 0] += _np.cos(theta) * _np.cos(phi)
-        # np_array[0, :, 1] -= _np.sin(theta) * _np.sin(phi)
-        # gs_array = gs.assignment_by_sum(
-        #     gs_array, gs.cos(theta) * gs.cos(phi), (0, 0), axis=1)
-        # gs_array = gs.assignment_by_sum(
-        #     gs_array, - gs.sin(theta) * gs.sin(phi), (0, 1), axis=1)
-        # print(gs_array, np_array)
-        # self.assertAllCloseToNp(gs_array, np_array)
+        n_samples = 3
+        theta = _np.array([0.1, 0.2, 0.3, 0.4, 5.5])
+        phi = _np.array([0.11, 0.22, 0.33, 0.44, -.55])
+        np_array = _np.ones((n_samples, 5, 4))
+        gs_array = gs.array(np_array)
+
+        gs_array = gs.assignment_by_sum(
+            gs_array, gs.cos(theta) * gs.cos(phi), (0, 0), axis=1)
+        gs_array = gs.assignment_by_sum(
+            gs_array, - gs.sin(theta) * gs.sin(phi), (0, 1), axis=1)
+
+        np_array[0, :, 0] += _np.cos(theta) * _np.cos(phi)
+        np_array[0, :, 1] -= _np.sin(theta) * _np.sin(phi)
+
+        # TODO(ninamiolane): This test fails 15% of the time,
+        # when gs and _np computations are in the reverse order.
+        # We should investigate this.
+        self.assertAllCloseToNp(gs_array, np_array)
 
         np_array = _np.array([
             [22., 55.],

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -653,18 +653,20 @@ class TestBackends(geomstats.tests.TestCase):
             gs_array_4_list, 1, [(0, 1), (1, 1)], axis=1)
         self.assertAllCloseToNp(gs_result, np_array_4_list)
 
-        n_samples = 3
-        theta = _np.array([0.1, 0.2, 0.3, 0.4, 5.5])
-        phi = _np.array([0.11, 0.22, 0.33, 0.44, -.55])
-        np_array = _np.ones((n_samples, 5, 4))
-        gs_array = gs.array(np_array)
-        np_array[0, :, 0] += _np.cos(theta) * _np.cos(phi)
-        np_array[0, :, 1] -= _np.sin(theta) * _np.sin(phi)
-        gs_array = gs.assignment_by_sum(
-            gs_array, gs.cos(theta) * gs.cos(phi), (0, 0), axis=1)
-        gs_array = gs.assignment_by_sum(
-            gs_array, - gs.sin(theta) * gs.sin(phi), (0, 1), axis=1)
-        self.assertAllCloseToNp(gs_array, np_array)
+        # TODO(pchauchat): Fix this test
+        # n_samples = 3
+        # theta = _np.array([0.1, 0.2, 0.3, 0.4, 5.5])
+        # phi = _np.array([0.11, 0.22, 0.33, 0.44, -.55])
+        # np_array = _np.ones((n_samples, 5, 4))
+        # gs_array = gs.array(np_array)
+        # np_array[0, :, 0] += _np.cos(theta) * _np.cos(phi)
+        # np_array[0, :, 1] -= _np.sin(theta) * _np.sin(phi)
+        # gs_array = gs.assignment_by_sum(
+        #     gs_array, gs.cos(theta) * gs.cos(phi), (0, 0), axis=1)
+        # gs_array = gs.assignment_by_sum(
+        #     gs_array, - gs.sin(theta) * gs.sin(phi), (0, 1), axis=1)
+        # print(gs_array, np_array)
+        # self.assertAllCloseToNp(gs_array, np_array)
 
         np_array = _np.array([
             [22., 55.],

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,32 @@
+"""Unit tests for errors."""
+
+import geomstats.backend as gs
+import geomstats.errors
+import geomstats.tests
+from geomstats.geometry.euclidean import Euclidean
+
+
+class TestBackends(geomstats.tests.TestCase):
+    def test_check_belongs(self):
+        euclidean = Euclidean(5)
+        point = gs.array([1, 2])
+
+        self.assertRaises(
+            RuntimeError,
+            lambda: geomstats.errors.check_belongs(
+                point, euclidean))
+
+    def test_check_integer(self):
+        a = -2
+
+        self.assertRaises(
+            ValueError,
+            lambda: geomstats.errors.check_integer(a, 'a'))
+
+    def test_check_parameter_accepted_values(self):
+        param = 'lefttt'
+        accepted_values = ['left', 'right']
+        self.assertRaises(
+            ValueError,
+            lambda: geomstats.errors.check_parameter_accepted_values(
+                param, 'left_or_right', accepted_values))

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -4,6 +4,7 @@ import geomstats.backend as gs
 import geomstats.errors
 import geomstats.tests
 from geomstats.geometry.euclidean import Euclidean
+from geomstats.geometry.spd_matrices import SPDMatrices
 
 
 class TestBackends(geomstats.tests.TestCase):
@@ -15,6 +16,13 @@ class TestBackends(geomstats.tests.TestCase):
             RuntimeError,
             lambda: geomstats.errors.check_belongs(
                 point, euclidean))
+
+    def test_check_belongs_with_tol(self):
+        spd = SPDMatrices(5)
+        point = spd.random_uniform()
+
+        geomstats.errors.check_belongs(
+            point, spd, atol=1e-5)
 
     def test_check_integer(self):
         a = -2

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -17,12 +17,12 @@ class TestBackends(geomstats.tests.TestCase):
             lambda: geomstats.errors.check_belongs(
                 point, euclidean))
 
-    def test_check_belongs_with_tol(self):
+    @staticmethod
+    def test_check_belongs_with_tol():
         spd = SPDMatrices(5)
         point = spd.random_uniform()
 
-        geomstats.errors.check_belongs(
-            point, spd, atol=1e-5)
+        geomstats.errors.check_belongs(point, spd, atol=1e-5)
 
     def test_check_integer(self):
         a = -2


### PR DESCRIPTION
Clean geomstats.errors module:
- geomstats.error -> geomstats.errors to be consistent with geomstats.tests (plural)
- clean check_belongs method, no need for manifold's name as parameter
- add unit tests