### PR TITLE
Add logic to allow Manifolds having the attribute metric

### DIFF
--- a/geomstats/geometry/hypersphere.py
+++ b/geomstats/geometry/hypersphere.py
@@ -607,7 +607,8 @@ class HypersphereMetric(RiemannianMetric):
         """
         return self.dist(point_a, point_b) ** 2
 
-    def parallel_transport(self, tangent_vec_a, tangent_vec_b, base_point):
+    @staticmethod
+    def parallel_transport(tangent_vec_a, tangent_vec_b, base_point):
         """Compute the parallel transport of a tangent vector.
 
         Closed-form solution for the parallel transport of a tangent vector a

--- a/geomstats/geometry/hypersphere.py
+++ b/geomstats/geometry/hypersphere.py
@@ -9,6 +9,7 @@ import math
 from itertools import product
 
 import geomstats.backend as gs
+import geomstats.errors
 import geomstats.vectorization
 from geomstats.geometry.embedded_manifold import EmbeddedManifold
 from geomstats.geometry.euclidean import Euclidean
@@ -33,8 +34,8 @@ INV_TAN_TAYLOR_COEFFS = [0., - 1. / 3.,
                          0., -1. / 4725.]
 
 
-class Hypersphere(EmbeddedManifold):
-    """Class for the n-dimensional hypersphere.
+class _Hypersphere(EmbeddedManifold):
+    """Private class for the n-dimensional hypersphere.
 
     Class for the n-dimensional hypersphere embedded in the
     (n+1)-dimensional Euclidean space.
@@ -44,16 +45,15 @@ class Hypersphere(EmbeddedManifold):
 
     Parameters
     ----------
-    dim: int
+    dim : int
         Dimension of the hypersphere.
     """
 
     def __init__(self, dim):
-        super(Hypersphere, self).__init__(
+        super(_Hypersphere, self).__init__(
             dim=dim,
             embedding_manifold=Euclidean(dim + 1))
         self.embedding_metric = self.embedding_manifold.metric
-        self.metric = HypersphereMetric(dim)
 
     def belongs(self, point, tolerance=TOLERANCE):
         """Test if a point belongs to the hypersphere.
@@ -386,6 +386,7 @@ class HypersphereMetric(RiemannianMetric):
             dim=dim,
             signature=(dim, 0, 0))
         self.embedding_metric = EuclideanMetric(dim + 1)
+        self._space = _Hypersphere(dim=dim)
 
     def inner_product(self, tangent_vec_a, tangent_vec_b, base_point=None):
         """Compute the inner-product of two tangent vectors at a base point.
@@ -447,9 +448,9 @@ class HypersphereMetric(RiemannianMetric):
             Point on the hypersphere equal to the Riemannian exponential
             of tangent_vec at the base point.
         """
-        # TODO(ninamiolane): Decide on metric.space or space.metric
-        #  for the hypersphere
         # TODO(ninamiolane): Raise error when vector is not tangent
+        geomstats.errors.check_belongs(base_point, self._space)
+
         _, extrinsic_dim = base_point.shape
         n_tangent_vecs, _ = tangent_vec.shape
 
@@ -510,6 +511,9 @@ class HypersphereMetric(RiemannianMetric):
             Tangent vector at the base point equal to the Riemannian logarithm
             of point at the base point.
         """
+        geomstats.errors.check_belongs(point, self._space)
+        geomstats.errors.check_belongs(base_point, self._space)
+
         norm_base_point = self.embedding_metric.norm(base_point)
         norm_point = self.embedding_metric.norm(point)
         inner_prod = self.embedding_metric.inner_product(base_point, point)
@@ -581,6 +585,9 @@ class HypersphereMetric(RiemannianMetric):
         dist : array-like, shape=[n_samples, 1]
             Geodesic distance between the two points.
         """
+        geomstats.errors.check_belongs(point_a, self._space)
+        geomstats.errors.check_belongs(point_b, self._space)
+
         norm_a = self.embedding_metric.norm(point_a)
         norm_b = self.embedding_metric.norm(point_b)
         inner_prod = self.embedding_metric.inner_product(point_a, point_b)
@@ -609,8 +616,7 @@ class HypersphereMetric(RiemannianMetric):
         """
         return self.dist(point_a, point_b) ** 2
 
-    @staticmethod
-    def parallel_transport(tangent_vec_a, tangent_vec_b, base_point):
+    def parallel_transport(self, tangent_vec_a, tangent_vec_b, base_point):
         """Compute the parallel transport of a tangent vector.
 
         Closed-form solution for the parallel transport of a tangent vector a
