### PR TITLE
Vectorize parallel transport on the hypersphere

### DIFF
--- a/geomstats/geometry/hypersphere.py
+++ b/geomstats/geometry/hypersphere.py
@@ -629,17 +629,13 @@ class HypersphereMetric(RiemannianMetric):
         transported_tangent_vec: array-like, shape=[..., dim + 1]
             Transported tangent vector at exp_(base_point)(tangent_vec_b).
         """
-        tangent_vec_a = gs.to_ndarray(tangent_vec_a, to_ndim=2)
-        tangent_vec_b = gs.to_ndarray(tangent_vec_b, to_ndim=2)
-        base_point = gs.to_ndarray(base_point, to_ndim=2)
-        # TODO (nguigs): work around this condition:
-        # assert len(base_point) == len(tangent_vec_a) == len(tangent_vec_b)
-        theta = gs.linalg.norm(tangent_vec_b, axis=1)
-        normalized_b = gs.einsum('n, ni->ni', 1 / theta, tangent_vec_b)
-        pb = gs.einsum('ni,ni->n', tangent_vec_a, normalized_b)
-        p_orth = tangent_vec_a - gs.einsum('n,ni->ni', pb, normalized_b)
-        transported = - gs.einsum('n,ni->ni', gs.sin(theta) * pb, base_point)\
-            + gs.einsum('n,ni->ni', gs.cos(theta) * pb, normalized_b)\
+        theta = gs.linalg.norm(tangent_vec_b, axis=-1)
+        normalized_b = gs.einsum('..., ...i->...i', 1 / theta, tangent_vec_b)
+        pb = gs.einsum('...i,...i->...', tangent_vec_a, normalized_b)
+        p_orth = tangent_vec_a - gs.einsum('..., ...i->...i', pb, normalized_b)
+        transported = \
+            - gs.einsum('..., ...i->...i', gs.sin(theta) * pb, base_point)\
+            + gs.einsum('..., ...i->...i', gs.cos(theta) * pb, normalized_b)\
             + p_orth
         return transported
 


### PR DESCRIPTION
This addresses #701 so that parallel transport can be applied to:

1. n base_points, n tan_a, n tan_b
2. 1 bp, n tan_a, n tan_b
3. 1 bp, 1 tan_a, n tan_b
4. 1 bp, n tan_a, 1 tan_b
5. 1 bp, 1 tan_a, 1 tan_b

The five cases are tested and work with numpy and tensorflow. Only cases 1 and 5 work with pytorch: it seems einsum is not entirely consistent with that of numpy?