### PR TITLE
Allow einsum to work with arrays of different dtypes

### DIFF
--- a/geomstats/_backend/__init__.py
+++ b/geomstats/_backend/__init__.py
@@ -34,6 +34,7 @@ BACKEND_ATTRIBUTES = {
         'ceil',
         'clip',
         'concatenate',
+        'convert_to_wider_dtype',
         'copy',
         'cos',
         'cosh',

--- a/geomstats/_backend/numpy/__init__.py
+++ b/geomstats/_backend/numpy/__init__.py
@@ -27,6 +27,7 @@ from autograd.numpy import (  # NOQA
     diagonal,
     divide,
     dot,
+    dtype,
     einsum,
     empty,
     empty_like,
@@ -93,18 +94,19 @@ from . import linalg  # NOQA
 from . import random  # NOQA
 from .common import to_ndarray  # NOQA
 
-DTYPES = [int32, int64, float32, float64]
+DTYPES = {
+    dtype('int32'): 0,
+    dtype('int64'): 1,
+    dtype('float32'): 2,
+    dtype('float64'): 3}
 
 
 def convert_to_wider_dtype(tensor_list):
-    dtype_list = [x.dtype for x in tensor_list]
-    wider_dtype = dtype_list[0]
-    wider_dtype_index = DTYPES.index(wider_dtype)
-    for dtype in dtype_list[1:]:
-        index = DTYPES.index(dtype)
-        if index > wider_dtype_index:
-            wider_dtype = dtype
-            wider_dtype_index = index
+    dtype_list = [DTYPES[x.dtype] for x in tensor_list]
+    wider_dtype_index = max(dtype_list)
+
+    wider_dtype = list(DTYPES.keys())[wider_dtype_index]
+
     tensor_list = [cast(x, dtype=wider_dtype) for x in tensor_list]
     return tensor_list
 

--- a/geomstats/_backend/numpy/__init__.py
+++ b/geomstats/_backend/numpy/__init__.py
@@ -93,6 +93,21 @@ from . import linalg  # NOQA
 from . import random  # NOQA
 from .common import to_ndarray  # NOQA
 
+DTYPES = [int32, int64, float32, float64]
+
+
+def convert_to_wider_dtype(tensor_list):
+    dtype_list = [x.dtype for x in tensor_list]
+    wider_dtype = dtype_list[0]
+    wider_dtype_index = DTYPES.index(wider_dtype)
+    for dtype in dtype_list[1:]:
+        index = DTYPES.index(dtype)
+        if index > wider_dtype_index:
+            wider_dtype = dtype
+            wider_dtype_index = index
+    tensor_list = [cast(x, dtype=wider_dtype) for x in tensor_list]
+    return tensor_list
+
 
 def flatten(x):
     return x.flatten()

--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -91,8 +91,6 @@ sin = _box_scalar(sin)
 sinh = _box_scalar(sinh)
 
 
-
-
 def convert_to_wider_dtype(tensor_list):
     dtype_list = [x.dtype for x in tensor_list]
     wider_dtype = dtype_list[0]

--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -63,7 +63,11 @@ from . import linalg  # NOQA
 from . import random  # NOQA
 
 
-DTYPES = [int32, int64, float32, float64]
+DTYPES = {
+    int32: 0,
+    int64: 1,
+    float32: 2,
+    float64: 3}
 
 
 def _raise_not_implemented_error(*args, **kwargs):
@@ -92,16 +96,25 @@ sinh = _box_scalar(sinh)
 
 
 def convert_to_wider_dtype(tensor_list):
-    dtype_list = [x.dtype for x in tensor_list]
-    wider_dtype = dtype_list[0]
-    wider_dtype_index = DTYPES.index(wider_dtype)
-    for dtype in dtype_list[1:]:
-        index = DTYPES.index(dtype)
-        if index > wider_dtype_index:
-            wider_dtype = dtype
-            wider_dtype_index = index
+    dtype_list = [DTYPES[x.dtype] for x in tensor_list]
+    wider_dtype_index = max(dtype_list)
+
+    wider_dtype = list(DTYPES.keys())[wider_dtype_index]
+
     tensor_list = [cast(x, dtype=wider_dtype) for x in tensor_list]
     return tensor_list
+
+# def convert_to_wider_dtype(tensor_list):
+#     dtype_list = [x.dtype for x in tensor_list]
+#     wider_dtype = dtype_list[0]
+#     wider_dtype_index = DTYPES.index(wider_dtype)
+#     for dtype in dtype_list[1:]:
+#         index = DTYPES.index(dtype)
+#         if index > wider_dtype_index:
+#             wider_dtype = dtype
+#             wider_dtype_index = index
+#     tensor_list = [cast(x, dtype=wider_dtype) for x in tensor_list]
+#     return tensor_list
 
 
 def less_equal(x, y, **kwargs):

--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -104,18 +104,6 @@ def convert_to_wider_dtype(tensor_list):
     tensor_list = [cast(x, dtype=wider_dtype) for x in tensor_list]
     return tensor_list
 
-# def convert_to_wider_dtype(tensor_list):
-#     dtype_list = [x.dtype for x in tensor_list]
-#     wider_dtype = dtype_list[0]
-#     wider_dtype_index = DTYPES.index(wider_dtype)
-#     for dtype in dtype_list[1:]:
-#         index = DTYPES.index(dtype)
-#         if index > wider_dtype_index:
-#             wider_dtype = dtype
-#             wider_dtype_index = index
-#     tensor_list = [cast(x, dtype=wider_dtype) for x in tensor_list]
-#     return tensor_list
-
 
 def less_equal(x, y, **kwargs):
     if not torch.is_tensor(x):

--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -63,6 +63,9 @@ from . import linalg  # NOQA
 from . import random  # NOQA
 
 
+DTYPES = [int32, int64, float32, float64]
+
+
 def _raise_not_implemented_error(*args, **kwargs):
     raise NotImplementedError
 
@@ -86,6 +89,21 @@ exp = _box_scalar(exp)
 log = _box_scalar(log)
 sin = _box_scalar(sin)
 sinh = _box_scalar(sinh)
+
+
+
+
+def convert_to_wider_dtype(tensor_list):
+    dtype_list = [x.dtype for x in tensor_list]
+    wider_dtype = dtype_list[0]
+    wider_dtype_index = DTYPES.index(wider_dtype)
+    for dtype in dtype_list[1:]:
+        index = DTYPES.index(dtype)
+        if index > wider_dtype_index:
+            wider_dtype = dtype
+            wider_dtype_index = index
+    tensor_list = [cast(x, dtype=wider_dtype) for x in tensor_list]
+    return tensor_list
 
 
 def less_equal(x, y, **kwargs):
@@ -345,6 +363,9 @@ def sum(x, axis=None, keepdims=None, **kwargs):
 def einsum(*args, **kwargs):
     einsum_str = args[0]
     input_tensors_list = args[1:]
+
+    input_tensors_list = convert_to_wider_dtype(
+        input_tensors_list)
 
     if len(input_tensors_list) == 1:
         return torch.einsum(einsum_str, input_tensors_list)

--- a/geomstats/_backend/tensorflow/__init__.py
+++ b/geomstats/_backend/tensorflow/__init__.py
@@ -62,7 +62,12 @@ from tensorflow import (  # NOQA
 from . import linalg  # NOQA
 from . import random  # NOQA
 
-DTYPES = [int32, int64, float32, float64]
+
+DTYPES = {
+    int32: 0,
+    int64: 1,
+    float32: 2,
+    float64: 3}
 
 
 arctanh = tf.math.atanh
@@ -83,14 +88,11 @@ def _raise_not_implemented_error(*args, **kwargs):
 
 
 def convert_to_wider_dtype(tensor_list):
-    dtype_list = [x.dtype for x in tensor_list]
-    wider_dtype = dtype_list[0]
-    wider_dtype_index = DTYPES.index(wider_dtype)
-    for dtype in dtype_list[1:]:
-        index = DTYPES.index(dtype)
-        if index > wider_dtype_index:
-            wider_dtype = dtype
-            wider_dtype_index = index
+    dtype_list = [DTYPES[x.dtype] for x in tensor_list]
+    wider_dtype_index = max(dtype_list)
+
+    wider_dtype = list(DTYPES.keys())[wider_dtype_index]
+
     tensor_list = [cast(x, dtype=wider_dtype) for x in tensor_list]
     return tensor_list
 

--- a/geomstats/_backend/tensorflow/__init__.py
+++ b/geomstats/_backend/tensorflow/__init__.py
@@ -578,6 +578,8 @@ def einsum(equation, *inputs, **kwargs):
     einsum_str = equation
     input_tensors_list = inputs
 
+    input_tensors_list = convert_to_wider_dtype(input_tensors_list)
+
     einsum_list = einsum_str.split('->')
     input_str = einsum_list[0]
     output_str = einsum_list[1]

--- a/geomstats/_backend/tensorflow/__init__.py
+++ b/geomstats/_backend/tensorflow/__init__.py
@@ -62,6 +62,9 @@ from tensorflow import (  # NOQA
 from . import linalg  # NOQA
 from . import random  # NOQA
 
+DTYPES = [int32, int64, float32, float64]
+
+
 arctanh = tf.math.atanh
 ceil = tf.math.ceil
 cross = tf.linalg.cross
@@ -77,6 +80,19 @@ std = tf.math.reduce_std
 
 def _raise_not_implemented_error(*args, **kwargs):
     raise NotImplementedError
+
+
+def convert_to_wider_dtype(tensor_list):
+    dtype_list = [x.dtype for x in tensor_list]
+    wider_dtype = dtype_list[0]
+    wider_dtype_index = DTYPES.index(wider_dtype)
+    for dtype in dtype_list[1:]:
+        index = DTYPES.index(dtype)
+        if index > wider_dtype_index:
+            wider_dtype = dtype
+            wider_dtype_index = index
+    tensor_list = [cast(x, dtype=wider_dtype) for x in tensor_list]
+    return tensor_list
 
 
 def repeat(a, repeats, axis=None):

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -855,3 +855,19 @@ class TestBackends(geomstats.tests.TestCase):
         result = [a.dtype == gs.float32 for a in gs_result]
 
         self.assertTrue(gs.all(result))
+
+        gs_list = [gs.array([1, 2]), gs.array([2.2, 3.3], dtype=gs.float64)]
+        gs_result = gs.convert_to_wider_dtype(gs_list)
+
+        result = [a.dtype == gs.float64 for a in gs_result]
+
+        self.assertTrue(gs.all(result))
+
+        gs_list = [
+            gs.array([11.11, 222.2], dtype=gs.float64),
+            gs.array([2.2, 3.3], dtype=gs.float32)]
+        gs_result = gs.convert_to_wider_dtype(gs_list)
+
+        result = [a.dtype == gs.float64 for a in gs_result]
+
+        self.assertTrue(gs.all(result))

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -318,6 +318,27 @@ class TestBackends(geomstats.tests.TestCase):
         gs_result = gs.einsum('...,...i->...i', array_1, array_2)
         self.assertAllCloseToNp(gs_result, np_result)
 
+    def test_einsum_dtypes(self):
+        np_array_1 = _np.array([[1, 4]])
+        np_array_2 = _np.array([[2., 3.]])
+        array_1 = gs.array([[1, 4]])
+        array_2 = gs.array([[2., 3.]])
+
+        np_result = _np.einsum('...i,...i->...', np_array_1, np_array_2)
+        gs_result = gs.einsum('...i,...i->...', array_1, array_2)
+
+        self.assertAllCloseToNp(gs_result, np_result)
+
+        np_array_1 = _np.array([[1., 4.], [-1., 5.]])
+        np_array_2 = _np.array([[2, 3]])
+        array_1 = gs.array([[1., 4.], [-1., 5.]])
+        array_2 = gs.array([[2, 3]])
+
+        np_result = _np.einsum('...i,...i->...', np_array_1, np_array_2)
+        gs_result = gs.einsum('...i,...i->...', array_1, array_2)
+
+        self.assertAllCloseToNp(gs_result, np_result)
+
     def test_assignment_with_matrices(self):
         np_array = _np.zeros((2, 3, 3))
         gs_array = gs.zeros((2, 3, 3))

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -826,3 +826,11 @@ class TestBackends(geomstats.tests.TestCase):
         expected = _np.where(np_array == 1, _np.ones(10), np_array)
         result = gs.where(gs_array == 1, gs.ones(10), gs_array)
         self.assertAllCloseToNp(result, expected)
+
+    def test_convert_to_wider_dtype(self):
+        gs_list = [gs.array([1, 2]), gs.array([2.2, 3.3], dtype=gs.float32)]
+        gs_result = gs.convert_to_wider_dtype(gs_list)
+
+        result = [a.dtype == gs.float32 for a in gs_result]
+
+        self.assertTrue(gs.all(result))


### PR DESCRIPTION
This PR starts to address issue #769 .

This PR adds the function `convert_to_wider_dtype` in the backends. This function casts arrays from a list of arrays into arrays of dtype the "wider" dtype. For example, a list of int32 and float32 arrays is cast to float32 and float32 arrays.

This allows einsum to work with arrays of different dtypes.

Note: The code of `convert_to_wider_dtype` is essentially the same for all backends. Could we factorize it somewhere? I tried to put it in a file `_backend/casting.py` but this leads to failure of backend's imports. @nkoep 