### PR TITLE
Adapt discrete curve to pytorch and tf

### DIFF
--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -76,7 +76,6 @@ def _raise_not_implemented_error(*args, **kwargs):
 
 
 searchsorted = _raise_not_implemented_error
-vectorize = _raise_not_implemented_error
 
 
 def _box_scalar(function):
@@ -746,3 +745,9 @@ def array_from_sparse(indices, data, target_shape):
         torch.LongTensor(indices).t(),
         torch.FloatTensor(cast(data, float32)),
         torch.Size(target_shape)).to_dense()
+
+
+def vectorize(x, pyfunc, multiple_args=False, **kwargs):
+    if multiple_args:
+        return stack(list(map(lambda y: pyfunc(*y), zip(*x))))
+    return stack(list(map(pyfunc, x)))

--- a/geomstats/geometry/discrete_curves.py
+++ b/geomstats/geometry/discrete_curves.py
@@ -330,7 +330,7 @@ class SRVMetric(RiemannianMetric):
         log_starting_points = self.ambient_metric.log(
             point=point[:, 0, :], base_point=base_point[:, 0, :])
         log_starting_points = gs.to_ndarray(
-                log_starting_points, to_ndim=3, axis=1)
+            log_starting_points, to_ndim=3, axis=1)
 
         log_cumsum = gs.hstack(
             [gs.zeros((n_curves, 1, n_coords)),

--- a/geomstats/geometry/discrete_curves.py
+++ b/geomstats/geometry/discrete_curves.py
@@ -195,7 +195,8 @@ class SRVMetric(RiemannianMetric):
         index = gs.arange(n_curves * n_sampling_points - 1)
         mask = ~((index + 1) % n_sampling_points == 0)
         index_select = index[mask]
-        srv = gs.reshape(gs.get_slice(srv, index_select), srv_shape)
+        srv = gs.reshape(srv[mask], srv_shape)
+        #srv = gs.reshape(gs.get_slice(srv, index_select), srv_shape)
 
         return srv
 
@@ -220,9 +221,8 @@ class SRVMetric(RiemannianMetric):
                                  'implemented for discrete curves embedded '
                                  'in a Euclidean space.')
         if gs.ndim(srv) != gs.ndim(starting_point):
-            starting_point = gs.transpose(
-                gs.tile(starting_point, (1, 1, 1)),
-                axes=(1, 0, 2))
+            starting_point = gs.to_ndarray(
+                starting_point, to_ndim=srv.ndim, axis=1)
         srv_shape = srv.shape
         srv = gs.to_ndarray(srv, to_ndim=3)
         n_curves, n_sampling_points_minus_one, n_coords = srv.shape
@@ -331,8 +331,8 @@ class SRVMetric(RiemannianMetric):
 
         log_starting_points = self.ambient_metric.log(
             point=point[:, 0, :], base_point=base_point[:, 0, :])
-        log_starting_points = gs.transpose(
-            gs.tile(log_starting_points, (1, 1, 1)), (1, 0, 2))
+        log_starting_points = gs.to_ndarray(
+                log_starting_points, to_ndim=3, axis=1)
 
         log_cumsum = gs.hstack(
             [gs.zeros((n_curves, 1, n_coords)),

--- a/geomstats/geometry/discrete_curves.py
+++ b/geomstats/geometry/discrete_curves.py
@@ -194,9 +194,7 @@ class SRVMetric(RiemannianMetric):
 
         index = gs.arange(n_curves * n_sampling_points - 1)
         mask = ~((index + 1) % n_sampling_points == 0)
-        index_select = index[mask]
         srv = gs.reshape(srv[mask], srv_shape)
-        #srv = gs.reshape(gs.get_slice(srv, index_select), srv_shape)
 
         return srv
 
@@ -373,7 +371,6 @@ class SRVMetric(RiemannianMetric):
                                  'discrete curves embedded in a '
                                  'Euclidean space.')
         curve_ndim = 2
-        curve_shape = initial_curve.shape
         initial_curve = gs.to_ndarray(initial_curve, to_ndim=curve_ndim + 1)
 
         if end_curve is None and initial_tangent_vec is None:

--- a/tests/test_discrete_curves.py
+++ b/tests/test_discrete_curves.py
@@ -50,7 +50,6 @@ class TestDiscreteCurves(geomstats.tests.TestCase):
         self.curve_b = discretized_curve_b
         self.curve_c = discretized_curve_c
 
-    @geomstats.tests.np_only
     def test_belongs(self):
         result = self.space_curves_in_sphere_2d.belongs(self.curve_a)
         self.assertTrue(result)
@@ -84,7 +83,6 @@ class TestDiscreteCurves(geomstats.tests.TestCase):
 
         self.assertAllClose(result, expected, atol=self.atol)
 
-    @geomstats.tests.np_only
     def test_l2_metric_inner_product_vectorization(self):
         """Test the vectorization inner_product."""
         n_samples = self.n_discretized_curves
@@ -101,7 +99,6 @@ class TestDiscreteCurves(geomstats.tests.TestCase):
 
         self.assertAllClose(gs.shape(result), (n_samples,))
 
-    @geomstats.tests.np_only
     def test_l2_metric_dist_vectorization(self):
         """Test the vectorization of dist."""
         n_samples = self.n_discretized_curves
@@ -114,7 +111,6 @@ class TestDiscreteCurves(geomstats.tests.TestCase):
             curves_ab, curves_bc)
         self.assertAllClose(gs.shape(result), (n_samples,))
 
-    @geomstats.tests.np_and_tf_only
     def test_l2_metric_exp_vectorization(self):
         """Test the vectorization of exp."""
         curves_ab = self.l2_metric_s2.geodesic(self.curve_a, self.curve_b)
@@ -130,7 +126,6 @@ class TestDiscreteCurves(geomstats.tests.TestCase):
             base_point=curves_ab)
         self.assertAllClose(gs.shape(result), gs.shape(curves_ab))
 