@@ -631,6 +637,8 @@ class HypersphereMetric(RiemannianMetric):
         transported_tangent_vec: array-like, shape=[n_samples, dim + 1]
             Transported tangent vector at exp_(base_point)(tangent_vec_b).
         """
+        geomstats.errors.check_belongs(base_point, self._space)
+
         tangent_vec_a = gs.to_ndarray(tangent_vec_a, to_ndim=2)
         tangent_vec_b = gs.to_ndarray(tangent_vec_b, to_ndim=2)
         base_point = gs.to_ndarray(base_point, to_ndim=2)
@@ -669,6 +677,8 @@ class HypersphereMetric(RiemannianMetric):
                 'The Christoffel symbols are only implemented'
                 ' for spherical coordinates in the 2-sphere')
 
+        geomstats.errors.check_belongs(point, self._space)
+
         point = gs.to_ndarray(point, to_ndim=2)
         christoffel = []
         for sample in point:
@@ -682,3 +692,23 @@ class HypersphereMetric(RiemannianMetric):
         if gs.ndim(christoffel) == 4 and gs.shape(christoffel)[0] == 1:
             christoffel = gs.squeeze(christoffel, axis=0)
         return christoffel
+
+
+class Hypersphere(_Hypersphere):
+    """Class for the n-dimensional hypersphere.
+
+    Class for the n-dimensional hypersphere embedded in the
+    (n+1)-dimensional Euclidean space.
+
+    By default, points are parameterized by their extrinsic
+    (n+1)-coordinates.
+
+    Parameters
+    ----------
+    dim : int
+        Dimension of the hypersphere.
+    """
+
+    def __init__(self, dim):
+        super(Hypersphere, self).__init__(dim)
+        self.metric = HypersphereMetric(dim)

--- a/geomstats/geometry/hypersphere.py
+++ b/geomstats/geometry/hypersphere.py
@@ -9,7 +9,6 @@ import math
 from itertools import product
 
 import geomstats.backend as gs
-import geomstats.errors
 import geomstats.vectorization
 from geomstats.geometry.embedded_manifold import EmbeddedManifold
 from geomstats.geometry.euclidean import Euclidean
@@ -449,8 +448,6 @@ class HypersphereMetric(RiemannianMetric):
             of tangent_vec at the base point.
         """
         # TODO(ninamiolane): Raise error when vector is not tangent
-        geomstats.errors.check_belongs(base_point, self._space)
-
         _, extrinsic_dim = base_point.shape
         n_tangent_vecs, _ = tangent_vec.shape
 
@@ -511,9 +508,6 @@ class HypersphereMetric(RiemannianMetric):
             Tangent vector at the base point equal to the Riemannian logarithm
             of point at the base point.
         """
-        geomstats.errors.check_belongs(point, self._space)
-        geomstats.errors.check_belongs(base_point, self._space)
-
         norm_base_point = self.embedding_metric.norm(base_point)
         norm_point = self.embedding_metric.norm(point)
         inner_prod = self.embedding_metric.inner_product(base_point, point)
@@ -585,9 +579,6 @@ class HypersphereMetric(RiemannianMetric):
         dist : array-like, shape=[n_samples, 1]
             Geodesic distance between the two points.
         """
-        geomstats.errors.check_belongs(point_a, self._space)
-        geomstats.errors.check_belongs(point_b, self._space)
-
         norm_a = self.embedding_metric.norm(point_a)
         norm_b = self.embedding_metric.norm(point_b)
         inner_prod = self.embedding_metric.inner_product(point_a, point_b)
@@ -637,8 +628,6 @@ class HypersphereMetric(RiemannianMetric):
         transported_tangent_vec: array-like, shape=[n_samples, dim + 1]
             Transported tangent vector at exp_(base_point)(tangent_vec_b).
         """
-        geomstats.errors.check_belongs(base_point, self._space)
-
         tangent_vec_a = gs.to_ndarray(tangent_vec_a, to_ndim=2)
         tangent_vec_b = gs.to_ndarray(tangent_vec_b, to_ndim=2)
         base_point = gs.to_ndarray(base_point, to_ndim=2)
@@ -676,8 +665,6 @@ class HypersphereMetric(RiemannianMetric):
             raise NotImplementedError(
                 'The Christoffel symbols are only implemented'
                 ' for spherical coordinates in the 2-sphere')
-
-        geomstats.errors.check_belongs(point, self._space)
 
         point = gs.to_ndarray(point, to_ndim=2)
         christoffel = []


### PR DESCRIPTION
There were discussions about whether:
- a Manifold should have an attribute `metric`,
- a Connection/RiemannianMetric should have an attribute `space`,
since having both results in `maximum depth exceeded` error, since both objects would call themselves.

This PR suggests to address this with the following logic (only on Hypersphere for now):
- add a private class `_Hypersphere`, with *no* `self.metric`,
- add a `self._space` private attribute in the class `HypersphereMetric`. 
    - For example, this private attribute will allow to:
        -  use `geomstats.errors.check_belongs(point, self._space)` in order to consistently check that input parameters of `exp`, `log`, etc., do belong to the manifold on which the metric is used, 
        - use space's methods that convert coordinate types,
        - etc.
   - This private attribute is not intended to be accessed by the user.
- add a wrapper class `Hypersphere` that inherits from `_Hypersphere` and adds a `self.metric` attribute.

If you agree with this logic, we could apply it to other manifolds, and in particular address issue #83 . 

Additionally, we could define `exp` and `log` methods in a `Manifold` class, which would call the `exp` and `log` of the default metric in `self.metric`.

@nguigs @stefanheyder @opeltre 