### PR TITLE
Changes to make notebooks and dataset loading work on Windows.

### DIFF
--- a/geomstats/datasets/utils.py
+++ b/geomstats/datasets/utils.py
@@ -37,7 +37,7 @@ def load_cities():
     name : list
         List of city names.
     """
-    with open(CITIES_PATH) as json_file:
+    with open(CITIES_PATH, encoding='utf-8') as json_file:
         data_file = json.load(json_file)
 
         names = [row['city'] for row in data_file]

--- a/notebooks/tangent_pca_s2.ipynb
+++ b/notebooks/tangent_pca_s2.ipynb
@@ -16,6 +16,32 @@
    "metadata": {},
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Working directory:  D:\\Code\\GitHub\\geomstats\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "import subprocess\n",
+    "\n",
+    "geomstats_gitroot_path = subprocess.check_output(\n",
+    "    ['git', 'rev-parse', '--show-toplevel'], \n",
+    "    universal_newlines=True)\n",
+    "\n",
+    "os.chdir(geomstats_gitroot_path[:-1])\n",
+    "\n",
+    "print('Working directory: ', os.getcwd())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
      "name": "stderr",
      "output_type": "stream",
      "text": [
@@ -36,7 +62,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1725,7 +1751,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -7,11 +7,12 @@ import geomstats.tests
 
 
 def _exec_notebook(path):
-    with tempfile.NamedTemporaryFile(suffix='.ipynb') as fout:
-        args = ['jupyter', 'nbconvert', '--to', 'notebook', '--execute',
-                '--ExecutePreprocessor.timeout=1000',
-                '--output', fout.name, path]
-        subprocess.check_call(args)
+
+    file_name = tempfile.NamedTemporaryFile(suffix='.ipynb').name
+    args = ['jupyter', 'nbconvert', '--to', 'notebook', '--execute',
+            '--ExecutePreprocessor.timeout=1000',
+            '--output', file_name, path]
+    subprocess.check_call(args)
 
 
 class TestNotebooks(geomstats.tests.TestCase):


### PR DESCRIPTION
This PR addresses #803 

On Windows, it seems the file encoding needed to be explicitly given in order for `json` to be able to load `cities`.

`NamedTemporaryFile` already opens the file in question, so having `check_call` inside the `with` tries to open it twice, which appears to be forbidden on Windows.

For some reason, the use of `chdir` was also needed for the `tangent_pca_s2` notebook (I simply pasted the same first cell used in the other two notebooks). 