### PR TITLE
Have notebooks directly integrated into the documentation website

### DIFF
--- a/ci-requirements.txt
+++ b/ci-requirements.txt
@@ -1,4 +1,6 @@
 codecov
 coverage
+nbsphinx
+pandoc
 sphinx
 sphinx_rtd_theme

--- a/docs/.nblink
+++ b/docs/.nblink
@@ -1,0 +1,3 @@
+{
+    "path": "../notebooks/01_data_on_manifolds.ipynb"
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,6 +9,8 @@ author = 'Geomstats Team'
 release = version = geomstats.__version__
 
 extensions = [
+    'nbsphinx',
+    'nbsphinx_link',
     'sphinx.ext.autodoc',
     'sphinx.ext.coverage',
     'sphinx.ext.doctest',

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -54,3 +54,4 @@ To contribute to `geomstats` visit the page :ref:`contributing`.
    examples.rst
    api-reference.rst
    contributing.rst
+   01_data_on_manifolds


### PR DESCRIPTION
Following issue #453, this PR starts integrating the notebooks directly to the documentation website. 