### PR TITLE
Point_type in PCA

### DIFF
--- a/geomstats/learning/pca.py
+++ b/geomstats/learning/pca.py
@@ -112,7 +112,7 @@ class TangentPCA(_BasePCA):
 
     def __init__(self, metric, n_components=None, copy=True,
                  whiten=False, tol=0.0, iterated_power='auto',
-                 random_state=None, point_type='vector'):
+                 random_state=None):
         self.metric = metric
         self.n_components = n_components
         self.copy = copy
@@ -120,7 +120,7 @@ class TangentPCA(_BasePCA):
         self.tol = tol
         self.iterated_power = iterated_power
         self.random_state = random_state
-        self.point_type = point_type
+        self.point_type = metric.default_point_type
         self.base_point_fit = None
 
     def fit(self, X, y=None, base_point=None):

--- a/geomstats/learning/pca.py
+++ b/geomstats/learning/pca.py
@@ -105,9 +105,6 @@ class TangentPCA(_BasePCA):
     n_components : int
         Number of principal components.
         Optional, default: None.
-    point_type : str, {'vector', 'matrix'}
-        Point type.
-        Optional, default: 'vector'.
     """
 
     def __init__(self, metric, n_components=None, copy=True,

--- a/tests/test_pca.py
+++ b/tests/test_pca.py
@@ -50,7 +50,7 @@ class TestTangentPCA(geomstats.tests.TestCase):
         X = self.spd.random_uniform(n_samples=5)
         target = 0.90
         tpca = TangentPCA(
-            self.spd_metric, point_type='matrix', n_components=target)
+            self.spd_metric, n_components=target)
         tpca.fit(X)
         result = gs.cumsum(tpca.explained_variance_ratio_)[-1] > target
         expected = True
@@ -61,7 +61,7 @@ class TestTangentPCA(geomstats.tests.TestCase):
         expected = 2
         X = self.spd.random_uniform(n_samples=5)
         tpca = TangentPCA(
-            metric=self.spd_metric, point_type='matrix', n_components=expected)
+            metric=self.spd_metric, n_components=expected)
         tpca.fit(X)
         result = tpca.n_components_
         self.assertAllClose(result, expected)
@@ -71,7 +71,7 @@ class TestTangentPCA(geomstats.tests.TestCase):
         expected = 2
         X = self.spd.random_uniform(n_samples=5)
         tpca = TangentPCA(
-            metric=self.spd_metric, point_type='matrix', n_components=expected)
+            metric=self.spd_metric, n_components=expected)
         tangent_projected_data = tpca.fit_transform(X)
         result = tangent_projected_data.shape[-1]
         self.assertAllClose(result, expected)
@@ -80,7 +80,7 @@ class TestTangentPCA(geomstats.tests.TestCase):
     def test_fit_inverse_transform_matrix(self):
         X = self.spd.random_uniform(n_samples=5)
         tpca = TangentPCA(
-            metric=self.spd_metric, point_type='matrix')
+            metric=self.spd_metric)
         tangent_projected_data = tpca.fit_transform(X)
         result = tpca.inverse_transform(tangent_projected_data)
         expected = X
@@ -90,14 +90,14 @@ class TestTangentPCA(geomstats.tests.TestCase):
     def test_fit_transform_vector(self):
         expected = 2
         tpca = TangentPCA(
-            metric=self.metric, point_type='vector', n_components=expected)
+            metric=self.metric, n_components=expected)
         tangent_projected_data = tpca.fit_transform(self.X)
         result = tangent_projected_data.shape[-1]
         self.assertAllClose(result, expected)
 
     @geomstats.tests.np_only
     def test_fit_inverse_transform_vector(self):
-        tpca = TangentPCA(metric=self.metric, point_type='vector')
+        tpca = TangentPCA(metric=self.metric)
         tangent_projected_data = tpca.fit_transform(self.X)
         result = tpca.inverse_transform(tangent_projected_data)
         expected = self.X
@@ -107,7 +107,7 @@ class TestTangentPCA(geomstats.tests.TestCase):
     def test_fit_fit_transform_matrix(self):
         X = self.spd.random_uniform(n_samples=5)
         tpca = TangentPCA(
-            metric=self.spd_metric, point_type='matrix')
+            metric=self.spd_metric)
         expected = tpca.fit_transform(X)
         result = tpca.fit(X).transform(X)
         self.assertAllClose(result, expected)
@@ -119,7 +119,7 @@ class TestTangentPCA(geomstats.tests.TestCase):
         estimator = ExponentialBarycenter(se_mat)
         estimator.fit(X)
         mean = estimator.estimate_
-        tpca = TangentPCA(metric=se_mat, point_type='matrix')
+        tpca = TangentPCA(metric=se_mat)
         tangent_projected_data = tpca.fit_transform(X, base_point=mean)
         result = tpca.inverse_transform(tangent_projected_data)
         expected = X


### PR DESCRIPTION
In tPCA. point_type is not a degree of liberty but it has to match metric.default_point_type. This ill avoid some issues