-    @geomstats.tests.np_and_tf_only
     def test_l2_metric_log_vectorization(self):
         """Test the vectorization of log."""
         curves_ab = self.l2_metric_s2.geodesic(self.curve_a, self.curve_b)
@@ -144,7 +139,6 @@ class TestDiscreteCurves(geomstats.tests.TestCase):
         result = tangent_vecs
         self.assertAllClose(gs.shape(result), gs.shape(curves_ab))
 
-    @geomstats.tests.np_and_tf_only
     def test_l2_metric_geodesic(self):
         """Test the geodesic method of L2Metric."""
         curves_ab = self.l2_metric_s2.geodesic(self.curve_a, self.curve_b)
@@ -160,7 +154,6 @@ class TestDiscreteCurves(geomstats.tests.TestCase):
         expected = gs.stack(expected, axis=1)
         self.assertAllClose(result, expected)
 
-    @geomstats.tests.np_and_tf_only
     def test_srv_metric_pointwise_inner_product(self):
         curves_ab = self.l2_metric_s2.geodesic(self.curve_a, self.curve_b)
         curves_bc = self.l2_metric_s2.geodesic(self.curve_b, self.curve_c)
@@ -183,7 +176,7 @@ class TestDiscreteCurves(geomstats.tests.TestCase):
         expected_shape = (self.n_sampling_points,)
         self.assertAllClose(gs.shape(result), expected_shape)
 
-    @geomstats.tests.np_only
+    @geomstats.tests.np_and_pytorch_only
     def test_square_root_velocity_and_inverse(self):
         """Test of square_root_velocity and its inverse.
 
@@ -201,7 +194,7 @@ class TestDiscreteCurves(geomstats.tests.TestCase):
 
         self.assertAllClose(result, expected)
 
-    @geomstats.tests.np_only
+    @geomstats.tests.np_and_pytorch_only
     def test_srv_metric_exp_and_log(self):
         """Test that exp and log are inverse maps and vectorized.
 
@@ -220,7 +213,7 @@ class TestDiscreteCurves(geomstats.tests.TestCase):
 
         self.assertAllClose(gs.squeeze(result), expected)
 
-    @geomstats.tests.np_only
+    @geomstats.tests.np_and_pytorch_only
     def test_srv_metric_geodesic(self):
         """Test that the geodesic between two curves in a Euclidean space.
 
@@ -249,7 +242,7 @@ class TestDiscreteCurves(geomstats.tests.TestCase):
 
         self.assertAllClose(result, expected)
 
-    @geomstats.tests.np_only
+    @geomstats.tests.np_and_pytorch_only
     def test_srv_metric_dist_and_geod(self):
         """Test that the length of the geodesic gives the distance.
 

--- a/tests/test_discrete_curves.py
+++ b/tests/test_discrete_curves.py
@@ -176,7 +176,6 @@ class TestDiscreteCurves(geomstats.tests.TestCase):
         expected_shape = (self.n_sampling_points,)
         self.assertAllClose(gs.shape(result), expected_shape)
 
-    @geomstats.tests.np_and_pytorch_only
     def test_square_root_velocity_and_inverse(self):
         """Test of square_root_velocity and its inverse.
 
@@ -194,7 +193,6 @@ class TestDiscreteCurves(geomstats.tests.TestCase):
 
         self.assertAllClose(result, expected)
 
-    @geomstats.tests.np_and_pytorch_only
     def test_srv_metric_exp_and_log(self):
         """Test that exp and log are inverse maps and vectorized.
 
@@ -213,7 +211,6 @@ class TestDiscreteCurves(geomstats.tests.TestCase):
 
         self.assertAllClose(gs.squeeze(result), expected)
 
-    @geomstats.tests.np_and_pytorch_only
     def test_srv_metric_geodesic(self):
         """Test that the geodesic between two curves in a Euclidean space.
 
@@ -242,14 +239,13 @@ class TestDiscreteCurves(geomstats.tests.TestCase):
 
         self.assertAllClose(result, expected)
 
-    @geomstats.tests.np_and_pytorch_only
     def test_srv_metric_dist_and_geod(self):
         """Test that the length of the geodesic gives the distance.
 
         N.B: Here curve_a and curve_b are seen as curves in R3 and not S2.
         """
-        geod = self.srv_metric_r3.geodesic(initial_curve=self.curve_a,
-                                           end_curve=self.curve_b)
+        geod = self.srv_metric_r3.geodesic(
+            initial_curve=self.curve_a, end_curve=self.curve_b)
         geod = geod(self.times)
 
         srv = self.srv_metric_r3.square_root_velocity(geod)
@@ -260,6 +256,5 @@ class TestDiscreteCurves(geomstats.tests.TestCase):
         norms = l2_metric.norm(srv_derivative, geod[:-1, :-1, :])
         result = gs.sum(norms, 0) / self.n_discretized_curves
 
-        expected = self.srv_metric_r3.dist(self.curve_a, self.curve_b)
-
+        expected = self.srv_metric_r3.dist(self.curve_a, self.curve_b)[0]
         self.assertAllClose(result, expected)


### PR DESCRIPTION
- Implement a vectorize method for pytorch. It may not behave exactly like the numpy one (which is flexible thanks to the signature argument)
- Remove decorators so that all methods are tested in the three backends

Remaining problems: The discrete curve class is thought for points on manifolds which have vector representations, it won't work for curves of matrices...