### PR TITLE
Clean docstrings in repo

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -423,8 +423,7 @@ These are some of the most common elements for functions (and ones we’d like y
 
 3. Parameters - a formatted list of arguments with type information and description
 
-   a. On the first line, state the parameter name, type, and shape when appropriate. The parameter name should be separated from the rest of the line by a ``:`` (with a space on either side). If a parameter is optional, write ``optional`` after the type information (separated by a comma and a space).
-
+   a. On the first line, state the parameter name, type, and shape when appropriate. The parameter name should be separated from the rest of the line by a ``:`` (with a space on either side). If a parameter is optional, write ``Optional, default: default_value.`` as a separate line in the description.
    b. On the next line, indent and write a summary of the parameter beginning with a capital letter and ending with a period.
 
    c. See :ref:`docstring_examples` below
@@ -449,7 +448,7 @@ Docstring Examples
 ^^^^^^^^^^^^^^^^^^
 Here's a generic docstring template::
 
-   def my_method(self, my_param_1, my_param_2):
+   def my_method(self, my_param_1, my_param_2='vector'):
       """Write a one-line summary for the method.
 
       Write a description of the method, including "big O"
@@ -461,6 +460,7 @@ Here's a generic docstring template::
          Write a short description of parameter my_param_1.
       my_param_2 : str, {'vector', 'matrix'}
          Write a short description of parameter my_param_2.
+         Optional, default: 'vector'.
 
       Returns
       -------

--- a/geomstats/geometry/beta_distributions.py
+++ b/geomstats/geometry/beta_distributions.py
@@ -23,7 +23,7 @@ class BetaDistributions(EmbeddedManifold):
     Attributes
     ----------
     dim : int
-        Dimension of the manifold of beta distributions.
+        Dimension of the manifold of beta distributions, equal to 2.
     embedding_manifold : Manifold
         Embedding manifold.
     """
@@ -237,12 +237,12 @@ class BetaMetric(RiemannianMetric):
         Parameters
         ----------
         tangent_vec : array-like, shape=[..., dim]
-            Tangent vector.
+            Tangent vector at base point.
         base_point : array-like, shape=[..., dim]
             Base point.
         n_steps : int
             Number of steps for integration.
-            Optional, default: N_STEPS.
+            Optional, default: 100.
 
         Returns
         -------
@@ -281,7 +281,7 @@ class BetaMetric(RiemannianMetric):
             Base point.
         n_steps : int
             Number of steps for integration.
-            Optional, default: N_STEPS.
+            Optional, default: 100.
 
         Returns
         -------

--- a/geomstats/geometry/connection.py
+++ b/geomstats/geometry/connection.py
@@ -14,12 +14,18 @@ EPSILON = 1e-3
 
 
 class Connection:
-    """Class for affine connections.
+    r"""Class for affine connections.
 
     Parameters
     ----------
-    dim: int
+    dim : int
         Dimension of the underlying manifold.
+    default_point_type : str, {\'vector\', \'matrix\'}
+        Point type.
+        Optional, default: \'vector\'.
+    default_coords_type : str, {\'intrinsic\', \'extrinsic\', etc}
+        Coordinate type.
+        Optional, default: \'intrinsic\'.
     """
 
     def __init__(
@@ -44,7 +50,7 @@ class Connection:
         Returns
         -------
         gamma : array-like, shape=[..., dim, dim, dim]
-            Values of the christoffel symbols, with the covariant index on
+            Christoffel symbols, with the covariant index on
             the first dimension.
         """
         raise NotImplementedError(
@@ -109,10 +115,13 @@ class Connection:
             Point on the manifold.
         n_steps : int
             Number of discrete time steps to take in the integration.
+            Optional, default: N_STEPS.
         step : str, {'euler', 'rk4'}
             The numerical scheme to use for integration.
+            Optional, default: 'euler'.
         point_type : str, {'vector', 'matrix'}
             Type of representation used for points.
+            Optional, default: None.
 
         Returns
         -------
@@ -140,8 +149,10 @@ class Connection:
             Point on the manifold.
         n_steps : int
             Number of discrete time steps to take in the integration.
+            Optional, default: N_STEPS.
         step : str, {'euler', 'rk4'}
             Numerical scheme to use for integration.
+            Optional, default: 'euler'.
 
         Returns
         -------
@@ -267,9 +278,10 @@ class Connection:
         base_shoot : array-like, shape=[..., dim]
             Point on the manifold, end point of the geodesics starting
             from the base point with initial speed to be transported.
-        return_geodesics : bool, optional (defaults to False)
+        return_geodesics : bool
             Whether to return points computed along each geodesic of the
             construction.
+            Optional, default: False.
 
         Returns
         -------
@@ -353,8 +365,10 @@ class Connection:
             which to transport.
         n_steps : int
             The number of pole ladder steps.
+            Optional, default: 1.
         step : str, {'pole', 'schild'}
             The scheme to use for the construction of the ladder at each step.
+            Optoinal, default: 'pole'.
         **single_step_kwargs : keyword arguments for the step functions
 
         Returns
@@ -433,16 +447,17 @@ class Connection:
             Point on the manifold, end point of the geodesic. If None,
             an initial tangent vector must be given.
         initial_tangent_vec : array-like, shape=[..., dim],
-            optional
             Tangent vector at base point, the initial speed of the geodesics.
+            Optional, default: None.
             If None, an end point must be given and a logarithm is computed.
         point_type : str, {'vector', 'matrix'}
-            The type of point.
+            Point type.
+            Optional, default: 'vector'.
 
         Returns
         -------
         path : callable
-            The time parameterized geodesic curve.
+            Time parameterized geodesic curve.
         """
         point_ndim = 1
         if point_type == 'matrix':

--- a/geomstats/geometry/embedded_manifold.py
+++ b/geomstats/geometry/embedded_manifold.py
@@ -12,6 +12,12 @@ class EmbeddedManifold(Manifold):
         Dimension of the embedded manifold.
     embedding_manifold : Manifold
         Embedding manifold.
+    default_point_type : str, {'vector', 'matrix'}
+        Point type.
+        Optional, default: 'vector'.
+    default_coords_type : str, {'intrinsic', 'extrinsic', etc}
+        Coordinate type.
+        Optional, default: 'intrinsic'.
     """
 
     def __init__(self, dim, embedding_manifold, default_point_type='vector',
@@ -28,6 +34,11 @@ class EmbeddedManifold(Manifold):
         ----------
         point_intrinsic : array-like, shape=[..., dim]
             Point in the embedded manifold in intrinsic coordinates.
+
+        Returns
+        -------
+        point_extrinsic : array-like, shape=[..., dim_embedding]
+            Point in the embedded manifold in extrinsic coordinates.
         """
         raise NotImplementedError(
             'intrinsic_to_extrinsic_coords is not implemented.')
@@ -40,6 +51,11 @@ class EmbeddedManifold(Manifold):
         point_extrinsic : array-like, shape=[..., dim_embedding]
             Point in the embedded manifold in extrinsic coordinates,
             i. e. in the coordinates of the embedding manifold.
+
+        Returns
+        -------
+        point_intrinsic : array-lie, shape=[..., dim]
+            Point in the embedded manifold in intrinsic coordinates.
         """
         raise NotImplementedError(
             'extrinsic_to_intrinsic_coords is not implemented.')
@@ -50,7 +66,11 @@ class EmbeddedManifold(Manifold):
         Parameters
         ----------
         point : array-like, shape=[..., dim_embedding]
-            Point in embedding manifold
+            Point in embedding manifold.
+
+        Returns
+        -------
+            Projected point.
         """
         raise NotImplementedError(
             'projection is not implemented.')

--- a/geomstats/geometry/euclidean.py
+++ b/geomstats/geometry/euclidean.py
@@ -47,8 +47,8 @@ class Euclidean(Manifold):
         Parameters
         ----------
         n_samples : int
-            Number of samples
-            Optional, default: 1
+            Number of samples.
+            Optional, default: 1.
         bound : float
             Side of hypercube support of the uniform distribution.
             Optional, default: 1.0

--- a/geomstats/geometry/euclidean.py
+++ b/geomstats/geometry/euclidean.py
@@ -27,6 +27,7 @@ class Euclidean(Manifold):
         Returns
         -------
         belongs : array-like, shape=[...,]
+            Boolean evaluating if point belongs to the Euclidean space.
         """
         point_dim = point.shape[-1]
         belongs = point_dim == self.dim
@@ -40,14 +41,17 @@ class Euclidean(Manifold):
 
         Parameters
         ----------
-        n_samples : int, optional
-            default: 1
-        bound : float, optional
-            default: 1.0
+        n_samples : int
+            Number of samples
+            Optional, default: 1
+        bound : float
+            Side of hypercube support of the uniform distribution.
+            Optional, default: 1.0
 
         Returns
         -------
         point : array-like, shape=[..., dim]
+           Sample.
         """
         size = (self.dim,)
         if n_samples != 1:

--- a/geomstats/geometry/euclidean.py
+++ b/geomstats/geometry/euclidean.py
@@ -109,7 +109,7 @@ class EuclideanMetric(RiemannianMetric):
         Parameters
         ----------
         tangent_vec : array-like, shape=[..., dim]
-            Tangent vector.
+            Tangent vector at base point.
         base_point : array-like, shape=[..., dim]
             Base point.
 

--- a/geomstats/geometry/euclidean.py
+++ b/geomstats/geometry/euclidean.py
@@ -10,6 +10,11 @@ class Euclidean(Manifold):
 
     By definition, a Euclidean space is a vector space of a given
     dimension, equipped with a Euclidean metric.
+
+    Parameters
+    ----------
+    dim : int
+        Dimension of the Euclidean space.
     """
 
     def __init__(self, dim):
@@ -65,9 +70,14 @@ class EuclideanMetric(RiemannianMetric):
     """Class for Euclidean metrics.
 
     As a Riemannian metric, the Euclidean metric is:
-    - flat: the inner product is independent of the base point.
+    - flat: the inner-product is independent of the base point.
     - positive definite: it has signature (dimension, 0, 0),
     where dimension is the dimension of the Euclidean space.
+
+    Parameters
+    ----------
+    dim : int
+        Dimension of the Euclidean space.
     """
 
     def __init__(self, dim):
@@ -75,15 +85,18 @@ class EuclideanMetric(RiemannianMetric):
             dim=dim, signature=(dim, 0, 0))
 
     def inner_product_matrix(self, base_point=None):
-        """Compute inner product matrix, independent of the base point.
+        """Compute the inner-product matrix, independent of the base point.
 
         Parameters
         ----------
         base_point : array-like, shape=[..., dim]
+            Base point.
+            Optional, default: None.
 
         Returns
         -------
         inner_prod_mat : array-like, shape=[..., dim, dim]
+            Inner-product matrix.
         """
         mat = gs.eye(self.dim)
         return mat
@@ -96,12 +109,14 @@ class EuclideanMetric(RiemannianMetric):
         Parameters
         ----------
         tangent_vec : array-like, shape=[..., dim]
-
+            Tangent vector.
         base_point : array-like, shape=[..., dim]
+            Base point.
 
         Returns
         -------
         exp : array-like, shape=[..., dim]
+            Riemannian exponential.
         """
         exp = base_point + tangent_vec
         return exp
@@ -114,12 +129,14 @@ class EuclideanMetric(RiemannianMetric):
         Parameters
         ----------
         point: array-like, shape=[..., dim]
-
+            Point.
         base_point: array-like, shape=[..., dim]
+            Base point.
 
         Returns
         -------
         log: array-like, shape=[..., dim]
+            Riemannian logarithm.
         """
         log = point - base_point
         return log

--- a/geomstats/geometry/general_linear.py
+++ b/geomstats/geometry/general_linear.py
@@ -7,7 +7,13 @@ from geomstats.geometry.matrices import Matrices
 
 
 class GeneralLinear(Matrices):
-    """Class for the general linear group GL(n)."""
+    """Class for the general linear group GL(n).
+
+    Parameters
+    ----------
+    n : int
+        Integer representing the shape of the matrices: n x n.
+    """
 
     def __init__(self, n, **kwargs):
         Matrices.__init__(self, n, n)
@@ -15,7 +21,18 @@ class GeneralLinear(Matrices):
         self.n = n
 
     def belongs(self, point):
-        """Test if a matrix is invertible and of the right size."""
+        """Check if a matrix is invertible and of the right shape.
+
+        Parameters
+        ----------
+        point : array-like, shape=[..., n, n]
+            Matrix to be checked.
+
+        Returns
+        -------
+        belongs : array-like, shape=[...,]
+            Boolean denoting if point is in GL(n).
+        """
         point_shape = point.shape
         mat_dim_1, mat_dim_2 = point_shape[-2], point_shape[-1]
         det = gs.linalg.det(point)
@@ -35,10 +52,17 @@ class GeneralLinear(Matrices):
 
     @staticmethod
     def inverse(point):
-        """Return the inverse of a matrix."""
+        """Return the inverse of a matrix.
+
+        Parameters
+        ----------
+        point : array-like, shape=[..., n, n]
+            Matrix to be inverted.
+        """
         return gs.linalg.inv(point)
 
     def _replace_values(self, samples, new_samples, indcs):
+        """Replace samples with new samples at specific indices."""
         replaced_indices = [
             i for i, is_replaced in enumerate(indcs) if is_replaced]
         value_indices = list(
@@ -50,11 +74,13 @@ class GeneralLinear(Matrices):
 
         Parameters
         ----------
-        n_samples : int, optional
+        n_samples : int
             Number of samples.
-        tol: float, optional
+            Optional, default: 1.
+        tol: float
             Threshold for the absolute value of the determinant of the
             returned matrix.
+            Optional, default: 1e-6.
 
         Returns
         -------
@@ -94,8 +120,10 @@ class GeneralLinear(Matrices):
         Parameters
         ----------
         tangent_vec : array-like, shape=[..., n, n]
+            Tangent vector.
         base_point : array-like, shape=[..., n, n]}
-            Defaults to identity.
+            Base point.
+            Optional, default: None.
 
         Returns
         -------
@@ -111,7 +139,7 @@ class GeneralLinear(Matrices):
     @classmethod
     def log(cls, point, base_point=None):
         r"""
-        Calculate a left-invariant vector field bringing base_point to point.
+        Compute a left-invariant vector field bringing base_point to point.
 
         The output is a vector of the tangent space at base_point, so not a Lie
         algebra element if it is not the identity.
@@ -119,8 +147,10 @@ class GeneralLinear(Matrices):
         Parameters
         ----------
         point : array-like, shape=[..., n, n]
+            Point.
         base_point : array-like, shape=[..., n, n]
-            Defaults to identity.
+            Base point.
+            Optional, default: None.
 
         Returns
         -------
@@ -152,12 +182,13 @@ class GeneralLinear(Matrices):
         point : array-like, shape=[n, n]
             Target point.
         base_point : array-like, shape=[n, n], optional
-            Base point. Defaults to identity.
+            Base point.
+            Optional, default: None.
 
         Returns
         -------
         path : callable
-            The one-parameter orbit.
+            One-parameter orbit.
             Satisfies `path(0) = base_point` and `path(1) = point`.
 
         Notes

--- a/geomstats/geometry/general_linear.py
+++ b/geomstats/geometry/general_linear.py
@@ -120,7 +120,7 @@ class GeneralLinear(Matrices):
         Parameters
         ----------
         tangent_vec : array-like, shape=[..., n, n]
-            Tangent vector.
+            Tangent vector at base point.
         base_point : array-like, shape=[..., n, n]}
             Base point.
             Optional, default to identity if None.

--- a/geomstats/geometry/general_linear.py
+++ b/geomstats/geometry/general_linear.py
@@ -123,7 +123,7 @@ class GeneralLinear(Matrices):
             Tangent vector.
         base_point : array-like, shape=[..., n, n]}
             Base point.
-            Optional, default: None.
+            Optional, default to identity if None.
 
         Returns
         -------
@@ -150,7 +150,7 @@ class GeneralLinear(Matrices):
             Point.
         base_point : array-like, shape=[..., n, n]
             Base point.
-            Optional, default: None.
+            Optional, default to identity if None.
 
         Returns
         -------
@@ -183,7 +183,7 @@ class GeneralLinear(Matrices):
             Target point.
         base_point : array-like, shape=[n, n], optional
             Base point.
-            Optional, default: None.
+            Optional, default to identity if None.
 
         Returns
         -------

--- a/geomstats/geometry/general_linear.py
+++ b/geomstats/geometry/general_linear.py
@@ -121,9 +121,9 @@ class GeneralLinear(Matrices):
         ----------
         tangent_vec : array-like, shape=[..., n, n]
             Tangent vector at base point.
-        base_point : array-like, shape=[..., n, n]}
+        base_point : array-like, shape=[..., n, n]
             Base point.
-            Optional, default to identity if None.
+            Optional, defaults to identity if None.
 
         Returns
         -------
@@ -150,7 +150,7 @@ class GeneralLinear(Matrices):
             Point.
         base_point : array-like, shape=[..., n, n]
             Base point.
-            Optional, default to identity if None.
+            Optional, defaults to identity if None.
 
         Returns
         -------
@@ -183,7 +183,7 @@ class GeneralLinear(Matrices):
             Target point.
         base_point : array-like, shape=[n, n], optional
             Base point.
-            Optional, default to identity if None.
+            Optional, defaults to identity if None.
 
         Returns
         -------

--- a/geomstats/geometry/grassmannian.py
+++ b/geomstats/geometry/grassmannian.py
@@ -16,10 +16,17 @@ class Grassmannian(EmbeddedManifold):
     """Class for Grassmann manifolds Gr(n, k).
 
     Class for Grassmann manifolds Gr(n, k) of k-dimensional
-    subspaces in the n-dimensional euclidean space.
+    subspaces in the n-dimensional Euclidean space.
 
     The subspaces are represented by their (unique) orthogonal projection
     matrix onto themselves.
+
+    Parameters
+    ----------
+    n : int
+        Dimension of the Euclidean space.
+    k : int
+        Dimension of the subspaces.
     """
 
     def __init__(self, n, k):
@@ -52,12 +59,14 @@ class Grassmannian(EmbeddedManifold):
         Parameters
         ----------
         point : array-like, shape=[..., n, n]
+            Point to be checked.
         tolerance : int
-            default: TOLERANCE
+            Optional, default: TOLERANCE
 
         Returns
         -------
-        belongs : bool
+        belongs : array-like, shape=[...,]
+            Boolean evaluating if point belongs to the Grassmannian.
         """
         raise NotImplementedError(
             'The Grassmann `belongs` is not implemented.'
@@ -68,6 +77,13 @@ class GrassmannianCanonicalMetric(RiemannianMetric):
     """Canonical metric of the Grassmann manifold.
 
     Coincides with the Frobenius metric.
+
+    Parameters
+    ----------
+    n : int
+        Dimension of the Euclidean space.
+    k : int
+        Dimension of the subspaces.
     """
 
     def __init__(self, n, p):
@@ -91,13 +107,16 @@ class GrassmannianCanonicalMetric(RiemannianMetric):
         Parameters
         ----------
         vector : array-like, shape=[..., n, n]
+            Tangent vector.
             `vector` is skew-symmetric, in so(n).
-        point : array-like, shape=[..., n, n]
-            `point` is a rank p projector of Gr(n, k).
+        base_point : array-like, shape=[..., n, n]
+            Base point.
+            `base_point` is a rank p projector of Gr(n, k).
 
         Returns
         -------
         exp : array-like, shape=[..., n, n]
+            Riemannian exponential.
         """
         expm = gs.linalg.expm
         mul = Matrices.mul
@@ -116,14 +135,14 @@ class GrassmannianCanonicalMetric(RiemannianMetric):
         Parameters
         ----------
         point : array-like, shape=[..., n, n]
-            Point in the Grassmannian.
+            Point.
         base_point : array-like, shape=[..., n, n]
-            Point in the Grassmannian.
+            Base point.
 
         Returns
         -------
         tangent_vec : array-like, shape=[..., n, n]
-            Tangent vector at `base_point`.
+            Riemannian logarithm, a tangent vector at `base_point`.
 
         References
         ----------

--- a/geomstats/geometry/grassmannian.py
+++ b/geomstats/geometry/grassmannian.py
@@ -107,7 +107,7 @@ class GrassmannianCanonicalMetric(RiemannianMetric):
         Parameters
         ----------
         vector : array-like, shape=[..., n, n]
-            Tangent vector.
+            Tangent vector at base point.
             `vector` is skew-symmetric, in so(n).
         base_point : array-like, shape=[..., n, n]
             Base point.

--- a/geomstats/geometry/grassmannian.py
+++ b/geomstats/geometry/grassmannian.py
@@ -61,7 +61,7 @@ class Grassmannian(EmbeddedManifold):
         point : array-like, shape=[..., n, n]
             Point to be checked.
         tolerance : int
-            Optional, default: TOLERANCE
+            Optional, default: 1e-5.
 
         Returns
         -------

--- a/geomstats/geometry/hyperbolic.py
+++ b/geomstats/geometry/hyperbolic.py
@@ -28,11 +28,13 @@ class Hyperbolic(Manifold):
     ----------
     dim : int
         Dimension of the hyperbolic space.
-    point_type : str, {'extrinsic', 'intrinsic', etc}, optional
+    point_type : str, {'extrinsic', 'intrinsic', etc}
         Default coordinates to represent points in hyperbolic space.
-    scale : int, optional
+        Optional, default: 'extrinsic'.
+    scale : int
         Scale of the hyperbolic space, defined as the set of points
         in Minkowski space whose squared norm is equal to -scale.
+        Optional, default: 1.
     """
 
     default_coords_type = 'extrinsic'
@@ -296,9 +298,10 @@ class Hyperbolic(Manifold):
         ----------
         point : array-like, shape=[..., dim]
             Point to be tested.
-        tolerance : float, optional
+        tolerance : float
             Tolerance at which to evaluate how close the squared norm
             is to the reference value.
+            Optional, default: TOLERANCE.
 
         Returns
         -------
@@ -318,8 +321,9 @@ class Hyperbolic(Manifold):
         ----------
         point : array-like, shape=[..., {dim, dim + 1}]
             Point in hyperbolic space.
-        to_point_type : str, {'extrinsic', 'intrinsic', etc}, optional
+        to_point_type : str, {'extrinsic', 'intrinsic', etc}
             Coordinates type.
+            Optional, default: 'ball'.
 
         Returns
         -------
@@ -362,10 +366,12 @@ class Hyperbolic(Manifold):
 
         Parameters
         ----------
-        n_samples : int, optional
+        n_samples : int
             Number of samples.
-        bound: float, optional
+            Optional, default: 1.
+        bound: float
             Bound defining the hypersquare in which to sample uniformly.
+            Optional, default: 1.
 
         Returns
         -------
@@ -417,8 +423,9 @@ class HyperbolicMetric(RiemannianMetric):
             First tangent vector at base point.
         tangent_vec_b : array-like, shape=[..., dim + 1]
             Second tangent vector at base point.
-        base_point : array-like, shape=[..., dim + 1], optional
+        base_point : array-like, shape=[..., dim + 1]
             Point in hyperbolic space.
+            Optional, default: None.
 
         Returns
         -------
@@ -440,8 +447,9 @@ class HyperbolicMetric(RiemannianMetric):
         ----------
         vector : array-like, shape=[..., dim + 1]
             Vector on the tangent space of the hyperbolic space at base point.
-        base_point : array-like, shape=[..., dim + 1], optional
+        base_point : array-like, shape=[..., dim + 1]
             Point in hyperbolic space in extrinsic coordinates.
+            Optional, default: None.
 
         Returns
         -------
@@ -462,8 +470,9 @@ class HyperbolicMetric(RiemannianMetric):
         ----------
         vector : array-like, shape=[..., dim + 1]
             Vector on the tangent space of the hyperbolic space at base point.
-        base_point : array-like, shape=[..., dim + 1], optional
+        base_point : array-like, shape=[..., dim + 1]
             Point in hyperbolic space in extrinsic coordinates.
+            Optional, default: None.
 
         Returns
         -------
@@ -481,8 +490,9 @@ class HyperbolicMetric(RiemannianMetric):
             First tangent vector at base point.
         tangent_vec_b : array-like, shape=[..., dim + 1]
             Second tangent vector at base point.
-        base_point : array-like, shape=[..., dim + 1], optional
+        base_point : array-like, shape=[..., dim + 1]
             Point in hyperbolic space.
+            Optional, default: None.
 
         Returns
         -------

--- a/geomstats/geometry/hyperboloid.py
+++ b/geomstats/geometry/hyperboloid.py
@@ -51,11 +51,13 @@ class Hyperboloid(Hyperbolic, EmbeddedManifold):
     ----------
     dim : int
         Dimension of the hyperbolic space.
-    point_type : str, {'extrinsic', 'intrinsic'}, optional
+    coords_type : str, {'extrinsic', 'intrinsic'}
         Default coordinates to represent points in hyperbolic space.
-    scale : int, optional
+        Optional, default: 'extrinsic'.
+    scale : int
         Scale of the hyperbolic space, defined as the set of points
         in Minkowski space whose squared norm is equal to -scale.
+        Optional, default: 1.
     """
 
     default_coords_type = 'extrinsic'
@@ -86,10 +88,11 @@ class Hyperboloid(Hyperbolic, EmbeddedManifold):
         tolerance : float, optional
             Tolerance at which to evaluate how close the squared norm
             is to the reference value.
+            Optional, default: TOLERANCE.
 
         Returns
         -------
-        belongs : array-like, shape=[..., 1]
+        belongs : array-like, shape=[...,]
             Array of booleans indicating whether the corresponding points
             belong to the hyperbolic space.
         """
@@ -183,24 +186,32 @@ class Hyperboloid(Hyperbolic, EmbeddedManifold):
         ----------
         point_intrinsic : array-like, shape=[..., dim]
             Point in the embedded manifold in intrinsic coordinates.
+
+        Returns
+        -------
+        point_extrinsic : array-like, shape=[..., dim + 1]
+            Point in the embedded manifold in extrinsic coordinates.
         """
         if self.dim != point_intrinsic.shape[-1]:
             raise NameError("Wrong intrinsic dimension: "
                             + str(point_intrinsic.shape[-1]) + " instead of "
                             + str(self.dim))
-        return\
-            Hyperbolic.change_coordinates_system(point_intrinsic,
-                                                 'intrinsic',
-                                                 'extrinsic')
+        return Hyperbolic.change_coordinates_system(
+            point_intrinsic, 'intrinsic', 'extrinsic')
 
     def extrinsic_to_intrinsic_coords(self, point_extrinsic):
         """Convert from extrinsic to intrinsic coordinates.
 
         Parameters
         ----------
-        point_extrinsic : array-like, shape=[..., dim_embedding]
+        point_extrinsic : array-like, shape=[..., dim + 1]
             Point in the embedded manifold in extrinsic coordinates,
             i. e. in the coordinates of the embedding manifold.
+
+        Returns
+        -------
+        point_intrinsic : array-like, shape=[..., dim]
+            Point in intrinsic coordinates.
         """
         belong_point = self.belongs(point_extrinsic)
         if not gs.all(belong_point):
@@ -218,11 +229,13 @@ class HyperboloidMetric(HyperbolicMetric):
     ----------
     dim : int
         Dimension of the hyperbolic space.
-    point_type : str, {'extrinsic', 'intrinsic', etc}, optional
+    point_type : str, {'extrinsic', 'intrinsic', etc}
         Default coordinates to represent points in hyperbolic space.
-    scale : int, optional
+        Optional, default: 'extrinsic'.
+    scale : int
         Scale of the hyperbolic space, defined as the set of points
         in Minkowski space whose squared norm is equal to -scale.
+        Optional, default: 1.
     """
 
     default_point_type = 'vector'
@@ -244,11 +257,14 @@ class HyperboloidMetric(HyperbolicMetric):
 
         Parameters
         ----------
-        base_point: array-like, shape=[..., dim+1]
+        base_point: array-like, shape=[..., dim + 1]
+            Base point.
+            Optional, default: None.
 
         Returns
         -------
-        inner_prod_mat: array-like, shape=[..., dim+1, dim+1]
+        inner_prod_mat: array-like, shape=[..., dim+1, dim + 1]
+            Inner-product matrix.
         """
         self.embedding_metric.inner_product_matrix(base_point)
 
@@ -266,7 +282,7 @@ class HyperboloidMetric(HyperbolicMetric):
 
         Returns
         -------
-        inner_prod : array-like, shape=[..., 1]
+        inner_prod : array-like, shape=[...,]
             Inner-product of the two tangent vectors.
         """
         inner_prod = self.embedding_metric.inner_product(
@@ -288,7 +304,7 @@ class HyperboloidMetric(HyperbolicMetric):
 
         Returns
         -------
-        sq_norm : array-like, shape=[..., 1]
+        sq_norm : array-like, shape=[...,]
             Squared norm of the vector.
         """
         sq_norm = self.embedding_metric.squared_norm(vector)
@@ -416,7 +432,7 @@ class HyperboloidMetric(HyperbolicMetric):
 
         Returns
         -------
-        dist : array-like, shape=[..., 1]
+        dist : array-like, shape=[...,]
             Geodesic distance between the two points.
         """
         sq_norm_a = self.embedding_metric.squared_norm(point_a)

--- a/geomstats/geometry/hyperboloid.py
+++ b/geomstats/geometry/hyperboloid.py
@@ -88,7 +88,7 @@ class Hyperboloid(Hyperbolic, EmbeddedManifold):
         tolerance : float, optional
             Tolerance at which to evaluate how close the squared norm
             is to the reference value.
-            Optional, default: TOLERANCE.
+            Optional, default: 1e-6.
 
         Returns
         -------

--- a/geomstats/geometry/hypersphere.py
+++ b/geomstats/geometry/hypersphere.py
@@ -63,12 +63,13 @@ class _Hypersphere(EmbeddedManifold):
         ----------
         point : array-like, shape=[..., dim + 1]
             Point in Euclidean space.
-        tolerance : float, optional
-            Tolerance at which to evaluate norm == 1 (default: TOLERANCE).
+        tolerance : floatl
+            Tolerance at which to evaluate norm == 1.
+            Optional, default: TOLERANCE.
 
         Returns
         -------
-        belongs : array-like, shape=[..., 1]
+        belongs : array-like, shape=[...,]
             Boolean evaluating if point belongs to the hypersphere.
         """
         point_dim = gs.shape(point)[-1]
@@ -94,12 +95,12 @@ class _Hypersphere(EmbeddedManifold):
         Parameters
         ----------
         point : array-like, shape=[..., dim + 1]
-            Points on the hypersphere.
+            Point on the hypersphere.
 
         Returns
         -------
         projected_point : array-like, shape=[..., dim + 1]
-            Points in canonical representation chosen for the hypersphere.
+            Point in canonical representation chosen for the hypersphere.
         """
         if not gs.all(self.belongs(point)):
             raise ValueError('Points do not belong to the manifold.')
@@ -299,8 +300,12 @@ class _Hypersphere(EmbeddedManifold):
 
         Parameters
         ----------
-        n_samples : int, optional
+        n_samples : int
             Number of samples.
+            Optional, default: 1.
+        tol : float
+            Tolerance.
+            Optional, default: 1e-6.
 
         Returns
         -------
@@ -337,10 +342,12 @@ class _Hypersphere(EmbeddedManifold):
 
         Parameters
         ----------
-        kappa : int, optional
+        kappa : int
             Kappa parameter of the von Mises distribution.
-        n_samples : int, optional
+            Optional, default: 10.
+        n_samples : int
             Number of samples.
+            Optional, default: 1.
 
         Returns
         -------
@@ -400,7 +407,7 @@ class HypersphereMetric(RiemannianMetric):
 
         Returns
         -------
-        inner_prod : array-like, shape=[..., 1]
+        inner_prod : array-like, shape=[...,]
             Inner-product of the two tangent vectors.
         """
         inner_prod = self.embedding_metric.inner_product(
@@ -654,6 +661,7 @@ class HypersphereMetric(RiemannianMetric):
 
         point_type: str, {'spherical', 'intrinsic', 'extrinsic'}
             Coordinates in which to express the Christoffel symbols.
+            Optional, default: 'spherical'.
 
         Returns
         -------

--- a/geomstats/geometry/hypersphere.py
+++ b/geomstats/geometry/hypersphere.py
@@ -62,15 +62,14 @@ class _Hypersphere(EmbeddedManifold):
         Parameters
         ----------
         point : array-like, shape=[..., dim + 1]
-            Points in Euclidean space.
+            Point in Euclidean space.
         tolerance : float, optional
             Tolerance at which to evaluate norm == 1 (default: TOLERANCE).
 
         Returns
         -------
         belongs : array-like, shape=[..., 1]
-            Array of booleans evaluating if each point belongs to
-            the hypersphere.
+            Boolean evaluating if point belongs to the hypersphere.
         """
         point_dim = gs.shape(point)[-1]
         if point_dim != self.dim + 1:

--- a/geomstats/geometry/hypersphere.py
+++ b/geomstats/geometry/hypersphere.py
@@ -63,9 +63,9 @@ class _Hypersphere(EmbeddedManifold):
         ----------
         point : array-like, shape=[..., dim + 1]
             Point in Euclidean space.
-        tolerance : floatl
+        tolerance : float
             Tolerance at which to evaluate norm == 1.
-            Optional, default: TOLERANCE.
+            Optional, default: 1e-6.
 
         Returns
         -------

--- a/geomstats/geometry/invariant_metric.py
+++ b/geomstats/geometry/invariant_metric.py
@@ -21,11 +21,13 @@ class InvariantMetric(RiemannianMetric):
     Parameters
     ----------
     group : LieGroup
-        The group to equip with the invariant metric
+        Group to equip with the invariant metric
     inner_product_mat_at_identity : array-like, shape=[dim, dim]
-        The matrix that defines the metric at identity.
+        Matrix that defines the metric at identity.
+        Optional, default to identity matrix if None.
     left_or_right : str, {'left', 'right'}
         Wether to use a left or right invariant metric.
+        Optional, default: 'left'.
     """
 
     def __init__(self, group,
@@ -104,8 +106,9 @@ class InvariantMetric(RiemannianMetric):
             First tangent vector at base_point.
         tangent_vec_b : array-like, shape=[..., dim]
             Second tangent vector at base_point.
-        base_point : array-like, shape=[..., dim], optional
-            Point in the group (the default is identity).
+        base_point : array-like, shape=[..., dim]
+            Point in the group.
+            Optional, default to identity if None.
 
         Returns
         -------
@@ -148,7 +151,7 @@ class InvariantMetric(RiemannianMetric):
         Returns
         -------
         metric_mat : array-like, shape=[..., dim, dim]
-            The metric matrix at base_point.
+            Metric matrix at base_point.
         """
         if self.group.default_point_type == 'matrix':
             raise NotImplementedError(
@@ -237,6 +240,7 @@ class InvariantMetric(RiemannianMetric):
             Tangent vector at a base point.
         base_point : array-like, shape=[..., dim]
             Point in the group.
+            Optional, default to identity if None.
 
         Returns
         -------

--- a/geomstats/geometry/invariant_metric.py
+++ b/geomstats/geometry/invariant_metric.py
@@ -24,7 +24,7 @@ class InvariantMetric(RiemannianMetric):
         Group to equip with the invariant metric
     inner_product_mat_at_identity : array-like, shape=[dim, dim]
         Matrix that defines the metric at identity.
-        Optional, default to identity matrix if None.
+        Optional, defaults to identity matrix if None.
     left_or_right : str, {'left', 'right'}
         Wether to use a left or right invariant metric.
         Optional, default: 'left'.
@@ -108,7 +108,7 @@ class InvariantMetric(RiemannianMetric):
             Second tangent vector at base_point.
         base_point : array-like, shape=[..., dim]
             Point in the group.
-            Optional, default to identity if None.
+            Optional, defaults to identity if None.
 
         Returns
         -------
@@ -240,7 +240,7 @@ class InvariantMetric(RiemannianMetric):
             Tangent vector at a base point.
         base_point : array-like, shape=[..., dim]
             Point in the group.
-            Optional, default to identity if None.
+            Optional, defaults to identity if None.
 
         Returns
         -------

--- a/geomstats/geometry/lie_algebra.py
+++ b/geomstats/geometry/lie_algebra.py
@@ -40,11 +40,14 @@ class MatrixLieAlgebra:
         Parameters
         ----------
         matrix_a : array-like, shape=[..., n, n]
+            Matrix.
         matrix_b : array-like, shape=[..., n, n]
+            Matrix.
 
         Returns
         -------
         bracket : shape=[..., n, n]
+            Lie bracket.
         """
         return gs.matmul(matrix_a, matrix_b) - gs.matmul(matrix_b, matrix_a)
 
@@ -63,9 +66,11 @@ class MatrixLieAlgebra:
         Parameters
         ----------
         matrix_a, matrix_b : array-like, shape=[..., n, n]
+            Matrices.
         order : int
             The order to which the approximation is calculated. Note that this
             is NOT the same as using only e_i with i < order.
+            Optional, default 2.
 
         References
         ----------
@@ -95,15 +100,17 @@ class MatrixLieAlgebra:
         return result
 
     def basis_representation(self, matrix_representation):
-        """Compute the coefficients of matrices in the given base.
+        """Compute the coefficients of matrices in the given basis.
 
         Parameters
         ----------
         matrix_representation : array-like, shape=[..., n, n]
+            Matrix.
 
         Returns
         -------
         basis_representation : array-like, shape=[..., dim]
+            Coefficients in the basis.
         """
         raise NotImplementedError("basis_representation not implemented.")
 
@@ -116,10 +123,12 @@ class MatrixLieAlgebra:
         Parameters
         ----------
         basis_representation : array-like, shape=[..., dim]
+            Coefficients in the basis.
 
         Returns
         -------
         matrix_representation : array-like, shape=[..., n, n]
+            Matrix.
         """
         basis_representation = gs.to_ndarray(basis_representation, to_ndim=2)
 

--- a/geomstats/geometry/lie_group.py
+++ b/geomstats/geometry/lie_group.py
@@ -191,7 +191,7 @@ class LieGroup(Manifold):
         Parameters
         ----------
         tangent_vec : array-like, shape=[..., {dim, [n, n]}]
-            Tangent vector.
+            Tangent vector at base point.
 
         Returns
         -------
@@ -208,7 +208,7 @@ class LieGroup(Manifold):
         Parameters
         ----------
         tangent_vec : array-like, shape=[..., {dim, [n, n]}]
-            Tangent vector.
+            Tangent vector at base point.
         base_point : array-like, shape=[..., {dim, [n, n]}]
             Base point.
 
@@ -241,7 +241,7 @@ class LieGroup(Manifold):
         Parameters
         ----------
         tangent_vec : array-like, shape=[..., {dim, [n, n]}]
-            Tangent vector.
+            Tangent vector at base point.
         base_point : array-like, shape=[..., {dim, [n, n]}]
             Base point.
             Optional, default: self.identity
@@ -365,9 +365,9 @@ class LieGroup(Manifold):
         Parameters
         ----------
         tangent_vector_a : array-like, shape=[..., n, n]
-            Tangent vector.
+            Tangent vector at base point.
         tangent_vector_b : array-like, shape=[..., n, n]
-            Tangent vector.
+            Tangent vector at base point.
         base_point : array-like, shape=[..., n, n]
             Base point.
 
@@ -438,7 +438,7 @@ class LieGroup(Manifold):
         Returns
         -------
         tangent_vec : array-like, shape=[..., n, n]
-            Tangent vector.
+            Tangent vector at base point.
         """
         if base_point is None:
             return self._to_lie_algebra(vector)

--- a/geomstats/geometry/lie_group.py
+++ b/geomstats/geometry/lie_group.py
@@ -17,16 +17,19 @@ def loss(y_pred, y_true, group, metric=None):
     Parameters
     ----------
     y_pred : array-like, shape=[..., {dim, [n, n]}]
+        Prediction.
     y_true : array-like, shape=[..., {dim, [n, n]}]
-        shape has to match y_pred
+        Ground-truth.
+        Shape has to match y_pred.
     group : LieGroup
-    metric : RiemannianMetric, optional
-        default: the left invariant metric of the Lie group
+    metric : RiemannianMetric
+        Riemannian metric.
+        Optional, default to the left invariant metric if None.
 
     Returns
     -------
     loss : array-like, shape=[..., {dim, [n, n]}]
-        the squared (geodesic) distance between y_pred and y_true
+        Squared (geodesic) distance between y_pred and y_true
     """
     if metric is None:
         metric = group.left_canonical_metric
@@ -40,16 +43,19 @@ def grad(y_pred, y_true, group, metric=None):
     Parameters
     ----------
     y_pred : array-like, shape=[..., {dim, [n, n]}]
+        Prediction.
     y_true : array-like, shape=[..., {dim, [n, n]}]
-        shape has to match y_pred
+        Ground-truth.
+        Shape has to match y_pred.
     group : LieGroup
-    metric : RiemannianMetric, optional
-        default: the left invariant metric of the Lie group
+    metric : RiemannianMetric
+        Riemannian metric.
+        optional, default to the left invariant metric if None.
 
     Returns
     -------
     grad : array-like, shape=[..., {dim, [n, n]}]
-        tangent vector at point `y_pred`
+        Tangent vector at point `y_pred`.
     """
     if metric is None:
         metric = group.left_canonical_metric
@@ -67,6 +73,14 @@ class LieGroup(Manifold):
     If point_type is 'matrix' the format of the inputs is
     [..., n, n] where n is the parameter of GL(n) e.g. the amount of rows
     and columns of the matrix.
+
+    Parameters
+    ----------
+    dim : int
+        Dimension of the Lie group.
+    default_point_type : str, {'vector', 'matrix'}
+        Point type.
+        Optional, default: 'vector'.
     """
 
     def __init__(self, dim, default_point_type='vector', **kwargs):
@@ -92,12 +106,14 @@ class LieGroup(Manifold):
 
         Parameters
         ----------
-        point_type : str, {'matrix', 'vector'}, optional
-            default: the default point type
+        point_type : str, {'matrix', 'vector'}
+            Point type.
+            Optional, default: None.
 
         Returns
         -------
         identity : array-like, shape={[dim], [n, n]}
+            Identity of the Lie group.
         """
         raise NotImplementedError(
             'The Lie group identity is not implemented.'
@@ -113,14 +129,14 @@ class LieGroup(Manifold):
         Parameters
         ----------
         point_a : array-like, shape=[..., {dim, [n, n]}]
-            the left factor in the product
+            Left factor in the product.
         point_b : array-like, shape=[..., {dim, [n, n]}]
-            the right factor in the product
+            Right factor in the product.
 
         Returns
         -------
         composed : array-like, shape=[..., {dim, [n, n]}]
-            the product of point_a and point_b along the first dim
+            Product of point_a and point_b along the first dimension.
         """
         raise NotImplementedError(
             'The Lie group composition is not implemented.'
@@ -133,12 +149,12 @@ class LieGroup(Manifold):
         Parameters
         ----------
         point : array-like, shape=[..., {dim, [n, n]}]
-            the points to be inverted
+            Point to be inverted.
 
         Returns
         -------
         inverse : array-like, shape=[..., {dim, [n, n]}]
-            the inverted point
+            Inverted point.
         """
         raise NotImplementedError('The Lie group inverse is not implemented.')
 
@@ -151,15 +167,16 @@ class LieGroup(Manifold):
         Parameters
         ----------
         point : array-like, shape=[..., {dim, [n, n]]
-            the points to be inverted
+            Point to be inverted.
         left_or_right : str, {'left', 'right'}
-            indicate whether to calculate the differential of left or right
-            translations
+            Indicate whether to calculate the differential of left or right
+            translations.
+            Optional, default: 'left'.
 
         Returns
         -------
-        jacobian :
-            the jacobian of the left/right translation by point
+        jacobian : array-like, shape=[..., dim, dim]
+            Jacobian of the left/right translation by point.
         """
         if self.default_point_type == 'matrix':
             return point
@@ -174,11 +191,12 @@ class LieGroup(Manifold):
         Parameters
         ----------
         tangent_vec : array-like, shape=[..., {dim, [n, n]}]
-            the tangent vector to exponentiate
+            Tangent vector.
 
         Returns
         -------
         point : array-like, shape=[..., {dim, [n, n]}]
+            Group exponential.
         """
         raise NotImplementedError(
             'The group exponential from the identity is not implemented.'
@@ -190,12 +208,14 @@ class LieGroup(Manifold):
         Parameters
         ----------
         tangent_vec : array-like, shape=[..., {dim, [n, n]}]
+            Tangent vector.
         base_point : array-like, shape=[..., {dim, [n, n]}]
+            Base point.
 
         Returns
         -------
         exp : array-like, shape=[..., {dim, [n, n]}]
-            the computed exponential
+            Group exponential.
         """
         if self.default_point_type == 'vector':
             jacobian = self.jacobian_translation(
@@ -221,13 +241,15 @@ class LieGroup(Manifold):
         Parameters
         ----------
         tangent_vec : array-like, shape=[..., {dim, [n, n]}]
+            Tangent vector.
         base_point : array-like, shape=[..., {dim, [n, n]}]
-            default: self.identity
+            Base point.
+            Optional, default: self.identity
 
         Returns
         -------
         result : array-like, shape=[..., {dim, [n, n]}]
-            The exponentiated tangent vector
+            Group exponential.
         """
         identity = self.get_identity()
 
@@ -248,10 +270,12 @@ class LieGroup(Manifold):
         Parameters
         ----------
         point : array-like, shape=[..., {dim, [n, n]}]
+            Point.
 
         Returns
         -------
         tangent_vec : array-like, shape=[..., {dim, [n, n]}]
+            Group logarithm.
         """
         raise NotImplementedError(
             'The group logarithm from the identity is not implemented.'
@@ -263,11 +287,14 @@ class LieGroup(Manifold):
         Parameters
         ----------
         point : array-like, shape=[..., {dim, [n, n]}]
+            Point.
         base_point : array-like, shape=[..., {dim, [n, n]}]
+            Base point.
 
         Returns
         -------
         tangent_vec : array-like, shape=[..., {dim, [n, n]}]
+            Group logarithm.
         """
         if self.default_point_type == 'vector':
             jacobian = self.jacobian_translation(
@@ -291,11 +318,15 @@ class LieGroup(Manifold):
         Parameters
         ----------
         point : array-like, shape=[..., {dim, [n, n]}]
+            Point.
         base_point : array-like, shape=[..., {dim, [n, n]}]
+            Base point.
+            Optional, default to identity if None.
 
         Returns
         -------
         tangent_vec : array-like, shape=[..., {dim, [n, n]}]
+            Group logarithm.
         """
         # TODO(ninamiolane): Build a standalone decorator that *only*
         # deals with point_type None and base_point None
@@ -313,7 +344,13 @@ class LieGroup(Manifold):
         return result
 
     def add_metric(self, metric):
-        """Add a metric to the instance's list of metrics."""
+        """Add a metric to the instance's list of metrics.
+
+        Parameters
+        ----------
+        metric : RiemannianMetric
+            Metric to add.
+        """
         self.metrics.append(metric)
 
     def lie_bracket(
@@ -327,13 +364,17 @@ class LieGroup(Manifold):
 
         Parameters
         ----------
-        tangent_vector_a : shape=[..., n, n]
-        tangent_vector_b : shape=[..., n, n]
+        tangent_vector_a : array-like, shape=[..., n, n]
+            Tangent vector.
+        tangent_vector_b : array-like, shape=[..., n, n]
+            Tangent vector.
         base_point : array-like, shape=[..., n, n]
+            Base point.
 
         Returns
         -------
         bracket : array-like, shape=[..., n, n]
+            Lie bracket.
         """
         if base_point is None:
             base_point = self.get_identity(point_type=self.default_point_type)
@@ -348,14 +389,9 @@ class LieGroup(Manifold):
         return first_term - second_term
 
     def _is_in_lie_algebra(self, tangent_vec, atol=ATOL):
-        """Check wether a tangent vector belongs to the lie algebra.
-
-        This method could also be in a separate class for the Lie algebra.
-
-        """
+        """Check wether a tangent vector belongs to the lie algebra."""
         raise NotImplementedError(
-            'The Lie Algebra belongs method is not implemented'
-        )
+            'The Lie Algebra belongs method is not implemented')
 
     def is_tangent(self, vector, base_point=None, atol=ATOL):
         """Check whether the vector is tangent at base_point.
@@ -402,6 +438,7 @@ class LieGroup(Manifold):
         Returns
         -------
         tangent_vec : array-like, shape=[..., n, n]
+            Tangent vector.
         """
         if base_point is None:
             return self._to_lie_algebra(vector)

--- a/geomstats/geometry/lie_group.py
+++ b/geomstats/geometry/lie_group.py
@@ -24,7 +24,7 @@ def loss(y_pred, y_true, group, metric=None):
     group : LieGroup
     metric : RiemannianMetric
         Riemannian metric.
-        Optional, default to the left invariant metric if None.
+        Optional, defaults to the left invariant metric if None.
 
     Returns
     -------
@@ -50,7 +50,7 @@ def grad(y_pred, y_true, group, metric=None):
     group : LieGroup
     metric : RiemannianMetric
         Riemannian metric.
-        optional, default to the left invariant metric if None.
+        optional, defaults to the left invariant metric if None.
 
     Returns
     -------
@@ -321,7 +321,7 @@ class LieGroup(Manifold):
             Point.
         base_point : array-like, shape=[..., {dim, [n, n]}]
             Base point.
-            Optional, default to identity if None.
+            Optional, defaults to identity if None.
 
         Returns
         -------

--- a/geomstats/geometry/manifold.py
+++ b/geomstats/geometry/manifold.py
@@ -19,8 +19,10 @@ class Manifold:
         Dimension of the manifold.
     default_point_type : str, {\'vector\', \'matrix\'}
         Point type.
+        Optional, default: 'vector'.
     default_coords_type : str, {\'intrinsic\', \'extrinsic\', etc}
         Coordinate type.
+        Optional, default: 'intrinsic'.
     """
 
     def __init__(
@@ -58,6 +60,10 @@ class Manifold:
             Vector.
         base_point : array-like, shape=[..., dim]
             Point on the manifold.
+            Optional, default: none.
+        atol : float
+            Absolute tolerance.
+            Optional, default: ATOL.
 
         Returns
         -------

--- a/geomstats/geometry/manifold.py
+++ b/geomstats/geometry/manifold.py
@@ -11,7 +11,17 @@ ATOL = 1e-6
 
 
 class Manifold:
-    """Class for manifolds."""
+    r"""Class for manifolds.
+
+    Parameters
+    ----------
+    dim : int
+        Dimension of the manifold.
+    default_point_type : str, {\'vector\', \'matrix\'}
+        Point type.
+    default_coords_type : str, {\'intrinsic\', \'extrinsic\', etc}
+        Coordinate type.
+    """
 
     def __init__(
             self, dim, default_point_type='vector',
@@ -30,11 +40,12 @@ class Manifold:
         Parameters
         ----------
         point : array-like, shape=[..., dim]
-                 Input points.
+            Point to evaluate.
 
         Returns
         -------
         belongs : array-like, shape=[...,]
+            Boolean evaluating if point belongs to the manifold.
         """
         raise NotImplementedError('belongs is not implemented.')
 
@@ -80,11 +91,12 @@ class Manifold:
         Parameters
         ----------
         point : array-like, shape=[..., dim]
-                 Input points.
+            Point.
 
         Returns
         -------
         regularized_point : array-like, shape=[..., dim]
+            Regularized point.
         """
         regularized_point = point
         return regularized_point

--- a/geomstats/geometry/manifold.py
+++ b/geomstats/geometry/manifold.py
@@ -63,7 +63,7 @@ class Manifold:
             Optional, default: none.
         atol : float
             Absolute tolerance.
-            Optional, default: ATOL.
+            Optional, default: 1e-6.
 
         Returns
         -------

--- a/geomstats/geometry/matrices.py
+++ b/geomstats/geometry/matrices.py
@@ -12,7 +12,13 @@ TOLERANCE = 1e-5
 
 
 class Matrices(Manifold):
-    """Class for the space of matrices (m, n)."""
+    """Class for the space of matrices (m, n).
+
+    Parameters
+    ----------
+    m, n : int
+        Integers representing the shapes of the matrices: m x n.
+    """
 
     def __init__(self, m, n):
         super(Matrices, self).__init__(dim=m * n)
@@ -24,15 +30,17 @@ class Matrices(Manifold):
         self.metric = MatricesMetric(m, n)
 
     def belongs(self, point):
-        """Check if point belongs to the Matrix space.
+        """Check if point belongs to the Matrices space.
 
         Parameters
         ----------
         point : array-like, shape=[..., m, n]
+            Point to be checked.
 
         Returns
         -------
-        belongs : boolean
+        belongs : array-like, shape=[...,]
+            Boolean evaluating if point belongs to the Matrices space.
         """
         point = gs.to_ndarray(point, to_ndim=3)
         _, mat_dim_1, mat_dim_2 = point.shape
@@ -45,12 +53,17 @@ class Matrices(Manifold):
         Parameters
         ----------
         mat_a : array-like, shape=[..., dim1, dim2]
+            Matrix.
         mat_b : array-like, shape=[..., dim2, dim3]
-        atol
+            Matrix.
+        atol : float
+            Tolerance.
+            Optional, default: TOLERANCE.
 
         Returns
         -------
-        eq : array-like boolean, shape=[...,]
+        eq : array-like, shape=[...,]
+            Boolean evaluating if the matrices are close.
         """
         is_vectorized = \
             (gs.ndim(gs.array(mat_a)) == 3) or (gs.ndim(gs.array(mat_b)) == 3)
@@ -59,33 +72,40 @@ class Matrices(Manifold):
 
     @staticmethod
     def mul(*args):
-        """Calculate the product of matrices a1, ..., an.
+        """Compute the product of matrices a1, ..., an.
 
         Parameters
         ----------
         a1 : array-like, shape=[..., dim_1, dim_2]
+            Matrix.
         a2 : array-like, shape=[..., dim_2, dim_3]
+            Matrix.
         ...
         an : array-like, shape=[..., dim_n-1, dim_n]
+            Matrix.
 
         Returns
         -------
         mul : array-like, shape=[..., dim_1, dim_n]
+            Result of the product of matrices.
         """
         return reduce(gs.matmul, args)
 
     @classmethod
     def bracket(cls, mat_a, mat_b):
-        """Calculate the commutator of a and b, i.e. `[a, b] = ab - ba`.
+        """Compute the commutator of a and b, i.e. `[a, b] = ab - ba`.
 
         Parameters
         ----------
-        mat_a : array-like, shape=[..., dim, dim]
-        mat_b : array-like, shape=[..., dim, dim]
+        mat_a : array-like, shape=[..., n, n]
+            Matrix.
+        mat_b : array-like, shape=[..., n, n]
+            Matrix.
 
         Returns
         -------
-        mat_c : array-like, shape=[..., dim, dim]
+        mat_c : array-like, shape=[..., n, n]
+            Commutator.
         """
         return cls.mul(mat_a, mat_b) - cls.mul(mat_b, mat_a)
 
@@ -95,11 +115,13 @@ class Matrices(Manifold):
 
         Parameters
         ----------
-        mat : array-like, shape=[..., dim, dim]
+        mat : array-like, shape=[..., n, n]
+            Matrix.
 
         Returns
         -------
-        transpose : array-like, shape=[..., dim, dim]
+        transpose : array-like, shape=[..., n, n]
+            Transposed matrix.
         """
         is_vectorized = (gs.ndim(gs.array(mat)) == 3)
         axes = (0, 2, 1) if is_vectorized else (1, 0)
@@ -112,27 +134,34 @@ class Matrices(Manifold):
         Parameters
         ----------
         mat : array-like, shape=[..., n, n]
-        atol : float, absolute tolerance. defaults to TOLERANCE
+            Matrix.
+        atol : float
+            Absolute tolerance.
+            Optional, default: TOLERANCE.
 
         Returns
         -------
-        is_sym : array-like boolean, shape=[...,]
+        is_sym : array-like, shape=[...,]
+            Boolean evaluating if the matrix is symmetric.
         """
         return cls.equal(mat, cls.transpose(mat), atol)
 
     @classmethod
     def is_skew_symmetric(cls, mat, atol=TOLERANCE):
-        """
-        Check if a matrix is skew symmetric.
+        """Check if a matrix is skew symmetric.
 
         Parameters
         ----------
         mat : array-like, shape=[..., n, n]
-        atol : float, absolute tolerance. defaults to TOLERANCE
+            Matrix.
+        atol : float
+            Absolute tolerance.
+            Optional, default: TOLERANCE.
 
         Returns
         -------
-        is_skew_sym : array-like boolean, shape=[...,]
+        is_skew_sym : array-like, shape=[...,]
+            Boolean evaluating if the matrix is skew-symmetric.
         """
         return cls.equal(mat, - cls.transpose(mat), atol)
 
@@ -143,10 +172,12 @@ class Matrices(Manifold):
         Parameters
         ----------
         mat : array-like, shape=[..., n, n]
+            Matrix.
 
         Returns
         -------
         sym : array-like, shape=[..., n, n]
+            Symmetric matrix.
         """
         return 1 / 2 * (mat + cls.transpose(mat))
 
@@ -158,25 +189,31 @@ class Matrices(Manifold):
         Parameters
         ----------
         mat : array-like, shape=[..., n, n]
+            Matrix.
 
         Returns
         -------
         skew_sym : array-like, shape=[..., n, n]
+            Skew-symmetric matrix.
         """
         return 1 / 2 * (mat - cls.transpose(mat))
 
     def random_uniform(self, n_samples=1, bound=1.):
-        """Generate n samples from a uniform distribution.
+        """Sample from a uniform distribution.
 
         Parameters
         ----------
         n_samples : int
-            Number of samples to generate.
+            Number of samples.
+            Optional, default: 1.
+        bound : float
+            Bound.
+            Optional, default: 1.
 
         Returns
         -------
-        point : array-like
-            Point sampled.
+        point : array-like, shape=[m, n] or [n_samples, m, n]
+            Sample.
         """
         m, n = self.m, self.n
         size = (n_samples, m, n) if n_samples != 1 else (m, n)
@@ -192,17 +229,26 @@ class Matrices(Manifold):
         Parameters
         ----------
         mat_1 : array-like, shape=[..., n, n]
+            Matrix.
         mat_2 : array-like, shape=[..., n, n]
+            Matrix.
 
         Returns
         -------
         cong : array-like, shape=[..., n, n]
+            Result of the congruent action.
         """
         return cls.mul(mat_2, mat_1, cls.transpose(mat_2))
 
 
 class MatricesMetric(RiemannianMetric):
-    """Euclidean metric on matrices given by Frobenius inner product."""
+    """Euclidean metric on matrices given by Frobenius inner-product.
+
+    Parameters
+    ----------
+    m, n : int
+        Integers representing the shapes of the matrices: m x n.
+    """
 
     def __init__(self, m, n):
         dimension = m * n
@@ -211,18 +257,22 @@ class MatricesMetric(RiemannianMetric):
             signature=(dimension, 0, 0))
 
     def inner_product(self, tangent_vec_a, tangent_vec_b, base_point=None):
-        """Compute Frobenius inner product of two tan vecs at `base_point`.
+        """Compute Frobenius inner-product of two tan vecs at `base_point`.
 
         Parameters
         ----------
         tangent_vec_a : array-like, shape=[..., m, n]
+            Tangent vector.
         tangent_vec_b : array-like, shape=[..., m, n]
-        base_point : array-like, shape=[..., m, n], optional
+            Tangent vector.
+        base_point : array-like, shape=[..., m, n]
+            Base point.
+            Optional, default: None.
 
         Returns
         -------
         inner_prod : array-like, shape=[...,]
-            Frobenius inner product of tangent_vec_a and tangent_vec_b.
+            Frobenius inner-product of tangent_vec_a and tangent_vec_b.
         """
         inner_prod = gs.einsum(
             '...ij,...ij->...', tangent_vec_a, tangent_vec_b)

--- a/geomstats/geometry/matrices.py
+++ b/geomstats/geometry/matrices.py
@@ -58,7 +58,7 @@ class Matrices(Manifold):
             Matrix.
         atol : float
             Tolerance.
-            Optional, default: TOLERANCE.
+            Optional, default: 1e-5.
 
         Returns
         -------
@@ -137,7 +137,7 @@ class Matrices(Manifold):
             Matrix.
         atol : float
             Absolute tolerance.
-            Optional, default: TOLERANCE.
+            Optional, default: 1e-5.
 
         Returns
         -------
@@ -156,7 +156,7 @@ class Matrices(Manifold):
             Matrix.
         atol : float
             Absolute tolerance.
-            Optional, default: TOLERANCE.
+            Optional, default: 1e-5.
 
         Returns
         -------

--- a/geomstats/geometry/minkowski.py
+++ b/geomstats/geometry/minkowski.py
@@ -6,7 +6,13 @@ from geomstats.geometry.riemannian_metric import RiemannianMetric
 
 
 class Minkowski(Manifold):
-    """Class for Minkowski Space."""
+    """Class for Minkowski space.
+
+    Parameters
+    ----------
+    dim : int
+       Dimension of Minkowski space.
+    """
 
     def __init__(self, dim):
         super(Minkowski, self).__init__(dim=dim)
@@ -18,11 +24,12 @@ class Minkowski(Manifold):
         Parameters
         ----------
         point : array-like, shape=[..., dim]
-            Input points.
+            Point to evaluate.
 
         Returns
         -------
         belongs : array-like, shape=[...,]
+            Boolean evaluating if point belongs to the Minkowski space.
         """
         point_dim = point.shape[-1]
         belongs = point_dim == self.dim
@@ -32,17 +39,21 @@ class Minkowski(Manifold):
         return belongs
 
     def random_uniform(self, n_samples=1, bound=1.):
-        """Sample in the Minkowski space with the uniform distribution.
+        """Sample in the Minkowski space from the uniform distribution.
 
         Parameters
         ----------
-        n_samples: int, optional
-        bound: float, optional
+        n_samples: int
+            Number of samples.
+            Optional, default: 1
+        bound : float
+            Side of hypercube support of the uniform distribution.
+            Optional, default: 1
 
         Returns
         -------
         points : array-like, shape=[..., dim]
-            Sampled points.
+            Sample.
         """
         size = (self.dim,)
         if n_samples != 1:
@@ -56,6 +67,11 @@ class MinkowskiMetric(RiemannianMetric):
     """Class for the pseudo-Riemannian Minkowski metric.
 
     The metric is flat: the inner product is independent of the base point.
+
+    Parameters
+    ----------
+    dim : int
+        Dimension of the Minkowski space.
     """
 
     def __init__(self, dim):
@@ -69,10 +85,12 @@ class MinkowskiMetric(RiemannianMetric):
         Parameters
         ----------
         base_point : array-like, shape=[..., dim]
+            Base point.
 
         Returns
         -------
         inner_prod_mat : array-like, shape=[..., dim, dim]
+            Inner-product matrix.
         """
         inner_prod_mat = gs.eye(self.dim - 1, self.dim - 1)
         first_row = gs.array([0.] * (self.dim - 1))
@@ -94,11 +112,14 @@ class MinkowskiMetric(RiemannianMetric):
         Parameters
         ----------
         tangent_vec : array-like, shape=[..., dim]
+            Tangent vector.
         base_point : array-like, shape=[..., dim]
+            Base point.
 
         Returns
         -------
         exp : array-like, shape=[..., dim]
+            Riemannian exponential.
         """
         exp = base_point + tangent_vec
         return exp
@@ -111,11 +132,14 @@ class MinkowskiMetric(RiemannianMetric):
         Parameters
         ----------
         point : array-like, shape=[..., dim]
+            Point.
         base_point : array-like, shape=[..., dim]
+            Base point.
 
         Returns
         -------
         log : array-like, shape=[..., dim]
+            Riemannian logarithm.
         """
         log = point - base_point
         return log

--- a/geomstats/geometry/minkowski.py
+++ b/geomstats/geometry/minkowski.py
@@ -112,7 +112,7 @@ class MinkowskiMetric(RiemannianMetric):
         Parameters
         ----------
         tangent_vec : array-like, shape=[..., dim]
-            Tangent vector.
+            Tangent vector at base point.
         base_point : array-like, shape=[..., dim]
             Base point.
 

--- a/geomstats/geometry/poincare_ball.py
+++ b/geomstats/geometry/poincare_ball.py
@@ -22,9 +22,10 @@ class PoincareBall(Hyperbolic):
     ----------
     dim : int
         Dimension of the hyperbolic space.
-    scale : int, optional
+    scale : int
         Scale of the hyperbolic space, defined as the set of points
         in Minkowski space whose squared norm is equal to -scale.
+        Optional, default: 1.
     """
 
     default_coords_type = 'ball'
@@ -51,6 +52,7 @@ class PoincareBall(Hyperbolic):
         tolerance : float, optional
             Tolerance at which to evaluate how close the squared norm
             is to the reference value.
+            Optional, default: TOLERANCE.
 
         Returns
         -------
@@ -68,9 +70,10 @@ class PoincareBallMetric(RiemannianMetric):
     ----------
     dim : int
         Dimension of the hyperbolic space.
-    scale : int, optional
+    scale : int
         Scale of the hyperbolic space, defined as the set of points
         in Minkowski space whose squared norm is equal to -scale.
+        Optional, default 1.
     """
 
     default_point_type = 'vector'
@@ -292,10 +295,13 @@ class PoincareBallMetric(RiemannianMetric):
         Parameters
         ----------
         base_point : array-like, shape=[..., dim]
+            Base point.
+            Optional, default to zeros if None.
 
         Returns
         -------
         inner_prod_mat : array-like, shape=[..., dim, dim]
+            Inner-product matrix.
         """
         if base_point is None:
             base_point = gs.zeros((1, self.dim))

--- a/geomstats/geometry/poincare_ball.py
+++ b/geomstats/geometry/poincare_ball.py
@@ -52,7 +52,7 @@ class PoincareBall(Hyperbolic):
         tolerance : float, optional
             Tolerance at which to evaluate how close the squared norm
             is to the reference value.
-            Optional, default: TOLERANCE.
+            Optional, default: 1e-6.
 
         Returns
         -------

--- a/geomstats/geometry/poincare_ball.py
+++ b/geomstats/geometry/poincare_ball.py
@@ -296,7 +296,7 @@ class PoincareBallMetric(RiemannianMetric):
         ----------
         base_point : array-like, shape=[..., dim]
             Base point.
-            Optional, default to zeros if None.
+            Optional, defaults to zeros if None.
 
         Returns
         -------

--- a/geomstats/geometry/poincare_polydisk.py
+++ b/geomstats/geometry/poincare_polydisk.py
@@ -90,7 +90,7 @@ class PoincarePolydisk(ProductManifold):
         Returns
         -------
         tangent_vec : array-like, shape=[..., n_disks, dim + 1]
-            Tangent vector.
+            Tangent vector at base point.
         """
         n_disks = base_point.shape[1]
         hyperbolic_space = Hyperboloid(2, self.coords_type)

--- a/geomstats/geometry/poincare_polydisk.py
+++ b/geomstats/geometry/poincare_polydisk.py
@@ -21,10 +21,18 @@ from geomstats.geometry.product_riemannian_metric \
 
 
 class PoincarePolydisk(ProductManifold):
-    """Class for the Poincare polydisk.
+    r"""Class for the Poincare polydisk.
 
     The Poincare polydisk is a direct product of n Poincare disks,
     i.e. hyperbolic spaces of dimension 2.
+
+    Parameters
+    ----------
+    n_disks : int
+        Number of disks.
+    coords_type : str, {\'intrinsic\', \'extrinsic\', etc}
+        Coordinate type.
+        Optional, default: \'extrinsic\'.
     """
 
     default_coords_type = 'extrinsic'
@@ -52,10 +60,12 @@ class PoincarePolydisk(ProductManifold):
         Parameters
         ----------
         point_intrinsic : array-like, shape=[..., n_disk, dim]
+            Point in intrinsic coordinates.
 
         Returns
         -------
         point_extrinsic : array-like, shape=[..., n_disks, dim + 1]
+            Point in extrinsic coordinates.
         """
         n_disks = point_intrinsic.shape[1]
         point_extrinsic = gs.stack(
@@ -73,11 +83,14 @@ class PoincarePolydisk(ProductManifold):
         Parameters
         ----------
         vector : array-like, shape=[..., n_disks, dim + 1]
+            Vector.
         base_point : array-like, shape=[..., n_disks, dim + 1]
+            Base point.
 
         Returns
         -------
         tangent_vec : array-like, shape=[..., n_disks, dim + 1]
+            Tangent vector.
         """
         n_disks = base_point.shape[1]
         hyperbolic_space = Hyperboloid(2, self.coords_type)
@@ -89,7 +102,7 @@ class PoincarePolydisk(ProductManifold):
 
 
 class PoincarePolydiskMetric(ProductRiemannianMetric):
-    """Class defining the Poincare polydisk metric.
+    r"""Class defining the Poincare polydisk metric.
 
     The Poincare polydisk metric is a product of n Poincare metrics,
     each of them being multiplied by a specific constant factor (see
@@ -97,6 +110,14 @@ class PoincarePolydiskMetric(ProductRiemannianMetric):
 
     This metric comes from a model used to represent
     stationary complex autoregressive Gaussian signals.
+
+    Parameters
+    ----------
+    n_disks : int
+        Number of disks.
+    coords_type : str, {\'intrinsic\', \'extrinsic\', etc}
+        Coordinate type.
+        Optional, default: \'extrinsic\'.
 
     References
     ----------

--- a/geomstats/geometry/product_manifold.py
+++ b/geomstats/geometry/product_manifold.py
@@ -32,6 +32,10 @@ class ProductManifold(Manifold):
         List of manifolds in the product.
     default_point_type : str, {'vector', 'matrix'}
         Default representation of points.
+        Optional, default: 'vector'.
+    n_jobs : int
+        Number of jobs for parallel computing.
+        Optional, default: 1.
     """
 
     # FIXME(nguigs): This only works for 1d points
@@ -80,10 +84,11 @@ class ProductManifold(Manifold):
             Point.
         point_type : str, {'vector', 'matrix'}
             Representation of point.
+            Optional, default: None.
 
         Returns
         -------
-        belongs : array-like, shape=[..., 1]
+        belongs : array-like, shape=[...,]
             Array of booleans evaluating if the corresponding points
             belong to the manifold.
         """
@@ -115,6 +120,7 @@ class ProductManifold(Manifold):
             Point to be regularized.
         point_type : str, {'vector', 'matrix'}
             Representation of point.
+            Optional, default: None.
 
         Returns
         -------
@@ -147,6 +153,7 @@ class ProductManifold(Manifold):
             Number of samples.
         point_type : str, {'vector', 'matrix'}
             Representation of point.
+            Optional, default: None.
 
         Returns
         -------

--- a/geomstats/geometry/product_manifold.py
+++ b/geomstats/geometry/product_manifold.py
@@ -89,8 +89,7 @@ class ProductManifold(Manifold):
         Returns
         -------
         belongs : array-like, shape=[...,]
-            Array of booleans evaluating if the corresponding points
-            belong to the manifold.
+            Boolean evaluating if the point belongs to the manifold.
         """
         if point_type is None:
             point_type = self.default_point_type

--- a/geomstats/geometry/product_riemannian_metric.py
+++ b/geomstats/geometry/product_riemannian_metric.py
@@ -18,6 +18,12 @@ class ProductRiemannianMetric(RiemannianMetric):
     ----------
     metrics : list
         List of metrics in the product.
+    default_point_type : str, {'vector', 'matrix'}
+        Point type.
+        Optional, default: 'vector'.
+    n_jobs : int
+        Number of jobs for parallel computing.
+        Optional, default: 1.
     """
 
     def __init__(self, metrics, default_point_type='vector', n_jobs=1):
@@ -47,10 +53,12 @@ class ProductRiemannianMetric(RiemannianMetric):
         Parameters
         ----------
         base_point : array-like, shape=[..., n_metrics, dim] or
-            [..., dim], optional
+            [..., dim]
             Point on the manifold at which to compute the inner-product matrix.
-        point_type : str, {'vector', 'matrix'}, optional
+            Optional, default: None.
+        point_type : str, {'vector', 'matrix'}
             Type of representation used for points.
+            Optional, default: None.
 
         Returns
         -------
@@ -95,7 +103,7 @@ class ProductRiemannianMetric(RiemannianMetric):
 
         Returns
         -------
-        intrinsic: bool
+        intrinsic : array-like, shape=[...,]
             Whether intrinsic coordinates are used for all manifolds.
         """
         if self.default_point_type != 'vector':
@@ -145,14 +153,16 @@ class ProductRiemannianMetric(RiemannianMetric):
             First tangent vector at base point.
         tangent_vec_b : array-like, shape=[..., dim + 1]
             Second tangent vector at base point.
-        base_point : array-like, shape=[..., dim + 1], optional
+        base_point : array-like, shape=[..., dim + 1]
             Point on the manifold.
-        point_type : str, {'vector', 'matrix'}, optional
+            Optional, default: None.
+        point_type : str, {'vector', 'matrix'}
             Type of representation used for points.
+            Optional, default: None.
 
         Returns
         -------
-        inner_prod : array-like, shape=[..., 1]
+        inner_prod : array-like, shape=[...,]
             Inner-product of the two tangent vectors.
         """
         if base_point is None:
@@ -201,8 +211,10 @@ class ProductRiemannianMetric(RiemannianMetric):
             Tangent vector at a base point.
         base_point : array-like, shape=[..., dim]
             Point on the manifold.
-        point_type : str, {'vector', 'matrix'}, optional
+            Optional, default: None.
+        point_type : str, {'vector', 'matrix'}
             Type of representation used for points.
+            Optional, default: None.
 
         Returns
         -------
@@ -243,8 +255,10 @@ class ProductRiemannianMetric(RiemannianMetric):
             Point on the manifold.
         base_point : array-like, shape=[..., dim]
             Point on the manifold.
-        point_type : str, {'vector', 'matrix'}, optional
+            Optional, default: None.
+        point_type : str, {'vector', 'matrix'}
             Type of representation used for points.
+            Optional, default: None.
 
         Returns
         -------

--- a/geomstats/geometry/riemannian_metric.py
+++ b/geomstats/geometry/riemannian_metric.py
@@ -180,9 +180,9 @@ class RiemannianMetric(Connection):
         Parameters
         ----------
         tangent_vec_a: array-like, shape=[..., dim]
-            Tangent vector.
+            Tangent vector at base point.
         tangent_vec_b: array-like, shape=[..., dim]
-            Tangent vector.
+            Tangent vector at base point.
         base_point: array-like, shape=[..., dim]
             Base point.
             Optional, default: None.

--- a/geomstats/geometry/skew_symmetric_matrices.py
+++ b/geomstats/geometry/skew_symmetric_matrices.py
@@ -18,7 +18,7 @@ class SkewSymmetricMatrices(MatrixLieAlgebra):
     Parameters
     ----------
     n : int
-        The number of rows and columns.
+        Number of rows and columns.
     """
 
     def __init__(self, n):
@@ -43,10 +43,12 @@ class SkewSymmetricMatrices(MatrixLieAlgebra):
             Square matrix to check.
         atol : float
             Tolerance for the equality evaluation.
+            Optional, default: TOLERANCE.
 
         Returns
         -------
-        belongs : bool
+        belongs : array-like, shape=[...,]
+            Boolean evaluating if matrix is skew symmetric.
         """
         return Matrices(self.n, self.n).is_skew_symmetric(mat=mat, atol=atol)
 
@@ -59,10 +61,12 @@ class SkewSymmetricMatrices(MatrixLieAlgebra):
         Parameters
         ----------
         matrix_representation : array-like, shape=[..., n, n]
+            Matrix.
 
         Returns
         -------
         basis_representation : array-like, shape=[..., dim]
+            Representation in the basis.
         """
         old_shape = gs.shape(matrix_representation)
         as_vector = gs.reshape(matrix_representation, (old_shape[0], -1))

--- a/geomstats/geometry/skew_symmetric_matrices.py
+++ b/geomstats/geometry/skew_symmetric_matrices.py
@@ -40,7 +40,7 @@ class SkewSymmetricMatrices(MatrixLieAlgebra):
         Parameters
         ----------
         mat : array-like, shape=[..., n, n]
-            The square matrix to check.
+            Square matrix to check.
         atol : float
             Tolerance for the equality evaluation.
 

--- a/geomstats/geometry/spd_matrices.py
+++ b/geomstats/geometry/spd_matrices.py
@@ -15,7 +15,13 @@ TOLERANCE = 1e-12
 
 
 class SPDMatrices(SymmetricMatrices, EmbeddedManifold):
-    """Class for the manifold of symmetric positive definite (SPD) matrices."""
+    """Class for the manifold of symmetric positive definite (SPD) matrices.
+
+    Parameters
+    ----------
+    n : int
+        Integer representing the shape of the matrices: n x n.
+    """
 
     def __init__(self, n):
         super(SPDMatrices, self).__init__(
@@ -24,7 +30,18 @@ class SPDMatrices(SymmetricMatrices, EmbeddedManifold):
             embedding_manifold=GeneralLinear(n=n))
 
     def belongs(self, mat, atol=TOLERANCE):
-        """Check if a matrix is symmetric and invertible."""
+        """Check if a matrix is symmetric and invertible.
+
+        Parameters
+        ----------
+        mat : array-like, shape=[..., n, n]
+            Matrix to be checked.
+
+        Returns
+        -------
+        belongs : array-like, shape=[...,]
+            Boolean denoting if mat is a SPD matrix.
+        """
         is_symmetric = super(SPDMatrices, self).belongs(mat, atol)
         eigvalues, _ = gs.linalg.eigh(mat)
         is_positive = gs.all(eigvalues > 0, axis=-1)
@@ -32,7 +49,18 @@ class SPDMatrices(SymmetricMatrices, EmbeddedManifold):
         return belongs
 
     def random_uniform(self, n_samples=1):
-        """Define a log-uniform random sample of SPD matrices."""
+        """Sample in SPD(n) from the log-uniform distribution.
+
+        Parameters
+        ----------
+        n_samples : int, optional (default: 1)
+            Number of samples.
+
+        Returns
+        -------
+        samples : array-like, shape=[..., n, n]
+            Points sampled in SPD(n).
+        """
         n = self.n
         size = (n_samples, n, n) if n_samples != 1 else (n, n)
 
@@ -42,7 +70,20 @@ class SPDMatrices(SymmetricMatrices, EmbeddedManifold):
         return spd_mat
 
     def random_tangent_vec_uniform(self, n_samples=1, base_point=None):
-        """Define a uniform random sample of tangent vectors."""
+        """Sample on the tangent space of SPD(n) from the uniform distribution.
+
+        Parameters
+        ----------
+        n_samples : int, optional (default: 1)
+            Number of samples.
+        base_point : array-like, shape=[..., n, n]
+            Base point of the tangent space.
+
+        Returns
+        -------
+        samples : array-like, shape=[..., n, n]
+            Points sampled in the tangent space at base_point.
+        """
         n = self.n
         size = (n_samples, n, n) if n_samples != 1 else (n, n)
 
@@ -146,15 +187,15 @@ class SPDMatrices(SymmetricMatrices, EmbeddedManifold):
     @classmethod
     @geomstats.vectorization.decorator(['else', 'else', 'matrix', 'matrix'])
     def differential_power(cls, power, tangent_vec, base_point):
-        """Compute the differential of the matrix power function.
+        r"""Compute the differential of the matrix power function.
 
-        Computes the differential of the power function on SPD
-        matrices (A^p=exp(p log(A))) at base_point applied to
-        tangent_vec.
+        Compute the differential of the power function on SPD(n)
+        (:math: `A^p=\exp(p \log(A))`) at base_point applied to tangent_vec.
 
         Parameters
         ----------
         power : int
+            Power.
         tangent_vec : array_like, shape=[..., n, n]
             Tangent vector.
         base_point : array_like, shape=[..., n, n]
@@ -163,6 +204,7 @@ class SPDMatrices(SymmetricMatrices, EmbeddedManifold):
         Returns
         -------
         differential_power : array-like, shape=[..., n, n]
+            Differential of the power function.
         """
         eigvectors, transp_eigvectors, numerator, denominator, temp_result =\
             cls.aux_differential_power(power, tangent_vec, base_point)
@@ -175,15 +217,16 @@ class SPDMatrices(SymmetricMatrices, EmbeddedManifold):
     @classmethod
     @geomstats.vectorization.decorator(['else', 'else', 'matrix', 'matrix'])
     def inverse_differential_power(cls, power, tangent_vec, base_point):
-        """Compute the inverse of the differential of the matrix power.
+        r"""Compute the inverse of the differential of the matrix power.
 
-        Computes the inverse of the differential of the power
-        function on SPD matrices (A^p=exp(p log(A))) at base_point
+        Compute the inverse of the differential of the power
+        function on SPD matrices (:math: `A^p=exp(p log(A))`) at base_point
         applied to tangent_vec.
 
         Parameters
         ----------
         power : int
+            Power.
         tangent_vec : array_like, shape=[..., n, n]
             Tangent vector.
         base_point : array_like, shape=[..., n, n]
@@ -192,6 +235,7 @@ class SPDMatrices(SymmetricMatrices, EmbeddedManifold):
         Returns
         -------
         inverse_differential_power : array-like, shape=[..., n, n]
+            Inverse of the differential of the power function.
         """
         eigvectors, transp_eigvectors, numerator, denominator, temp_result =\
             cls.aux_differential_power(power, tangent_vec, base_point)
@@ -206,7 +250,7 @@ class SPDMatrices(SymmetricMatrices, EmbeddedManifold):
     def differential_log(cls, tangent_vec, base_point):
         """Compute the differential of the matrix logarithm.
 
-        Computes the differential of the matrix logarithm on SPD
+        Compute the differential of the matrix logarithm on SPD
         matrices at base_point applied to tangent_vec.
 
         Parameters
@@ -219,6 +263,7 @@ class SPDMatrices(SymmetricMatrices, EmbeddedManifold):
         Returns
         -------
         differential_log : array-like, shape=[..., n, n]
+            Differential of the matrix logarithm.
         """
         eigvectors, transp_eigvectors, numerator, denominator, temp_result =\
             cls.aux_differential_power(0, tangent_vec, base_point)
@@ -233,7 +278,7 @@ class SPDMatrices(SymmetricMatrices, EmbeddedManifold):
     def inverse_differential_log(cls, tangent_vec, base_point):
         """Compute the inverse of the differential of the matrix logarithm.
 
-        Computes the inverse of the differential of the matrix
+        Compute the inverse of the differential of the matrix
         logarithm on SPD matrices at base_point applied to
         tangent_vec.
 
@@ -247,6 +292,7 @@ class SPDMatrices(SymmetricMatrices, EmbeddedManifold):
         Returns
         -------
         inverse_differential_log : array-like, shape=[..., n, n]
+            Inverse of the differential of the matrix logarithm.
         """
         eigvectors, transp_eigvectors, numerator, denominator, temp_result =\
             cls.aux_differential_power(0, tangent_vec, base_point)
@@ -274,6 +320,7 @@ class SPDMatrices(SymmetricMatrices, EmbeddedManifold):
         Returns
         -------
         differential_exp : array-like, shape=[..., n, n]
+            Differential of the matrix exponential.
         """
         eigvectors, transp_eigvectors, numerator, denominator, temp_result = \
             cls.aux_differential_power(math.inf, tangent_vec, base_point)
@@ -302,6 +349,7 @@ class SPDMatrices(SymmetricMatrices, EmbeddedManifold):
         Returns
         -------
         inverse_differential_exp : array-like, shape=[..., n, n]
+            Inverse of the differential of the matrix exponential.
         """
         eigvectors, transp_eigvectors, numerator, denominator, temp_result = \
             cls.aux_differential_power(math.inf, tangent_vec, base_point)
@@ -312,21 +360,21 @@ class SPDMatrices(SymmetricMatrices, EmbeddedManifold):
         return result
 
     @classmethod
-    def logm(cls, x):
+    def logm(cls, mat):
         """
         Compute the matrix log for a symmetric matrix.
 
         Parameters
         ----------
-        x : array_like, shape=[..., n, n]
+        mat : array_like, shape=[..., n, n]
             Symmetric matrix.
 
         Returns
         -------
         log : array_like, shape=[..., n, n]
-            Logarithm of x.
+            Matrix logarithm of mat.
         """
-        return cls.apply_func_to_eigvals(x, gs.log, check_positive=True)
+        return cls.apply_func_to_eigvals(mat, gs.log, check_positive=True)
 
 
 class SPDMetricAffine(RiemannianMetric):
@@ -335,12 +383,10 @@ class SPDMetricAffine(RiemannianMetric):
     def __init__(self, n, power_affine=1):
         """Build the affine-invariant metric.
 
-        Based on [TP2019]_.
-
         Parameters
         ----------
         n : int
-            Matrix dimension.
+            Integer representing the shape of the matrices: n x n.
         power_affine : int, optional
             Power transformation of the classical SPD metric.
 
@@ -361,7 +407,7 @@ class SPDMetricAffine(RiemannianMetric):
 
     @staticmethod
     def _aux_inner_product(tangent_vec_a, tangent_vec_b, inv_base_point):
-        """Compute the inner product (auxiliary).
+        """Compute the inner-product (auxiliary).
 
         Parameters
         ----------
@@ -383,20 +429,24 @@ class SPDMetricAffine(RiemannianMetric):
         return inner_product
 
     def inner_product(self, tangent_vec_a, tangent_vec_b, base_point):
-        """Compute the affine-invariant inner product.
+        """Compute the affine-invariant inner-product.
 
-        Compute the inner product of tangent_vec_a and tangent_vec_b
+        Compute the inner-product of tangent_vec_a and tangent_vec_b
         at point base_point using the affine invariant Riemannian metric.
 
         Parameters
         ----------
         tangent_vec_a : array-like, shape=[..., n, n]
+            Tangent vector.
         tangent_vec_b : array-like, shape=[..., n, n]
+            Tangent vector.
         base_point : array-like, shape=[..., n, n]
+            Base point.
 
         Returns
         -------
         inner_product : array-like, shape=[..., n, n]
+            Inner-product.
         """
         power_affine = self.power_affine
         spd_space = self.space
@@ -428,12 +478,12 @@ class SPDMetricAffine(RiemannianMetric):
         Parameters
         ----------
         tangent_vec : array-like, shape=[..., n, n]
-        sqrt_base_point
-        inv_sqrt_base_point
+        sqrt_base_point : array-like, shape=[..., n, n]
+        inv_sqrt_base_point : array-like, shape=[..., n, n]
 
         Returns
         -------
-        exp
+        exp : array-like, shape=[..., n, n]
         """
         tangent_vec_at_id = gs.einsum(
             '...ij,...jk->...ik', inv_sqrt_base_point, tangent_vec)
@@ -458,11 +508,14 @@ class SPDMetricAffine(RiemannianMetric):
         Parameters
         ----------
         tangent_vec : array-like, shape=[..., n, n]
+            Tangent vector.
         base_point : array-like, shape=[..., n, n]
+            Base point.
 
         Returns
         -------
         exp : array-like, shape=[..., n, n]
+            Riemannian exponential.
         """
         power_affine = self.power_affine
 
@@ -492,13 +545,13 @@ class SPDMetricAffine(RiemannianMetric):
 
         Parameters
         ----------
-        point
-        sqrt_base_point
-        inv_sqrt_base_point
+        point : array-like, shape=[..., n, n]
+        sqrt_base_point : array-like, shape=[..., n, n]
+        inv_sqrt_base_point : array-like, shape=[.., n, n]
 
         Returns
         -------
-        log
+        log : array-like, shape=[..., n, n]
         """
         point_near_id = gs.einsum(
             '...ij,...jk->...ik', inv_sqrt_base_point, point)
@@ -523,11 +576,14 @@ class SPDMetricAffine(RiemannianMetric):
         Parameters
         ----------
         point : array-like, shape=[..., n, n]
+            Point.
         base_point : array-like, shape=[..., n, n]
+            Base point.
 
         Returns
         -------
         log : array-like, shape=[..., n, n]
+            Riemannian logarithm of point at base_point.
         """
         power_affine = self.power_affine
 
@@ -553,12 +609,16 @@ class SPDMetricAffine(RiemannianMetric):
 
         Parameters
         ----------
-        initial_point
-        initial_tangent_vec
+        initial_point : array-like, shape=[..., n, n]
+            Initial point of the geodesic.
+        initial_tangent_vec : array-like, shape=[..., n, n]
+            Tangent vector at the initial point, the initial speed
+            of the geodesic.
 
         Returns
         -------
-        geodesic
+        geodesic : callable
+            Time-parameterized geodesic curve.
         """
         return super(SPDMetricAffine, self).geodesic(
             initial_point=initial_point,
@@ -586,7 +646,7 @@ class SPDMetricAffine(RiemannianMetric):
             Tangent vector at base point, initial speed of the geodesic along
             which the parallel transport is computed.
         base_point : array-like, shape=[..., dim + 1]
-            point on the manifold of SPD matrices
+            Point on the manifold of SPD matrices.
 
         Returns
         -------
@@ -603,7 +663,10 @@ class SPDMetricAffine(RiemannianMetric):
 class SPDMetricProcrustes(RiemannianMetric):
     """Class for the Procrustes metric on the SPD manifold.
 
-    Based on [BJL2017].
+    Parameters
+    ----------
+    n : int
+        Integer representing the shape of the matrices: n x n.
 
     References
     ----------
@@ -621,20 +684,24 @@ class SPDMetricProcrustes(RiemannianMetric):
         self.space = SPDMatrices(n)
 
     def inner_product(self, tangent_vec_a, tangent_vec_b, base_point):
-        """Compute the Procrustes inner product.
+        """Compute the Procrustes inner-product.
 
-        Compute the inner product of tangent_vec_a and tangent_vec_b
+        Compute the inner-product of tangent_vec_a and tangent_vec_b
         at point base_point using the Procrustes Riemannian metric.
 
         Parameters
         ----------
         tangent_vec_a : array-like, shape=[..., n, n]
+            Tangent vector.
         tangent_vec_b : array-like, shape=[..., n, n]
+            Tangent vector.
         base_point : array-like, shape=[..., n, n]
+            Base point.
 
         Returns
         -------
-        inner_product : float
+        inner_product : array-like, shape=[...,]
+            Inner-product.
         """
         spd_space = self.space
         modified_tangent_vec_a =\
@@ -658,20 +725,24 @@ class SPDMetricEuclidean(RiemannianMetric):
         self.power_euclidean = power_euclidean
 
     def inner_product(self, tangent_vec_a, tangent_vec_b, base_point):
-        """Compute the Euclidean inner product.
+        """Compute the Euclidean inner-product.
 
-        Compute the inner product of tangent_vec_a and tangent_vec_b
+        Compute the inner-product of tangent_vec_a and tangent_vec_b
         at point base_point using the power-Euclidean metric.
 
         Parameters
         ----------
         tangent_vec_a : array-like, shape=[..., n, n]
+            Tangent vector.
         tangent_vec_b : array-like, shape=[..., n, n]
+            Tangent vector.
         base_point : array-like, shape=[..., n, n]
+            Base point.
 
         Returns
         -------
-        inner_product : float
+        inner_product : array-like, shape=[...,]
+            Inner-product.
         """
         power_euclidean = self.power_euclidean
 
@@ -705,11 +776,14 @@ class SPDMetricEuclidean(RiemannianMetric):
         Parameters
         ----------
         tangent_vec : array-like, shape=[..., n, n]
+            Tangent vector.
         base_point : array-like, shape=[..., n, n]
+            Base point.
 
         Returns
         -------
         exp_domain : array-like, shape=[..., 2]
+            Interval of time where the geodesic is defined.
         """
         invsqrt_base_point = gs.linalg.powerm(base_point, -.5)
 
@@ -730,7 +804,13 @@ class SPDMetricEuclidean(RiemannianMetric):
 
 
 class SPDMetricLogEuclidean(RiemannianMetric):
-    """Class for the Log-Euclidean metric on the SPD manifold."""
+    """Class for the Log-Euclidean metric on the SPD manifold.
+
+    Parameters
+    ----------
+    n : int
+        Integer representing the shape of the matrices: n x n.
+    """
 
     def __init__(self, n):
         dim = int(n * (n + 1) / 2)
@@ -741,20 +821,24 @@ class SPDMetricLogEuclidean(RiemannianMetric):
         self.space = SPDMatrices(n)
 
     def inner_product(self, tangent_vec_a, tangent_vec_b, base_point):
-        """Compute the Log-Euclidean inner product.
+        """Compute the Log-Euclidean inner-product.
 
-        Compute the inner product of tangent_vec_a and tangent_vec_b
+        Compute the inner-product of tangent_vec_a and tangent_vec_b
         at point base_point using the log-Euclidean metric.
 
         Parameters
         ----------
         tangent_vec_a : array-like, shape=[..., n, n]
+            Tangent vector.
         tangent_vec_b : array-like, shape=[..., n, n]
+            Tangent vector.
         base_point : array-like, shape=[..., n, n]
+            Base point.
 
         Returns
         -------
-        inner_product : float
+        inner_product : array-like, shape=[...,]
+            Inner-product.
         """
         spd_space = self.space
 
@@ -779,11 +863,14 @@ class SPDMetricLogEuclidean(RiemannianMetric):
         Parameters
         ----------
         tangent_vec : array-like, shape=[..., n, n]
+            Tangent vector.
         base_point : array-like, shape=[..., n, n]
+            Base point.
 
         Returns
         -------
         exp : array-like, shape=[..., n, n]
+            Riemannian exponential.
         """
         log_base_point = self.space.logm(base_point)
         dlog_tangent_vec = self.space.differential_log(tangent_vec, base_point)
@@ -801,11 +888,14 @@ class SPDMetricLogEuclidean(RiemannianMetric):
         Parameters
         ----------
         point : array-like, shape=[..., n, n]
+            Point.
         base_point : array-like, shape=[..., n, n]
+            Base point.
 
         Returns
         -------
         log : array-like, shape=[..., n, n]
+            Riemannian logarithm.
         """
         log_base_point = SPDMatrices.logm(base_point)
         log_point = SPDMatrices.logm(point)
@@ -820,12 +910,15 @@ class SPDMetricLogEuclidean(RiemannianMetric):
         Parameters
         ----------
         initial_point : array-like, shape=[..., n, n]
+            Initial point of the geodesic.
         initial_tangent_vec : array-like, shape=[..., n, n]
+            Tangent vector at the initial point, the initial speed
+            of the geodesic.
 
         Returns
         -------
-        path : callable
-            The time parameterized geodesic.
+        geodesic : callable
+            Time-parameterized geodesic curve.
         """
         def path(t):
             return self.exp(t * initial_tangent_vec, initial_point)

--- a/geomstats/geometry/spd_matrices.py
+++ b/geomstats/geometry/spd_matrices.py
@@ -36,6 +36,9 @@ class SPDMatrices(SymmetricMatrices, EmbeddedManifold):
         ----------
         mat : array-like, shape=[..., n, n]
             Matrix to be checked.
+        atol : float
+            Tolerance.
+            Optional, default: TOLERANCE.
 
         Returns
         -------
@@ -53,8 +56,9 @@ class SPDMatrices(SymmetricMatrices, EmbeddedManifold):
 
         Parameters
         ----------
-        n_samples : int, optional (default: 1)
+        n_samples : int
             Number of samples.
+            Optional, default: 1.
 
         Returns
         -------
@@ -74,10 +78,12 @@ class SPDMatrices(SymmetricMatrices, EmbeddedManifold):
 
         Parameters
         ----------
-        n_samples : int, optional (default: 1)
+        n_samples : int
             Number of samples.
+            Optional, default: 1.
         base_point : array-like, shape=[..., n, n]
             Base point of the tangent space.
+            Optional, default: None.
 
         Returns
         -------
@@ -387,8 +393,9 @@ class SPDMetricAffine(RiemannianMetric):
         ----------
         n : int
             Integer representing the shape of the matrices: n x n.
-        power_affine : int, optional
+        power_affine : int
             Power transformation of the classical SPD metric.
+            Optional, default: 1.
 
         References
         ----------

--- a/geomstats/geometry/spd_matrices.py
+++ b/geomstats/geometry/spd_matrices.py
@@ -121,7 +121,7 @@ class SPDMatrices(SymmetricMatrices, EmbeddedManifold):
         power : float
             Power function to differentiate.
         tangent_vec : array_like, shape=[..., n, n]
-            Tangent vector.
+            Tangent vector at base point.
         base_point : array_like, shape=[..., n, n]
             Base point.
 
@@ -203,7 +203,7 @@ class SPDMatrices(SymmetricMatrices, EmbeddedManifold):
         power : int
             Power.
         tangent_vec : array_like, shape=[..., n, n]
-            Tangent vector.
+            Tangent vector at base point.
         base_point : array_like, shape=[..., n, n]
             Base point.
 
@@ -234,7 +234,7 @@ class SPDMatrices(SymmetricMatrices, EmbeddedManifold):
         power : int
             Power.
         tangent_vec : array_like, shape=[..., n, n]
-            Tangent vector.
+            Tangent vector at base point.
         base_point : array_like, shape=[..., n, n]
             Base point.
 
@@ -262,7 +262,7 @@ class SPDMatrices(SymmetricMatrices, EmbeddedManifold):
         Parameters
         ----------
         tangent_vec : array_like, shape=[..., n, n]
-            Tangent vector.
+            Tangent vector at base point.
         base_point : array_like, shape=[..., n, n]
             Base point.
 
@@ -291,7 +291,7 @@ class SPDMatrices(SymmetricMatrices, EmbeddedManifold):
         Parameters
         ----------
         tangent_vec : array_like, shape=[..., n, n]
-            Tangent vector.
+            Tangent vector at base point.
         base_point : array_like, shape=[..., n, n]
             Base point.
 
@@ -319,7 +319,7 @@ class SPDMatrices(SymmetricMatrices, EmbeddedManifold):
         Parameters
         ----------
         tangent_vec : array_like, shape=[..., n, n]
-            Tangent vector.
+            Tangent vector at base point.
         base_point : array_like, shape=[..., n, n]
             Base point.
 
@@ -348,7 +348,7 @@ class SPDMatrices(SymmetricMatrices, EmbeddedManifold):
         Parameters
         ----------
         tangent_vec : array_like, shape=[..., n, n]
-            Tangent vector.
+            Tangent vector at base point.
         base_point : array_like, shape=[..., n, n]
             Base point.
 
@@ -444,9 +444,9 @@ class SPDMetricAffine(RiemannianMetric):
         Parameters
         ----------
         tangent_vec_a : array-like, shape=[..., n, n]
-            Tangent vector.
+            Tangent vector at base point.
         tangent_vec_b : array-like, shape=[..., n, n]
-            Tangent vector.
+            Tangent vector at base point.
         base_point : array-like, shape=[..., n, n]
             Base point.
 
@@ -515,7 +515,7 @@ class SPDMetricAffine(RiemannianMetric):
         Parameters
         ----------
         tangent_vec : array-like, shape=[..., n, n]
-            Tangent vector.
+            Tangent vector at base point.
         base_point : array-like, shape=[..., n, n]
             Base point.
 
@@ -699,9 +699,9 @@ class SPDMetricProcrustes(RiemannianMetric):
         Parameters
         ----------
         tangent_vec_a : array-like, shape=[..., n, n]
-            Tangent vector.
+            Tangent vector at base point.
         tangent_vec_b : array-like, shape=[..., n, n]
-            Tangent vector.
+            Tangent vector at base point.
         base_point : array-like, shape=[..., n, n]
             Base point.
 
@@ -740,9 +740,9 @@ class SPDMetricEuclidean(RiemannianMetric):
         Parameters
         ----------
         tangent_vec_a : array-like, shape=[..., n, n]
-            Tangent vector.
+            Tangent vector at base point.
         tangent_vec_b : array-like, shape=[..., n, n]
-            Tangent vector.
+            Tangent vector at base point.
         base_point : array-like, shape=[..., n, n]
             Base point.
 
@@ -783,7 +783,7 @@ class SPDMetricEuclidean(RiemannianMetric):
         Parameters
         ----------
         tangent_vec : array-like, shape=[..., n, n]
-            Tangent vector.
+            Tangent vector at base point.
         base_point : array-like, shape=[..., n, n]
             Base point.
 
@@ -836,9 +836,9 @@ class SPDMetricLogEuclidean(RiemannianMetric):
         Parameters
         ----------
         tangent_vec_a : array-like, shape=[..., n, n]
-            Tangent vector.
+            Tangent vector at base point.
         tangent_vec_b : array-like, shape=[..., n, n]
-            Tangent vector.
+            Tangent vector at base point.
         base_point : array-like, shape=[..., n, n]
             Base point.
 
@@ -870,7 +870,7 @@ class SPDMetricLogEuclidean(RiemannianMetric):
         Parameters
         ----------
         tangent_vec : array-like, shape=[..., n, n]
-            Tangent vector.
+            Tangent vector at base point.
         base_point : array-like, shape=[..., n, n]
             Base point.
 

--- a/geomstats/geometry/spd_matrices.py
+++ b/geomstats/geometry/spd_matrices.py
@@ -43,7 +43,7 @@ class SPDMatrices(SymmetricMatrices, EmbeddedManifold):
         Returns
         -------
         belongs : array-like, shape=[...,]
-            Boolean denoting if mat is a SPD matrix.
+            Boolean denoting if mat is an SPD matrix.
         """
         is_symmetric = super(SPDMatrices, self).belongs(mat, atol)
         eigvalues, _ = gs.linalg.eigh(mat)

--- a/geomstats/geometry/special_euclidean.py
+++ b/geomstats/geometry/special_euclidean.py
@@ -125,12 +125,12 @@ class _SpecialEuclideanMatrices(GeneralLinear, LieGroup):
         ----------
         n_samples : int, optional (1)
             Number of samples.
-        tol :  unused
+        tol : unused
 
         Returns
         -------
         samples : array-like, shape=[..., n + 1, n + 1]
-            Points sampled on the SE(n).
+            Points sampled in SE(n).
         """
         random_translation = self.translations.random_uniform(n_samples)
         random_rotation = self.rotations.random_uniform(n_samples)
@@ -156,7 +156,7 @@ class _SpecialEuclidean3Vectors(LieGroup):
 
     i.e. the Lie group of rigid transformations. Elements of SE(3) can either
     be represented as vectors (in 3d) or as matrices in general. The matrix
-    representation corresponds to homogeneous coordinates.This class is
+    representation corresponds to homogeneous coordinates. This class is
     specific to the vector representation of rotations. For the matrix
     representation use the SpecialEuclidean class and set `n=3`.
 
@@ -345,7 +345,7 @@ class _SpecialEuclidean3Vectors(LieGroup):
             Point of the group.
 
         Equation
-        ---------
+        --------
         (:math: `(R_1, t_1) \\cdot (R_2, t_2) = (R_1 R_2, R_1 t_2 + t_1)`)
 
         Returns

--- a/geomstats/geometry/special_euclidean.py
+++ b/geomstats/geometry/special_euclidean.py
@@ -259,7 +259,7 @@ class _SpecialEuclidean3Vectors(LieGroup):
         Parameters
         ----------
         tangent_vec: array-like, shape=[..., 3]
-            Tangent vector.
+            Tangent vector at base point.
         metric : RiemannianMetric
             Metric.
             Optional, default: None.
@@ -279,7 +279,7 @@ class _SpecialEuclidean3Vectors(LieGroup):
         Parameters
         ----------
         tangent_vec: array-like, shape=[..., 3]
-            Tangent vector.
+            Tangent vector at base point.
         base_point : array-like, shape=[..., 3]
             Base point.
         metric : RiemannianMetric
@@ -501,7 +501,7 @@ class _SpecialEuclidean3Vectors(LieGroup):
         Parameters
         ----------
         tangent_vec: array-like, shape=[..., 3]
-            Tangent vector.
+            Tangent vector at base point.
 
         Returns
         -------

--- a/geomstats/geometry/special_euclidean.py
+++ b/geomstats/geometry/special_euclidean.py
@@ -123,14 +123,15 @@ class _SpecialEuclideanMatrices(GeneralLinear, LieGroup):
 
         Parameters
         ----------
-        n_samples : int, optional (1)
+        n_samples : int
             Number of samples.
+            Optional, default: 1.
         tol : unused
 
         Returns
         -------
         samples : array-like, shape=[..., n + 1, n + 1]
-            Points sampled in SE(n).
+            Sample in SE(n).
         """
         random_translation = self.translations.random_uniform(n_samples)
         random_rotation = self.rotations.random_uniform(n_samples)
@@ -162,9 +163,10 @@ class _SpecialEuclidean3Vectors(LieGroup):
 
     Parameter
     ---------
-    epsilon : float, optional (defaults to 0)
+    epsilon : float
         Precision to use for calculations involving potential
         division by 0 in rotations.
+        Optional, default: 0.
     """
 
     def __init__(self, epsilon=0.):
@@ -182,9 +184,9 @@ class _SpecialEuclidean3Vectors(LieGroup):
 
         Parameters
         ----------
-        point_type : str, {'vector', 'matrix'}, optional
+        point_type : str, {'vector', 'matrix'}
             The point_type of the returned value.
-            default: self.default_point_type
+            Optional, default: self.default_point_type
 
         Returns
         -------
@@ -208,11 +210,11 @@ class _SpecialEuclidean3Vectors(LieGroup):
         Parameters
         ----------
         point : array-like, shape=[..., 3]
-            The point of which to check whether it belongs to SE(3).
+            Point to check.
 
         Returns
         -------
-        belongs : array-like, shape=[..., 1]
+        belongs : array-like, shape=[...,]
             Boolean indicating whether point belongs to SE(3).
         """
         point_dim = point.shape[-1]
@@ -229,11 +231,12 @@ class _SpecialEuclidean3Vectors(LieGroup):
         Parameters
         ----------
         point : array-like, shape=[..., 3]
-            The point to regularize.
+            Point to regularize.
 
         Returns
         -------
         point : array-like, shape=[..., 3]
+            Regularized point.
         """
         rotations = self.rotations
         dim_rotations = rotations.dim
@@ -256,11 +259,15 @@ class _SpecialEuclidean3Vectors(LieGroup):
         Parameters
         ----------
         tangent_vec: array-like, shape=[..., 3]
-        metric : RiemannianMetric, optional
+            Tangent vector.
+        metric : RiemannianMetric
+            Metric.
+            Optional, default: None.
 
         Returns
         -------
-        regularized_vec : the regularized tangent vector
+        regularized_vec : array-like, shape=[..., 3]
+            Regularized vector.
         """
         return self.regularize_tangent_vec(
             tangent_vec, self.identity, metric)
@@ -272,13 +279,17 @@ class _SpecialEuclidean3Vectors(LieGroup):
         Parameters
         ----------
         tangent_vec: array-like, shape=[..., 3]
+            Tangent vector.
         base_point : array-like, shape=[..., 3]
-        metric : RiemannianMetric, optional
-            default: self.left_canonical_metric
+            Base point.
+        metric : RiemannianMetric
+            Metric.
+            Optional, default to self.left_canonical_metric if None.
 
         Returns
         -------
-        regularized_vec : the regularized tangent vector
+        regularized_vec : array-like, shape=[..., 3]
+            Regularized vector.
         """
         if metric is None:
             metric = self.left_canonical_metric
@@ -310,11 +321,13 @@ class _SpecialEuclidean3Vectors(LieGroup):
 
         Parameters
         ----------
-        vec: array-like, shape=[..., 3]
+        vec : array-like, shape=[..., 3]
+            Vector.
 
         Returns
         -------
-        mat: array-like, shape=[..., n+1, n+1]
+        mat : array-like, shape=[..., 4, 4]
+            Matrix.
         """
         vec = self.regularize(vec)
         n_vecs, _ = vec.shape
@@ -350,9 +363,8 @@ class _SpecialEuclidean3Vectors(LieGroup):
 
         Returns
         -------
-        composition :
-            The composition of point_a and point_b.
-
+        composition : array-like, shape=[..., 3]
+            Composition of point_a and point_b.
         """
         rotations = self.rotations
         dim_rotations = rotations.dim
@@ -387,11 +399,12 @@ class _SpecialEuclidean3Vectors(LieGroup):
         Parameters
         ----------
         point: array-like, shape=[..., 3]
+            Point.
 
         Returns
         -------
         inverse_point : array-like, shape=[..., 3]
-            The inverted point.
+            Inverted point.
 
         Notes
         -----
@@ -429,13 +442,15 @@ class _SpecialEuclidean3Vectors(LieGroup):
         Parameters
         ----------
         point: array-like, shape=[..., 3]
-        left_or_right: str, {'left', 'right'}, optional
+            Point.
+        left_or_right: str, {'left', 'right'}
             Whether to compute the jacobian of the left or right translation.
+            Optional, default: 'left'.
 
         Returns
         -------
         jacobian : array-like, shape=[..., 3]
-            The jacobian of the left / right translation.
+            Jacobian of the left / right translation.
         """
         if left_or_right not in ('left', 'right'):
             raise ValueError('`left_or_right` must be `left` or `right`.')
@@ -486,11 +501,12 @@ class _SpecialEuclidean3Vectors(LieGroup):
         Parameters
         ----------
         tangent_vec: array-like, shape=[..., 3]
+            Tangent vector.
 
         Returns
         -------
         group_exp: array-like, shape=[..., 3]
-            The group exponential of the tangent vectors calculated
+            Group exponential of the tangent vectors computed
             at the identity.
         """
         rotations = self.rotations
@@ -561,11 +577,12 @@ class _SpecialEuclidean3Vectors(LieGroup):
         Parameters
         ----------
         point: array-like, shape=[..., 3]
+            Point.
 
         Returns
         -------
         group_log: array-like, shape=[..., 3]
-            the group logarithm in the Lie algbra
+            Group logarithm in the Lie algebra.
         """
         point = self.regularize(point)
 
@@ -639,13 +656,14 @@ class _SpecialEuclidean3Vectors(LieGroup):
 
         Parameters
         ----------
-        n_samples : int, optional
-            default : 1
+        n_samples : int
+            Number of samples.
+            Optional, default: 1
 
         Returns
         -------
         random_point : array-like, shape=[..., 3]
-            An array of random elements in SE(3) having the given.
+            Sample.
         """
         random_translation = self.translations.random_uniform(n_samples)
         random_rot_vec = self.rotations.random_uniform(n_samples)
@@ -660,7 +678,7 @@ class _SpecialEuclidean3Vectors(LieGroup):
 
         Returns
         -------
-        exponential_mat : The matrix exponential of rot_vec
+        exponential_mat : Matrix exponential of rot_vec
         """
         # TODO(nguigs): find usecase for this method
         rot_vec = self.rotations.regularize(rot_vec)
@@ -716,10 +734,11 @@ class SpecialEuclidean(_SpecialEuclidean3Vectors, _SpecialEuclideanMatrices):
         Integer representing the shapes of the matrices : n x n.
     point_type : str, {\'vector\', \'matrix\'}
         Representation of the elements of the group.
-    epsilon : float, optional
-        precision to use for calculations involving potential divison by 0 in
-        rotations
-        default: 0
+        Optional, default: 'matrix',
+    epsilon : float
+        Precision used for calculations involving potential divison by 0 in
+        rotations.
+        Optional, default: 0.
     """
 
     def __new__(cls, n, point_type='matrix', epsilon=0.):

--- a/geomstats/geometry/special_euclidean.py
+++ b/geomstats/geometry/special_euclidean.py
@@ -284,7 +284,7 @@ class _SpecialEuclidean3Vectors(LieGroup):
             Base point.
         metric : RiemannianMetric
             Metric.
-            Optional, default to self.left_canonical_metric if None.
+            Optional, defaults to self.left_canonical_metric if None.
 
         Returns
         -------

--- a/geomstats/geometry/special_orthogonal.py
+++ b/geomstats/geometry/special_orthogonal.py
@@ -89,7 +89,7 @@ class _SpecialOrthogonalMatrices(GeneralLinear, LieGroup):
         Returns
         -------
         tangent_vec : array-like, shape=[..., n, n]
-            Tangent vector.
+            Tangent vector at base point.
         """
         return cls.to_skew_symmetric(vec)
 
@@ -241,7 +241,7 @@ class _SpecialOrthogonal3Vectors(LieGroup):
         Parameters
         ----------
         tangent_vec : array-like, shape=[..., 3]
-            Tangent vector.
+            Tangent vector at base point.
         metric : RiemannianMetric
             Metric.
             Optional, default: self.left_canonical_metric.
@@ -1386,7 +1386,7 @@ class _SpecialOrthogonal3Vectors(LieGroup):
         Parameters
         ----------
         tangent_vec : array-like, shape=[..., 3]
-            Tangent vector.
+            Tangent vector at base point.
         point_type : str, {'vector', 'matrix'}
             Point type.
             Optional, default: self.default_point_type.
@@ -1430,9 +1430,9 @@ class _SpecialOrthogonal3Vectors(LieGroup):
         Parameters
         ----------
         tangent_vector_a : shape=[..., n, n]
-            Tangent vector.
+            Tangent vector at base point.
         tangent_vector_b : shape=[..., n, n]
-            Tangent vector.
+            Tangent vector at base point.
         base_point : array-like, shape=[..., n, n]
             Base point.
             Optional, default: None.
@@ -1450,7 +1450,7 @@ class _SpecialOrthogonal3Vectors(LieGroup):
         Parameters
         ----------
         tangent_vec : array-like, shape=[..., 3]
-            Tangent vector.
+            Tangent vector at base point.
 
         Returns
         -------

--- a/geomstats/geometry/special_orthogonal.py
+++ b/geomstats/geometry/special_orthogonal.py
@@ -43,30 +43,64 @@ class _SpecialOrthogonalMatrices(GeneralLinear, LieGroup):
         self.bi_invariant_metric = BiInvariantMetric(group=self)
 
     def belongs(self, point):
-        """Check whether point is an orthogonal matrix."""
+        """Check whether point is an orthogonal matrix.
+
+        Parameters
+        ----------
+        point : array-like, shape=[..., n, n]
+            Point to check.
+
+        Returns
+        -------
+        belongs : array-like, shape=[...,]
+            Boolean evaluating if point belongs to SO(n).
+        """
         return self.equal(
             self.mul(point, self.transpose(point)), self.identity)
 
     @classmethod
     def inverse(cls, point):
-        """Return the transpose matrix of point."""
+        """Return the transpose matrix of point.
+
+        Parameters
+        ----------
+        point : array-like, shape=[..., n, n]
+            Point in SO(n)
+
+        Returns
+        -------
+        inverse : array-like, shape=[..., n, n]
+            Inverse.
+        """
         return cls.transpose(point)
 
     def _is_in_lie_algebra(self, tangent_vec, atol=ATOL):
         return self.lie_algebra.belongs(tangent_vec, atol=atol)
 
     @classmethod
-    def _to_lie_algebra(cls, tangent_vec):
-        """Project vector onto skew-symmetric matrices."""
-        return cls.to_skew_symmetric(tangent_vec)
+    def _to_lie_algebra(cls, vec):
+        """Project vector onto skew-symmetric matrices.
+
+        Parameters
+        ----------
+        vec : array-like, shape=[..., n, n]
+            Vector.
+
+        Returns
+        -------
+        tangent_vec : array-like, shape=[..., n, n]
+            Tangent vector.
+        """
+        return cls.to_skew_symmetric(vec)
 
     def random_uniform(self, n_samples=1, tol=1e-6):
         """Sample in SO(n) from the uniform distribution.
 
         Parameters
         ----------
-        n_samples : int, optional (1)
+        n_samples : int
             Number of samples.
+            Optional, default: 1.
         tol : unused
 
         Returns
@@ -91,10 +125,10 @@ class _SpecialOrthogonal3Vectors(LieGroup):
 
     Parameters
     ----------
-    epsilon : float, optional
-        precision to use for calculations involving potential divison by 0 in
-        rotations
-        default: 0
+    epsilon : float
+        Precision to use for calculations involving potential divison by 0 in
+        rotations.
+        Optional, default: 0.
     """
 
     def __init__(self, epsilon=0.):
@@ -110,12 +144,13 @@ class _SpecialOrthogonal3Vectors(LieGroup):
 
         Parameters
         ----------
-        point_type : str,
+        point_type : str, {'vector', 'matrix'}
             Point_type of the returned value. Unused here.
 
         Returns
         -------
         identity : array-like, shape=[3,]
+            Identity.
         """
         identity = gs.zeros(self.dim)
         if point_type == 'matrix':
@@ -157,10 +192,12 @@ class _SpecialOrthogonal3Vectors(LieGroup):
         Parameters
         ----------
         point : array-like, shape=[...,3]
+            Point.
 
         Returns
         -------
         regularized_point : array-like, shape=[..., 3]
+            Regularized point.
         """
         regularized_point = point
         angle = gs.linalg.norm(regularized_point, axis=-1)
@@ -203,13 +240,16 @@ class _SpecialOrthogonal3Vectors(LieGroup):
 
         Parameters
         ----------
-        tangent_vec : array-like, shape=[..., 3]]
-        metric : RiemannianMetric, optional
-            default: self.left_canonical_metric
+        tangent_vec : array-like, shape=[..., 3]
+            Tangent vector.
+        metric : RiemannianMetric
+            Metric.
+            Optional, default: self.left_canonical_metric.
 
         Returns
         -------
-        regularized_vec : array-like, shape=[..., 3]]
+        regularized_vec : array-like, shape=[..., 3]
+            Regularized tangent vector.
         """
         if metric is None:
             metric = self.left_canonical_metric
@@ -266,13 +306,14 @@ class _SpecialOrthogonal3Vectors(LieGroup):
             Tangent vector at base point.
         base_point : array-like, shape=[..., 3]
             Point on the manifold.
-        metric : RiemannianMetric, optional
-            default: self.left_canonical_metric
+        metric : RiemannianMetric
+            Metric.
+            Optional, default: self.left_canonical_metric.
 
         Returns
         -------
-        regularized_tangent_vec : array-like,
-            shape=[..., 3]
+        regularized_tangent_vec : array-like, shape=[..., 3]
+            Regularized tangent vector.
         """
         if metric is None:
             metric = self.left_canonical_metric
@@ -307,10 +348,12 @@ class _SpecialOrthogonal3Vectors(LieGroup):
         Parameters
         ----------
         mat : array-like, shape=[..., n, n]
+            Matrix.
 
         Returns
         -------
         rot_mat : array-like, shape=[..., n, n]
+            Rotation matrix.
         """
         mat = point
         n_mats, n, _ = mat.shape
@@ -359,10 +402,12 @@ class _SpecialOrthogonal3Vectors(LieGroup):
         Parameters
         ----------
         vec : array-like, shape=[..., dim]
+            Vector.
 
         Returns
         -------
         skew_mat : array-like, shape=[..., n, n]
+            Skew symmetric matrix.
         """
         n_vecs, vec_dim = gs.shape(vec)
 
@@ -441,10 +486,12 @@ class _SpecialOrthogonal3Vectors(LieGroup):
         Parameters
         ----------
         skew_mat : array-like, shape=[..., n, n]
+            Skew symmetric matrix.
 
         Returns
         -------
         vec : array-like, shape=[..., dim]
+            Vector.
         """
         n_skew_mats, _, _ = skew_mat.shape
 
@@ -486,10 +533,12 @@ class _SpecialOrthogonal3Vectors(LieGroup):
         Parameters
         ----------
         rot_mat : array-like, shape=[..., n, n]
+            Rotation matrix.
 
         Returns
         -------
         regularized_rot_vec : array-like, shape=[..., 3]
+            Rotation vector.
         """
         n_rot_mats, _, _ = rot_mat.shape
 
@@ -534,10 +583,12 @@ class _SpecialOrthogonal3Vectors(LieGroup):
         Parameters
         ----------
         rot_vec: array-like, shape=[..., 3]
+            Rotation vector.
 
         Returns
         -------
         rot_mat: array-like, shape=[..., 3]
+            Rotation matrix.
         """
         rot_vec = self.regularize(rot_vec)
 
@@ -585,10 +636,12 @@ class _SpecialOrthogonal3Vectors(LieGroup):
         Parameters
         ----------
         rot_mat : array-like, shape=[..., 3, 3]
+            Rotation matrix.
 
         Returns
         -------
         quaternion : array-like, shape=[..., 4]
+            Quaternion.
         """
         rot_vec = self.rotation_vector_from_matrix(rot_mat)
         quaternion = self.quaternion_from_rotation_vector(rot_vec)
@@ -602,10 +655,12 @@ class _SpecialOrthogonal3Vectors(LieGroup):
         Parameters
         ----------
         rot_vec : array-like, shape=[..., 3]
+            Rotation vector.
 
         Returns
         -------
         quaternion : array-like, shape=[..., 4]
+            Quaternion.
         """
         rot_vec = self.regularize(rot_vec)
 
@@ -635,10 +690,12 @@ class _SpecialOrthogonal3Vectors(LieGroup):
         Parameters
         ----------
         quaternion : array-like, shape=[..., 4]
+            Quaternion.
 
         Returns
         -------
         rot_vec : array-like, shape=[..., 3]
+            Rotation vector.
         """
         cos_half_angle = quaternion[:, 0]
         cos_half_angle = gs.clip(cos_half_angle, -1, 1)
@@ -669,10 +726,12 @@ class _SpecialOrthogonal3Vectors(LieGroup):
         Parameters
         ----------
         quaternion : array-like, shape=[..., 4]
+            Quaternion.
 
         Returns
         -------
         rot_mat : array-like, shape=[..., 3]
+            Rotation matrix.
         """
         n_quaternions, _ = quaternion.shape
 
@@ -1186,10 +1245,12 @@ class _SpecialOrthogonal3Vectors(LieGroup):
         Parameters
         ----------
         point : array-like, shape=[..., 3]
+            Point.
 
         Returns
         -------
         inv_point : array-like, shape=[..., 3]
+            Inverse.
         """
         return -self.regularize(point)
 
@@ -1205,14 +1266,17 @@ class _SpecialOrthogonal3Vectors(LieGroup):
         Parameters
         ----------
         point : array-like, shape=[..., 3]
-        left_or_right : str, {'left', 'right'}, optional
-            default: 'left'
-        point_type : str, {'vector', 'matrix'}, optional
-            default: self.default_point_type
+            Point.
+        left_or_right : str, {'left', 'right'}
+            Wether to use left or right invariant metric.
+            Optional, default: 'left'.
+        point_type : str, {'vector', 'matrix'}
+            Optional, default: self.default_point_type
 
         Returns
         -------
         jacobian : array-like, shape=[..., 3, 3]
+            Jacobian.
         """
         geomstats.errors.check_parameter_accepted_values(
             left_or_right, 'left_or_right', ['left', 'right'])
@@ -1295,11 +1359,13 @@ class _SpecialOrthogonal3Vectors(LieGroup):
         Parameters
         ----------
         n_samples : int
-            the amount of samples
+            Number of samples.
+            Optional, default: 1.
 
         Returns
         -------
         point : array-like, shape=[..., 3]
+            Sample.
         """
         random_point = gs.random.rand(n_samples, self.dim) * 2 - 1
         random_point = self.regularize(random_point)
@@ -1320,12 +1386,15 @@ class _SpecialOrthogonal3Vectors(LieGroup):
         Parameters
         ----------
         tangent_vec : array-like, shape=[..., 3]
-        point_type : str, {'vector', 'matrix'}, optional
-            default: self.default_point_type
+            Tangent vector.
+        point_type : str, {'vector', 'matrix'}
+            Point type.
+            Optional, default: self.default_point_type.
 
         Returns
         -------
         point : array-like, shape=[..., 3]
+            Point.
         """
         return tangent_vec
 
@@ -1341,10 +1410,12 @@ class _SpecialOrthogonal3Vectors(LieGroup):
         Parameters
         ----------
         point : array-like, shape=[..., 3]
+            Point.
 
         Returns
         -------
         tangent_vec : array-like, shape=[..., {dimension, [n, n]}]
+            Group logarithm.
         """
         return self.regularize(point)
 
@@ -1359,19 +1430,48 @@ class _SpecialOrthogonal3Vectors(LieGroup):
         Parameters
         ----------
         tangent_vector_a : shape=[..., n, n]
+            Tangent vector.
         tangent_vector_b : shape=[..., n, n]
+            Tangent vector.
         base_point : array-like, shape=[..., n, n]
+            Base point.
+            Optional, default: None.
 
         Returns
         -------
         bracket : array-like, shape=[..., n, n]
+            Lie bracket.
         """
         return gs.cross(tangent_vector_a, tangent_vector_b)
 
     def exp(self, tangent_vec, base_point=None):
+        """Compute the group exponential.
+
+        Parameters
+        ----------
+        tangent_vec : array-like, shape=[..., 3]
+            Tangent vector.
+
+        Returns
+        -------
+        point : array-like, shape=[..., {dimension, [n, n]}]
+            Group exponential.
+        """
         return LieGroup.exp(self, tangent_vec, base_point)
 
     def log(self, point, base_point=None):
+        """Compute the group logarithm.
+
+        Parameters
+        ----------
+        point : array-like, shape=[..., 3]
+            Point.
+
+        Returns
+        -------
+        tangent_vec : array-like, shape=[..., {dimension, [n, n]}]
+            Group logarithm.
+        """
         return LieGroup.log(self, point, base_point)
 
 

--- a/geomstats/geometry/special_orthogonal.py
+++ b/geomstats/geometry/special_orthogonal.py
@@ -65,7 +65,7 @@ class _SpecialOrthogonalMatrices(GeneralLinear, LieGroup):
         Parameters
         ----------
         point : array-like, shape=[..., n, n]
-            Point in SO(n)
+            Point in SO(n).
 
         Returns
         -------
@@ -407,7 +407,7 @@ class _SpecialOrthogonal3Vectors(LieGroup):
         Returns
         -------
         skew_mat : array-like, shape=[..., n, n]
-            Skew symmetric matrix.
+            Skew-symmetric matrix.
         """
         n_vecs, vec_dim = gs.shape(vec)
 
@@ -486,7 +486,7 @@ class _SpecialOrthogonal3Vectors(LieGroup):
         Parameters
         ----------
         skew_mat : array-like, shape=[..., n, n]
-            Skew symmetric matrix.
+            Skew-symmetric matrix.
 
         Returns
         -------

--- a/geomstats/geometry/stiefel.py
+++ b/geomstats/geometry/stiefel.py
@@ -58,10 +58,11 @@ class Stiefel(EmbeddedManifold):
             Point.
         tolerance : float, optional
             Tolerance at which to evaluate.
+            Optional, default: TOLERANCE.
 
         Returns
         -------
-        belongs : array-like, shape=[..., 1]
+        belongs : array-like, shape=[...,]
             Array of booleans evaluating if the corresponding points
             belong to the Stiefel manifold.
         """
@@ -92,10 +93,12 @@ class Stiefel(EmbeddedManifold):
         Parameters
         ----------
         point : array-like, shape=[..., n, p]
+            Point.
 
         Returns
         -------
-        projector : array-like, shape=[..., n, n]
+        projected : array-like, shape=[..., n, n]
+            Projected point.
         """
         return Matrices.mul(point, Matrices.transpose(point))
 
@@ -108,8 +111,9 @@ class Stiefel(EmbeddedManifold):
 
         Parameters
         ----------
-        n_samples : int, optional
+        n_samples : int
             Number of samples.
+            Optional, default: 1.
 
         Returns
         -------

--- a/geomstats/geometry/stiefel.py
+++ b/geomstats/geometry/stiefel.py
@@ -58,7 +58,7 @@ class Stiefel(EmbeddedManifold):
             Point.
         tolerance : float, optional
             Tolerance at which to evaluate.
-            Optional, default: TOLERANCE.
+            Optional, default: 1e-5.
 
         Returns
         -------

--- a/geomstats/geometry/symmetric_matrices.py
+++ b/geomstats/geometry/symmetric_matrices.py
@@ -155,19 +155,19 @@ class SymmetricMatrices(EmbeddedManifold):
     @staticmethod
     def apply_func_to_eigvals(mat, function, check_positive=False):
         """
-        Apply function to eigenvalues and reconstruct the matrimat.
+        Apply function to eigenvalues and reconstruct the matrix.
 
         Parameters
         ----------
         mat : array_like, shape=[..., n, n]
-            Symmetric matrimat.
+            Symmetric matrix.
         function : callable
             Function to apply to eigenvalues.
 
         Returns
         -------
         mat : array_like, shape=[..., n, n]
-            Symmetric matrimat.
+            Symmetric matrix.
         """
         eigvals, eigvecs = gs.linalg.eigh(mat)
         if check_positive:
@@ -176,7 +176,7 @@ class SymmetricMatrices(EmbeddedManifold):
                     'Negative eigenvalue encountered in'
                     ' {}'.format(function.__name__))
         eigvals = function(eigvals)
-        eigvals = algebra_utils.from_vector_to_diagonal_matrimat(eigvals)
+        eigvals = algebra_utils.from_vector_to_diagonal_matrix(eigvals)
         transp_eigvecs = Matrices.transpose(eigvecs)
         reconstuction = gs.matmul(eigvecs, eigvals)
         reconstuction = gs.matmul(reconstuction, transp_eigvecs)

--- a/geomstats/geometry/symmetric_matrices.py
+++ b/geomstats/geometry/symmetric_matrices.py
@@ -59,7 +59,7 @@ class SymmetricMatrices(EmbeddedManifold):
     @staticmethod
     @geomstats.vectorization.decorator(['matrix'])
     def to_vector(mat):
-        """Convert the symmetric part of a symmetric matrix into a vector.
+        """Convert a symmetric matrix into a vector.
 
         Parameters
         ----------

--- a/geomstats/learning/agglomerative_hierarchical_clustering.py
+++ b/geomstats/learning/agglomerative_hierarchical_clustering.py
@@ -66,7 +66,7 @@ class AgglomerativeHierarchicalClustering(AgglomerativeClustering):
         The number of clusters found by the algorithm. If
         ``distance_threshold=None``, it will be equal to the given
         ``n_clusters``.
-    labels_ : ndarray, shape=[n_samples,]
+    labels_ : ndarray, shape=[...,]
         Cluster labels for each point.
     n_leaves_ : int
         Number of leaves in the hierarchical tree.
@@ -100,7 +100,7 @@ class AgglomerativeHierarchicalClustering(AgglomerativeClustering):
         else:
             def affinity(data):
                 n_samples = data.shape[0]
-                affinity_matrix = gs.zeros([n_samples, n_samples])
+                affinity_matrix = gs.zeros([..., n_samples])
                 for i_sample in range(1, n_samples):
                     affinity_matrix[i_sample, :i_sample] = distance(
                         data[i_sample, ...], data[:i_sample, ...]).reshape(

--- a/geomstats/learning/agglomerative_hierarchical_clustering.py
+++ b/geomstats/learning/agglomerative_hierarchical_clustering.py
@@ -100,7 +100,7 @@ class AgglomerativeHierarchicalClustering(AgglomerativeClustering):
         else:
             def affinity(data):
                 n_samples = data.shape[0]
-                affinity_matrix = gs.zeros([..., n_samples])
+                affinity_matrix = gs.zeros([n_samples, n_samples])
                 for i_sample in range(1, n_samples):
                     affinity_matrix[i_sample, :i_sample] = distance(
                         data[i_sample, ...], data[:i_sample, ...]).reshape(

--- a/geomstats/learning/exponential_barycenter.py
+++ b/geomstats/learning/exponential_barycenter.py
@@ -24,21 +24,21 @@ def _default_gradient_descent(
         Input points lying in the Lie Group.
     weights : array-like, shape=[n_samples,]
         default is 1 for each point
-        Weights of each point.
+        Weights associated to the points.
     max_iter : int, optional (defaults to 32)
-        The maximum number of iterations to perform in the gradient descent.
+        Maximum number of iterations to perform in the gradient descent.
     epsilon : float, optional (defaults to 1e-6)
-        The tolerance to reach convergence. The exstrinsic norm of the
+        Tolerance to reach convergence. The exstrinsic norm of the
         gradient is used as criterion.
     step : float, optional (defaults to 1.)
-        The learning rate in the gradient descent.
+        Learning rate in the gradient descent.
     verbose : bool
         Level of verbosity to inform about convergence.
 
     Returns
     -------
     exp_bar : array-like, shape=[n,n]
-        The exponential_barycenter of the input points.
+        Exponential_barycenter of the input points.
     """
     ndim = 2 if group.default_point_type == 'vector' else 3
     if gs.ndim(gs.array(points)) < ndim or len(points) == 1:
@@ -91,14 +91,14 @@ class ExponentialBarycenter(BaseEstimator):
     Parameters
     ----------
     group : LieGroup
-        A Lie group instance on which the data lie.
+        Lie group instance on which the data lie.
     max_iter : int, optional (defaults to 32)
-        The maximum number of iterations to perform in the gradient descent.
+        Maximum number of iterations to perform in the gradient descent.
     epsilon : float, optional (defaults to 1e-6)
-        The tolerance to reach convergence. The exstrinsic norm of the
+        Tolerance to reach convergence. The exstrinsic norm of the
         gradient is used as criterion.
     step : float, optional (defaults to 1.)
-        The learning rate in the gradient descent.
+        Learning rate in the gradient descent.
     verbose : bool
         Level of verbosity to inform about convergence.
 
@@ -126,13 +126,15 @@ class ExponentialBarycenter(BaseEstimator):
 
         Parameters
         ----------
-        X : {array-like, sparse matrix}, shape (n_samples, n_features)
-            The training input samples.
-        y : array-like, shape (n_samples,) or (n_samples, n_outputs)
-            The target values (class labels in classification, real numbers in
+        X : {array-like, sparse matrix}, shape=[n_samples, n_features]
+            Training input samples.
+        y : array-like, shape=[n_samples,] or [n_samples, n_outputs]
+            Target values (class labels in classification, real numbers in
             regression).
-            Ignored
-        weights : array-like, shape=[n_samples,], optional
+            Ignored.
+        weights : array-like, shape=[n_samples,]
+            Weights associated to the points.
+            Optional, default: None.
 
         Returns
         -------

--- a/geomstats/learning/exponential_barycenter.py
+++ b/geomstats/learning/exponential_barycenter.py
@@ -20,18 +20,21 @@ def _default_gradient_descent(
     ----------
     group : LieGroup
         Instance of the class LieGroup.
-    points : array-like, shape=[n_samples, [n,n]]
+    points : array-like, shape=[..., [n,n]]
         Input points lying in the Lie Group.
-    weights : array-like, shape=[n_samples,]
-        default is 1 for each point
+    weights : array-like, shape=[...,]
         Weights associated to the points.
-    max_iter : int, optional (defaults to 32)
+        Optional, defaults to 1 for each point if None.
+    max_iter : int
         Maximum number of iterations to perform in the gradient descent.
-    epsilon : float, optional (defaults to 1e-6)
+        Optional, default: 32.
+    epsilon : float
         Tolerance to reach convergence. The exstrinsic norm of the
         gradient is used as criterion.
-    step : float, optional (defaults to 1.)
+        Optional, default: 1e-6.
+    step : float
         Learning rate in the gradient descent.
+        Optional, default: 1.
     verbose : bool
         Level of verbosity to inform about convergence.
 
@@ -92,13 +95,16 @@ class ExponentialBarycenter(BaseEstimator):
     ----------
     group : LieGroup
         Lie group instance on which the data lie.
-    max_iter : int, optional (defaults to 32)
+    max_iter : int
         Maximum number of iterations to perform in the gradient descent.
-    epsilon : float, optional (defaults to 1e-6)
+        Optional, default: 32.
+    epsilon : float
         Tolerance to reach convergence. The exstrinsic norm of the
         gradient is used as criterion.
-    step : float, optional (defaults to 1.)
+        Optional, default: 1e-6.
+    step : float
         Learning rate in the gradient descent.
+        Optional, default: 1.
     verbose : bool
         Level of verbosity to inform about convergence.
 
@@ -126,13 +132,13 @@ class ExponentialBarycenter(BaseEstimator):
 
         Parameters
         ----------
-        X : {array-like, sparse matrix}, shape=[n_samples, n_features]
+        X : {array-like, sparse matrix}, shape=[..., n_features]
             Training input samples.
-        y : array-like, shape=[n_samples,] or [n_samples, n_outputs]
+        y : array-like, shape=[...,] or [..., n_outputs]
             Target values (class labels in classification, real numbers in
             regression).
             Ignored.
-        weights : array-like, shape=[n_samples,]
+        weights : array-like, shape=[...,]
             Weights associated to the points.
             Optional, default: None.
 

--- a/geomstats/learning/exponential_barycenter.py
+++ b/geomstats/learning/exponential_barycenter.py
@@ -37,6 +37,7 @@ def _default_gradient_descent(
         Optional, default: 1.
     verbose : bool
         Level of verbosity to inform about convergence.
+        Optional, default: False.
 
     Returns
     -------
@@ -107,6 +108,7 @@ class ExponentialBarycenter(BaseEstimator):
         Optional, default: 1.
     verbose : bool
         Level of verbosity to inform about convergence.
+        Optional, default: 1.
 
     Attributes
     ----------

--- a/geomstats/learning/frechet_mean.py
+++ b/geomstats/learning/frechet_mean.py
@@ -26,8 +26,9 @@ def variance(points,
     ----------
     points : array-like, shape=[n_samples, dim]
         Points.
-    weights : array-like, shape=[n_samples, 1], optional
+    weights : array-like, shape=[n_samples,]
         Weights associated to the points.
+        Optional, default: None.
 
     Returns
     -------
@@ -61,12 +62,13 @@ def linear_mean(points, weights=None, point_type='vector'):
     ----------
     points : array-like, shape=[n_samples, dim]
         Points to be averaged.
-    weights : array-like, shape=[n_samples, 1], optional
+    weights : array-like, shape=[n_samples,]
         Weights associated to the points.
+        Optional, default: None.
 
     Returns
     -------
-    mean : array-like, shape=[1, dim]
+    mean : array-like, shape=[dim,]
         Weighted linear mean of the points.
     """
     # TODO(ninamiolane): Factorize this code to handle lists
@@ -95,6 +97,7 @@ def linear_mean(points, weights=None, point_type='vector'):
 
 def _default_gradient_descent(points, metric, weights,
                               max_iter, point_type, epsilon, verbose):
+    """Perform default gradient descent."""
     if point_type == 'vector':
         points = gs.to_ndarray(points, to_ndim=2)
         einsum_str = 'n,nj->j'
@@ -158,6 +161,7 @@ def _default_gradient_descent(points, metric, weights,
 
 def _ball_gradient_descent(points, metric, weights, max_iter,
                            lr=1e-3, tau=5e-3):
+    """Perform ball gradient descent."""
     if len(points) == 1:
         return points
 
@@ -193,7 +197,7 @@ def _adaptive_gradient_descent(points,
                                epsilon=1e-12,
                                init_point=None,
                                point_type='vector'):
-    """Compute the Frechet mean using gradient descent.
+    """Perform adaptive gradient descent.
 
     Frechet mean of (weighted) points using adaptive time-steps
     The loss function optimized is :math:`||M_1(x)||_x`
@@ -283,11 +287,24 @@ def _adaptive_gradient_descent(points,
 
 
 class FrechetMean(BaseEstimator):
-    """Empirical Frechet mean.
+    r"""Empirical Frechet mean.
 
     Parameters
     ----------
-    max_iter:
+    metric : RiemannianMetric
+        Riemannian metric.
+    max_iter : int
+        Maximum number of iterations for gradient descent.
+        Optional, default: 32.
+    point_type : str, {\'vector\', \'matrix\'}
+        Point type.
+        Optional, default: None.
+    method : str, {\'default\', \'adaptive\', \'ball\'}
+        Gradient descent method.
+        Optional, default: \'default\'.
+    verbose : bool
+        Verbose option.
+        Optional, default: False.
     """
 
     def __init__(self, metric,
@@ -315,13 +332,15 @@ class FrechetMean(BaseEstimator):
 
         Parameters
         ----------
-        X : {array-like, sparse matrix}, shape (n_samples, n_features)
-            The training input samples.
-        y : array-like, shape (n_samples,) or (n_samples, n_outputs)
-            The target values (class labels in classification, real numbers in
+        X : {array-like, sparse matrix}, shape=[n_samples, n_features]
+            Training input samples.
+        y : array-like, shap=[n_samples,] or [n_samples, n_outputs]
+            Target values (class labels in classification, real numbers in
             regression).
-            Ignored
-        weights : array-like, shape=[n_samples, 1], optional
+            Ignored.
+        weights : array-like, shape=[n_samples,]
+            Weights associated to the points.
+            Optional, default: None.
 
         Returns
         -------

--- a/geomstats/learning/frechet_mean.py
+++ b/geomstats/learning/frechet_mean.py
@@ -24,9 +24,9 @@ def variance(points,
 
     Parameters
     ----------
-    points : array-like, shape=[n_samples, dim]
+    points : array-like, shape=[..., dim]
         Points.
-    weights : array-like, shape=[n_samples,]
+    weights : array-like, shape=[...,]
         Weights associated to the points.
         Optional, default: None.
 
@@ -60,9 +60,9 @@ def linear_mean(points, weights=None, point_type='vector'):
 
     Parameters
     ----------
-    points : array-like, shape=[n_samples, dim]
+    points : array-like, shape=[..., dim]
         Points to be averaged.
-    weights : array-like, shape=[n_samples,]
+    weights : array-like, shape=[...,]
         Weights associated to the points.
         Optional, default: None.
 
@@ -208,9 +208,9 @@ def _adaptive_gradient_descent(points,
 
     Parameters
     ----------
-    points : array-like, shape=[n_samples, dim]
+    points : array-like, shape=[..., dim]
         Points to be averaged.
-    weights : array-like, shape=[n_samples, 1], optional
+    weights : array-like, shape=[..., 1], optional
         Weights associated to the points.
     max_iter : int, optional
         Maximum number of iterations for the gradient descent.
@@ -221,7 +221,7 @@ def _adaptive_gradient_descent(points,
 
     Returns
     -------
-    current_mean: array-like, shape=[n_samples, dim]
+    current_mean: array-like, shape=[..., dim]
         Weighted Frechet mean of the points.
     """
     if point_type == 'matrix':
@@ -332,13 +332,13 @@ class FrechetMean(BaseEstimator):
 
         Parameters
         ----------
-        X : {array-like, sparse matrix}, shape=[n_samples, n_features]
+        X : {array-like, sparse matrix}, shape=[..., n_features]
             Training input samples.
-        y : array-like, shap=[n_samples,] or [n_samples, n_outputs]
+        y : array-like, shape=[...,] or [..., n_outputs]
             Target values (class labels in classification, real numbers in
             regression).
             Ignored.
-        weights : array-like, shape=[n_samples,]
+        weights : array-like, shape=[...,]
             Weights associated to the points.
             Optional, default: None.
 

--- a/geomstats/learning/kernel_density_estimation_classifier.py
+++ b/geomstats/learning/kernel_density_estimation_classifier.py
@@ -91,7 +91,7 @@ class KernelDensityEstimationClassifier(RadiusNeighborsClassifier):
         but may also contain the `p` parameter value if the
         `effective_metric_` attribute is set to 'minkowski'.
     outputs_2d_ : bool
-        False when `y`'s shape is [n_samples,] or [n_samples, 1] during fit,
+        False when `y`'s shape is [...,] or [..., 1] during fit,
         otherwise True.
 
     References
@@ -141,10 +141,10 @@ class KernelDensityEstimationClassifier(RadiusNeighborsClassifier):
 
         Parameters
         ----------
-        X : array-like, shape=[n_samples, n_features], [n_samples,] or
-            [n_samples, n_samples] if distance is 'precomputed'
+        X : array-like, shape=[..., n_features], [...,] or
+            [..., n_samples] if distance is 'precomputed'
             Training data.
-        y : array-like, shape=[n_samples] or [n_samples, n_outputs]
+        y : array-like, shape=[...,] or [..., n_outputs]
             Target values.
         """
         data_shape = gs.shape(X)

--- a/geomstats/learning/kmeans.py
+++ b/geomstats/learning/kmeans.py
@@ -19,19 +19,15 @@ class RiemannianKMeans(TransformerMixin, ClusterMixin, BaseEstimator):
     ----------
     n_clusters : int
         Number of clusters (k value of the k-means).
-
     riemannian_metric : object of class RiemannianMetric
         The geomstats Riemmanian metric associate to the space used.
-
     init : str
         How to initialize centroids at the beginning of the algorithm. The
         choice 'random' will select training points as initial centroids
         uniformly at random.
-
     tol : float
         Convergence factor. Convergence is achieved when the difference of mean
         distance between two steps is lower than tol.
-
     verbose : int
         If verbose > 0, information will be printed during learning.
 
@@ -65,9 +61,8 @@ class RiemannianKMeans(TransformerMixin, ClusterMixin, BaseEstimator):
         X : array-like, shape=[n_samples, n_features]
             Training data, where n_samples is the number of samples and
             n_features is the number of features.
-
         max_iter : int
-            Maximum number of iterations
+            Maximum number of iterations.
 
         Returns
         -------
@@ -135,12 +130,12 @@ class RiemannianKMeans(TransformerMixin, ClusterMixin, BaseEstimator):
         Parameters
         ----------
         X : array-like, shape=[n_samples, n_features]
-            Input data
+            Input data.
 
         Returns
         -------
         self : array-like, shape=[n_samples,]
-            Array of predicted cluster indices for each sample
+            Array of predicted cluster indices for each sample.
         """
         if self.centroids is None:
             raise RuntimeError('fit needs to be called first.')

--- a/geomstats/learning/kmeans.py
+++ b/geomstats/learning/kmeans.py
@@ -19,17 +19,21 @@ class RiemannianKMeans(TransformerMixin, ClusterMixin, BaseEstimator):
     ----------
     n_clusters : int
         Number of clusters (k value of the k-means).
+        Optional, default: 8.
     riemannian_metric : object of class RiemannianMetric
         The geomstats Riemmanian metric associate to the space used.
     init : str
         How to initialize centroids at the beginning of the algorithm. The
         choice 'random' will select training points as initial centroids
         uniformly at random.
+        Optional, default: 'random'.
     tol : float
         Convergence factor. Convergence is achieved when the difference of mean
         distance between two steps is lower than tol.
+        Optional, default: 1e-2.
     verbose : int
         If verbose > 0, information will be printed during learning.
+        Optional, default: 0.
 
     Example
     -------
@@ -58,16 +62,17 @@ class RiemannianKMeans(TransformerMixin, ClusterMixin, BaseEstimator):
 
         Parameters
         ----------
-        X : array-like, shape=[n_samples, n_features]
+        X : array-like, shape=[..., n_features]
             Training data, where n_samples is the number of samples and
             n_features is the number of features.
         max_iter : int
             Maximum number of iterations.
+            Optional, default: 100.
 
         Returns
         -------
         self : array-like, shape=[n_clusters,]
-            centroids array
+            Centroids.
         """
         n_samples = X.shape[0]
         belongs = gs.zeros(n_samples)
@@ -129,12 +134,12 @@ class RiemannianKMeans(TransformerMixin, ClusterMixin, BaseEstimator):
 
         Parameters
         ----------
-        X : array-like, shape=[n_samples, n_features]
+        X : array-like, shape=[..., n_features]
             Input data.
 
         Returns
         -------
-        self : array-like, shape=[n_samples,]
+        self : array-like, shape=[...,]
             Array of predicted cluster indices for each sample.
         """
         if self.centroids is None:

--- a/geomstats/learning/online_kmeans.py
+++ b/geomstats/learning/online_kmeans.py
@@ -193,6 +193,7 @@ class OnlineKMeans(BaseEstimator, ClusterMixin):
 
         Returns
         -------
-        labels : Index of the cluster each sample belongs to.
+        labels : int
+            Index of the cluster each sample belongs to.
         """
         return self.metric.closest_neighbor_index(point, self.cluster_centers_)

--- a/geomstats/learning/online_kmeans.py
+++ b/geomstats/learning/online_kmeans.py
@@ -28,7 +28,7 @@ def online_kmeans(X, metric, n_clusters, n_repetitions=20,
 
     Parameters
     ----------
-    X : array-like, shape=[n_samples, n_features]
+    X : array-like, shape=[..., n_features]
         Input data. It is treated sequentially by the algorithm, i.e.
         one datum is chosen randomly at each iteration.
     metric : object

--- a/geomstats/learning/pca.py
+++ b/geomstats/learning/pca.py
@@ -35,7 +35,7 @@ def _assess_dimension_(spectrum, rank, n_samples, n_features):
 
     Returns
     -------
-    ll : float,
+    ll : float
         The log-likelihood
 
     Notes
@@ -79,7 +79,7 @@ def _assess_dimension_(spectrum, rank, n_samples, n_features):
 
 
 def _infer_dimension_(spectrum, n_samples, n_features):
-    """Infers the dimension of a dataset of shape (n_samples, n_features).
+    """Infer the dimension of a dataset of shape (n_samples, n_features).
 
     The dataset is described by its spectrum `spectrum`.
     """
@@ -91,12 +91,21 @@ def _infer_dimension_(spectrum, n_samples, n_features):
 
 
 class TangentPCA(_BasePCA):
-    """Tangent Principal component analysis (tPCA).
+    r"""Tangent Principal component analysis (tPCA).
 
     Linear dimensionality reduction using
     Singular Value Decomposition of the
     Riemannian Log of the data at the tangent space
     of the Frechet mean.
+
+    Parameters
+    ----------
+    metric : RiemannianMetric
+        Riemannian metric.
+    n_components : int
+        Number of principal components.
+    point_type : str, {\'vector\', \'matrix\'}
+        Point type.
     """
 
     def __init__(self, metric, n_components=None, copy=True,
@@ -123,7 +132,7 @@ class TangentPCA(_BasePCA):
         y : Ignored (Compliance with scikit-learn interface)
         base_point : array-like, shape=[n_samples, n_features], optional
             Point at which to perform the tangent PCA
-            Optional, default to Frechet mean if None
+            Optional, default to Frechet mean if None.
 
         Returns
         -------
@@ -144,11 +153,12 @@ class TangentPCA(_BasePCA):
         y : Ignored (Compliance with scikit-learn interface)
         base_point : array-like, shape=[n_samples, n_features]
             Point at which to perform the tangent PCA
-            Optional, default to Frechet mean if None
+            Optional, default to Frechet mean if None.
 
         Returns
         -------
-        X_new : array-like, shape (n_samples, n_components)
+        X_new : array-like, shape=[n_samples, n_components]
+            Projected data.
         """
         U, S, _ = self._fit(X, base_point=base_point)
 
@@ -170,6 +180,7 @@ class TangentPCA(_BasePCA):
         Returns
         -------
         X_new : array-like, shape=[n_samples, n_components]
+            Projected data.
         """
         tangent_vecs = self.metric.log(X, base_point=self.base_point_fit)
         if self.point_type == 'matrix':
@@ -197,7 +208,8 @@ class TangentPCA(_BasePCA):
 
         Returns
         -------
-        X_original array-like, shape=[n_samples, n_features]
+        X_original : array-like, shape=[n_samples, n_features]
+            Original data.
         """
         scores = self.mean_ + gs.matmul(
             X, self.components_)
@@ -221,14 +233,13 @@ class TangentPCA(_BasePCA):
             and n_features is the number of features.
         y : Ignored (Compliance with scikit-learn interface)
         base_point : array-like, shape=[n_samples, n_features]
-            Point at which to perform the tangent PCA
-            Optional, default to Frechet mean if None
-        point_type : str, {'vector', 'matrix'}
-            Optional
+            Point at which to perform the tangent PCA.
+            Optional, default to Frechet mean if None.
 
         Returns
         -------
-        U, S, V: SVD decomposition
+        U, S, V : array-like
+            Matrices of the SVD decomposition
         """
         if base_point is None:
             mean = FrechetMean(metric=self.metric, point_type=self.point_type)

--- a/geomstats/learning/pca.py
+++ b/geomstats/learning/pca.py
@@ -36,7 +36,7 @@ def _assess_dimension_(spectrum, rank, n_samples, n_features):
     Returns
     -------
     ll : float
-        The log-likelihood
+        Log-likelihood.
 
     Notes
     -----
@@ -104,8 +104,10 @@ class TangentPCA(_BasePCA):
         Riemannian metric.
     n_components : int
         Number of principal components.
-    point_type : str, {\'vector\', \'matrix\'}
+        Optional, default: None.
+    point_type : str, {'vector', 'matrix'}
         Point type.
+        Optional, default: 'vector'.
     """
 
     def __init__(self, metric, n_components=None, copy=True,

--- a/geomstats/learning/pca.py
+++ b/geomstats/learning/pca.py
@@ -126,11 +126,11 @@ class TangentPCA(_BasePCA):
 
         Parameters
         ----------
-        X : array-like, shape=[n_samples, n_features]
+        X : array-like, shape=[..., n_features]
             Training data, where n_samples is the number of samples
             and n_features is the number of features.
         y : Ignored (Compliance with scikit-learn interface)
-        base_point : array-like, shape=[n_samples, n_features], optional
+        base_point : array-like, shape=[..., n_features], optional
             Point at which to perform the tangent PCA
             Optional, default to Frechet mean if None.
 
@@ -147,17 +147,17 @@ class TangentPCA(_BasePCA):
 
         Parameters
         ----------
-        X : array-like, shape=[n_samples, n_features]
+        X : array-like, shape=[..., n_features]
             Training data, where n_samples is the number of samples
             and n_features is the number of features.
         y : Ignored (Compliance with scikit-learn interface)
-        base_point : array-like, shape=[n_samples, n_features]
+        base_point : array-like, shape=[..., n_features]
             Point at which to perform the tangent PCA
             Optional, default to Frechet mean if None.
 
         Returns
         -------
-        X_new : array-like, shape=[n_samples, n_components]
+        X_new : array-like, shape=[..., n_components]
             Projected data.
         """
         U, S, _ = self._fit(X, base_point=base_point)
@@ -172,14 +172,14 @@ class TangentPCA(_BasePCA):
 
         Parameters
         ----------
-        X : array-like, shape=[n_samples, n_features]
+        X : array-like, shape=[..., n_features]
             Data, where n_samples is the number of samples
             and n_features is the number of features.
         y : Ignored (Compliance with scikit-learn interface)
 
         Returns
         -------
-        X_new : array-like, shape=[n_samples, n_components]
+        X_new : array-like, shape=[..., n_components]
             Projected data.
         """
         tangent_vecs = self.metric.log(X, base_point=self.base_point_fit)
@@ -202,13 +202,13 @@ class TangentPCA(_BasePCA):
 
         Parameters
         ----------
-        X : array-like, shape=[n_samples, n_components]
+        X : array-like, shape=[..., n_components]
             New data, where n_samples is the number of samples
             and n_components is the number of components.
 
         Returns
         -------
-        X_original : array-like, shape=[n_samples, n_features]
+        X_original : array-like, shape=[..., n_features]
             Original data.
         """
         scores = self.mean_ + gs.matmul(
@@ -228,11 +228,11 @@ class TangentPCA(_BasePCA):
 
         Parameters
         ----------
-        X : array-like, shape=[n_samples, n_features]
+        X : array-like, shape=[..., n_features]
             Training data, where n_samples is the number of samples
             and n_features is the number of features.
         y : Ignored (Compliance with scikit-learn interface)
-        base_point : array-like, shape=[n_samples, n_features]
+        base_point : array-like, shape=[..., n_features]
             Point at which to perform the tangent PCA.
             Optional, default to Frechet mean if None.
 

--- a/geomstats/learning/preprocessing.py
+++ b/geomstats/learning/preprocessing.py
@@ -70,9 +70,12 @@ class ToTangentSpace(BaseEstimator, TransformerMixin):
             The training input samples.
         y : array-like, shape (n_samples,) or (n_samples, n_outputs)
             Ignored
-        weights : array-like, shape=[n_samples, 1], optional
+        weights : array-like, shape=[n_samples, 1]
+            Weights associated to the points.
+            Optional, default: None
         base_point : array-like, shape=[{dim, [n, n]}]
-            Point similar to the input data from which to compute the logs
+            Point similar to the input data from which to compute the logs.
+            Optional, default: None.
 
         Returns
         -------
@@ -103,6 +106,7 @@ class ToTangentSpace(BaseEstimator, TransformerMixin):
         Returns
         -------
         X_new : array-like, shape=[n_samples, dim]
+            Lifted data.
         """
         if base_point is None:
             base_point = self.estimator.estimate_

--- a/geomstats/learning/preprocessing.py
+++ b/geomstats/learning/preprocessing.py
@@ -66,11 +66,11 @@ class ToTangentSpace(BaseEstimator, TransformerMixin):
 
         Parameters
         ----------
-        X : array-like, shape=[n_samples, {dim, [n, n]}]
+        X : array-like, shape=[..., {dim, [n, n]}]
             The training input samples.
         y : array-like, shape (n_samples,) or (n_samples, n_outputs)
             Ignored
-        weights : array-like, shape=[n_samples, 1]
+        weights : array-like, shape=[..., 1]
             Weights associated to the points.
             Optional, default: None
         base_point : array-like, shape=[{dim, [n, n]}]
@@ -96,7 +96,7 @@ class ToTangentSpace(BaseEstimator, TransformerMixin):
 
         Parameters
         ----------
-        X : array-like, shape=[n_samples, {dim, [n, n]}]
+        X : array-like, shape=[..., {dim, [n, n]}]
             Data to transform.
         y : Ignored (Compliance with scikit-learn interface)
         base_point : array-like, shape={dim, [n,n]}, optional (mean)
@@ -105,7 +105,7 @@ class ToTangentSpace(BaseEstimator, TransformerMixin):
 
         Returns
         -------
-        X_new : array-like, shape=[n_samples, dim]
+        X_new : array-like, shape=[..., dim]
             Lifted data.
         """
         if base_point is None:
@@ -138,7 +138,7 @@ class ToTangentSpace(BaseEstimator, TransformerMixin):
 
         Parameters
         ----------
-        X : array-like, shape=[n_samples, dim]
+        X : array-like, shape=[..., dim]
             New data, where dim is the dimension of the manifold data belong
             to.
         base_point : array-like, shape={dim, [n,n]}, optional (mean)
@@ -147,7 +147,7 @@ class ToTangentSpace(BaseEstimator, TransformerMixin):
 
         Returns
         -------
-        X_original : array-like, shape=[n_samples, {dim, [n, n]}
+        X_original : array-like, shape=[..., {dim, [n, n]}
             Data lying on the manifold.
         """
         if base_point is None:

--- a/tests/test_beta_distributions.py
+++ b/tests/test_beta_distributions.py
@@ -122,12 +122,3 @@ class TestBetaDistributions(geomstats.tests.TestCase):
         expected = gs.array(
             [self.n_samples, self.dim, self.dim, self.dim])
         self.assertAllClose(result, expected)
-
-    def test_inner_product_matrix(self):
-        point = gs.array([1., 1.])
-        result = self.beta.metric.inner_product_matrix(point)
-        expected = gs.array([[1., -0.644934066], [-0.644934066, 1.]])
-        self.assertAllClose(result, expected)
-
-        self.assertRaises(
-            ValueError, self.metric.inner_product_matrix)

--- a/tests/test_beta_distributions.py
+++ b/tests/test_beta_distributions.py
@@ -122,3 +122,9 @@ class TestBetaDistributions(geomstats.tests.TestCase):
         expected = gs.array(
             [self.n_samples, self.dim, self.dim, self.dim])
         self.assertAllClose(result, expected)
+
+    def test_inner_product_matrix(self):
+        point = gs.array([1., 1.])
+        result = self.beta.metric.inner_product_matrix(point)
+        expected = gs.array([[1., -0.644934066], [-0.644934066, 1.]])
+        self.assertAllClose(result, expected)


### PR DESCRIPTION
This PR cleans docstrings and specifically:
- Use singular form for point and tangent vectors, see issue #505.
- Update convention to write optional parameters, which is now: `Optional, default: default_value.` on a new line of the parameter description.
- Update contributing.rst to add the convention for optional parameters in docstrings.
- Add missing docstrings.

`landmarks.py` and `discretized_curves.py` remain to be done @nguigs .