### PR TITLE
Vector parametrisation for SO(2) and SE(2)

### DIFF
--- a/geomstats/geometry/special_euclidean.py
+++ b/geomstats/geometry/special_euclidean.py
@@ -602,13 +602,13 @@ class _SpecialEuclidean2Vectors(_SpecialEuclideanVectors):
         inv_determinant = gs.zeros_like(rot_vec)
 
         inv_determinant += 0.5 * mask_close_0_float / (
-                TAYLOR_COEFFS_1_AT_0[0]
-                + TAYLOR_COEFFS_1_AT_0[1] * rot_vec ** 2
-                + TAYLOR_COEFFS_1_AT_0[2] * rot_vec ** 6)
+            TAYLOR_COEFFS_1_AT_0[0]
+            + TAYLOR_COEFFS_1_AT_0[1] * rot_vec ** 2
+            + TAYLOR_COEFFS_1_AT_0[2] * rot_vec ** 6)
 
         rot_vec = rot_vec + 1e-6
         inv_determinant += mask_else_float * (
-                rot_vec ** 2 / (2 * (1 - gs.cos(rot_vec))))
+            rot_vec ** 2 / (2 * (1 - gs.cos(rot_vec))))
 
         transform = gs.einsum(
             'il, ijk -> ijk', inv_determinant,
@@ -835,15 +835,15 @@ class _SpecialEuclidean3Vectors(_SpecialEuclideanVectors):
         coef_2 += mask_0_float * 1. / 6. * gs.ones_like(angle)
 
         coef_1 += mask_close_0_float * (
-                TAYLOR_COEFFS_1_AT_0[0]
-                + TAYLOR_COEFFS_1_AT_0[2] * angle ** 2
-                + TAYLOR_COEFFS_1_AT_0[4] * angle ** 4
-                + TAYLOR_COEFFS_1_AT_0[6] * angle ** 6)
+            TAYLOR_COEFFS_1_AT_0[0]
+            + TAYLOR_COEFFS_1_AT_0[2] * angle ** 2
+            + TAYLOR_COEFFS_1_AT_0[4] * angle ** 4
+            + TAYLOR_COEFFS_1_AT_0[6] * angle ** 6)
         coef_2 += mask_close_0_float * (
-                TAYLOR_COEFFS_2_AT_0[0]
-                + TAYLOR_COEFFS_2_AT_0[2] * angle ** 2
-                + TAYLOR_COEFFS_2_AT_0[4] * angle ** 4
-                + TAYLOR_COEFFS_2_AT_0[6] * angle ** 6)
+            TAYLOR_COEFFS_2_AT_0[0]
+            + TAYLOR_COEFFS_2_AT_0[2] * angle ** 2
+            + TAYLOR_COEFFS_2_AT_0[4] * angle ** 4
+            + TAYLOR_COEFFS_2_AT_0[6] * angle ** 6)
 
         angle += mask_0_float * 1.
 
@@ -892,24 +892,24 @@ class _SpecialEuclidean3Vectors(_SpecialEuclideanVectors):
         coef_2 = gs.zeros_like(angle)
 
         coef_2 += mask_close_0_float * (
-                1. / 12. + angle ** 2 / 720.
-                + angle ** 4 / 30240.
-                + angle ** 6 / 1209600.)
+            1. / 12. + angle ** 2 / 720.
+            + angle ** 4 / 30240.
+            + angle ** 6 / 1209600.)
 
         delta_angle = angle - gs.pi
         coef_2 += mask_close_pi_float * (
-                1. / PI2
-                + (PI2 - 8.) * delta_angle / (4. * PI3)
-                - ((PI2 - 12.)
-                   * delta_angle ** 2 / (4. * PI4))
-                + ((-192. + 12. * PI2 + PI4)
-                   * delta_angle ** 3 / (48. * PI5))
-                - ((-240. + 12. * PI2 + PI4)
-                   * delta_angle ** 4 / (48. * PI6))
-                + ((-2880. + 120. * PI2 + 10. * PI4 + PI6)
-                   * delta_angle ** 5 / (480. * PI7))
-                - ((-3360 + 120. * PI2 + 10. * PI4 + PI6)
-                   * delta_angle ** 6 / (480. * PI8)))
+            1. / PI2
+            + (PI2 - 8.) * delta_angle / (4. * PI3)
+            - ((PI2 - 12.)
+               * delta_angle ** 2 / (4. * PI4))
+            + ((-192. + 12. * PI2 + PI4)
+               * delta_angle ** 3 / (48. * PI5))
+            - ((-240. + 12. * PI2 + PI4)
+               * delta_angle ** 4 / (48. * PI6))
+            + ((-2880. + 120. * PI2 + 10. * PI4 + PI6)
+               * delta_angle ** 5 / (480. * PI7))
+            - ((-3360 + 120. * PI2 + 10. * PI4 + PI6)
+               * delta_angle ** 6 / (480. * PI8)))
 
         psi = 0.5 * angle * gs.sin(angle) / (1 - gs.cos(angle))
         coef_2 += mask_else_float * (1 - psi) / (angle ** 2)

--- a/geomstats/geometry/special_euclidean.py
+++ b/geomstats/geometry/special_euclidean.py
@@ -155,7 +155,7 @@ class _SpecialEuclideanMatrices(GeneralLinear, LieGroup):
 class _SpecialEuclideanVectors(LieGroup):
     """Base Class for the special euclidean groups in 2d and 3d in vector form.
 
-    i.e. the Lie group of rigid transformations. Elements of SE(2) and SE(3) can
+    i.e. the Lie group of rigid transformations. Elements of SE(2), SE(3) can
     either be represented as vectors (in 2d) or as matrices in general. The
     matrix representation corresponds to homogeneous coordinates. This class is
     specific to the vector representation of rotations. For the matrix

--- a/geomstats/geometry/special_euclidean.py
+++ b/geomstats/geometry/special_euclidean.py
@@ -156,9 +156,9 @@ class _SpecialEuclideanVectors(LieGroup):
     """Base Class for the special euclidean groups in 2d and 3d in vector form.
 
     i.e. the Lie group of rigid transformations. Elements of SE(2), SE(3) can
-    either be represented as vectors (in 2d) or as matrices in general. The
-    matrix representation corresponds to homogeneous coordinates. This class is
-    specific to the vector representation of rotations. For the matrix
+    either be represented as vectors (in 2d or 3d) or as matrices in general.
+    The matrix representation corresponds to homogeneous coordinates. This
+    class is specific to the vector representation of rotations. For the matrix
     representation use the SpecialEuclidean class and set `n=2` or `n=3`.
 
     Parameter
@@ -204,17 +204,17 @@ class _SpecialEuclideanVectors(LieGroup):
         return self.get_identity(point_type).shape
 
     def belongs(self, point):
-        """Evaluate if a point belongs to SE(2).
+        """Evaluate if a point belongs to SE(2) or SE(3).
 
         Parameters
         ----------
-        point : array-like, shape=[..., 3]
+        point : array-like, shape=[..., dimension]
             Point to check.
 
         Returns
         -------
         belongs : array-like, shape=[...,]
-            Boolean indicating whether point belongs to SE(2).
+            Boolean indicating whether point belongs to SE(2) or SE(3).
         """
         point_dim = point.shape[-1]
         point_ndim = point.ndim
@@ -810,7 +810,7 @@ class _SpecialEuclidean3Vectors(_SpecialEuclideanVectors):
         Returns
         -------
         transform : array-like, shape=[..., 3, 3]
-        Matrix to be applied to the translation part in exp
+            Matrix to be applied to the translation part in exp.
         """
         n_samples = rot_vec.shape[0]
 

--- a/geomstats/geometry/special_euclidean.py
+++ b/geomstats/geometry/special_euclidean.py
@@ -1045,13 +1045,13 @@ class _SpecialEuclidean2Vectors(LieGroup):
         sin_coef = gs.zeros_like(angle)
 
         cos_coef += mask_close_0_float * (
-                TAYLOR_COEFFS_1_AT_0[0] * angle
-                + TAYLOR_COEFFS_1_AT_0[1] * angle ** 3
-                + TAYLOR_COEFFS_1_AT_0[2] * angle ** 5)
+            TAYLOR_COEFFS_1_AT_0[0] * angle
+            + TAYLOR_COEFFS_1_AT_0[1] * angle ** 3
+            + TAYLOR_COEFFS_1_AT_0[2] * angle ** 5)
         sin_coef += mask_close_0_float * (
-                1
-                - TAYLOR_COEFFS_2_AT_0[0] * angle ** 2
-                - TAYLOR_COEFFS_2_AT_0[2] * angle ** 4)
+            1
+            - TAYLOR_COEFFS_2_AT_0[0] * angle ** 2
+            - TAYLOR_COEFFS_2_AT_0[2] * angle ** 4)
 
         angle = angle + mask_close_0_float * 1e-6
         cos_coef += mask_else_float * ((1. - gs.cos(angle)) / angle)
@@ -1088,7 +1088,6 @@ class _SpecialEuclidean2Vectors(LieGroup):
 
         transform = self._exp_translation_transform(angle)
 
-        n_tangent_vecs, _ = tangent_vec.shape
         exp_translation = gs.einsum('ijk, ik -> ij', transform, translation)
 
         group_exp = gs.concatenate(
@@ -1130,13 +1129,13 @@ class _SpecialEuclidean2Vectors(LieGroup):
         inv_determinant = gs.zeros_like(angle)
 
         inv_determinant += 0.5 * mask_close_0_float / (
-                TAYLOR_COEFFS_1_AT_0[0]
-                + TAYLOR_COEFFS_1_AT_0[1] * angle ** 2
-                + TAYLOR_COEFFS_1_AT_0[2] * angle ** 6)
+            TAYLOR_COEFFS_1_AT_0[0]
+            + TAYLOR_COEFFS_1_AT_0[1] * angle ** 2
+            + TAYLOR_COEFFS_1_AT_0[2] * angle ** 6)
 
         angle = angle + 1e-6
         inv_determinant += mask_else_float * (
-                angle ** 2 / (2 * (1 - gs.cos(angle))))
+            angle ** 2 / (2 * (1 - gs.cos(angle))))
 
         transform = gs.einsum(
             'il, ijk -> ijk', inv_determinant,
@@ -1144,7 +1143,6 @@ class _SpecialEuclidean2Vectors(LieGroup):
 
         translation = point[:, dim_rotations:]
 
-        n_points, _ = point.shape
         log_translation = gs.einsum('ijk, ik -> ij', transform, translation)
 
         return gs.concatenate(

--- a/geomstats/geometry/special_euclidean.py
+++ b/geomstats/geometry/special_euclidean.py
@@ -152,14 +152,14 @@ class _SpecialEuclideanMatrices(GeneralLinear, LieGroup):
         return random_point
 
 
-class _SpecialEuclidean3Vectors(LieGroup):
-    """Class for the special euclidean group in 3d, SE(3).
+class _SpecialEuclideanVectors(LieGroup):
+    """Base Class for the special euclidean groups in 2d and 3d in vector form.
 
-    i.e. the Lie group of rigid transformations. Elements of SE(3) can either
-    be represented as vectors (in 3d) or as matrices in general. The matrix
-    representation corresponds to homogeneous coordinates. This class is
+    i.e. the Lie group of rigid transformations. Elements of SE(2) and SE(3) can
+    either be represented as vectors (in 2d) or as matrices in general. The
+    matrix representation corresponds to homogeneous coordinates. This class is
     specific to the vector representation of rotations. For the matrix
-    representation use the SpecialEuclidean class and set `n=3`.
+    representation use the SpecialEuclidean class and set `n=2` or `n=3`.
 
     Parameter
     ---------
@@ -169,15 +169,16 @@ class _SpecialEuclidean3Vectors(LieGroup):
         Optional, default: 0.
     """
 
-    def __init__(self, epsilon=0.):
-        super(_SpecialEuclidean3Vectors, self).__init__(
-            dim=6, default_point_type='vector')
+    def __init__(self, n, epsilon=0.):
+        dim = n * (n + 1) // 2
+        LieGroup.__init__(
+            self, dim=dim, default_point_type='vector')
 
-        self.n = 3
+        self.n = n
         self.epsilon = epsilon
         self.rotations = SpecialOrthogonal(
-            n=3, point_type='vector', epsilon=epsilon)
-        self.translations = Euclidean(dim=3)
+            n=n, point_type='vector', epsilon=epsilon)
+        self.translations = Euclidean(dim=n)
 
     def get_identity(self, point_type=None):
         """Get the identity of the group.
@@ -195,8 +196,6 @@ class _SpecialEuclidean3Vectors(LieGroup):
         if point_type is None:
             point_type = self.default_point_type
         identity = gs.zeros(self.dim)
-        if point_type == 'matrix':
-            identity = gs.eye(self.n + 1)
         return identity
     identity = property(get_identity)
 
@@ -205,7 +204,7 @@ class _SpecialEuclidean3Vectors(LieGroup):
         return self.get_identity(point_type).shape
 
     def belongs(self, point):
-        """Evaluate if a point belongs to SE(3).
+        """Evaluate if a point belongs to SE(2).
 
         Parameters
         ----------
@@ -215,14 +214,13 @@ class _SpecialEuclidean3Vectors(LieGroup):
         Returns
         -------
         belongs : array-like, shape=[...,]
-            Boolean indicating whether point belongs to SE(3).
+            Boolean indicating whether point belongs to SE(2).
         """
         point_dim = point.shape[-1]
         point_ndim = point.ndim
         belongs = gs.logical_and(point_dim == self.dim, point_ndim < 3)
-
         belongs = gs.logical_and(
-            belongs, self.rotations.belongs(point[..., :self.n]))
+            belongs, self.rotations.belongs(point[..., :self.rotations.dim]))
         return belongs
 
     def regularize(self, point):
@@ -241,11 +239,12 @@ class _SpecialEuclidean3Vectors(LieGroup):
         rotations = self.rotations
         dim_rotations = rotations.dim
 
-        rot_vec = point[..., :dim_rotations]
+        regularized_point = point
+        rot_vec = regularized_point[..., :dim_rotations]
         regularized_rot_vec = rotations.regularize(
             rot_vec)
 
-        translation = point[..., dim_rotations:]
+        translation = regularized_point[..., dim_rotations:]
 
         return gs.concatenate(
             [regularized_rot_vec, translation], axis=-1)
@@ -271,6 +270,373 @@ class _SpecialEuclidean3Vectors(LieGroup):
         """
         return self.regularize_tangent_vec(
             tangent_vec, self.identity, metric)
+
+    @geomstats.vectorization.decorator(['else', 'vector'])
+    def matrix_from_vector(self, vec):
+        """Convert point in vector point-type to matrix.
+
+        Parameters
+        ----------
+        vec : array-like, shape=[..., dimension]
+            Vector.
+
+        Returns
+        -------
+        mat : array-like, shape=[..., n+1, n+1]
+            Matrix.
+        """
+        vec = self.regularize(vec)
+        n_vecs, _ = vec.shape
+
+        rot_vec = vec[:, :self.rotations.dim]
+        trans_vec = vec[:, self.rotations.dim:]
+
+        rot_mat = self.rotations.matrix_from_rotation_vector(rot_vec)
+        trans_vec = gs.reshape(trans_vec, (n_vecs, self.n, 1))
+        mat = gs.concatenate((rot_mat, trans_vec), axis=2)
+        last_lines = gs.array(gs.get_mask_i_float(self.n, self.n + 1))
+        last_lines = gs.to_ndarray(last_lines, to_ndim=2)
+        last_lines = gs.to_ndarray(last_lines, to_ndim=3)
+        mat = gs.concatenate((mat, last_lines), axis=1)
+
+        return mat
+
+    @geomstats.vectorization.decorator(
+        ['else', 'vector', 'vector'])
+    def compose(self, point_a, point_b):
+        r"""Compose two elements of SE(2) or SE(3).
+
+        Parameters
+        ----------
+        point_a : array-like, shape=[..., dimension]
+            Point of the group.
+        point_b : array-like, shape=[..., dimension]
+            Point of the group.
+
+        Equation
+        --------
+        (:math: `(R_1, t_1) \\cdot (R_2, t_2) = (R_1 R_2, R_1 t_2 + t_1)`)
+
+        Returns
+        -------
+        composition : array-like, shape=[..., dimension]
+            Composition of point_a and point_b.
+        """
+        rotations = self.rotations
+        dim_rotations = rotations.dim
+
+        point_a = self.regularize(point_a)
+        point_b = self.regularize(point_b)
+
+        rot_vec_a = point_a[..., :dim_rotations]
+        rot_mat_a = rotations.matrix_from_rotation_vector(rot_vec_a)
+
+        rot_vec_b = point_b[..., :dim_rotations]
+        rot_mat_b = rotations.matrix_from_rotation_vector(rot_vec_b)
+
+        translation_a = point_a[..., dim_rotations:]
+        translation_b = point_b[..., dim_rotations:]
+
+        composition_rot_mat = gs.matmul(rot_mat_a, rot_mat_b)
+        composition_rot_vec = rotations.rotation_vector_from_matrix(
+            composition_rot_mat)
+
+        composition_translation = gs.einsum(
+            '...j,...kj->...k', translation_b, rot_mat_a) + translation_a
+
+        composition = gs.concatenate((composition_rot_vec,
+                                      composition_translation), axis=-1)
+        return self.regularize(composition)
+
+    @geomstats.vectorization.decorator(['else', 'vector'])
+    def inverse(self, point):
+        r"""Compute the group inverse in SE(n).
+
+        Parameters
+        ----------
+        point: array-like, shape=[..., dimension]
+            Point.
+
+        Returns
+        -------
+        inverse_point : array-like, shape=[..., dimension]
+            Inverted point.
+
+        Notes
+        -----
+        :math:`(R, t)^{-1} = (R^{-1}, R^{-1}.(-t))`
+        """
+        rotations = self.rotations
+        dim_rotations = rotations.dim
+
+        point = self.regularize(point)
+
+        rot_vec = point[:, :dim_rotations]
+        translation = point[:, dim_rotations:]
+
+        inverse_rotation = -rot_vec
+
+        inv_rot_mat = rotations.matrix_from_rotation_vector(
+            inverse_rotation)
+
+        inverse_translation = gs.einsum(
+            'ni,nij->nj',
+            -translation,
+            gs.transpose(inv_rot_mat, axes=(0, 2, 1)))
+
+        inverse_point = gs.concatenate(
+            [inverse_rotation, inverse_translation], axis=-1)
+        return self.regularize(inverse_point)
+
+    @geomstats.vectorization.decorator(['else', 'vector'])
+    def exp_from_identity(self, tangent_vec):
+        """Compute group exponential of the tangent vector at the identity.
+
+        Parameters
+        ----------
+        tangent_vec: array-like, shape=[..., 3]
+            Tangent vector at base point.
+
+        Returns
+        -------
+        group_exp: array-like, shape=[..., 3]
+            Group exponential of the tangent vectors computed
+            at the identity.
+        """
+        rotations = self.rotations
+        dim_rotations = rotations.dim
+
+        rot_vec = tangent_vec[..., :dim_rotations]
+        rot_vec_regul = self.rotations.regularize(rot_vec)
+        rot_vec_regul = gs.to_ndarray(rot_vec_regul, to_ndim=2, axis=1)
+
+        transform = self._exp_translation_transform(rot_vec_regul)
+
+        translation = tangent_vec[..., dim_rotations:]
+        exp_translation = gs.einsum('ijk, ik -> ij', transform, translation)
+
+        group_exp = gs.concatenate(
+            [rot_vec, exp_translation], axis=1)
+
+        group_exp = self.regularize(group_exp)
+        return group_exp
+
+    @geomstats.vectorization.decorator(['else', 'vector'])
+    def log_from_identity(self, point):
+        """Compute the group logarithm of the point at the identity.
+
+        Parameters
+        ----------
+        point: array-like, shape=[..., 3]
+            Point.
+
+        Returns
+        -------
+        group_log: array-like, shape=[..., 3]
+            Group logarithm in the Lie algebra.
+        """
+        point = self.regularize(point)
+
+        rotations = self.rotations
+        dim_rotations = rotations.dim
+
+        rot_vec = point[:, :dim_rotations]
+
+        transform = self._log_translation_transform(rot_vec)
+
+        translation = point[:, dim_rotations:]
+
+        log_translation = gs.einsum('ijk, ik -> ij', transform, translation)
+
+        return gs.concatenate(
+            [rot_vec, log_translation], axis=1)
+
+    def random_uniform(self, n_samples=1):
+        """Sample in SE(n) with the uniform distribution.
+
+        Parameters
+        ----------
+        n_samples : int
+            Number of samples.
+            Optional, default: 1
+
+        Returns
+        -------
+        random_point : array-like, shape=[..., dimension]
+            Sample.
+        """
+        random_translation = self.translations.random_uniform(n_samples)
+        random_rot_vec = self.rotations.random_uniform(n_samples)
+        return gs.concatenate([random_rot_vec, random_translation], axis=-1)
+
+
+class _SpecialEuclidean2Vectors(_SpecialEuclideanVectors):
+    """Class for the special euclidean group in 2d, SE(2).
+
+    i.e. the Lie group of rigid transformations. Elements of SE(32 can either
+    be represented as vectors (in 2d) or as matrices in general. The matrix
+    representation corresponds to homogeneous coordinates. This class is
+    specific to the vector representation of rotations. For the matrix
+    representation use the SpecialEuclidean class and set `n=2`.
+
+    Parameter
+    ---------
+    epsilon : float
+        Precision to use for calculations involving potential
+        division by 0 in rotations.
+        Optional, default: 0.
+    """
+
+    def __init__(self, epsilon=0.):
+        super(_SpecialEuclidean2Vectors, self).__init__(
+            n=2, epsilon=epsilon)
+
+    def regularize_tangent_vec(
+            self, tangent_vec, base_point, metric=None):
+        """Regularize a tangent vector at a base point.
+
+        Parameters
+        ----------
+        tangent_vec: array-like, shape=[..., 3]
+            Tangent vector at base point.
+        base_point : array-like, shape=[..., 3]
+            Base point.
+        metric : RiemannianMetric
+            Metric.
+            Optional, defaults to self.left_canonical_metric if None.
+
+        Returns
+        -------
+        regularized_vec : array-like, shape=[..., 3]
+            Regularized vector.
+        """
+        if metric is None:
+            metric = self.left_canonical_metric
+
+        rotations = self.rotations
+        dim_rotations = rotations.dim
+
+        rot_tangent_vec = tangent_vec[..., :dim_rotations]
+        rot_base_point = base_point[..., :dim_rotations]
+
+        rotations_vec = rotations.regularize_tangent_vec(
+            tangent_vec=rot_tangent_vec,
+            base_point=rot_base_point)
+
+        return gs.concatenate(
+            [rotations_vec, tangent_vec[..., dim_rotations:]], axis=-1)
+
+    @geomstats.vectorization.decorator(['else', 'vector', 'else'])
+    def jacobian_translation(self, point, left_or_right='left'):
+        """Compute the Jacobian matrix resulting from translation.
+
+        Compute the matrix of the differential of the left/right translations
+        from the identity to point in SE(3).
+
+        Parameters
+        ----------
+        point: array-like, shape=[..., 3]
+            Point.
+        left_or_right: str, {'left', 'right'}
+            Whether to compute the jacobian of the left or right translation.
+            Optional, default: 'left'.
+
+        Returns
+        -------
+        jacobian : array-like, shape=[..., 3]
+            Jacobian of the left / right translation.
+        """
+        if left_or_right not in ('left', 'right'):
+            raise ValueError('`left_or_right` must be `left` or `right`.')
+
+        point = self.regularize(point)
+
+        n_points, _ = point.shape
+
+        return gs.array([gs.eye(self.dim)] * n_points)
+
+    def _exp_translation_transform(self, rot_vec):
+        n_samples = rot_vec.shape[0]
+        base_1 = gs.array([gs.eye(2)] * n_samples)
+        base_2 = -gs.array(
+            [self.rotations.skew_matrix_from_vector([1])] * n_samples)
+
+        mask_close_0 = gs.isclose(rot_vec, 0.)
+        mask_else = ~mask_close_0
+
+        mask_close_0_float = gs.cast(mask_close_0, gs.float32)
+        mask_else_float = gs.cast(mask_else, gs.float32)
+
+        cos_coef = gs.zeros_like(rot_vec)
+        sin_coef = gs.zeros_like(rot_vec)
+
+        cos_coef += mask_close_0_float * (
+            TAYLOR_COEFFS_1_AT_0[0] * rot_vec
+            + TAYLOR_COEFFS_1_AT_0[1] * rot_vec ** 3
+            + TAYLOR_COEFFS_1_AT_0[2] * rot_vec ** 5)
+        sin_coef += mask_close_0_float * (
+            1
+            - TAYLOR_COEFFS_2_AT_0[0] * rot_vec ** 2
+            - TAYLOR_COEFFS_2_AT_0[2] * rot_vec ** 4)
+
+        rot_vec = rot_vec + mask_close_0_float * 1e-6
+        cos_coef += mask_else_float * ((1. - gs.cos(rot_vec)) / rot_vec)
+        sin_coef += mask_else_float * (gs.sin(rot_vec) / rot_vec)
+
+        sin_term = gs.einsum('...i,...ij->...ij', sin_coef, base_1)
+        cos_term = gs.einsum('...i,...ij->...ij', cos_coef, base_2)
+        transform = sin_term + cos_term
+
+        return transform
+
+    def _log_translation_transform(self, rot_vec):
+        rot_vec = gs.to_ndarray(rot_vec, to_ndim=2, axis=1)
+        exp_transform = self._exp_translation_transform(rot_vec)
+
+        mask_close_0 = gs.isclose(rot_vec, 0.)
+        mask_else = ~mask_close_0
+
+        mask_close_0_float = gs.cast(mask_close_0, gs.float32)
+        mask_else_float = gs.cast(mask_else, gs.float32)
+
+        inv_determinant = gs.zeros_like(rot_vec)
+
+        inv_determinant += 0.5 * mask_close_0_float / (
+                TAYLOR_COEFFS_1_AT_0[0]
+                + TAYLOR_COEFFS_1_AT_0[1] * rot_vec ** 2
+                + TAYLOR_COEFFS_1_AT_0[2] * rot_vec ** 6)
+
+        rot_vec = rot_vec + 1e-6
+        inv_determinant += mask_else_float * (
+                rot_vec ** 2 / (2 * (1 - gs.cos(rot_vec))))
+
+        transform = gs.einsum(
+            'il, ijk -> ijk', inv_determinant,
+            gs.transpose(exp_transform, axes=[0, 2, 1]))
+
+        return transform
+
+
+class _SpecialEuclidean3Vectors(_SpecialEuclideanVectors):
+    """Class for the special euclidean group in 3d, SE(3).
+
+    i.e. the Lie group of rigid transformations. Elements of SE(3) can either
+    be represented as vectors (in 3d) or as matrices in general. The matrix
+    representation corresponds to homogeneous coordinates. This class is
+    specific to the vector representation of rotations. For the matrix
+    representation use the SpecialEuclidean class and set `n=3`.
+
+    Parameter
+    ---------
+    epsilon : float
+        Precision to use for calculations involving potential
+        division by 0 in rotations.
+        Optional, default: 0.
+    """
+
+    def __init__(self, epsilon=0.):
+        super(_SpecialEuclidean3Vectors, self).__init__(
+            n=3, epsilon=epsilon)
 
     def regularize_tangent_vec(
             self, tangent_vec, base_point, metric=None):
@@ -314,123 +680,6 @@ class _SpecialEuclidean3Vectors(LieGroup):
 
         return gs.concatenate(
             [rotations_vec, tangent_vec[..., dim_rotations:]], axis=-1)
-
-    @geomstats.vectorization.decorator(['else', 'vector'])
-    def matrix_from_vector(self, vec):
-        """Convert point in vector point-type to matrix.
-
-        Parameters
-        ----------
-        vec : array-like, shape=[..., 3]
-            Vector.
-
-        Returns
-        -------
-        mat : array-like, shape=[..., 4, 4]
-            Matrix.
-        """
-        vec = self.regularize(vec)
-        n_vecs, _ = vec.shape
-
-        rot_vec = vec[:, :self.rotations.dim]
-        trans_vec = vec[:, self.rotations.dim:]
-
-        rot_mat = self.rotations.matrix_from_rotation_vector(rot_vec)
-        trans_vec = gs.reshape(trans_vec, (n_vecs, self.n, 1))
-        mat = gs.concatenate((rot_mat, trans_vec), axis=2)
-        last_lines = gs.array(gs.get_mask_i_float(self.n, self.n + 1))
-        last_lines = gs.to_ndarray(last_lines, to_ndim=2)
-        last_lines = gs.to_ndarray(last_lines, to_ndim=3)
-        mat = gs.concatenate((mat, last_lines), axis=1)
-
-        return mat
-
-    @geomstats.vectorization.decorator(
-        ['else', 'vector', 'vector'])
-    def compose(self, point_a, point_b):
-        r"""Compose two elements of SE(3).
-
-        Parameters
-        ----------
-        point_a : array-like, shape=[..., 3]
-            Point of the group.
-        point_b : array-like, shape=[..., 3]
-            Point of the group.
-
-        Equation
-        --------
-        (:math: `(R_1, t_1) \\cdot (R_2, t_2) = (R_1 R_2, R_1 t_2 + t_1)`)
-
-        Returns
-        -------
-        composition : array-like, shape=[..., 3]
-            Composition of point_a and point_b.
-        """
-        rotations = self.rotations
-        dim_rotations = rotations.dim
-
-        point_a = self.regularize(point_a)
-        point_b = self.regularize(point_b)
-
-        rot_vec_a = point_a[..., :dim_rotations]
-        rot_mat_a = rotations.matrix_from_rotation_vector(rot_vec_a)
-
-        rot_vec_b = point_b[..., :dim_rotations]
-        rot_mat_b = rotations.matrix_from_rotation_vector(rot_vec_b)
-
-        translation_a = point_a[..., dim_rotations:]
-        translation_b = point_b[..., dim_rotations:]
-
-        composition_rot_mat = gs.matmul(rot_mat_a, rot_mat_b)
-        composition_rot_vec = rotations.rotation_vector_from_matrix(
-            composition_rot_mat)
-
-        composition_translation = gs.einsum(
-            '...j,...kj->...k', translation_b, rot_mat_a) + translation_a
-
-        composition = gs.concatenate((composition_rot_vec,
-                                      composition_translation), axis=-1)
-        return self.regularize(composition)
-
-    @geomstats.vectorization.decorator(['else', 'vector'])
-    def inverse(self, point):
-        r"""Compute the group inverse in SE(n).
-
-        Parameters
-        ----------
-        point: array-like, shape=[..., 3]
-            Point.
-
-        Returns
-        -------
-        inverse_point : array-like, shape=[..., 3]
-            Inverted point.
-
-        Notes
-        -----
-        :math:`(R, t)^{-1} = (R^{-1}, R^{-1}.(-t))`
-        """
-        rotations = self.rotations
-        dim_rotations = rotations.dim
-
-        point = self.regularize(point)
-
-        rot_vec = point[:, :dim_rotations]
-        translation = point[:, dim_rotations:]
-
-        inverse_rotation = -rot_vec
-
-        inv_rot_mat = rotations.matrix_from_rotation_vector(
-            inverse_rotation)
-
-        inverse_translation = gs.einsum(
-            'ni,nij->nj',
-            -translation,
-            gs.transpose(inv_rot_mat, axes=(0, 2, 1)))
-
-        inverse_point = gs.concatenate(
-            [inverse_rotation, inverse_translation], axis=-1)
-        return self.regularize(inverse_point)
 
     @geomstats.vectorization.decorator(['else', 'vector', 'else'])
     def jacobian_translation(self, point, left_or_right='left'):
@@ -496,181 +745,6 @@ class _SpecialEuclidean3Vectors(LieGroup):
         return jacobian[0] if (len(point) == 1 or point.ndim == 1) \
             else jacobian
 
-    @geomstats.vectorization.decorator(['else', 'vector'])
-    def exp_from_identity(self, tangent_vec):
-        """Compute group exponential of the tangent vector at the identity.
-
-        Parameters
-        ----------
-        tangent_vec: array-like, shape=[..., 3]
-            Tangent vector at base point.
-
-        Returns
-        -------
-        group_exp: array-like, shape=[..., 3]
-            Group exponential of the tangent vectors computed
-            at the identity.
-        """
-        rotations = self.rotations
-        dim_rotations = rotations.dim
-
-        rot_vec = tangent_vec[..., :dim_rotations]
-        rot_vec = self.rotations.regularize(rot_vec)
-        translation = tangent_vec[..., dim_rotations:]
-
-        angle = gs.linalg.norm(rot_vec, axis=-1)
-        angle = gs.to_ndarray(angle, to_ndim=2, axis=1)
-
-        skew_mat = self.rotations.skew_matrix_from_vector(rot_vec)
-        sq_skew_mat = gs.matmul(skew_mat, skew_mat)
-
-        mask_0 = gs.equal(angle, 0.)
-        mask_close_0 = gs.isclose(angle, 0.) & ~mask_0
-        mask_else = ~mask_0 & ~mask_close_0
-
-        mask_0_float = gs.cast(mask_0, gs.float32)
-        mask_close_0_float = gs.cast(mask_close_0, gs.float32)
-        mask_else_float = gs.cast(mask_else, gs.float32)
-
-        angle += mask_0_float * gs.ones_like(angle)
-
-        coef_1 = gs.zeros_like(angle)
-        coef_2 = gs.zeros_like(angle)
-
-        coef_1 += mask_0_float * 1. / 2. * gs.ones_like(angle)
-        coef_2 += mask_0_float * 1. / 6. * gs.ones_like(angle)
-
-        coef_1 += mask_close_0_float * (
-            TAYLOR_COEFFS_1_AT_0[0]
-            + TAYLOR_COEFFS_1_AT_0[2] * angle ** 2
-            + TAYLOR_COEFFS_1_AT_0[4] * angle ** 4
-            + TAYLOR_COEFFS_1_AT_0[6] * angle ** 6)
-        coef_2 += mask_close_0_float * (
-            TAYLOR_COEFFS_2_AT_0[0]
-            + TAYLOR_COEFFS_2_AT_0[2] * angle ** 2
-            + TAYLOR_COEFFS_2_AT_0[4] * angle ** 4
-            + TAYLOR_COEFFS_2_AT_0[6] * angle ** 6)
-
-        coef_1 += mask_else_float * ((1. - gs.cos(angle)) / angle ** 2)
-        coef_2 += mask_else_float * ((angle - gs.sin(angle)) / angle ** 3)
-
-        n_tangent_vecs, _ = tangent_vec.shape
-        exp_translation = gs.zeros((n_tangent_vecs, self.n))
-        for i in range(n_tangent_vecs):
-            translation_i = translation[i]
-            term_1_i = coef_1[i] * gs.dot(translation_i,
-                                          gs.transpose(skew_mat[i]))
-            term_2_i = coef_2[i] * gs.dot(translation_i,
-                                          gs.transpose(sq_skew_mat[i]))
-            mask_i_float = gs.get_mask_i_float(i, n_tangent_vecs)
-            exp_translation += gs.outer(
-                mask_i_float, translation_i + term_1_i + term_2_i)
-
-        group_exp = gs.concatenate(
-            [rot_vec, exp_translation], axis=1)
-
-        group_exp = self.regularize(group_exp)
-        return group_exp
-
-    @geomstats.vectorization.decorator(['else', 'vector'])
-    def log_from_identity(self, point):
-        """Compute the group logarithm of the point at the identity.
-
-        Parameters
-        ----------
-        point: array-like, shape=[..., 3]
-            Point.
-
-        Returns
-        -------
-        group_log: array-like, shape=[..., 3]
-            Group logarithm in the Lie algebra.
-        """
-        point = self.regularize(point)
-
-        rotations = self.rotations
-        dim_rotations = rotations.dim
-
-        rot_vec = point[:, :dim_rotations]
-        angle = gs.linalg.norm(rot_vec, axis=1)
-        angle = gs.to_ndarray(angle, to_ndim=2, axis=1)
-
-        translation = point[:, dim_rotations:]
-
-        skew_rot_vec = rotations.skew_matrix_from_vector(rot_vec)
-        sq_skew_rot_vec = gs.matmul(skew_rot_vec, skew_rot_vec)
-
-        mask_close_0 = gs.isclose(angle, 0.)
-        mask_close_pi = gs.isclose(angle, gs.pi)
-        mask_else = ~mask_close_0 & ~mask_close_pi
-
-        mask_close_0_float = gs.cast(mask_close_0, gs.float32)
-        mask_close_pi_float = gs.cast(mask_close_pi, gs.float32)
-        mask_else_float = gs.cast(mask_else, gs.float32)
-
-        mask_0 = gs.isclose(angle, 0., atol=1e-6)
-        mask_0_float = gs.cast(mask_0, gs.float32)
-        angle += mask_0_float * gs.ones_like(angle)
-
-        coef_1 = - 0.5 * gs.ones_like(angle)
-        coef_2 = gs.zeros_like(angle)
-
-        coef_2 += mask_close_0_float * (
-            1. / 12. + angle ** 2 / 720.
-            + angle ** 4 / 30240.
-            + angle ** 6 / 1209600.)
-
-        delta_angle = angle - gs.pi
-        coef_2 += mask_close_pi_float * (
-            1. / PI2
-            + (PI2 - 8.) * delta_angle / (4. * PI3)
-            - ((PI2 - 12.)
-               * delta_angle ** 2 / (4. * PI4))
-            + ((-192. + 12. * PI2 + PI4)
-               * delta_angle ** 3 / (48. * PI5))
-            - ((-240. + 12. * PI2 + PI4)
-               * delta_angle ** 4 / (48. * PI6))
-            + ((-2880. + 120. * PI2 + 10. * PI4 + PI6)
-               * delta_angle ** 5 / (480. * PI7))
-            - ((-3360 + 120. * PI2 + 10. * PI4 + PI6)
-               * delta_angle ** 6 / (480. * PI8)))
-
-        psi = 0.5 * angle * gs.sin(angle) / (1 - gs.cos(angle))
-        coef_2 += mask_else_float * (1 - psi) / (angle ** 2)
-
-        n_points, _ = point.shape
-        log_translation = gs.zeros((n_points, self.n))
-        for i in range(n_points):
-            translation_i = translation[i]
-            term_1_i = coef_1[i] * gs.dot(translation_i,
-                                          gs.transpose(skew_rot_vec[i]))
-            term_2_i = coef_2[i] * gs.dot(translation_i,
-                                          gs.transpose(sq_skew_rot_vec[i]))
-            mask_i_float = gs.get_mask_i_float(i, n_points)
-            log_translation += gs.outer(
-                mask_i_float, translation_i + term_1_i + term_2_i)
-
-        return gs.concatenate(
-            [rot_vec, log_translation], axis=1)
-
-    def random_uniform(self, n_samples=1):
-        """Sample in SE(3) with the uniform distribution.
-
-        Parameters
-        ----------
-        n_samples : int
-            Number of samples.
-            Optional, default: 1
-
-        Returns
-        -------
-        random_point : array-like, shape=[..., 3]
-            Sample.
-        """
-        random_translation = self.translations.random_uniform(n_samples)
-        random_rot_vec = self.rotations.random_uniform(n_samples)
-        return gs.concatenate([random_rot_vec, random_translation], axis=-1)
-
     def _exponential_matrix(self, rot_vec):
         """Compute exponential of rotation matrix represented by rot_vec.
 
@@ -726,445 +800,126 @@ class _SpecialEuclidean3Vectors(LieGroup):
 
         return exponential_mat
 
-
-class _SpecialEuclidean2Vectors(LieGroup):
-    """Class for the special euclidean group in 2d, SE(2).
-
-    i.e. the Lie group of rigid transformations. Elements of SE(32 can either
-    be represented as vectors (in 2d) or as matrices in general. The matrix
-    representation corresponds to homogeneous coordinates. This class is
-    specific to the vector representation of rotations. For the matrix
-    representation use the SpecialEuclidean class and set `n=2`.
-
-    Parameter
-    ---------
-    epsilon : float
-        Precision to use for calculations involving potential
-        division by 0 in rotations.
-        Optional, default: 0.
-    """
-
-    def __init__(self, epsilon=0.):
-        super(_SpecialEuclidean2Vectors, self).__init__(
-            dim=3, default_point_type='vector')
-
-        self.n = 2
-        self.epsilon = epsilon
-        self.rotations = SpecialOrthogonal(
-            n=2, point_type='vector', epsilon=epsilon)
-        self.translations = Euclidean(dim=2)
-
-    def get_identity(self, point_type=None):
-        """Get the identity of the group.
+    def _exp_translation_transform(self, rot_vec):
+        """Compute matrix associated to rot_vec for the translation part in exp.
 
         Parameters
         ----------
-        point_type : str, {'vector', 'matrix'}
-            The point_type of the returned value.
-            Optional, default: self.default_point_type
+        rot_vec : array-like, shape=[..., 3]
 
         Returns
         -------
-        identity : array-like, shape={[dim], [n + 1, n + 1]}
+        transform : array-like, shape=[..., 3, 3]
+        Matrix to be applied to the translation part in exp
         """
-        if point_type is None:
-            point_type = self.default_point_type
-        identity = gs.zeros(self.dim)
-        if point_type == 'matrix':
-            identity = gs.eye(self.n + 1)
-        return identity
-    identity = property(get_identity)
+        n_samples = rot_vec.shape[0]
 
-    def get_point_type_shape(self, point_type=None):
-        """Get the shape of the instance given the default_point_style."""
-        return self.get_identity(point_type).shape
+        angle = gs.linalg.norm(rot_vec, axis=-1)
+        angle = gs.to_ndarray(angle, to_ndim=2, axis=1)
 
-    def belongs(self, point):
-        """Evaluate if a point belongs to SE(2).
+        skew_mat = self.rotations.skew_matrix_from_vector(rot_vec)
+        sq_skew_mat = gs.matmul(skew_mat, skew_mat)
 
-        Parameters
-        ----------
-        point : array-like, shape=[..., 3]
-            Point to check.
+        mask_0 = gs.equal(angle, 0.)
+        mask_close_0 = gs.isclose(angle, 0.) & ~mask_0
+        mask_else = ~mask_0 & ~mask_close_0
 
-        Returns
-        -------
-        belongs : array-like, shape=[...,]
-            Boolean indicating whether point belongs to SE(2).
-        """
-        point_dim = point.shape[-1]
-        point_ndim = point.ndim
-        belongs = gs.logical_and(point_dim == self.dim, point_ndim < 3)
-        belongs = gs.logical_and(
-            belongs, self.rotations.belongs(point[..., :self.rotations.dim]))
-        return belongs
-
-    def regularize(self, point):
-        """Regularize a point to the default representation for SE(n).
-
-        Parameters
-        ----------
-        point : array-like, shape=[..., 3]
-            Point to regularize.
-
-        Returns
-        -------
-        point : array-like, shape=[..., 3]
-            Regularized point.
-        """
-        rotations = self.rotations
-        dim_rotations = rotations.dim
-
-        regularized_point = point
-        # regularized_point = gs.to_ndarray(regularized_point, to_ndim=2)
-        rot_vec = regularized_point[..., :dim_rotations]
-        regularized_rot_vec = rotations.regularize(
-            rot_vec)
-
-        translation = regularized_point[..., dim_rotations:]
-
-        return gs.concatenate(
-            [regularized_rot_vec, translation], axis=-1)
-
-    @geomstats.vectorization.decorator([
-        'else', 'vector', 'else'])
-    def regularize_tangent_vec_at_identity(
-            self, tangent_vec, metric=None):
-        """Regularize a tangent vector at the identity.
-
-        Parameters
-        ----------
-        tangent_vec: array-like, shape=[..., 3]
-            Tangent vector at base point.
-        metric : RiemannianMetric
-            Metric.
-            Optional, default: None.
-
-        Returns
-        -------
-        regularized_vec : array-like, shape=[..., 3]
-            Regularized vector.
-        """
-        return self.regularize_tangent_vec(
-            tangent_vec, self.identity, metric)
-
-    def regularize_tangent_vec(
-            self, tangent_vec, base_point, metric=None):
-        """Regularize a tangent vector at a base point.
-
-        Parameters
-        ----------
-        tangent_vec: array-like, shape=[..., 3]
-            Tangent vector at base point.
-        base_point : array-like, shape=[..., 3]
-            Base point.
-        metric : RiemannianMetric
-            Metric.
-            Optional, defaults to self.left_canonical_metric if None.
-
-        Returns
-        -------
-        regularized_vec : array-like, shape=[..., 3]
-            Regularized vector.
-        """
-        if metric is None:
-            metric = self.left_canonical_metric
-
-        rotations = self.rotations
-        dim_rotations = rotations.dim
-
-        rot_tangent_vec = tangent_vec[..., :dim_rotations]
-        rot_base_point = base_point[..., :dim_rotations]
-
-        rotations_vec = rotations.regularize_tangent_vec(
-            tangent_vec=rot_tangent_vec,
-            base_point=rot_base_point)
-
-        return gs.concatenate(
-            [rotations_vec, tangent_vec[..., dim_rotations:]], axis=-1)
-
-    @geomstats.vectorization.decorator(['else', 'vector'])
-    def matrix_from_vector(self, vec):
-        """Convert point in vector point-type to matrix.
-
-        Parameters
-        ----------
-        vec : array-like, shape=[..., 3]
-            Vector.
-
-        Returns
-        -------
-        mat : array-like, shape=[..., 4, 4]
-            Matrix.
-        """
-        vec = self.regularize(vec)
-        n_vecs, _ = vec.shape
-
-        rot_vec = vec[:, :self.rotations.dim]
-        trans_vec = vec[:, self.rotations.dim:]
-
-        rot_mat = self.rotations.matrix_from_rotation_vector(rot_vec)
-        trans_vec = gs.reshape(trans_vec, (n_vecs, self.n, 1))
-        mat = gs.concatenate((rot_mat, trans_vec), axis=2)
-        last_lines = gs.array(gs.get_mask_i_float(self.n, self.n + 1))
-        last_lines = gs.to_ndarray(last_lines, to_ndim=2)
-        last_lines = gs.to_ndarray(last_lines, to_ndim=3)
-        mat = gs.concatenate((mat, last_lines), axis=1)
-
-        return mat
-
-    @geomstats.vectorization.decorator(
-        ['else', 'vector', 'vector'])
-    def compose(self, point_a, point_b):
-        r"""Compose two elements of SE(3).
-
-        Parameters
-        ----------
-        point_a : array-like, shape=[..., 3]
-            Point of the group.
-        point_b : array-like, shape=[..., 3]
-            Point of the group.
-
-        Equation
-        --------
-        (:math: `(R_1, t_1) \\cdot (R_2, t_2) = (R_1 R_2, R_1 t_2 + t_1)`)
-
-        Returns
-        -------
-        composition : array-like, shape=[..., 3]
-            Composition of point_a and point_b.
-        """
-        rotations = self.rotations
-        dim_rotations = rotations.dim
-
-        point_a = self.regularize(point_a)
-        point_b = self.regularize(point_b)
-
-        rot_vec_a = point_a[..., :dim_rotations]
-        rot_mat_a = rotations.matrix_from_rotation_vector(rot_vec_a)
-
-        rot_vec_b = point_b[..., :dim_rotations]
-        rot_mat_b = rotations.matrix_from_rotation_vector(rot_vec_b)
-
-        translation_a = point_a[..., dim_rotations:]
-        translation_b = point_b[..., dim_rotations:]
-
-        composition_rot_mat = gs.matmul(rot_mat_a, rot_mat_b)
-        composition_rot_vec = rotations.rotation_vector_from_matrix(
-            composition_rot_mat)
-
-        composition_translation = gs.einsum(
-            '...j,...kj->...k', translation_b, rot_mat_a) + translation_a
-
-        composition = gs.concatenate((composition_rot_vec,
-                                      composition_translation), axis=-1)
-        return self.regularize(composition)
-
-    @geomstats.vectorization.decorator(['else', 'vector'])
-    def inverse(self, point):
-        r"""Compute the group inverse in SE(n).
-
-        Parameters
-        ----------
-        point: array-like, shape=[..., 3]
-            Point.
-
-        Returns
-        -------
-        inverse_point : array-like, shape=[..., 3]
-            Inverted point.
-
-        Notes
-        -----
-        :math:`(R, t)^{-1} = (R^{-1}, R^{-1}.(-t))`
-        """
-        rotations = self.rotations
-        dim_rotations = rotations.dim
-
-        point = self.regularize(point)
-
-        rot_vec = point[:, :dim_rotations]
-        translation = point[:, dim_rotations:]
-
-        inverse_rotation = -rot_vec
-
-        inv_rot_mat = rotations.matrix_from_rotation_vector(
-            inverse_rotation)
-
-        inverse_translation = gs.einsum(
-            'ni,nij->nj',
-            -translation,
-            gs.transpose(inv_rot_mat, axes=(0, 2, 1)))
-
-        inverse_point = gs.concatenate(
-            [inverse_rotation, inverse_translation], axis=-1)
-        return self.regularize(inverse_point)
-
-    @geomstats.vectorization.decorator(['else', 'vector', 'else'])
-    def jacobian_translation(self, point, left_or_right='left'):
-        """Compute the Jacobian matrix resulting from translation.
-
-        Compute the matrix of the differential of the left/right translations
-        from the identity to point in SE(3).
-
-        Parameters
-        ----------
-        point: array-like, shape=[..., 3]
-            Point.
-        left_or_right: str, {'left', 'right'}
-            Whether to compute the jacobian of the left or right translation.
-            Optional, default: 'left'.
-
-        Returns
-        -------
-        jacobian : array-like, shape=[..., 3]
-            Jacobian of the left / right translation.
-        """
-        if left_or_right not in ('left', 'right'):
-            raise ValueError('`left_or_right` must be `left` or `right`.')
-
-        point = self.regularize(point)
-
-        n_points, _ = point.shape
-
-        return gs.array([gs.eye(self.dim)] * n_points)
-
-    def _exp_translation_transform(self, angle):
-        n_samples = angle.shape[0]
-        base_1 = gs.array([gs.eye(2)] * n_samples)
-        base_2 = -gs.array(
-            [self.rotations.skew_matrix_from_vector([1])] * n_samples)
-
-        mask_close_0 = gs.isclose(angle, 0.)
-        mask_else = ~mask_close_0
-
+        mask_0_float = gs.cast(mask_0, gs.float32)
         mask_close_0_float = gs.cast(mask_close_0, gs.float32)
         mask_else_float = gs.cast(mask_else, gs.float32)
 
-        cos_coef = gs.zeros_like(angle)
-        sin_coef = gs.zeros_like(angle)
+        coef_1 = gs.zeros_like(angle)
+        coef_2 = gs.zeros_like(angle)
 
-        cos_coef += mask_close_0_float * (
-            TAYLOR_COEFFS_1_AT_0[0] * angle
-            + TAYLOR_COEFFS_1_AT_0[1] * angle ** 3
-            + TAYLOR_COEFFS_1_AT_0[2] * angle ** 5)
-        sin_coef += mask_close_0_float * (
-            1
-            - TAYLOR_COEFFS_2_AT_0[0] * angle ** 2
-            - TAYLOR_COEFFS_2_AT_0[2] * angle ** 4)
+        coef_1 += mask_0_float * 1. / 2. * gs.ones_like(angle)
+        coef_2 += mask_0_float * 1. / 6. * gs.ones_like(angle)
 
-        angle = angle + mask_close_0_float * 1e-6
-        cos_coef += mask_else_float * ((1. - gs.cos(angle)) / angle)
-        sin_coef += mask_else_float * (gs.sin(angle) / angle)
+        coef_1 += mask_close_0_float * (
+                TAYLOR_COEFFS_1_AT_0[0]
+                + TAYLOR_COEFFS_1_AT_0[2] * angle ** 2
+                + TAYLOR_COEFFS_1_AT_0[4] * angle ** 4
+                + TAYLOR_COEFFS_1_AT_0[6] * angle ** 6)
+        coef_2 += mask_close_0_float * (
+                TAYLOR_COEFFS_2_AT_0[0]
+                + TAYLOR_COEFFS_2_AT_0[2] * angle ** 2
+                + TAYLOR_COEFFS_2_AT_0[4] * angle ** 4
+                + TAYLOR_COEFFS_2_AT_0[6] * angle ** 6)
 
-        sin_term = gs.einsum('...i,...ij->...ij', sin_coef, base_1)
-        cos_term = gs.einsum('...i,...ij->...ij', cos_coef, base_2)
-        transform = sin_term + cos_term
+        angle += mask_0_float * 1.
+
+        coef_1 += mask_else_float * ((1. - gs.cos(angle)) / angle ** 2)
+        coef_2 += mask_else_float * ((angle - gs.sin(angle)) / angle ** 3)
+
+        term_1 = gs.einsum('...i,...ij->...ij', coef_1, skew_mat)
+        term_2 = gs.einsum('...i,...ij->...ij', coef_2, sq_skew_mat)
+        term_id = gs.array([gs.eye(3)] * n_samples)
+        transform = term_id + term_1 + term_2
 
         return transform
 
-    @geomstats.vectorization.decorator(['else', 'vector'])
-    def exp_from_identity(self, tangent_vec):
-        """Compute group exponential of the tangent vector at the identity.
+    def _log_translation_transform(self, rot_vec):
+        """Compute matrix associated to rot_vec for the translation part in log.
 
         Parameters
         ----------
-        tangent_vec: array-like, shape=[..., 3]
-            Tangent vector at base point.
+        rot_vec : array-like, shape=[..., 3]
 
         Returns
         -------
-        group_exp: array-like, shape=[..., 3]
-            Group exponential of the tangent vectors computed
-            at the identity.
+        transform : array-like, shape=[..., 3, 3]
+        Matrix to be applied to the translation part in log
         """
-        rotations = self.rotations
-        dim_rotations = rotations.dim
-
-        rot_vec = tangent_vec[..., :dim_rotations]
-        angle = self.rotations.regularize(rot_vec)
-        translation = tangent_vec[..., dim_rotations:]
+        n_samples = rot_vec.shape[0]
+        angle = gs.linalg.norm(rot_vec, axis=1)
         angle = gs.to_ndarray(angle, to_ndim=2, axis=1)
 
-        transform = self._exp_translation_transform(angle)
-
-        exp_translation = gs.einsum('ijk, ik -> ij', transform, translation)
-
-        group_exp = gs.concatenate(
-            [rot_vec, exp_translation], axis=1)
-
-        group_exp = self.regularize(group_exp)
-        return group_exp
-
-    @geomstats.vectorization.decorator(['else', 'vector'])
-    def log_from_identity(self, point):
-        """Compute the group logarithm of the point at the identity.
-
-        Parameters
-        ----------
-        point: array-like, shape=[..., 3]
-            Point.
-
-        Returns
-        -------
-        group_log: array-like, shape=[..., 3]
-            Group logarithm in the Lie algebra.
-        """
-        point = self.regularize(point)
-
-        rotations = self.rotations
-        dim_rotations = rotations.dim
-
-        rot_vec = point[:, :dim_rotations]
-        angle = gs.to_ndarray(rot_vec, to_ndim=2, axis=1)
-
-        exp_transform = self._exp_translation_transform(angle)
+        skew_mat = self.rotations.skew_matrix_from_vector(rot_vec)
+        sq_skew_mat = gs.matmul(skew_mat, skew_mat)
 
         mask_close_0 = gs.isclose(angle, 0.)
-        mask_else = ~mask_close_0
+        mask_close_pi = gs.isclose(angle, gs.pi)
+        mask_else = ~mask_close_0 & ~mask_close_pi
 
         mask_close_0_float = gs.cast(mask_close_0, gs.float32)
+        mask_close_pi_float = gs.cast(mask_close_pi, gs.float32)
         mask_else_float = gs.cast(mask_else, gs.float32)
 
-        inv_determinant = gs.zeros_like(angle)
+        mask_0 = gs.isclose(angle, 0., atol=1e-6)
+        mask_0_float = gs.cast(mask_0, gs.float32)
+        angle += mask_0_float * gs.ones_like(angle)
 
-        inv_determinant += 0.5 * mask_close_0_float / (
-            TAYLOR_COEFFS_1_AT_0[0]
-            + TAYLOR_COEFFS_1_AT_0[1] * angle ** 2
-            + TAYLOR_COEFFS_1_AT_0[2] * angle ** 6)
+        coef_1 = - 0.5 * gs.ones_like(angle)
+        coef_2 = gs.zeros_like(angle)
 
-        angle = angle + 1e-6
-        inv_determinant += mask_else_float * (
-            angle ** 2 / (2 * (1 - gs.cos(angle))))
+        coef_2 += mask_close_0_float * (
+                1. / 12. + angle ** 2 / 720.
+                + angle ** 4 / 30240.
+                + angle ** 6 / 1209600.)
 
-        transform = gs.einsum(
-            'il, ijk -> ijk', inv_determinant,
-            gs.transpose(exp_transform, axes=[0, 2, 1]))
+        delta_angle = angle - gs.pi
+        coef_2 += mask_close_pi_float * (
+                1. / PI2
+                + (PI2 - 8.) * delta_angle / (4. * PI3)
+                - ((PI2 - 12.)
+                   * delta_angle ** 2 / (4. * PI4))
+                + ((-192. + 12. * PI2 + PI4)
+                   * delta_angle ** 3 / (48. * PI5))
+                - ((-240. + 12. * PI2 + PI4)
+                   * delta_angle ** 4 / (48. * PI6))
+                + ((-2880. + 120. * PI2 + 10. * PI4 + PI6)
+                   * delta_angle ** 5 / (480. * PI7))
+                - ((-3360 + 120. * PI2 + 10. * PI4 + PI6)
+                   * delta_angle ** 6 / (480. * PI8)))
 
-        translation = point[:, dim_rotations:]
+        psi = 0.5 * angle * gs.sin(angle) / (1 - gs.cos(angle))
+        coef_2 += mask_else_float * (1 - psi) / (angle ** 2)
 
-        log_translation = gs.einsum('ijk, ik -> ij', transform, translation)
+        term_1 = gs.einsum('...i,...ij->...ij', coef_1, skew_mat)
+        term_2 = gs.einsum('...i,...ij->...ij', coef_2, sq_skew_mat)
+        term_id = gs.array([gs.eye(3)] * n_samples)
+        transform = term_id + term_1 + term_2
 
-        return gs.concatenate(
-            [rot_vec, log_translation], axis=1)
-
-    def random_uniform(self, n_samples=1):
-        """Sample in SE(3) with the uniform distribution.
-
-        Parameters
-        ----------
-        n_samples : int
-            Number of samples.
-            Optional, default: 1
-
-        Returns
-        -------
-        random_point : array-like, shape=[..., 3]
-            Sample.
-        """
-        random_translation = self.translations.random_uniform(n_samples)
-        random_rot_vec = self.rotations.random_uniform(n_samples)
-        return gs.concatenate([random_rot_vec, random_translation], axis=-1)
+        return transform
 
 
 class SpecialEuclidean(_SpecialEuclidean2Vectors,
@@ -1194,7 +949,7 @@ class SpecialEuclidean(_SpecialEuclidean2Vectors,
             return _SpecialEuclidean2Vectors(epsilon)
         if n == 3 and point_type == 'vector':
             return _SpecialEuclidean3Vectors(epsilon)
-        if n != 3 and point_type == 'vector':
+        if point_type == 'vector':
             raise NotImplementedError(
                 'SE(n) is only implemented in matrix representation'
                 ' when n > 3.')

--- a/geomstats/geometry/special_orthogonal.py
+++ b/geomstats/geometry/special_orthogonal.py
@@ -835,8 +835,9 @@ class _SpecialOrthogonal3Vectors(_SpecialOrthogonalVectors):
             [cross_prod_1, cross_prod_2, cross_prod_3], axis=1)
         return skew_mat
 
+    @staticmethod
     @geomstats.vectorization.decorator(['else', 'matrix', 'output_point'])
-    def vector_from_skew_matrix(self, skew_mat):
+    def vector_from_skew_matrix(skew_mat):
         """Derive a vector from the skew-symmetric matrix.
 
         In 3D, compute the vector defining the cross product
@@ -852,8 +853,6 @@ class _SpecialOrthogonal3Vectors(_SpecialOrthogonalVectors):
         vec : array-like, shape=[..., dim]
             Vector.
         """
-        n_skew_mats, _, _ = skew_mat.shape
-
         vec_1 = gs.to_ndarray(skew_mat[:, 2, 1], to_ndim=2, axis=1)
         vec_2 = gs.to_ndarray(skew_mat[:, 0, 2], to_ndim=2, axis=1)
         vec_3 = gs.to_ndarray(skew_mat[:, 1, 0], to_ndim=2, axis=1)

--- a/geomstats/geometry/special_orthogonal.py
+++ b/geomstats/geometry/special_orthogonal.py
@@ -1561,10 +1561,10 @@ class _SpecialOrthogonal2Vectors(LieGroup):
             Regularized point.
         """
         regularized_point = point
-        # regularized_point = gs.to_ndarray(regularized_point, to_ndim=2, axis=1)
         regularized_point = gs.mod(regularized_point, 2 * gs.pi)
-        regularized_point = regularized_point * (regularized_point < gs.pi) + (
-                    regularized_point - 2 * gs.pi) * (regularized_point > gs.pi)
+        regularized_point = gs.where(
+            regularized_point < gs.pi,
+            regularized_point, regularized_point - 2 * gs.pi)
         return regularized_point
 
     @geomstats.vectorization.decorator(

--- a/geomstats/geometry/special_orthogonal.py
+++ b/geomstats/geometry/special_orthogonal.py
@@ -1654,9 +1654,8 @@ class _SpecialOrthogonal2Vectors(LieGroup):
             gs.einsum('nij,njk->nik', aux_mat, mat_unitary_v))
         return rot_mat
 
-    @staticmethod
     @geomstats.vectorization.decorator(['else', 'vector'])
-    def skew_matrix_from_vector(vec):
+    def skew_matrix_from_vector(self, vec):
         """Get the skew-symmetric matrix derived from the vector.
 
         In 3D, compute the skew-symmetric matrix,known as the cross-product of
@@ -1676,8 +1675,8 @@ class _SpecialOrthogonal2Vectors(LieGroup):
         """
         n_vecs, _ = gs.shape(vec)
 
-        vec = gs.tile(vec, [1, 2])
-        vec = gs.reshape(vec, (n_vecs, 2))
+        vec = gs.tile(vec, [1, self.n])
+        vec = gs.reshape(vec, (n_vecs, self.n))
 
         id_skew = gs.array(
             gs.tile([[[0., 1.], [-1., 0.]]], (n_vecs, 1, 1)))

--- a/geomstats/geometry/special_orthogonal.py
+++ b/geomstats/geometry/special_orthogonal.py
@@ -170,9 +170,9 @@ class _SpecialOrthogonalMatrices(GeneralLinear, LieGroup):
 class _SpecialOrthogonalVectors(LieGroup):
     """Class for the special orthogonal groups SO({2,3}) in vector form.
 
-    i.e. the Lie groups of planar and 3D rotations. This class is specific to the
-    vector representation of rotations. For the matrix representation use the
-    SpecialOrthogonal class and set `n=2` or `n=3`.
+    i.e. the Lie groups of planar and 3D rotations. This class is specific to
+    the vector representation of rotations. For the matrix representation use
+    the SpecialOrthogonal class and set `n=2` or `n=3`.
 
     Parameters
     ----------

--- a/geomstats/geometry/special_orthogonal.py
+++ b/geomstats/geometry/special_orthogonal.py
@@ -167,12 +167,12 @@ class _SpecialOrthogonalMatrices(GeneralLinear, LieGroup):
         return skew_mat
 
 
-class _SpecialOrthogonal3Vectors(LieGroup):
-    """Class for the special orthogonal group SO(3) in vector representation.
+class _SpecialOrthogonalVectors(LieGroup):
+    """Class for the special orthogonal groups SO({2,3}) in vector form.
 
-    i.e. the Lie group of rotations. This class is specific to the vector
-    representation of rotations. For the matrix representation use the
-    SpecialOrthogonal class and set `n=3`.
+    i.e. the Lie groups of planar and 3D rotations. This class is specific to the
+    vector representation of rotations. For the matrix representation use the
+    SpecialOrthogonal class and set `n=2` or `n=3`.
 
     Parameters
     ----------
@@ -182,13 +182,13 @@ class _SpecialOrthogonal3Vectors(LieGroup):
         Optional, default: 0.
     """
 
-    def __init__(self, epsilon=0.):
+    def __init__(self, n, epsilon=0.):
+        dim = n * (n - 1) // 2
         LieGroup.__init__(
-            self, dim=3, default_point_type='vector')
+            self, dim=dim, default_point_type='vector')
 
-        self.n = 3
+        self.n = n
         self.epsilon = epsilon
-        self.bi_invariant_metric = BiInvariantMetric(group=self)
 
     def get_identity(self, point_type='vector'):
         """Get the identity of the group.
@@ -200,13 +200,10 @@ class _SpecialOrthogonal3Vectors(LieGroup):
 
         Returns
         -------
-        identity : array-like, shape=[3,]
+        identity : array-like, shape=[1,]
             Identity.
         """
-        identity = gs.zeros(self.dim)
-        if point_type == 'matrix':
-            identity = gs.eye(self.n)
-        return identity
+        return gs.zeros(self.dim)
 
     identity = property(get_identity)
 
@@ -229,6 +226,393 @@ class _SpecialOrthogonal3Vectors(LieGroup):
         if point.ndim == 2:
             belongs = gs.tile([belongs], (point.shape[0],))
         return belongs
+
+    @geomstats.vectorization.decorator(['else', 'matrix'])
+    def projection(self, point):
+        """Project a matrix on SO(2) or SO(3) using the Frobenius norm.
+
+        Parameters
+        ----------
+        point : array-like, shape=[..., n, n]
+            Matrix.
+
+        Returns
+        -------
+        rot_mat : array-like, shape=[..., n, n]
+            Rotation matrix.
+        """
+        mat = point
+        n_mats, _, _ = mat.shape
+
+        mat_unitary_u, _, mat_unitary_v = gs.linalg.svd(mat)
+        rot_mat = gs.einsum('nij,njk->nik', mat_unitary_u, mat_unitary_v)
+        mask = gs.less(gs.linalg.det(rot_mat), 0.)
+        mask_float = gs.cast(mask, gs.float32) + self.epsilon
+        diag = gs.concatenate((gs.ones(self.n - 1), -gs.ones(1)), axis=0)
+        diag = gs.to_ndarray(diag, to_ndim=2)
+        diag = gs.to_ndarray(
+            algebra_utils.from_vector_to_diagonal_matrix(diag),
+            to_ndim=3) + self.epsilon
+        new_mat_diag_s = gs.tile(diag, [n_mats, 1, 1])
+
+        aux_mat = gs.einsum(
+            'nij,njk->nik', mat_unitary_u, new_mat_diag_s)
+        rot_mat += gs.einsum(
+            'n,njk->njk', mask_float,
+            gs.einsum('nij,njk->nik', aux_mat, mat_unitary_v))
+        return rot_mat
+
+    def inverse(self, point):
+        """Compute the group inverse in SO(3).
+
+        Parameters
+        ----------
+        point : array-like, shape=[..., 3]
+            Point.
+
+        Returns
+        -------
+        inv_point : array-like, shape=[..., 3]
+            Inverse.
+        """
+        return -self.regularize(point)
+
+    @geomstats.vectorization.decorator(['else', 'vector', 'output_point'])
+    def exp_from_identity(self, tangent_vec):
+        """Compute the group exponential of the tangent vector at the identity.
+
+        As rotations are represented by their rotation vector,
+        which corresponds to the element `X` in the Lie Algebra such that
+        `exp(X) = R`, this methods returns its input without change.
+
+        Parameters
+        ----------
+        tangent_vec : array-like, shape=[..., dimension]
+            Tangent vector at base point.
+        point_type : str, {'vector', 'matrix'}
+            Point type.
+            Optional, default: self.default_point_type.
+
+        Returns
+        -------
+        point : array-like, shape=[..., dimension]
+            Point.
+        """
+        return self.regularize(tangent_vec)
+
+    @geomstats.vectorization.decorator(['else', 'vector', 'output_point'])
+    def log_from_identity(self, point):
+        """Compute the group logarithm of the point at the identity.
+
+        As rotations are represented by their rotation vector,
+        which corresponds to the element `X` in the Lie Algebra such that
+        `exp(X) = R`, this methods returns its input after regularization.
+
+
+        Parameters
+        ----------
+        point : array-like, shape=[..., dimension]
+            Point.
+
+        Returns
+        -------
+        tangent_vec : array-like, shape=[..., dimension]
+            Group logarithm.
+        """
+        return self.regularize(point)
+
+
+class _SpecialOrthogonal2Vectors(_SpecialOrthogonalVectors):
+    """Class for the special orthogonal group SO(2) in vector representation.
+
+    i.e. the Lie group of planar rotations. This class is specific to the
+    vector representation of rotations. For the matrix representation use the
+    SpecialOrthogonal class and set `n=2`.
+
+    Parameters
+    ----------
+    epsilon : float
+        Precision to use for calculations involving potential divison by 0 in
+        rotations.
+        Optional, default: 0.
+    """
+
+    def __init__(self, epsilon=0.):
+        super(_SpecialOrthogonal2Vectors, self).__init__(
+            n=2, epsilon=epsilon)
+
+    def regularize(self, point):
+        """Regularize a point to be in accordance with convention.
+
+        In 2D, regularize the norm of the rotation angle,
+        to be between -pi and pi, following the axis-angle
+        representation's convention.
+
+        If the angle angle is between pi and 2pi,
+        the function computes its complementary in 2pi and
+        inverts the direction of the rotation axis.
+
+        Parameters
+        ----------
+        point : array-like, shape=[...,1]
+            Point.
+
+        Returns
+        -------
+        regularized_point : array-like, shape=[..., 1]
+            Regularized point.
+        """
+        regularized_point = point
+        regularized_point = gs.mod(regularized_point, 2 * gs.pi)
+        regularized_point = gs.where(
+            regularized_point < gs.pi,
+            regularized_point, regularized_point - 2 * gs.pi)
+        return regularized_point
+
+    @geomstats.vectorization.decorator(
+        ['else', 'vector', 'else', 'output_point'])
+    def regularize_tangent_vec_at_identity(
+            self, tangent_vec, metric=None):
+        """Regularize a tangent vector at the identity.
+
+        In 2D, regularize a tangent_vector by getting its norm at the identity,
+        to be less than pi.
+
+        Parameters
+        ----------
+        tangent_vec : array-like, shape=[..., 1]
+            Tangent vector at base point.
+
+        Returns
+        -------
+        regularized_vec : array-like, shape=[..., 1]
+            Regularized tangent vector.
+        """
+        return self.regularize(tangent_vec)
+
+    @geomstats.vectorization.decorator(
+        ['else', 'vector', 'vector', 'else', 'output_point'])
+    def regularize_tangent_vec(
+            self, tangent_vec, base_point, metric=None):
+        """Regularize tangent vector at a base point.
+
+        In 2D, regularize a tangent_vector by getting the norm of its parallel
+        transport to the identity, determined by the metric, less than pi.
+
+        Parameters
+        ----------
+        tangent_vec : array-like, shape=[...,1]
+            Tangent vector at base point.
+        base_point : array-like, shape=[..., 1]
+            Point on the manifold.
+
+        Returns
+        -------
+        regularized_tangent_vec : array-like, shape=[..., 1]
+            Regularized tangent vector.
+        """
+        return self.regularize_tangent_vec_at_identity(tangent_vec)
+
+    @geomstats.vectorization.decorator(['else', 'vector'])
+    def skew_matrix_from_vector(self, vec):
+        """Get the skew-symmetric matrix derived from the vector.
+
+        In 3D, compute the skew-symmetric matrix,known as the cross-product of
+        a vector, associated to the vector `vec`.
+
+        In nD, fill a skew-symmetric matrix with the values of the vector.
+
+        Parameters
+        ----------
+        vec : array-like, shape=[..., dim]
+            Vector.
+
+        Returns
+        -------
+        skew_mat : array-like, shape=[..., n, n]
+            Skew-symmetric matrix.
+        """
+        n_vecs, _ = gs.shape(vec)
+
+        vec = gs.tile(vec, [1, self.n])
+        vec = gs.reshape(vec, (n_vecs, self.n))
+
+        id_skew = gs.array(
+            gs.tile([[[0., 1.], [-1., 0.]]], (n_vecs, 1, 1)))
+        skew_mat = gs.einsum(
+            '...ij,...i->...ij', gs.cast(id_skew, gs.float32), vec)
+
+        return skew_mat
+
+    @geomstats.vectorization.decorator(['else', 'matrix', 'output_point'])
+    def vector_from_skew_matrix(self, skew_mat):
+        """Derive a vector from the skew-symmetric matrix.
+
+        In 3D, compute the vector defining the cross product
+        associated to the skew-symmetric matrix skew mat.
+
+        Parameters
+        ----------
+        skew_mat : array-like, shape=[..., n, n]
+            Skew-symmetric matrix.
+
+        Returns
+        -------
+        vec : array-like, shape=[..., dim]
+            Vector.
+        """
+        n_skew_mats, _, _ = skew_mat.shape
+
+        vec_dim = self.dim
+        vec = gs.zeros((n_skew_mats, vec_dim))
+
+        vec = skew_mat[:, 0, 1]
+        vec = gs.expand_dims(vec, axis=1)
+
+        return vec
+
+    @geomstats.vectorization.decorator(['else', 'matrix', 'output_point'])
+    def rotation_vector_from_matrix(self, rot_mat):
+        r"""Convert rotation matrix (in 2D) to rotation vector (axis-angle).
+
+        Get the angle through the atan2 function:
+
+        Parameters
+        ----------
+        rot_mat : array-like, shape=[..., 2, 2]
+            Rotation matrix.
+
+        Returns
+        -------
+        regularized_rot_vec : array-like, shape=[..., 1]
+            Rotation vector.
+        """
+        rot_vec = gs.arctan2(rot_mat[:, 1, 0], rot_mat[:, 0, 0])
+        n_states = rot_vec.shape[0]
+        rot_vec = gs.reshape(rot_vec, (n_states, 1))
+        return self.regularize(rot_vec)
+
+    @geomstats.vectorization.decorator(['else', 'vector'])
+    def matrix_from_rotation_vector(self, rot_vec):
+        """Convert rotation vector to rotation matrix.
+
+        Parameters
+        ----------
+        rot_vec: array-like, shape=[..., 1]
+            Rotation vector.
+
+        Returns
+        -------
+        rot_mat: array-like, shape=[..., 2, 2]
+            Rotation matrix.
+        """
+        rot_vec = self.regularize(rot_vec)
+        n_samples = rot_vec.shape[0]
+
+        cos_term = gs.to_ndarray(gs.cos(rot_vec), to_ndim=3, axis=2)
+        cos_matrix = cos_term * gs.array([gs.eye(2)] * n_samples)
+        sin_term = gs.to_ndarray(gs.sin(rot_vec), to_ndim=3, axis=2)
+        sin_matrix = -sin_term * self.skew_matrix_from_vector(
+            gs.array([[1]] * n_samples))
+        return cos_matrix + sin_matrix
+
+    def compose(self, point_a, point_b):
+        """Compose two elements of SO(3).
+
+        Parameters
+        ----------
+        point_a : array-like, shape=[..., 3]
+        point_b : array-like, shape=[..., 3]
+
+        Returns
+        -------
+        point_prod : array-like, shape=[..., 3]
+        """
+        point_a = self.regularize(point_a)
+        point_b = self.regularize(point_b)
+
+        point_prod = point_a + point_b
+        point_prod = self.regularize(point_prod)
+
+        return point_prod
+
+    def random_uniform(self, n_samples=1):
+        """Sample in SO(2) with the uniform distribution.
+
+        Parameters
+        ----------
+        n_samples : int
+            Number of samples.
+            Optional, default: 1.
+
+        Returns
+        -------
+        point : array-like, shape=[..., 1]
+            Sample.
+        """
+        random_point = (gs.random.rand(n_samples, self.dim) * 2 - 1) * gs.pi
+        random_point = self.regularize(random_point)
+
+        if n_samples == 1:
+            random_point = gs.squeeze(random_point, axis=0)
+
+        return random_point
+
+    def exp(self, tangent_vec, base_point=None):
+        """Compute the group exponential.
+
+        Parameters
+        ----------
+        tangent_vec : array-like, shape=[..., 1]
+            Tangent vector at base point.
+        base_point : array-like, shape=[..., 1]
+            Point from which the exponential is computed.
+
+        Returns
+        -------
+        point : array-like, shape=[..., 1]
+            Group exponential.
+        """
+        return self.regularize(tangent_vec + base_point)
+
+    def log(self, point, base_point=None):
+        """Compute the group logarithm.
+
+        Parameters
+        ----------
+        point : array-like, shape=[..., 3]
+            Point.
+        base_point : array-like, shape=[..., 1]
+            Point from which the log is computed.
+
+        Returns
+        -------
+        tangent_vec : array-like, shape=[..., 1]
+            Group logarithm.
+        """
+        return self.regularize(point - base_point)
+
+
+class _SpecialOrthogonal3Vectors(_SpecialOrthogonalVectors):
+    """Class for the special orthogonal group SO(3) in vector representation.
+
+    i.e. the Lie group of rotations. This class is specific to the vector
+    representation of rotations. For the matrix representation use the
+    SpecialOrthogonal class and set `n=3`.
+
+    Parameters
+    ----------
+    epsilon : float
+        Precision to use for calculations involving potential divison by 0 in
+        rotations.
+        Optional, default: 0.
+    """
+
+    def __init__(self, epsilon=0.):
+        super(_SpecialOrthogonal3Vectors, self).__init__(
+            n=3, epsilon=epsilon)
+
+        self.bi_invariant_metric = BiInvariantMetric(group=self)
 
     def regularize(self, point):
         """Regularize a point to be in accordance with convention.
@@ -384,40 +768,6 @@ class _SpecialOrthogonal3Vectors(LieGroup):
 
         return regularized_tangent_vec
 
-    @geomstats.vectorization.decorator(['else', 'matrix'])
-    def projection(self, point):
-        """Project a matrix on SO(3) using the Frobenius norm.
-
-        Parameters
-        ----------
-        point : array-like, shape=[..., n, n]
-            Matrix.
-
-        Returns
-        -------
-        rot_mat : array-like, shape=[..., n, n]
-            Rotation matrix.
-        """
-        mat = point
-        n_mats, _, _ = mat.shape
-
-        mat_unitary_u, _, mat_unitary_v = gs.linalg.svd(mat)
-        rot_mat = gs.einsum('nij,njk->nik', mat_unitary_u, mat_unitary_v)
-        mask = gs.less(gs.linalg.det(rot_mat), 0.)
-        mask_float = gs.cast(mask, gs.float32) + self.epsilon
-        diag = gs.array([[1., 1., -1.]])
-        diag = gs.to_ndarray(
-            algebra_utils.from_vector_to_diagonal_matrix(diag),
-            to_ndim=3) + self.epsilon
-        new_mat_diag_s = gs.tile(diag, [n_mats, 1, 1])
-
-        aux_mat = gs.einsum(
-            'nij,njk->nik', mat_unitary_u, new_mat_diag_s)
-        rot_mat += gs.einsum(
-            'n,njk->njk', mask_float,
-            gs.einsum('nij,njk->nik', aux_mat, mat_unitary_v))
-        return rot_mat
-
     @geomstats.vectorization.decorator(['else', 'vector'])
     def skew_matrix_from_vector(self, vec):
         """Get the skew-symmetric matrix derived from the vector.
@@ -504,18 +854,10 @@ class _SpecialOrthogonal3Vectors(LieGroup):
         """
         n_skew_mats, _, _ = skew_mat.shape
 
-        vec_dim = self.dim
-        vec = gs.zeros((n_skew_mats, vec_dim))
-
-        if self.n == 2:  # SO(2)
-            vec = skew_mat[:, 0, 1]
-            vec = gs.expand_dims(vec, axis=1)
-
-        elif self.n == 3:  # SO(3)
-            vec_1 = gs.to_ndarray(skew_mat[:, 2, 1], to_ndim=2, axis=1)
-            vec_2 = gs.to_ndarray(skew_mat[:, 0, 2], to_ndim=2, axis=1)
-            vec_3 = gs.to_ndarray(skew_mat[:, 1, 0], to_ndim=2, axis=1)
-            vec = gs.concatenate([vec_1, vec_2, vec_3], axis=1)
+        vec_1 = gs.to_ndarray(skew_mat[:, 2, 1], to_ndim=2, axis=1)
+        vec_2 = gs.to_ndarray(skew_mat[:, 0, 2], to_ndim=2, axis=1)
+        vec_3 = gs.to_ndarray(skew_mat[:, 1, 0], to_ndim=2, axis=1)
+        vec = gs.concatenate([vec_1, vec_2, vec_3], axis=1)
 
         return vec
 
@@ -1251,21 +1593,6 @@ class _SpecialOrthogonal3Vectors(LieGroup):
 
         return point_prod
 
-    def inverse(self, point):
-        """Compute the group inverse in SO(3).
-
-        Parameters
-        ----------
-        point : array-like, shape=[..., 3]
-            Point.
-
-        Returns
-        -------
-        inv_point : array-like, shape=[..., 3]
-            Inverse.
-        """
-        return -self.regularize(point)
-
     def jacobian_translation(
             self, point, left_or_right='left'):
         """Compute the jacobian matrix corresponding to translation.
@@ -1385,50 +1712,6 @@ class _SpecialOrthogonal3Vectors(LieGroup):
 
         return random_point
 
-    @geomstats.vectorization.decorator(['else', 'vector'])
-    def exp_from_identity(self, tangent_vec):
-        """Compute the group exponential of the tangent vector at the identity.
-
-        As rotations are represented by their rotation vector,
-        which corresponds to the element `X` in the Lie Algebra such that
-        `exp(X) = R`, this methods returns its input without change.
-
-        Parameters
-        ----------
-        tangent_vec : array-like, shape=[..., 3]
-            Tangent vector at base point.
-        point_type : str, {'vector', 'matrix'}
-            Point type.
-            Optional, default: self.default_point_type.
-
-        Returns
-        -------
-        point : array-like, shape=[..., 3]
-            Point.
-        """
-        return tangent_vec
-
-    @geomstats.vectorization.decorator(['else', 'vector'])
-    def log_from_identity(self, point):
-        """Compute the group logarithm of the point at the identity.
-
-        As rotations are represented by their rotation vector,
-        which corresponds to the element `X` in the Lie Algebra such that
-        `exp(X) = R`, this methods returns its input after regularization.
-
-
-        Parameters
-        ----------
-        point : array-like, shape=[..., 3]
-            Point.
-
-        Returns
-        -------
-        tangent_vec : array-like, shape=[..., {dimension, [n, n]}]
-            Group logarithm.
-        """
-        return self.regularize(point)
-
     def lie_bracket(
             self, tangent_vector_a, tangent_vector_b, base_point=None):
         """Compute the lie bracket of two tangent vectors.
@@ -1485,414 +1768,6 @@ class _SpecialOrthogonal3Vectors(LieGroup):
         return LieGroup.log(self, point, base_point)
 
 
-class _SpecialOrthogonal2Vectors(LieGroup):
-    """Class for the special orthogonal group SO(2) in vector representation.
-
-    i.e. the Lie group of planar rotations. This class is specific to the
-    vector representation of rotations. For the matrix representation use the
-    SpecialOrthogonal class and set `n=2`.
-
-    Parameters
-    ----------
-    epsilon : float
-        Precision to use for calculations involving potential divison by 0 in
-        rotations.
-        Optional, default: 0.
-    """
-
-    def __init__(self, epsilon=0.):
-        LieGroup.__init__(
-            self, dim=1, default_point_type='vector')
-
-        self.n = 2
-        self.epsilon = epsilon
-        self.bi_invariant_metric = BiInvariantMetric(group=self)
-
-    def get_identity(self, point_type='vector'):
-        """Get the identity of the group.
-
-        Parameters
-        ----------
-        point_type : str, {'vector', 'matrix'}
-            Point_type of the returned value. Unused here.
-
-        Returns
-        -------
-        identity : array-like, shape=[1,]
-            Identity.
-        """
-        identity = gs.zeros(self.dim)
-        if point_type == 'matrix':
-            identity = gs.eye(self.n)
-        return identity
-
-    identity = property(get_identity)
-
-    def belongs(self, point, atol=ATOL):
-        """Evaluate if a point belongs to SO(3).
-
-        Parameters
-        ----------
-        point : array-like, shape=[..., 3]
-            Point to check whether it belongs to SO(3).
-        atol : unused
-
-        Returns
-        -------
-        belongs : array-like, shape=[...,]
-            Boolean indicating whether point belongs to SO(3).
-        """
-        vec_dim = point.shape[-1]
-        belongs = vec_dim == self.dim
-        if point.ndim == 2:
-            belongs = gs.tile([belongs], (point.shape[0],))
-        return belongs
-
-    def regularize(self, point):
-        """Regularize a point to be in accordance with convention.
-
-        In 2D, regularize the norm of the rotation angle,
-        to be between -pi and pi, following the axis-angle
-        representation's convention.
-
-        If the angle angle is between pi and 2pi,
-        the function computes its complementary in 2pi and
-        inverts the direction of the rotation axis.
-
-        Parameters
-        ----------
-        point : array-like, shape=[...,1]
-            Point.
-
-        Returns
-        -------
-        regularized_point : array-like, shape=[..., 1]
-            Regularized point.
-        """
-        regularized_point = point
-        regularized_point = gs.mod(regularized_point, 2 * gs.pi)
-        regularized_point = gs.where(
-            regularized_point < gs.pi,
-            regularized_point, regularized_point - 2 * gs.pi)
-        return regularized_point
-
-    @geomstats.vectorization.decorator(
-        ['else', 'vector', 'else', 'output_point'])
-    def regularize_tangent_vec_at_identity(
-            self, tangent_vec, metric=None):
-        """Regularize a tangent vector at the identity.
-
-        In 2D, regularize a tangent_vector by getting its norm at the identity,
-        to be less than pi.
-
-        Parameters
-        ----------
-        tangent_vec : array-like, shape=[..., 1]
-            Tangent vector at base point.
-
-        Returns
-        -------
-        regularized_vec : array-like, shape=[..., 1]
-            Regularized tangent vector.
-        """
-        return self.regularize(tangent_vec)
-
-    @geomstats.vectorization.decorator(
-        ['else', 'vector', 'vector', 'else', 'output_point'])
-    def regularize_tangent_vec(
-            self, tangent_vec, base_point, metric=None):
-        """Regularize tangent vector at a base point.
-
-        In 2D, regularize a tangent_vector by getting the norm of its parallel
-        transport to the identity, determined by the metric, less than pi.
-
-        Parameters
-        ----------
-        tangent_vec : array-like, shape=[...,1]
-            Tangent vector at base point.
-        base_point : array-like, shape=[..., 1]
-            Point on the manifold.
-
-        Returns
-        -------
-        regularized_tangent_vec : array-like, shape=[..., 1]
-            Regularized tangent vector.
-        """
-        return self.regularize_tangent_vec_at_identity(tangent_vec)
-
-    @geomstats.vectorization.decorator(['else', 'matrix'])
-    def projection(self, point):
-        """Project a matrix on SO(2) using the Frobenius norm.
-
-        Parameters
-        ----------
-        point : array-like, shape=[..., 2, 2]
-            Matrix.
-
-        Returns
-        -------
-        rot_mat : array-like, shape=[..., 2, 2]
-            Rotation matrix.
-        """
-        mat = point
-        n_mats, _, _ = mat.shape
-
-        mat_unitary_u, _, mat_unitary_v = gs.linalg.svd(mat)
-        rot_mat = gs.einsum('nij,njk->nik', mat_unitary_u, mat_unitary_v)
-        mask = gs.less(gs.linalg.det(rot_mat), 0.)
-        mask_float = gs.cast(mask, gs.float32) + self.epsilon
-        diag = gs.array([[1., -1.]])
-        diag = gs.to_ndarray(
-            algebra_utils.from_vector_to_diagonal_matrix(diag),
-            to_ndim=3) + self.epsilon
-        new_mat_diag_s = gs.tile(diag, [n_mats, 1, 1])
-
-        aux_mat = gs.einsum(
-            'nij,njk->nik', mat_unitary_u, new_mat_diag_s)
-        rot_mat += gs.einsum(
-            'n,njk->njk', mask_float,
-            gs.einsum('nij,njk->nik', aux_mat, mat_unitary_v))
-        return rot_mat
-
-    @geomstats.vectorization.decorator(['else', 'vector'])
-    def skew_matrix_from_vector(self, vec):
-        """Get the skew-symmetric matrix derived from the vector.
-
-        In 3D, compute the skew-symmetric matrix,known as the cross-product of
-        a vector, associated to the vector `vec`.
-
-        In nD, fill a skew-symmetric matrix with the values of the vector.
-
-        Parameters
-        ----------
-        vec : array-like, shape=[..., dim]
-            Vector.
-
-        Returns
-        -------
-        skew_mat : array-like, shape=[..., n, n]
-            Skew-symmetric matrix.
-        """
-        n_vecs, _ = gs.shape(vec)
-
-        vec = gs.tile(vec, [1, self.n])
-        vec = gs.reshape(vec, (n_vecs, self.n))
-
-        id_skew = gs.array(
-            gs.tile([[[0., 1.], [-1., 0.]]], (n_vecs, 1, 1)))
-        skew_mat = gs.einsum(
-            '...ij,...i->...ij', gs.cast(id_skew, gs.float32), vec)
-
-        return skew_mat
-
-    @geomstats.vectorization.decorator(['else', 'matrix', 'output_point'])
-    def vector_from_skew_matrix(self, skew_mat):
-        """Derive a vector from the skew-symmetric matrix.
-
-        In 3D, compute the vector defining the cross product
-        associated to the skew-symmetric matrix skew mat.
-
-        Parameters
-        ----------
-        skew_mat : array-like, shape=[..., n, n]
-            Skew-symmetric matrix.
-
-        Returns
-        -------
-        vec : array-like, shape=[..., dim]
-            Vector.
-        """
-        n_skew_mats, _, _ = skew_mat.shape
-
-        vec_dim = self.dim
-        vec = gs.zeros((n_skew_mats, vec_dim))
-
-        vec = skew_mat[:, 0, 1]
-        vec = gs.expand_dims(vec, axis=1)
-
-        return vec
-
-    @geomstats.vectorization.decorator(['else', 'matrix', 'output_point'])
-    def rotation_vector_from_matrix(self, rot_mat):
-        r"""Convert rotation matrix (in 2D) to rotation vector (axis-angle).
-
-        Get the angle through the atan2 function:
-
-        Parameters
-        ----------
-        rot_mat : array-like, shape=[..., 2, 2]
-            Rotation matrix.
-
-        Returns
-        -------
-        regularized_rot_vec : array-like, shape=[..., 1]
-            Rotation vector.
-        """
-        rot_vec = gs.arctan2(rot_mat[:, 1, 0], rot_mat[:, 0, 0])
-        n_states = rot_vec.shape[0]
-        rot_vec = gs.reshape(rot_vec, (n_states, 1))
-        return self.regularize(rot_vec)
-
-    @geomstats.vectorization.decorator(['else', 'vector'])
-    def matrix_from_rotation_vector(self, rot_vec):
-        """Convert rotation vector to rotation matrix.
-
-        Parameters
-        ----------
-        rot_vec: array-like, shape=[..., 1]
-            Rotation vector.
-
-        Returns
-        -------
-        rot_mat: array-like, shape=[..., 2, 2]
-            Rotation matrix.
-        """
-        rot_vec = self.regularize(rot_vec)
-        n_samples = rot_vec.shape[0]
-
-        cos_term = gs.to_ndarray(gs.cos(rot_vec), to_ndim=3, axis=2)
-        cos_matrix = cos_term * gs.array([gs.eye(2)] * n_samples)
-        sin_term = gs.to_ndarray(gs.sin(rot_vec), to_ndim=3, axis=2)
-        sin_matrix = -sin_term * self.skew_matrix_from_vector(
-            gs.array([[1]] * n_samples))
-        return cos_matrix + sin_matrix
-
-    def compose(self, point_a, point_b):
-        """Compose two elements of SO(3).
-
-        Parameters
-        ----------
-        point_a : array-like, shape=[..., 3]
-        point_b : array-like, shape=[..., 3]
-
-        Returns
-        -------
-        point_prod : array-like, shape=[..., 3]
-        """
-        point_a = self.regularize(point_a)
-        point_b = self.regularize(point_b)
-
-        point_prod = point_a + point_b
-        point_prod = self.regularize(point_prod)
-
-        return point_prod
-
-    def inverse(self, point):
-        """Compute the group inverse in SO(3).
-
-        Parameters
-        ----------
-        point : array-like, shape=[..., 3]
-            Point.
-
-        Returns
-        -------
-        inv_point : array-like, shape=[..., 3]
-            Inverse.
-        """
-        return -self.regularize(point)
-
-    def random_uniform(self, n_samples=1):
-        """Sample in SO(2) with the uniform distribution.
-
-        Parameters
-        ----------
-        n_samples : int
-            Number of samples.
-            Optional, default: 1.
-
-        Returns
-        -------
-        point : array-like, shape=[..., 1]
-            Sample.
-        """
-        random_point = (gs.random.rand(n_samples, self.dim) * 2 - 1) * gs.pi
-        random_point = self.regularize(random_point)
-
-        if n_samples == 1:
-            random_point = gs.squeeze(random_point, axis=0)
-
-        return random_point
-
-    @geomstats.vectorization.decorator(['else', 'vector', 'output_point'])
-    def exp_from_identity(self, tangent_vec):
-        """Compute the group exponential of the tangent vector at the identity.
-
-        As rotations are represented by their rotation vector,
-        which corresponds to the element `X` in the Lie Algebra such that
-        `exp(X) = R`, this methods returns its input without change.
-
-        Parameters
-        ----------
-        tangent_vec : array-like, shape=[..., 1]
-            Tangent vector at base point.
-        point_type : str, {'vector', 'matrix'}
-            Point type.
-            Optional, default: self.default_point_type.
-
-        Returns
-        -------
-        point : array-like, shape=[..., 1]
-            Point.
-        """
-        return self.regularize(tangent_vec)
-
-    @geomstats.vectorization.decorator(['else', 'vector', 'output_point'])
-    def log_from_identity(self, point):
-        """Compute the group logarithm of the point at the identity.
-
-        As rotations are represented by their rotation vector,
-        which corresponds to the element `X` in the Lie Algebra such that
-        `exp(X) = R`, this methods returns its input after regularization.
-
-
-        Parameters
-        ----------
-        point : array-like, shape=[..., 3]
-            Point.
-
-        Returns
-        -------
-        tangent_vec : array-like, shape=[..., {dimension, [n, n]}]
-            Group logarithm.
-        """
-        return self.regularize(point)
-
-    def exp(self, tangent_vec, base_point=None):
-        """Compute the group exponential.
-
-        Parameters
-        ----------
-        tangent_vec : array-like, shape=[..., 1]
-            Tangent vector at base point.
-        base_point : array-like, shape=[..., 1]
-            Point from which the exponential is computed.
-
-        Returns
-        -------
-        point : array-like, shape=[..., 1]
-            Group exponential.
-        """
-        return self.regularize(tangent_vec + base_point)
-
-    def log(self, point, base_point=None):
-        """Compute the group logarithm.
-
-        Parameters
-        ----------
-        point : array-like, shape=[..., 3]
-            Point.
-        base_point : array-like, shape=[..., 1]
-            Point from which the log is computed.
-
-        Returns
-        -------
-        tangent_vec : array-like, shape=[..., 1]
-            Group logarithm.
-        """
-        return self.regularize(point - base_point)
-
-
 class SpecialOrthogonal(_SpecialOrthogonal2Vectors,
                         _SpecialOrthogonal3Vectors,
                         _SpecialOrthogonalMatrices):
@@ -1919,8 +1794,8 @@ class SpecialOrthogonal(_SpecialOrthogonal2Vectors,
             return _SpecialOrthogonal2Vectors(epsilon)
         if n == 3 and point_type == 'vector':
             return _SpecialOrthogonal3Vectors(epsilon)
-        if n != 3 and point_type == 'vector':
+        if point_type == 'vector':
             raise NotImplementedError(
                 'SO(n) is only implemented in matrix representation'
-                ' when n != 3.')
+                ' when n > 3.')
         return _SpecialOrthogonalMatrices(n)

--- a/geomstats/geometry/special_orthogonal.py
+++ b/geomstats/geometry/special_orthogonal.py
@@ -138,9 +138,8 @@ class _SpecialOrthogonalMatrices(GeneralLinear, LieGroup):
         skew = self.to_tangent(random_mat)
         return self.exp(skew)
 
-    @staticmethod
     @geomstats.vectorization.decorator(['else', 'vector'])
-    def skew_matrix_from_vector(vec):
+    def skew_matrix_from_vector(self, vec):
         """Get the skew-symmetric matrix derived from the vector.
 
         In nD, fill a skew-symmetric matrix with the values of the vector.
@@ -438,7 +437,7 @@ class _SpecialOrthogonal3Vectors(LieGroup):
         skew_mat : array-like, shape=[..., n, n]
             Skew-symmetric matrix.
         """
-        n_vecs, vec_dim = gs.shape(vec)
+        n_vecs, _ = gs.shape(vec)
 
         levi_civita_symbol = gs.tile([[
             [[0., 0., 0.],

--- a/geomstats/geometry/special_orthogonal.py
+++ b/geomstats/geometry/special_orthogonal.py
@@ -257,7 +257,7 @@ class _SpecialOrthogonal3Vectors(LieGroup):
         ['else', 'vector', 'else', 'output_point'])
     def regularize_tangent_vec_at_identity(
             self, tangent_vec, metric=None):
-        """Regularize a tangent vector at the identify.
+        """Regularize a tangent vector at the identity.
 
         In 3D, regularize a tangent_vector by getting its norm at the identity,
         determined by the metric, to be less than pi.
@@ -1476,8 +1476,417 @@ class _SpecialOrthogonal3Vectors(LieGroup):
         return LieGroup.log(self, point, base_point)
 
 
-class SpecialOrthogonal(
-        _SpecialOrthogonal3Vectors, _SpecialOrthogonalMatrices):
+class _SpecialOrthogonal2Vectors(LieGroup):
+    """Class for the special orthogonal group SO(2) in vector representation.
+
+    i.e. the Lie group of planar rotations. This class is specific to the
+    vector representation of rotations. For the matrix representation use the
+    SpecialOrthogonal class and set `n=2`.
+
+    Parameters
+    ----------
+    epsilon : float
+        Precision to use for calculations involving potential divison by 0 in
+        rotations.
+        Optional, default: 0.
+    """
+
+    def __init__(self, epsilon=0.):
+        LieGroup.__init__(
+            self, dim=1, default_point_type='vector')
+
+        self.n = 2
+        self.epsilon = epsilon
+        self.bi_invariant_metric = BiInvariantMetric(group=self)
+
+    def get_identity(self, point_type='vector'):
+        """Get the identity of the group.
+
+        Parameters
+        ----------
+        point_type : str, {'vector', 'matrix'}
+            Point_type of the returned value. Unused here.
+
+        Returns
+        -------
+        identity : array-like, shape=[1,]
+            Identity.
+        """
+        identity = gs.zeros(self.dim)
+        if point_type == 'matrix':
+            identity = gs.eye(self.n)
+        return identity
+
+    identity = property(get_identity)
+
+    def belongs(self, point, atol=ATOL):
+        """Evaluate if a point belongs to SO(3).
+
+        Parameters
+        ----------
+        point : array-like, shape=[..., 3]
+            Point to check whether it belongs to SO(3).
+        atol : unused
+
+        Returns
+        -------
+        belongs : array-like, shape=[...,]
+            Boolean indicating whether point belongs to SO(3).
+        """
+        vec_dim = point.shape[-1]
+        belongs = vec_dim == self.dim
+        if point.ndim == 2:
+            belongs = gs.tile([belongs], (point.shape[0],))
+        return belongs
+
+    def regularize(self, point):
+        """Regularize a point to be in accordance with convention.
+
+        In 2D, regularize the norm of the rotation angle,
+        to be between -pi and pi, following the axis-angle
+        representation's convention.
+
+        If the angle angle is between pi and 2pi,
+        the function computes its complementary in 2pi and
+        inverts the direction of the rotation axis.
+
+        Parameters
+        ----------
+        point : array-like, shape=[...,1]
+            Point.
+
+        Returns
+        -------
+        regularized_point : array-like, shape=[..., 1]
+            Regularized point.
+        """
+        regularized_point = point
+        # regularized_point = gs.to_ndarray(regularized_point, to_ndim=2, axis=1)
+        regularized_point = gs.mod(regularized_point, 2 * gs.pi)
+        regularized_point = regularized_point * (regularized_point < gs.pi) + (
+                    regularized_point - 2 * gs.pi) * (regularized_point > gs.pi)
+        return regularized_point
+
+    @geomstats.vectorization.decorator(
+        ['else', 'vector', 'else', 'output_point'])
+    def regularize_tangent_vec_at_identity(
+            self, tangent_vec, metric=None):
+        """Regularize a tangent vector at the identity.
+
+        In 2D, regularize a tangent_vector by getting its norm at the identity,
+        to be less than pi.
+
+        Parameters
+        ----------
+        tangent_vec : array-like, shape=[..., 1]
+            Tangent vector at base point.
+
+        Returns
+        -------
+        regularized_vec : array-like, shape=[..., 1]
+            Regularized tangent vector.
+        """
+        return self.regularize(tangent_vec)
+
+    @geomstats.vectorization.decorator(
+        ['else', 'vector', 'vector', 'else', 'output_point'])
+    def regularize_tangent_vec(
+            self, tangent_vec, base_point, metric=None):
+        """Regularize tangent vector at a base point.
+
+        In 2D, regularize a tangent_vector by getting the norm of its parallel
+        transport to the identity, determined by the metric, less than pi.
+
+        Parameters
+        ----------
+        tangent_vec : array-like, shape=[...,1]
+            Tangent vector at base point.
+        base_point : array-like, shape=[..., 1]
+            Point on the manifold.
+
+        Returns
+        -------
+        regularized_tangent_vec : array-like, shape=[..., 1]
+            Regularized tangent vector.
+        """
+        return self.regularize_tangent_vec_at_identity(tangent_vec)
+
+    @geomstats.vectorization.decorator(['else', 'matrix'])
+    def projection(self, point):
+        """Project a matrix on SO(2) using the Frobenius norm.
+
+        Parameters
+        ----------
+        point : array-like, shape=[..., 2, 2]
+            Matrix.
+
+        Returns
+        -------
+        rot_mat : array-like, shape=[..., 2, 2]
+            Rotation matrix.
+        """
+        mat = point
+        n_mats, _, _ = mat.shape
+
+        mat_unitary_u, _, mat_unitary_v = gs.linalg.svd(mat)
+        rot_mat = gs.einsum('nij,njk->nik', mat_unitary_u, mat_unitary_v)
+        mask = gs.less(gs.linalg.det(rot_mat), 0.)
+        mask_float = gs.cast(mask, gs.float32) + self.epsilon
+        diag = gs.array([[1., -1.]])
+        diag = gs.to_ndarray(
+            algebra_utils.from_vector_to_diagonal_matrix(diag),
+            to_ndim=3) + self.epsilon
+        new_mat_diag_s = gs.tile(diag, [n_mats, 1, 1])
+
+        aux_mat = gs.einsum(
+            'nij,njk->nik', mat_unitary_u, new_mat_diag_s)
+        rot_mat += gs.einsum(
+            'n,njk->njk', mask_float,
+            gs.einsum('nij,njk->nik', aux_mat, mat_unitary_v))
+        return rot_mat
+
+    @geomstats.vectorization.decorator(['else', 'vector'])
+    def skew_matrix_from_vector(self, vec):
+        """Get the skew-symmetric matrix derived from the vector.
+
+        In 3D, compute the skew-symmetric matrix,known as the cross-product of
+        a vector, associated to the vector `vec`.
+
+        In nD, fill a skew-symmetric matrix with the values of the vector.
+
+        Parameters
+        ----------
+        vec : array-like, shape=[..., dim]
+            Vector.
+
+        Returns
+        -------
+        skew_mat : array-like, shape=[..., n, n]
+            Skew-symmetric matrix.
+        """
+        n_vecs, vec_dim = gs.shape(vec)
+
+        vec = gs.tile(vec, [1, 2])
+        vec = gs.reshape(vec, (n_vecs, 2))
+
+        id_skew = gs.array(
+            gs.tile([[[0., 1.], [-1., 0.]]], (n_vecs, 1, 1)))
+        skew_mat = gs.einsum(
+            '...ij,...i->...ij', gs.cast(id_skew, gs.float32), vec)
+
+        return skew_mat
+
+    @geomstats.vectorization.decorator(['else', 'matrix', 'output_point'])
+    def vector_from_skew_matrix(self, skew_mat):
+        """Derive a vector from the skew-symmetric matrix.
+
+        In 3D, compute the vector defining the cross product
+        associated to the skew-symmetric matrix skew mat.
+
+        Parameters
+        ----------
+        skew_mat : array-like, shape=[..., n, n]
+            Skew-symmetric matrix.
+
+        Returns
+        -------
+        vec : array-like, shape=[..., dim]
+            Vector.
+        """
+        n_skew_mats, _, _ = skew_mat.shape
+
+        vec_dim = self.dim
+        vec = gs.zeros((n_skew_mats, vec_dim))
+
+        vec = skew_mat[:, 0, 1]
+        vec = gs.expand_dims(vec, axis=1)
+
+        return vec
+
+    @geomstats.vectorization.decorator(['else', 'matrix', 'output_point'])
+    def rotation_vector_from_matrix(self, rot_mat):
+        r"""Convert rotation matrix (in 2D) to rotation vector (axis-angle).
+
+        Get the angle through the atan2 function:
+
+        Parameters
+        ----------
+        rot_mat : array-like, shape=[..., 2, 2]
+            Rotation matrix.
+
+        Returns
+        -------
+        regularized_rot_vec : array-like, shape=[..., 1]
+            Rotation vector.
+        """
+        rot_vec = gs.arctan2(rot_mat[:, 1, 0], rot_mat[:, 0, 0])
+        n_states = rot_vec.shape[0]
+        rot_vec = gs.reshape(rot_vec, (n_states, 1))
+        return self.regularize(rot_vec)
+
+    @geomstats.vectorization.decorator(['else', 'vector'])
+    def matrix_from_rotation_vector(self, rot_vec):
+        """Convert rotation vector to rotation matrix.
+
+        Parameters
+        ----------
+        rot_vec: array-like, shape=[..., 1]
+            Rotation vector.
+
+        Returns
+        -------
+        rot_mat: array-like, shape=[..., 2, 2]
+            Rotation matrix.
+        """
+        rot_vec = self.regularize(rot_vec)
+        n_samples = rot_vec.shape[0]
+
+        cos_term = gs.to_ndarray(gs.cos(rot_vec), to_ndim=3, axis=2)
+        cos_matrix = cos_term * gs.array([gs.eye(2)] * n_samples)
+        sin_term = gs.to_ndarray(gs.sin(rot_vec), to_ndim=3, axis=2)
+        sin_matrix = -sin_term * self.skew_matrix_from_vector(
+            gs.array([[1]] * n_samples))
+        return cos_matrix + sin_matrix
+
+    def compose(self, point_a, point_b):
+        """Compose two elements of SO(3).
+
+        Parameters
+        ----------
+        point_a : array-like, shape=[..., 3]
+        point_b : array-like, shape=[..., 3]
+
+        Returns
+        -------
+        point_prod : array-like, shape=[..., 3]
+        """
+        point_a = self.regularize(point_a)
+        point_b = self.regularize(point_b)
+
+        point_prod = point_a + point_b
+        point_prod = self.regularize(point_prod)
+
+        return point_prod
+
+    def inverse(self, point):
+        """Compute the group inverse in SO(3).
+
+        Parameters
+        ----------
+        point : array-like, shape=[..., 3]
+            Point.
+
+        Returns
+        -------
+        inv_point : array-like, shape=[..., 3]
+            Inverse.
+        """
+        return -self.regularize(point)
+
+    def random_uniform(self, n_samples=1):
+        """Sample in SO(2) with the uniform distribution.
+
+        Parameters
+        ----------
+        n_samples : int
+            Number of samples.
+            Optional, default: 1.
+
+        Returns
+        -------
+        point : array-like, shape=[..., 1]
+            Sample.
+        """
+        random_point = (gs.random.rand(n_samples, self.dim) * 2 - 1) * gs.pi
+        random_point = self.regularize(random_point)
+
+        if n_samples == 1:
+            random_point = gs.squeeze(random_point, axis=0)
+
+        return random_point
+
+    @geomstats.vectorization.decorator(['else', 'vector', 'output_point'])
+    def exp_from_identity(self, tangent_vec):
+        """Compute the group exponential of the tangent vector at the identity.
+
+        As rotations are represented by their rotation vector,
+        which corresponds to the element `X` in the Lie Algebra such that
+        `exp(X) = R`, this methods returns its input without change.
+
+        Parameters
+        ----------
+        tangent_vec : array-like, shape=[..., 1]
+            Tangent vector at base point.
+        point_type : str, {'vector', 'matrix'}
+            Point type.
+            Optional, default: self.default_point_type.
+
+        Returns
+        -------
+        point : array-like, shape=[..., 1]
+            Point.
+        """
+        return self.regularize(tangent_vec)
+
+    @geomstats.vectorization.decorator(['else', 'vector', 'output_point'])
+    def log_from_identity(self, point):
+        """Compute the group logarithm of the point at the identity.
+
+        As rotations are represented by their rotation vector,
+        which corresponds to the element `X` in the Lie Algebra such that
+        `exp(X) = R`, this methods returns its input after regularization.
+
+
+        Parameters
+        ----------
+        point : array-like, shape=[..., 3]
+            Point.
+
+        Returns
+        -------
+        tangent_vec : array-like, shape=[..., {dimension, [n, n]}]
+            Group logarithm.
+        """
+        return self.regularize(point)
+
+    def exp(self, tangent_vec, base_point=None):
+        """Compute the group exponential.
+
+        Parameters
+        ----------
+        tangent_vec : array-like, shape=[..., 1]
+            Tangent vector at base point.
+        base_point : array-like, shape=[..., 1]
+            Point from which the exponential is computed.
+
+        Returns
+        -------
+        point : array-like, shape=[..., 1]
+            Group exponential.
+        """
+        return self.regularize(tangent_vec + base_point)
+
+    def log(self, point, base_point=None):
+        """Compute the group logarithm.
+
+        Parameters
+        ----------
+        point : array-like, shape=[..., 3]
+            Point.
+        base_point : array-like, shape=[..., 1]
+            Point from which the log is computed.
+
+        Returns
+        -------
+        tangent_vec : array-like, shape=[..., 1]
+            Group logarithm.
+        """
+        return self.regularize(point - base_point)
+
+
+class SpecialOrthogonal(_SpecialOrthogonal2Vectors,
+                        _SpecialOrthogonal3Vectors,
+                        _SpecialOrthogonalMatrices):
     r"""Class for the special orthogonal groups.
 
     Parameters
@@ -1497,6 +1906,8 @@ class SpecialOrthogonal(
 
         Select the object to instantiate depending on the point_type.
         """
+        if n == 2 and point_type == 'vector':
+            return _SpecialOrthogonal2Vectors(epsilon)
         if n == 3 and point_type == 'vector':
             return _SpecialOrthogonal3Vectors(epsilon)
         if n != 3 and point_type == 'vector':

--- a/geomstats/geometry/special_orthogonal.py
+++ b/geomstats/geometry/special_orthogonal.py
@@ -836,7 +836,7 @@ class _SpecialOrthogonal3Vectors(_SpecialOrthogonalVectors):
         return skew_mat
 
     @staticmethod
-    @geomstats.vectorization.decorator(['else', 'matrix', 'output_point'])
+    @geomstats.vectorization.decorator(['matrix', 'output_point'])
     def vector_from_skew_matrix(skew_mat):
         """Derive a vector from the skew-symmetric matrix.
 

--- a/tests/test_special_euclidean2.py
+++ b/tests/test_special_euclidean2.py
@@ -1,0 +1,359 @@
+"""Unit tests for special euclidean group SE(n).
+
+Note: Only the *canonical* left- and right- invariant
+metrics on SE(3) are tested here. Other invariant
+metrics are tested with the tests of the invariant_metric
+module.
+"""
+
+import warnings
+
+import tests.helper as helper
+
+import geomstats.backend as gs
+import geomstats.tests
+from geomstats.geometry.invariant_metric import InvariantMetric
+from geomstats.geometry.special_euclidean import SpecialEuclidean
+
+# Tolerance for errors on predicted vectors, relative to the *norm*
+# of the vector, as opposed to the standard behavior of gs.allclose
+# where it is relative to each element of the array
+
+RTOL = 1e-5
+
+
+class TestSpecialEuclidean2Methods(geomstats.tests.TestCase):
+    def setUp(self):
+        warnings.simplefilter('ignore', category=ImportWarning)
+        gs.random.seed(1234)
+
+        group = SpecialEuclidean(n=2, point_type='vector')
+
+        point_1 = gs.array([0.1, 0.2, 0.3])
+        point_2 = gs.array([0.5, 5., 60.])
+
+        translation_large = gs.array([0., 5., 6.])
+        translation_small = gs.array([0., 0.6, 0.7])
+
+        elements_all = {
+            'translation_large': translation_large,
+            'translation_small': translation_small,
+            'point_1': point_1,
+            'point_2': point_2}
+        elements = elements_all
+        if geomstats.tests.tf_backend():
+            # Tf is extremely slow
+            elements = {
+                'point_1': point_1,
+                'point_2': point_2}
+
+        elements_matrices_all = {
+            key: group.matrix_from_vector(elements_all[key]) for key in
+            elements_all}
+        elements_matrices = elements_matrices_all
+
+        self.group = group
+        self.elements_all = elements_all
+        self.elements = elements
+        self.elements_matrices_all = elements_matrices_all
+        self.elements_matrices = elements_matrices
+
+        self.n_samples = 4
+
+    def test_random_and_belongs(self):
+        """Checks random_uniform and belongs
+
+        Test that the random uniform method samples
+        on the special euclidean group.
+        """
+        base_point = self.group.random_uniform()
+        result = self.group.belongs(base_point)
+        expected = True
+        self.assertAllClose(result, expected)
+
+    def test_random_and_belongs_vectorization(self):
+        n_samples = self.n_samples
+        points = self.group.random_uniform(n_samples=n_samples)
+        result = self.group.belongs(points)
+        expected = gs.array([True] * n_samples)
+        self.assertAllClose(result, expected)
+
+    def test_regularize(self):
+        point = self.elements_all['point_1']
+        result = self.group.regularize(point)
+        expected = point
+        self.assertAllClose(result, expected)
+
+    def test_regularize_vectorization(self):
+        n_samples = self.n_samples
+        points = self.group.random_uniform(n_samples=n_samples)
+        regularized_points = self.group.regularize(points)
+
+        self.assertAllClose(
+            gs.shape(regularized_points),
+            (n_samples, *self.group.get_point_type_shape()))
+
+    def test_compose(self):
+        # Composition by identity, on the right
+        # Expect the original transformation
+        point = self.elements_all['point_1']
+        result = self.group.compose(point,
+                                    self.group.identity)
+        expected = point
+        self.assertAllClose(result, expected)
+
+        if not geomstats.tests.tf_backend():
+            # Composition by identity, on the left
+            # Expect the original transformation
+            result = self.group.compose(self.group.identity,
+                                        point)
+            expected = point
+            self.assertAllClose(result, expected)
+
+            # Composition of translations (no rotational part)
+            # Expect the sum of the translations
+            result = self.group.compose(self.elements_all['translation_small'],
+                                        self.elements_all['translation_large'])
+            expected = (self.elements_all['translation_small']
+                        + self.elements_all['translation_large'])
+            self.assertAllClose(result, expected)
+
+    def test_compose_and_inverse(self):
+        point = self.elements_all['point_1']
+        inv_point = self.group.inverse(point)
+        # Compose transformation by its inverse on the right
+        # Expect the group identity
+        result = self.group.compose(point, inv_point)
+        expected = self.group.identity
+        self.assertAllClose(result, expected)
+
+        if not geomstats.tests.tf_backend():
+            # Compose transformation by its inverse on the left
+            # Expect the group identity
+            result = self.group.compose(inv_point, point)
+            expected = self.group.identity
+            self.assertAllClose(result, expected)
+
+    def test_compose_vectorization(self):
+        n_samples = self.n_samples
+        n_points_a = self.group.random_uniform(n_samples=n_samples)
+        n_points_b = self.group.random_uniform(n_samples=n_samples)
+        one_point = self.group.random_uniform(n_samples=1)
+
+        result = self.group.compose(one_point,
+                                    n_points_a)
+        self.assertAllClose(
+            gs.shape(result), (n_samples, *self.group.get_point_type_shape()))
+
+        result = self.group.compose(n_points_a,
+                                    one_point)
+
+        if not geomstats.tests.tf_backend():
+            self.assertAllClose(
+                gs.shape(result),
+                (n_samples, *self.group.get_point_type_shape()))
+
+            result = self.group.compose(n_points_a,
+                                        n_points_b)
+            self.assertAllClose(
+                gs.shape(result),
+                (n_samples, *self.group.get_point_type_shape()))
+
+    def test_inverse_vectorization(self):
+        n_samples = self.n_samples
+        points = self.group.random_uniform(n_samples=n_samples)
+        result = self.group.inverse(points)
+        self.assertAllClose(
+            gs.shape(result), (n_samples, *self.group.get_point_type_shape()))
+
+    @geomstats.tests.np_only
+    def test_group_exp_from_identity_vectorization(self):
+        n_samples = self.n_samples
+        tangent_vecs = self.group.random_uniform(n_samples=n_samples)
+        result = self.group.exp_from_identity(tangent_vecs)
+
+        self.assertAllClose(
+            gs.shape(result), (n_samples, *self.group.get_point_type_shape()))
+
+    @geomstats.tests.np_only
+    def test_group_log_from_identity_vectorization(self):
+        n_samples = self.n_samples
+        points = self.group.random_uniform(n_samples=n_samples)
+        result = self.group.log_from_identity(points)
+
+        self.assertAllClose(
+            gs.shape(result),
+            (n_samples, *self.group.get_point_type_shape()))
+
+    @geomstats.tests.np_only
+    def test_group_exp_vectorization(self):
+        n_samples = self.n_samples
+        # Test with the 1 base_point, and several different tangent_vecs
+        tangent_vecs = self.group.random_uniform(n_samples=n_samples)
+        base_point = self.group.random_uniform(n_samples=1)
+        result = self.group.exp(tangent_vecs, base_point)
+
+        self.assertAllClose(
+            gs.shape(result), (n_samples, *self.group.get_point_type_shape()))
+
+        if not geomstats.tests.tf_backend():
+            # Test with the same number of base_points and tangent_vecs
+            tangent_vecs = self.group.random_uniform(n_samples=n_samples)
+            base_points = self.group.random_uniform(n_samples=n_samples)
+            result = self.group.exp(tangent_vecs, base_points)
+
+            self.assertAllClose(
+                gs.shape(result),
+                (n_samples, *self.group.get_point_type_shape()))
+
+            # Test with the several base_points, and 1 tangent_vec
+            tangent_vec = self.group.random_uniform(n_samples=1)
+            base_points = self.group.random_uniform(n_samples=n_samples)
+            result = self.group.exp(tangent_vec, base_points)
+
+            self.assertAllClose(
+                gs.shape(result),
+                (n_samples, *self.group.get_point_type_shape()))
+
+    @geomstats.tests.np_only
+    def test_group_log_vectorization(self):
+        n_samples = self.n_samples
+        # Test with the 1 base point, and several different points
+        points = self.group.random_uniform(n_samples=n_samples)
+        base_point = self.group.random_uniform(n_samples=1)
+        result = self.group.log(points, base_point)
+
+        self.assertAllClose(
+            gs.shape(result), (n_samples, *self.group.get_point_type_shape()))
+
+        if not geomstats.tests.tf_backend():
+
+            # Test with the same number of base points and points
+            points = self.group.random_uniform(n_samples=n_samples)
+            base_points = self.group.random_uniform(n_samples=n_samples)
+            result = self.group.log(points, base_points)
+
+            self.assertAllClose(
+                gs.shape(result),
+                (n_samples, *self.group.get_point_type_shape()))
+
+            # Test with the several base points, and 1 point
+            point = self.group.random_uniform(n_samples=1)
+            base_points = self.group.random_uniform(n_samples=n_samples)
+            result = self.group.log(point, base_points)
+
+            self.assertAllClose(
+                gs.shape(result),
+                (n_samples, *self.group.get_point_type_shape()))
+
+    @geomstats.tests.np_only
+    def test_group_exp_from_identity(self):
+        # Group exponential of a translation (no rotational part)
+        # Expect the original translation
+        tangent_vec = self.elements_all['translation_small']
+        result = self.group.exp(
+            base_point=self.group.identity, tangent_vec=tangent_vec)
+        expected = tangent_vec
+        self.assertAllClose(result, expected)
+
+    @geomstats.tests.np_only
+    def test_group_log_from_identity(self):
+        # Group logarithm of a translation (no rotational part)
+        # Expect the original translation
+        point = self.elements_all['translation_small']
+        result = self.group.log(
+            base_point=self.group.identity, point=point)
+        expected = point
+        self.assertAllClose(result, expected)
+
+    @geomstats.tests.np_only
+    def test_group_log_then_exp_from_identity(self):
+        """
+        Test that the group exponential from the identity
+        and the group logarithm from the identity
+        are inverse.
+        Expect their composition to give the identity function.
+        """
+        for element_type in self.elements:
+            point = self.elements[element_type]
+            result = helper.group_log_then_exp_from_identity(
+                group=self.group, point=point)
+            expected = self.group.regularize(point)
+            self.assertAllClose(result, expected, atol=1e-3)
+
+            if geomstats.tests.tf_backend():
+                break
+
+    @geomstats.tests.np_only
+    def test_group_exp(self):
+        # Reference point is a translation (no rotational part)
+        # so that the jacobian of the left-translation of the Lie group
+        # is the 6x6 identity matrix
+        # Tangent vector is a translation (no infinitesimal rotational part)
+        # Expect the sum of the translation
+        # with the translation of the reference point
+        result = self.group.exp(
+            base_point=self.elements_all['translation_small'],
+            tangent_vec=self.elements_all['translation_large'])
+        expected = (self.elements_all['translation_small']
+                    + self.elements_all['translation_large'])
+        self.assertAllClose(result, expected)
+
+    @geomstats.tests.np_only
+    def test_group_log(self):
+        # Reference point is a translation (no rotational part)
+        # so that the jacobian of the left-translation of the Lie group
+        # is the 6x6 identity matrix
+        # Point is a translation (no rotational part)
+        # Expect the difference of the translation
+        # by the translation of the reference point
+        result = self.group.log(
+            base_point=self.elements_all['translation_small'],
+            point=self.elements_all['translation_large'])
+        expected = (self.elements_all['translation_large']
+                    - self.elements_all['translation_small'])
+
+        self.assertAllClose(result, expected)
+
+    @geomstats.tests.np_only
+    def test_group_log_then_exp(self):
+        """
+        Test that the group exponential
+        and the group logarithm are inverse.
+        Expect their composition to give the identity function.
+        """
+        for base_point in self.elements.values():
+            for element_type in self.elements:
+                point = self.elements[element_type]
+
+                result = helper.group_log_then_exp(group=self.group,
+                                                   point=point,
+                                                   base_point=base_point)
+                expected = self.group.regularize(point)
+                self.assertAllClose(result, expected, rtol=1e-4, atol=1e-4)
+
+                if geomstats.tests.tf_backend():
+                    break
+
+    @geomstats.tests.np_only
+    def test_group_exp_then_log(self):
+        """
+        Test that the group exponential
+        and the group logarithm are inverse.
+        Expect their composition to give the identity function.
+        """
+        for base_point_type in self.elements:
+            base_point = self.elements[base_point_type]
+            for element_type in self.elements:
+                tangent_vec = self.elements[element_type]
+                result = helper.group_exp_then_log(
+                    group=self.group,
+                    tangent_vec=tangent_vec,
+                    base_point=base_point)
+                expected = self.group.regularize_tangent_vec(
+                    tangent_vec=tangent_vec,
+                    base_point=base_point)
+                self.assertAllClose(result, expected, rtol=1e-4, atol=1e-4)
+
+                if geomstats.tests.tf_backend():
+                    break

--- a/tests/test_special_euclidean2.py
+++ b/tests/test_special_euclidean2.py
@@ -12,7 +12,6 @@ import tests.helper as helper
 
 import geomstats.backend as gs
 import geomstats.tests
-from geomstats.geometry.invariant_metric import InvariantMetric
 from geomstats.geometry.special_euclidean import SpecialEuclidean
 
 # Tolerance for errors on predicted vectors, relative to the *norm*

--- a/tests/test_special_orthogonal2.py
+++ b/tests/test_special_orthogonal2.py
@@ -4,9 +4,9 @@ import warnings
 
 import tests.helper as helper
 
-from geomstats import algebra_utils
 import geomstats.backend as gs
 import geomstats.tests
+from geomstats import algebra_utils
 from geomstats.geometry.special_orthogonal import SpecialOrthogonal
 
 

--- a/tests/test_special_orthogonal2.py
+++ b/tests/test_special_orthogonal2.py
@@ -1,0 +1,431 @@
+"""Unit tests for special orthogonal group SO(3)."""
+
+import warnings
+
+import tests.helper as helper
+
+from geomstats import algebra_utils
+import geomstats.backend as gs
+import geomstats.tests
+from geomstats.geometry.invariant_metric import InvariantMetric
+from geomstats.geometry.special_orthogonal import SpecialOrthogonal
+
+
+EPSILON = 1e-5
+ATOL = 1e-5
+
+
+class TestSpecialOrthogonal2(geomstats.tests.TestCase):
+    def setUp(self):
+        warnings.simplefilter('ignore', category=ImportWarning)
+        warnings.simplefilter('ignore', category=UserWarning)
+
+        gs.random.seed(1234)
+
+        n_seq = [2]
+        so = {n: SpecialOrthogonal(n=n, point_type='vector') for n in n_seq}
+
+        # -- Set attributes
+        self.n_seq = n_seq
+        self.so = so
+
+        self.n_samples = 4
+
+    def test_projection(self):
+        # Test 2D and nD cases
+        for n in self.n_seq:
+            group = self.so[n]
+            rot_mat = gs.eye(n)
+            delta = 1e-12 * gs.ones((n, n))
+            rot_mat_plus_delta = rot_mat + delta
+            result = group.projection(rot_mat_plus_delta)
+            expected = rot_mat
+            self.assertAllClose(result, expected)
+
+    def test_projection_vectorization(self):
+        for n in self.n_seq:
+            group = self.so[n]
+            n_samples = self.n_samples
+            mats = gs.ones((n_samples, n, n))
+            result = group.projection(mats)
+            self.assertAllClose(gs.shape(result), (n_samples, n, n))
+
+    def test_skew_matrix_from_vector(self):
+        # Specific to 2D case
+        n = 2
+        group = self.so[n]
+        rot_vec = gs.array([0.9])
+        skew_matrix = group.skew_matrix_from_vector(rot_vec)
+        result = gs.dot(skew_matrix, skew_matrix)
+        diag = gs.array([-0.81, -0.81])
+        expected = algebra_utils.from_vector_to_diagonal_matrix(diag)
+
+        self.assertAllClose(result, expected)
+
+    def test_skew_matrix_and_vector(self):
+        n = 2
+
+        group = self.so[n]
+        rot_vec = gs.array([0.8])
+
+        skew_mat = group.skew_matrix_from_vector(rot_vec)
+        result = group.vector_from_skew_matrix(skew_mat)
+        expected = rot_vec
+
+        self.assertAllClose(result, expected)
+
+    def test_skew_matrix_from_vector_vectorization(self):
+        n_samples = self.n_samples
+        for n in self.n_seq:
+            group = self.so[n]
+            rot_vecs = group.random_uniform(n_samples=n_samples)
+            result = group.skew_matrix_from_vector(rot_vecs)
+
+            self.assertAllClose(gs.shape(result), (n_samples, n, n))
+
+    def test_random_uniform_shape(self):
+        group = self.so[2]
+        result = group.random_uniform()
+        self.assertAllClose(gs.shape(result), (group.dim,))
+
+    def test_random_and_belongs(self):
+        for n in self.n_seq:
+            group = self.so[n]
+            point = group.random_uniform()
+            result = group.belongs(point)
+            expected = True
+            self.assertAllClose(result, expected)
+
+    def test_random_and_belongs_vectorization(self):
+        n_samples = self.n_samples
+        for n in self.n_seq:
+            group = self.so[n]
+            points = group.random_uniform(n_samples=n_samples)
+            result = group.belongs(points)
+            expected = gs.array([True] * n_samples)
+            self.assertAllClose(result, expected)
+
+    def test_regularize(self):
+        # Specific to 2D
+        for n in self.n_seq:
+            group = self.so[n]
+            if n == 2:
+                angle = 2 * gs.pi + 1
+                result = group.regularize(gs.array([angle]))
+                expected = gs.array([1.])
+                self.assertAllClose(result, expected)
+
+    def test_regularize_vectorization(self):
+        for n in self.n_seq:
+            group = self.so[n]
+
+            n_samples = self.n_samples
+            rot_vecs = group.random_uniform(n_samples=n_samples)
+            result = group.regularize(rot_vecs)
+
+            self.assertAllClose(gs.shape(result), (n_samples, group.dim))
+
+    def test_matrix_from_rotation_vector(self):
+        n = 2
+        group = self.so[n]
+
+        angle = gs.pi / 3
+        expected = gs.array([[1. / 2, -gs.sqrt(3) / 2],
+                             [gs.sqrt(3) / 2, 1. / 2]])
+        result = group.matrix_from_rotation_vector(gs.array([angle]))
+        self.assertAllClose(result, expected)
+
+    def test_matrix_from_rotation_vector_vectorization(self):
+        for n in self.n_seq:
+            group = self.so[n]
+
+            n_samples = self.n_samples
+            rot_vecs = group.random_uniform(n_samples=n_samples)
+
+            rot_mats = group.matrix_from_rotation_vector(rot_vecs)
+
+            self.assertAllClose(
+                gs.shape(rot_mats), (n_samples, group.n, group.n))
+
+    def test_rotation_vector_from_matrix(self):
+        n = 2
+        group = self.so[n]
+
+        angle = .12
+        rot_mat = gs.array([[gs.cos(angle), -gs.sin(angle)],
+                            [gs.sin(angle), gs.cos(angle)]])
+        result = group.rotation_vector_from_matrix(rot_mat)
+        expected = gs.array([.12])
+
+        self.assertAllClose(result, expected)
+
+    def test_rotation_vector_and_rotation_matrix(self):
+        """
+        This tests that the composition of
+        rotation_vector_from_matrix
+        and
+        matrix_from_rotation_vector
+        is the identity.
+        """
+        for n in self.n_seq:
+            group = self.so[n]
+            if n == 2:
+                # TODO(nguigs): bring back a 1d representation of SO2
+                point = gs.array([0.78])
+
+                rot_mat = group.matrix_from_rotation_vector(point)
+                result = group.rotation_vector_from_matrix(rot_mat)
+
+                expected = point
+
+                self.assertAllClose(result, expected)
+
+    def test_rotation_vector_and_rotation_matrix_vectorization(self):
+        for n in self.n_seq:
+            group = self.so[n]
+
+            if n == 2:
+                rot_vecs = gs.array([
+                    [2.],
+                    [1.3],
+                    [0.8],
+                    [0.03]])
+
+            rot_mats = group.matrix_from_rotation_vector(rot_vecs)
+            result = group.rotation_vector_from_matrix(rot_mats)
+
+            expected = group.regularize(rot_vecs)
+
+            self.assertAllClose(result, expected)
+
+    def test_compose(self):
+        for n in self.n_seq:
+            group = self.so[n]
+            if n == 2:
+                point_a = gs.array([.12])
+                point_b = gs.array([-.15])
+                result = group.compose(point_a, point_b)
+                expected = group.regularize(gs.array([-.03]))
+                self.assertAllClose(result, expected)
+
+    def test_compose_and_inverse(self):
+        for n in self.n_seq:
+            group = self.so[n]
+
+            if n == 2:
+                angle = 0.986
+                point = gs.array([angle])
+                inv_point = group.inverse(point)
+                result = group.compose(point, inv_point)
+                expected = group.identity
+                self.assertAllClose(result, expected)
+
+                result = group.compose(inv_point, point)
+                expected = group.identity
+                self.assertAllClose(result, expected)
+
+    def test_compose_vectorization(self):
+        point_type = 'vector'
+        for n in self.n_seq:
+            group = self.so[n]
+            group.default_point_type = point_type
+
+            n_samples = self.n_samples
+            n_points_a = group.random_uniform(n_samples=n_samples)
+            n_points_b = group.random_uniform(n_samples=n_samples)
+            one_point = group.random_uniform(n_samples=1)
+
+            result = group.compose(one_point, n_points_a)
+            if point_type == 'vector':
+                self.assertAllClose(
+                    gs.shape(result), (n_samples, group.dim))
+            if point_type == 'matrix':
+                self.assertAllClose(
+                    gs.shape(result), (n_samples, n, n))
+
+            result = group.compose(n_points_a, one_point)
+            if point_type == 'vector':
+                self.assertAllClose(
+                    gs.shape(result), (n_samples, group.dim))
+            if point_type == 'matrix':
+                self.assertAllClose(
+                    gs.shape(result), (n_samples, n, n))
+
+            result = group.compose(n_points_a, n_points_b)
+            if point_type == 'vector':
+                self.assertAllClose(
+                    gs.shape(result), (n_samples, group.dim))
+            if point_type == 'matrix':
+                self.assertAllClose(
+                    gs.shape(result), (n_samples, n, n))
+
+    def test_inverse_vectorization(self):
+        for n in self.n_seq:
+            group = self.so[n]
+
+            n_samples = self.n_samples
+            points = group.random_uniform(n_samples=n_samples)
+            result = group.inverse(points)
+
+            if n == 2:
+                self.assertAllClose(
+                    gs.shape(result), (n_samples, group.dim))
+            else:
+                self.assertAllClose(
+                    gs.shape(result), (n_samples, n, n))
+
+    def test_group_exp(self):
+        """
+        The Riemannian exp and log are inverse functions of each other.
+        This test is the inverse of test_log's.
+        """
+        n = 2
+        group = self.so[n]
+
+        rot_vec_base_point = gs.array([gs.pi / 5])
+        rot_vec = gs.array([2 * gs.pi / 5])
+
+        expected = gs.array([3 * gs.pi / 5])
+        result = group.exp(base_point=rot_vec_base_point, tangent_vec=rot_vec)
+        self.assertAllClose(result, expected)
+
+    def test_group_exp_vectorization(self):
+        n = 2
+        group = self.so[n]
+
+        n_samples = self.n_samples
+
+        one_tangent_vec = group.random_uniform(n_samples=1)
+        one_base_point = group.random_uniform(n_samples=1)
+        n_tangent_vec = group.random_uniform(n_samples=n_samples)
+        n_base_point = group.random_uniform(n_samples=n_samples)
+
+        # Test with the 1 base point, and n tangent vecs
+        result = group.exp(n_tangent_vec, one_base_point)
+        self.assertAllClose(
+            gs.shape(result), (n_samples, group.dim))
+
+        # Test with the several base point, and one tangent vec
+        result = group.exp(one_tangent_vec, n_base_point)
+        self.assertAllClose(
+            gs.shape(result), (n_samples, group.dim))
+
+        # Test with the same number n of base point and n tangent vec
+        result = group.exp(n_tangent_vec, n_base_point)
+        self.assertAllClose(
+            gs.shape(result), (n_samples, group.dim))
+
+    def test_group_log(self):
+        """
+        The Riemannian exp and log are inverse functions of each other.
+        This test is the inverse of test_exp's.
+        """
+        n = 2
+        group = self.so[n]
+
+        rot_vec_base_point = gs.array([gs.pi / 5])
+        rot_vec = gs.array([2 * gs.pi / 5])
+
+        expected = gs.array([1 * gs.pi / 5])
+        result = group.log(point=rot_vec, base_point=rot_vec_base_point)
+        self.assertAllClose(result, expected)
+
+    def test_group_log_vectorization(self):
+        n = 2
+        group = self.so[n]
+
+        n_samples = self.n_samples
+
+        one_point = group.random_uniform(n_samples=1)
+        one_base_point = group.random_uniform(n_samples=1)
+        n_point = group.random_uniform(n_samples=n_samples)
+        n_base_point = group.random_uniform(n_samples=n_samples)
+
+        # Test with the 1 base point, and several different points
+        result = group.log(n_point, one_base_point)
+        self.assertAllClose(
+            gs.shape(result), (n_samples, group.dim))
+
+        # Test with the several base point, and 1 point
+        result = group.log(one_point, n_base_point)
+        self.assertAllClose(
+            gs.shape(result), (n_samples, group.dim))
+
+        # Test with the same number n of base point and point
+        result = group.log(n_point, n_base_point)
+        self.assertAllClose(
+            gs.shape(result), (n_samples, group.dim))
+
+    def test_group_exp_then_log_from_identity(self):
+        """
+        Test that the group exponential
+        and the group logarithm are inverse.
+        Expect their composition to give the identity function.
+        """
+        n = 2
+        group = self.so[n]
+
+        tangent_vec = gs.array([0.12])
+        result = helper.group_exp_then_log_from_identity(
+            group=group, tangent_vec=tangent_vec)
+        expected = group.regularize(tangent_vec)
+        self.assertAllClose(result, expected)
+
+    def test_group_log_then_exp_from_identity(self):
+        """
+        Test that the group exponential
+        and the group logarithm are inverse.
+        Expect their composition to give the identity function.
+        """
+        n = 2
+        group = self.so[n]
+
+        point = gs.array([0.12])
+        result = helper.group_log_then_exp_from_identity(
+            group=group, point=point)
+        expected = group.regularize(point)
+        self.assertAllClose(result, expected)
+
+    def test_group_exp_then_log(self):
+        """
+        This tests that the composition of
+        log and exp gives identity.
+
+        """
+        n = 2
+        group = self.so[n]
+
+        base_point = gs.array([0.12])
+        tangent_vec = gs.array([.35])
+
+        result = helper.group_exp_then_log(
+            group=group,
+            tangent_vec=tangent_vec,
+            base_point=base_point)
+
+        expected = group.regularize_tangent_vec(
+            tangent_vec=tangent_vec,
+            base_point=base_point)
+
+        self.assertAllClose(result, expected, atol=1e-5)
+
+    def test_group_log_then_exp(self):
+        """
+        This tests that the composition of
+        log and exp gives identity.
+        """
+
+        n = 2
+        group = self.so[n]
+
+        base_point = gs.array([0.12])
+        point = gs.array([.35])
+
+        result = helper.group_log_then_exp(
+            group=group,
+            point=point,
+            base_point=base_point)
+
+        expected = group.regularize(point)
+
+        self.assertAllClose(result, expected, atol=1e-5)

--- a/tests/test_special_orthogonal2.py
+++ b/tests/test_special_orthogonal2.py
@@ -56,10 +56,9 @@ class TestSpecialOrthogonal2(geomstats.tests.TestCase):
         group = self.so[n]
         rot_vec = gs.array([0.9])
         skew_matrix = group.skew_matrix_from_vector(rot_vec)
-        result = gs.dot(skew_matrix, skew_matrix)
+        result = gs.matmul(skew_matrix, skew_matrix)
         diag = gs.array([-0.81, -0.81])
         expected = algebra_utils.from_vector_to_diagonal_matrix(diag)
-
         self.assertAllClose(result, expected)
 
     def test_skew_matrix_and_vector(self):
@@ -130,8 +129,8 @@ class TestSpecialOrthogonal2(geomstats.tests.TestCase):
         group = self.so[n]
 
         angle = gs.pi / 3
-        expected = gs.array([[1. / 2, -gs.sqrt(3) / 2],
-                             [gs.sqrt(3) / 2, 1. / 2]])
+        expected = gs.array([[1. / 2, -gs.sqrt(3.) / 2],
+                             [gs.sqrt(3.) / 2, 1. / 2]])
         result = group.matrix_from_rotation_vector(gs.array([angle]))
         self.assertAllClose(result, expected)
 

--- a/tests/test_special_orthogonal2.py
+++ b/tests/test_special_orthogonal2.py
@@ -21,138 +21,101 @@ class TestSpecialOrthogonal2(geomstats.tests.TestCase):
 
         gs.random.seed(1234)
 
-        n_seq = [2]
-        so = {n: SpecialOrthogonal(n=n, point_type='vector') for n in n_seq}
+        self.group = SpecialOrthogonal(n=2, point_type='vector')
 
         # -- Set attributes
-        self.n_seq = n_seq
-        self.so = so
-
         self.n_samples = 4
 
     def test_projection(self):
         # Test 2D and nD cases
-        for n in self.n_seq:
-            group = self.so[n]
-            rot_mat = gs.eye(n)
-            delta = 1e-12 * gs.ones((n, n))
-            rot_mat_plus_delta = rot_mat + delta
-            result = group.projection(rot_mat_plus_delta)
-            expected = rot_mat
-            self.assertAllClose(result, expected)
+        rot_mat = gs.eye(2)
+        delta = 1e-12 * gs.ones((2, 2))
+        rot_mat_plus_delta = rot_mat + delta
+        result = self.group.projection(rot_mat_plus_delta)
+        expected = rot_mat
+        self.assertAllClose(result, expected)
 
     def test_projection_vectorization(self):
-        for n in self.n_seq:
-            group = self.so[n]
-            n_samples = self.n_samples
-            mats = gs.ones((n_samples, n, n))
-            result = group.projection(mats)
-            self.assertAllClose(gs.shape(result), (n_samples, n, n))
+        n_samples = self.n_samples
+        mats = gs.ones((n_samples, 2, 2))
+        result = self.group.projection(mats)
+        self.assertAllClose(gs.shape(result), (n_samples, 2, 2))
 
     def test_skew_matrix_from_vector(self):
-        # Specific to 2D case
-        n = 2
-        group = self.so[n]
         rot_vec = gs.array([0.9])
-        skew_matrix = group.skew_matrix_from_vector(rot_vec)
+        skew_matrix = self.group.skew_matrix_from_vector(rot_vec)
         result = gs.matmul(skew_matrix, skew_matrix)
         diag = gs.array([-0.81, -0.81])
         expected = algebra_utils.from_vector_to_diagonal_matrix(diag)
         self.assertAllClose(result, expected)
 
     def test_skew_matrix_and_vector(self):
-        n = 2
-
-        group = self.so[n]
         rot_vec = gs.array([0.8])
 
-        skew_mat = group.skew_matrix_from_vector(rot_vec)
-        result = group.vector_from_skew_matrix(skew_mat)
+        skew_mat = self.group.skew_matrix_from_vector(rot_vec)
+        result = self.group.vector_from_skew_matrix(skew_mat)
         expected = rot_vec
 
         self.assertAllClose(result, expected)
 
     def test_skew_matrix_from_vector_vectorization(self):
         n_samples = self.n_samples
-        for n in self.n_seq:
-            group = self.so[n]
-            rot_vecs = group.random_uniform(n_samples=n_samples)
-            result = group.skew_matrix_from_vector(rot_vecs)
+        rot_vecs = self.group.random_uniform(n_samples=n_samples)
+        result = self.group.skew_matrix_from_vector(rot_vecs)
 
-            self.assertAllClose(gs.shape(result), (n_samples, n, n))
+        self.assertAllClose(gs.shape(result), (n_samples, 2, 2))
 
     def test_random_uniform_shape(self):
-        group = self.so[2]
-        result = group.random_uniform()
-        self.assertAllClose(gs.shape(result), (group.dim,))
+        result = self.group.random_uniform()
+        self.assertAllClose(gs.shape(result), (self.group.dim,))
 
     def test_random_and_belongs(self):
-        for n in self.n_seq:
-            group = self.so[n]
-            point = group.random_uniform()
-            result = group.belongs(point)
-            expected = True
-            self.assertAllClose(result, expected)
+        point = self.group.random_uniform()
+        result = self.group.belongs(point)
+        expected = True
+        self.assertAllClose(result, expected)
 
     def test_random_and_belongs_vectorization(self):
         n_samples = self.n_samples
-        for n in self.n_seq:
-            group = self.so[n]
-            points = group.random_uniform(n_samples=n_samples)
-            result = group.belongs(points)
-            expected = gs.array([True] * n_samples)
-            self.assertAllClose(result, expected)
+        points = self.group.random_uniform(n_samples=n_samples)
+        result = self.group.belongs(points)
+        expected = gs.array([True] * n_samples)
+        self.assertAllClose(result, expected)
 
     def test_regularize(self):
-        # Specific to 2D
-        for n in self.n_seq:
-            group = self.so[n]
-            if n == 2:
-                angle = 2 * gs.pi + 1
-                result = group.regularize(gs.array([angle]))
-                expected = gs.array([1.])
-                self.assertAllClose(result, expected)
+        angle = 2 * gs.pi + 1
+        result = self.group.regularize(gs.array([angle]))
+        expected = gs.array([1.])
+        self.assertAllClose(result, expected)
 
     def test_regularize_vectorization(self):
-        for n in self.n_seq:
-            group = self.so[n]
+        n_samples = self.n_samples
+        rot_vecs = self.group.random_uniform(n_samples=n_samples)
+        result = self.group.regularize(rot_vecs)
 
-            n_samples = self.n_samples
-            rot_vecs = group.random_uniform(n_samples=n_samples)
-            result = group.regularize(rot_vecs)
-
-            self.assertAllClose(gs.shape(result), (n_samples, group.dim))
+        self.assertAllClose(gs.shape(result), (n_samples, self.group.dim))
 
     def test_matrix_from_rotation_vector(self):
-        n = 2
-        group = self.so[n]
-
         angle = gs.pi / 3
         expected = gs.array([[1. / 2, -gs.sqrt(3.) / 2],
                              [gs.sqrt(3.) / 2, 1. / 2]])
-        result = group.matrix_from_rotation_vector(gs.array([angle]))
+        result = self.group.matrix_from_rotation_vector(gs.array([angle]))
         self.assertAllClose(result, expected)
 
     def test_matrix_from_rotation_vector_vectorization(self):
-        for n in self.n_seq:
-            group = self.so[n]
+        n_samples = self.n_samples
+        rot_vecs = self.group.random_uniform(n_samples=n_samples)
 
-            n_samples = self.n_samples
-            rot_vecs = group.random_uniform(n_samples=n_samples)
+        rot_mats = self.group.matrix_from_rotation_vector(rot_vecs)
 
-            rot_mats = group.matrix_from_rotation_vector(rot_vecs)
-
-            self.assertAllClose(
-                gs.shape(rot_mats), (n_samples, group.n, group.n))
+        self.assertAllClose(
+            gs.shape(rot_mats), (n_samples, self.group.n, self.group.n))
 
     def test_rotation_vector_from_matrix(self):
-        n = 2
-        group = self.so[n]
-
         angle = .12
         rot_mat = gs.array([[gs.cos(angle), -gs.sin(angle)],
                             [gs.sin(angle), gs.cos(angle)]])
-        result = group.rotation_vector_from_matrix(rot_mat)
+        result = self.group.rotation_vector_from_matrix(rot_mat)
         expected = gs.array([.12])
 
         self.assertAllClose(result, expected)
@@ -165,194 +128,148 @@ class TestSpecialOrthogonal2(geomstats.tests.TestCase):
         matrix_from_rotation_vector
         is the identity.
         """
-        for n in self.n_seq:
-            group = self.so[n]
-            if n == 2:
-                # TODO(nguigs): bring back a 1d representation of SO2
-                point = gs.array([0.78])
+        # TODO(nguigs): bring back a 1d representation of SO2
+        point = gs.array([0.78])
 
-                rot_mat = group.matrix_from_rotation_vector(point)
-                result = group.rotation_vector_from_matrix(rot_mat)
+        rot_mat = self.group.matrix_from_rotation_vector(point)
+        result = self.group.rotation_vector_from_matrix(rot_mat)
 
-                expected = point
+        expected = point
 
-                self.assertAllClose(result, expected)
+        self.assertAllClose(result, expected)
 
     def test_rotation_vector_and_rotation_matrix_vectorization(self):
-        for n in self.n_seq:
-            group = self.so[n]
+        rot_vecs = gs.array([
+            [2.],
+            [1.3],
+            [0.8],
+            [0.03]])
 
-            if n == 2:
-                rot_vecs = gs.array([
-                    [2.],
-                    [1.3],
-                    [0.8],
-                    [0.03]])
+        rot_mats = self.group.matrix_from_rotation_vector(rot_vecs)
+        result = self.group.rotation_vector_from_matrix(rot_mats)
 
-            rot_mats = group.matrix_from_rotation_vector(rot_vecs)
-            result = group.rotation_vector_from_matrix(rot_mats)
+        expected = self.group.regularize(rot_vecs)
 
-            expected = group.regularize(rot_vecs)
-
-            self.assertAllClose(result, expected)
+        self.assertAllClose(result, expected)
 
     def test_compose(self):
-        for n in self.n_seq:
-            group = self.so[n]
-            if n == 2:
-                point_a = gs.array([.12])
-                point_b = gs.array([-.15])
-                result = group.compose(point_a, point_b)
-                expected = group.regularize(gs.array([-.03]))
-                self.assertAllClose(result, expected)
+        point_a = gs.array([.12])
+        point_b = gs.array([-.15])
+        result = self.group.compose(point_a, point_b)
+        expected = self.group.regularize(gs.array([-.03]))
+        self.assertAllClose(result, expected)
 
     def test_compose_and_inverse(self):
-        for n in self.n_seq:
-            group = self.so[n]
+        angle = 0.986
+        point = gs.array([angle])
+        inv_point = self.group.inverse(point)
+        result = self.group.compose(point, inv_point)
+        expected = self.group.identity
+        self.assertAllClose(result, expected)
 
-            if n == 2:
-                angle = 0.986
-                point = gs.array([angle])
-                inv_point = group.inverse(point)
-                result = group.compose(point, inv_point)
-                expected = group.identity
-                self.assertAllClose(result, expected)
-
-                result = group.compose(inv_point, point)
-                expected = group.identity
-                self.assertAllClose(result, expected)
+        result = self.group.compose(inv_point, point)
+        expected = self.group.identity
+        self.assertAllClose(result, expected)
 
     def test_compose_vectorization(self):
         point_type = 'vector'
-        for n in self.n_seq:
-            group = self.so[n]
-            group.default_point_type = point_type
+        self.group.default_point_type = point_type
 
-            n_samples = self.n_samples
-            n_points_a = group.random_uniform(n_samples=n_samples)
-            n_points_b = group.random_uniform(n_samples=n_samples)
-            one_point = group.random_uniform(n_samples=1)
+        n_samples = self.n_samples
+        n_points_a = self.group.random_uniform(n_samples=n_samples)
+        n_points_b = self.group.random_uniform(n_samples=n_samples)
+        one_point = self.group.random_uniform(n_samples=1)
 
-            result = group.compose(one_point, n_points_a)
-            if point_type == 'vector':
-                self.assertAllClose(
-                    gs.shape(result), (n_samples, group.dim))
-            if point_type == 'matrix':
-                self.assertAllClose(
-                    gs.shape(result), (n_samples, n, n))
+        result = self.group.compose(one_point, n_points_a)
+        self.assertAllClose(
+            gs.shape(result), (n_samples, self.group.dim))
 
-            result = group.compose(n_points_a, one_point)
-            if point_type == 'vector':
-                self.assertAllClose(
-                    gs.shape(result), (n_samples, group.dim))
-            if point_type == 'matrix':
-                self.assertAllClose(
-                    gs.shape(result), (n_samples, n, n))
+        result = self.group.compose(n_points_a, one_point)
+        self.assertAllClose(
+            gs.shape(result), (n_samples, self.group.dim))
 
-            result = group.compose(n_points_a, n_points_b)
-            if point_type == 'vector':
-                self.assertAllClose(
-                    gs.shape(result), (n_samples, group.dim))
-            if point_type == 'matrix':
-                self.assertAllClose(
-                    gs.shape(result), (n_samples, n, n))
+        result = self.group.compose(n_points_a, n_points_b)
+        self.assertAllClose(
+            gs.shape(result), (n_samples, self.group.dim))
 
     def test_inverse_vectorization(self):
-        for n in self.n_seq:
-            group = self.so[n]
+        n_samples = self.n_samples
+        points = self.group.random_uniform(n_samples=n_samples)
+        result = self.group.inverse(points)
 
-            n_samples = self.n_samples
-            points = group.random_uniform(n_samples=n_samples)
-            result = group.inverse(points)
-
-            if n == 2:
-                self.assertAllClose(
-                    gs.shape(result), (n_samples, group.dim))
-            else:
-                self.assertAllClose(
-                    gs.shape(result), (n_samples, n, n))
+        self.assertAllClose(
+            gs.shape(result), (n_samples, self.group.dim))
 
     def test_group_exp(self):
         """
         The Riemannian exp and log are inverse functions of each other.
         This test is the inverse of test_log's.
         """
-        n = 2
-        group = self.so[n]
-
         rot_vec_base_point = gs.array([gs.pi / 5])
         rot_vec = gs.array([2 * gs.pi / 5])
 
         expected = gs.array([3 * gs.pi / 5])
-        result = group.exp(base_point=rot_vec_base_point, tangent_vec=rot_vec)
+        result = self.group.exp(base_point=rot_vec_base_point,
+                                tangent_vec=rot_vec)
         self.assertAllClose(result, expected)
 
     def test_group_exp_vectorization(self):
-        n = 2
-        group = self.so[n]
-
         n_samples = self.n_samples
 
-        one_tangent_vec = group.random_uniform(n_samples=1)
-        one_base_point = group.random_uniform(n_samples=1)
-        n_tangent_vec = group.random_uniform(n_samples=n_samples)
-        n_base_point = group.random_uniform(n_samples=n_samples)
+        one_tangent_vec = self.group.random_uniform(n_samples=1)
+        one_base_point = self.group.random_uniform(n_samples=1)
+        n_tangent_vec = self.group.random_uniform(n_samples=n_samples)
+        n_base_point = self.group.random_uniform(n_samples=n_samples)
 
         # Test with the 1 base point, and n tangent vecs
-        result = group.exp(n_tangent_vec, one_base_point)
+        result = self.group.exp(n_tangent_vec, one_base_point)
         self.assertAllClose(
-            gs.shape(result), (n_samples, group.dim))
+            gs.shape(result), (n_samples, self.group.dim))
 
         # Test with the several base point, and one tangent vec
-        result = group.exp(one_tangent_vec, n_base_point)
+        result = self.group.exp(one_tangent_vec, n_base_point)
         self.assertAllClose(
-            gs.shape(result), (n_samples, group.dim))
+            gs.shape(result), (n_samples, self.group.dim))
 
         # Test with the same number n of base point and n tangent vec
-        result = group.exp(n_tangent_vec, n_base_point)
+        result = self.group.exp(n_tangent_vec, n_base_point)
         self.assertAllClose(
-            gs.shape(result), (n_samples, group.dim))
+            gs.shape(result), (n_samples, self.group.dim))
 
     def test_group_log(self):
         """
         The Riemannian exp and log are inverse functions of each other.
         This test is the inverse of test_exp's.
         """
-        n = 2
-        group = self.so[n]
-
         rot_vec_base_point = gs.array([gs.pi / 5])
         rot_vec = gs.array([2 * gs.pi / 5])
 
         expected = gs.array([1 * gs.pi / 5])
-        result = group.log(point=rot_vec, base_point=rot_vec_base_point)
+        result = self.group.log(point=rot_vec, base_point=rot_vec_base_point)
         self.assertAllClose(result, expected)
 
     def test_group_log_vectorization(self):
-        n = 2
-        group = self.so[n]
-
         n_samples = self.n_samples
 
-        one_point = group.random_uniform(n_samples=1)
-        one_base_point = group.random_uniform(n_samples=1)
-        n_point = group.random_uniform(n_samples=n_samples)
-        n_base_point = group.random_uniform(n_samples=n_samples)
+        one_point = self.group.random_uniform(n_samples=1)
+        one_base_point = self.group.random_uniform(n_samples=1)
+        n_point = self.group.random_uniform(n_samples=n_samples)
+        n_base_point = self.group.random_uniform(n_samples=n_samples)
 
         # Test with the 1 base point, and several different points
-        result = group.log(n_point, one_base_point)
+        result = self.group.log(n_point, one_base_point)
         self.assertAllClose(
-            gs.shape(result), (n_samples, group.dim))
+            gs.shape(result), (n_samples, self.group.dim))
 
         # Test with the several base point, and 1 point
-        result = group.log(one_point, n_base_point)
+        result = self.group.log(one_point, n_base_point)
         self.assertAllClose(
-            gs.shape(result), (n_samples, group.dim))
+            gs.shape(result), (n_samples, self.group.dim))
 
         # Test with the same number n of base point and point
-        result = group.log(n_point, n_base_point)
+        result = self.group.log(n_point, n_base_point)
         self.assertAllClose(
-            gs.shape(result), (n_samples, group.dim))
+            gs.shape(result), (n_samples, self.group.dim))
 
     def test_group_exp_then_log_from_identity(self):
         """
@@ -360,13 +277,10 @@ class TestSpecialOrthogonal2(geomstats.tests.TestCase):
         and the group logarithm are inverse.
         Expect their composition to give the identity function.
         """
-        n = 2
-        group = self.so[n]
-
         tangent_vec = gs.array([0.12])
         result = helper.group_exp_then_log_from_identity(
-            group=group, tangent_vec=tangent_vec)
-        expected = group.regularize(tangent_vec)
+            group=self.group, tangent_vec=tangent_vec)
+        expected = self.group.regularize(tangent_vec)
         self.assertAllClose(result, expected)
 
     def test_group_log_then_exp_from_identity(self):
@@ -375,13 +289,10 @@ class TestSpecialOrthogonal2(geomstats.tests.TestCase):
         and the group logarithm are inverse.
         Expect their composition to give the identity function.
         """
-        n = 2
-        group = self.so[n]
-
         point = gs.array([0.12])
         result = helper.group_log_then_exp_from_identity(
-            group=group, point=point)
-        expected = group.regularize(point)
+            group=self.group, point=point)
+        expected = self.group.regularize(point)
         self.assertAllClose(result, expected)
 
     def test_group_exp_then_log(self):
@@ -390,18 +301,15 @@ class TestSpecialOrthogonal2(geomstats.tests.TestCase):
         log and exp gives identity.
 
         """
-        n = 2
-        group = self.so[n]
-
         base_point = gs.array([0.12])
         tangent_vec = gs.array([.35])
 
         result = helper.group_exp_then_log(
-            group=group,
+            group=self.group,
             tangent_vec=tangent_vec,
             base_point=base_point)
 
-        expected = group.regularize_tangent_vec(
+        expected = self.group.regularize_tangent_vec(
             tangent_vec=tangent_vec,
             base_point=base_point)
 
@@ -412,18 +320,14 @@ class TestSpecialOrthogonal2(geomstats.tests.TestCase):
         This tests that the composition of
         log and exp gives identity.
         """
-
-        n = 2
-        group = self.so[n]
-
         base_point = gs.array([0.12])
         point = gs.array([.35])
 
         result = helper.group_log_then_exp(
-            group=group,
+            group=self.group,
             point=point,
             base_point=base_point)
 
-        expected = group.regularize(point)
+        expected = self.group.regularize(point)
 
         self.assertAllClose(result, expected, atol=1e-5)

--- a/tests/test_special_orthogonal2.py
+++ b/tests/test_special_orthogonal2.py
@@ -7,7 +7,6 @@ import tests.helper as helper
 from geomstats import algebra_utils
 import geomstats.backend as gs
 import geomstats.tests
-from geomstats.geometry.invariant_metric import InvariantMetric
 from geomstats.geometry.special_orthogonal import SpecialOrthogonal
 
 

--- a/tests/test_special_orthogonal3.py
+++ b/tests/test_special_orthogonal3.py
@@ -1,4 +1,4 @@
-"""Unit tests for special orthogonal self.group SO(3)."""
+"""Unit tests for special orthogonal group SO(3)."""
 
 import warnings
 

--- a/tests/test_special_orthogonal3.py
+++ b/tests/test_special_orthogonal3.py
@@ -116,7 +116,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                     group=self.group,
                     inner_product_mat_at_identity=mats[3],
                     left_or_right='right')}
-                }
+            }
 
         angles_close_to_pi_all = {
             3: ['with_angle_close_pi_low',
@@ -156,7 +156,6 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
 
     def test_skew_matrix_from_vector(self):
         # Specific to 3D case
-        n = 3
         rot_vec = gs.array([0.9, -0.5, 1.1])
         skew_matrix = self.group.skew_matrix_from_vector(rot_vec)
         result = gs.dot(skew_matrix, rot_vec)
@@ -337,12 +336,11 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
             point = self.elements[3][angle_type]
             if angle_type in self.angles_close_to_pi[3]:
                 continue
-    
             rot_mat = self.group.matrix_from_rotation_vector(point)
             result = self.group.rotation_vector_from_matrix(rot_mat)
-    
+
             expected = self.group.regularize(point)
-    
+
             self.assertAllClose(result, expected)
 
     def test_matrix_from_tait_bryan_angles_extrinsic_xyz(self):
@@ -2485,8 +2483,8 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
     def test_left_jacobian_through_its_determinant(self):
         for angle_type in self.elements[3]:
             point = self.elements[3][angle_type]
-            jacobian = self.group.jacobian_translation(point=point,
-                                                  left_or_right='left')
+            jacobian = self.group.jacobian_translation(
+                point=point, left_or_right='left')
             result = gs.linalg.det(jacobian)
             point = self.group.regularize(point)
             angle = gs.linalg.norm(point)
@@ -2537,8 +2535,8 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                     + (1 - phi) / 3 * gs.ones([3, 3])
                     + gs.pi / (10 * gs.sqrt(3.)) * skew)
         inv_jacobian = gs.linalg.inv(jacobian)
-        expected = self.group.compose(rot_vec_base_point,
-                                 gs.dot(inv_jacobian, rot_vec_2))
+        expected = self.group.compose(
+            rot_vec_base_point, gs.dot(inv_jacobian, rot_vec_2))
 
         result = metric.exp(
             base_point=rot_vec_base_point, tangent_vec=rot_vec_2)
@@ -2598,11 +2596,10 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                     + gs.pi / (10 * gs.sqrt(3.)) * skew)
         inv_jacobian = gs.linalg.inv(jacobian)
         aux = gs.dot(inv_jacobian, expected)
-        rot_vec_2 = self.group.compose(rot_vec_base_point,
-                                  aux)
+        rot_vec_2 = self.group.compose(rot_vec_base_point, aux)
 
-        result = metric.log(base_point=rot_vec_base_point,
-                            point=rot_vec_2)
+        result = metric.log(
+            base_point=rot_vec_base_point, point=rot_vec_2)
 
         self.assertAllClose(result, expected)
 

--- a/tests/test_special_orthogonal3.py
+++ b/tests/test_special_orthogonal3.py
@@ -1,4 +1,4 @@
-"""Unit tests for special orthogonal group SO(3)."""
+"""Unit tests for special orthogonal self.group SO(3)."""
 
 import warnings
 
@@ -21,8 +21,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
 
         gs.random.seed(1234)
 
-        n_seq = [3]
-        so = {n: SpecialOrthogonal(n=n, point_type='vector') for n in n_seq}
+        self.group = SpecialOrthogonal(n=3, point_type='vector')
 
         # -- Rotation vectors with angles
         # 0, close to 0, closely lower than pi, pi,
@@ -62,45 +61,40 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                     'with_angle_in_pi_2pi': with_angle_in_pi_2pi,
                     'with_angle_close_pi_low': with_angle_close_pi_low}}
         # -- Metrics - only diagonals for now
-        canonical_metrics = {n: group.bi_invariant_metric
-                             for n, group in so.items()}
+        canonical_metrics = {3: self.group.bi_invariant_metric}
 
-        diag_mats = {n: 9 * gs.eye(group.dim) for n, group in so.items()}
+        diag_mats = {3: 9 * gs.eye(self.group.dim)}
         left_diag_metrics = {
-            n: InvariantMetric(
-                group=so[n],
-                inner_product_mat_at_identity=diag_mats[n],
+            3: InvariantMetric(
+                group=self.group,
+                inner_product_mat_at_identity=diag_mats[3],
                 left_or_right='left')
-            for n in n_seq
         }
 
         right_diag_metrics = {
-            n: InvariantMetric(
-                group=so[n],
-                inner_product_mat_at_identity=diag_mats[n],
+            3: InvariantMetric(
+                group=self.group,
+                inner_product_mat_at_identity=diag_mats[3],
                 left_or_right='right')
-            for n in n_seq
         }
 
         mats = {2: 4 * gs.eye(1),
                 3: 87 * gs.eye(3)}
 
         left_metrics = {
-            n: InvariantMetric(
-                group=so[n],
-                inner_product_mat_at_identity=mats[n],
+            3: InvariantMetric(
+                group=self.group,
+                inner_product_mat_at_identity=mats[3],
                 left_or_right='left')
-            for n in n_seq
         }
 
         right_metrics = {
-            n: InvariantMetric(
-                group=so[n],
-                inner_product_mat_at_identity=mats[n],
+            3: InvariantMetric(
+                group=self.group,
+                inner_product_mat_at_identity=mats[3],
                 left_or_right='right')
-            for n in n_seq
         }
-        all_metrics = zip(n_seq,
+        all_metrics = zip([3],
                           canonical_metrics.values(),
                           left_diag_metrics.values(),
                           right_diag_metrics.values(),
@@ -118,11 +112,11 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         metrics = metrics_all
         if geomstats.tests.tf_backend():
             metrics = {
-                n: {'right': InvariantMetric(
-                    group=so[n],
-                    inner_product_mat_at_identity=mats[n],
+                3: {'right': InvariantMetric(
+                    group=self.group,
+                    inner_product_mat_at_identity=mats[3],
                     left_or_right='right')}
-                for n in n_seq}
+                }
 
         angles_close_to_pi_all = {
             3: ['with_angle_close_pi_low',
@@ -136,8 +130,6 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
             }
 
         # -- Set attributes
-        self.n_seq = n_seq
-        self.so = so
         self.elements = elements
         self.elements_all = elements_all
 
@@ -149,171 +141,136 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
 
     def test_projection(self):
         # Test 3D and nD cases
-        for n in self.n_seq:
-            group = self.so[n]
-            rot_mat = gs.eye(n)
-            delta = 1e-12 * gs.ones((n, n))
-            rot_mat_plus_delta = rot_mat + delta
-            result = group.projection(rot_mat_plus_delta)
-            expected = rot_mat
-            self.assertAllClose(result, expected)
+        rot_mat = gs.eye(3)
+        delta = 1e-12 * gs.ones((3, 3))
+        rot_mat_plus_delta = rot_mat + delta
+        result = self.group.projection(rot_mat_plus_delta)
+        expected = rot_mat
+        self.assertAllClose(result, expected)
 
     def test_projection_vectorization(self):
-        for n in self.n_seq:
-            group = self.so[n]
-            n_samples = self.n_samples
-            mats = gs.ones((n_samples, n, n))
-            result = group.projection(mats)
-            self.assertAllClose(gs.shape(result), (n_samples, n, n))
+        n_samples = self.n_samples
+        mats = gs.ones((n_samples, 3, 3))
+        result = self.group.projection(mats)
+        self.assertAllClose(gs.shape(result), (n_samples, 3, 3))
 
     def test_skew_matrix_from_vector(self):
         # Specific to 3D case
         n = 3
-        group = self.so[n]
         rot_vec = gs.array([0.9, -0.5, 1.1])
-        skew_matrix = group.skew_matrix_from_vector(rot_vec)
+        skew_matrix = self.group.skew_matrix_from_vector(rot_vec)
         result = gs.dot(skew_matrix, rot_vec)
-        expected = gs.zeros(n)
+        expected = gs.zeros(3)
 
         self.assertAllClose(result, expected)
 
     def test_skew_matrix_and_vector(self):
-        n = 3
-
-        group = self.so[n]
         rot_vec = gs.array([0.8, 0.2, -0.1])
 
-        skew_mat = group.skew_matrix_from_vector(rot_vec)
-        result = group.vector_from_skew_matrix(skew_mat)
+        skew_mat = self.group.skew_matrix_from_vector(rot_vec)
+        result = self.group.vector_from_skew_matrix(skew_mat)
         expected = rot_vec
 
         self.assertAllClose(result, expected)
 
     def test_skew_matrix_from_vector_vectorization(self):
         n_samples = self.n_samples
-        for n in self.n_seq:
-            group = self.so[n]
-            rot_vecs = group.random_uniform(n_samples=n_samples)
-            result = group.skew_matrix_from_vector(rot_vecs)
+        rot_vecs = self.group.random_uniform(n_samples=n_samples)
+        result = self.group.skew_matrix_from_vector(rot_vecs)
 
-            self.assertAllClose(gs.shape(result), (n_samples, n, n))
+        self.assertAllClose(gs.shape(result), (n_samples, 3, 3))
 
     def test_random_uniform_shape(self):
-        group = self.so[3]
-        result = group.random_uniform()
-        self.assertAllClose(gs.shape(result), (group.dim,))
+        result = self.group.random_uniform()
+        self.assertAllClose(gs.shape(result), (self.group.dim,))
 
     def test_random_and_belongs(self):
-        for n in self.n_seq:
-            group = self.so[n]
-            point = group.random_uniform()
-            result = group.belongs(point)
-            expected = True
-            self.assertAllClose(result, expected)
+        point = self.group.random_uniform()
+        result = self.group.belongs(point)
+        expected = True
+        self.assertAllClose(result, expected)
 
     def test_random_and_belongs_vectorization(self):
         n_samples = self.n_samples
-        for n in self.n_seq:
-            group = self.so[n]
-            points = group.random_uniform(n_samples=n_samples)
-            result = group.belongs(points)
-            expected = gs.array([True] * n_samples)
-            self.assertAllClose(result, expected)
+        points = self.group.random_uniform(n_samples=n_samples)
+        result = self.group.belongs(points)
+        expected = gs.array([True] * n_samples)
+        self.assertAllClose(result, expected)
 
     def test_regularize(self):
-        # Specific to 3D
-        for n in self.n_seq:
-            group = self.so[n]
+        point = self.elements_all[3]['with_angle_0']
+        self.assertAllClose(gs.linalg.norm(point), 0.)
+        result = self.group.regularize(point)
+        expected = point
+        self.assertAllClose(result, expected)
 
-            if n == 3:
-                point = self.elements_all[3]['with_angle_0']
-                self.assertAllClose(gs.linalg.norm(point), 0.)
-                result = group.regularize(point)
-                expected = point
-                self.assertAllClose(result, expected)
+        less_than_pi = ['with_angle_close_0',
+                        'with_angle_close_pi_low']
+        for angle_type in less_than_pi:
+            point = self.elements_all[3][angle_type]
+            result = self.group.regularize(point)
+            expected = point
+            self.assertAllClose(result, expected)
 
-                less_than_pi = ['with_angle_close_0',
-                                'with_angle_close_pi_low']
-                for angle_type in less_than_pi:
-                    point = self.elements_all[3][angle_type]
-                    result = group.regularize(point)
-                    expected = point
-                    self.assertAllClose(result, expected)
+        # Note: by default, the rotation vector is inverted by
+        # the function regularize when the angle of the rotation is pi.
+        angle_type = 'with_angle_pi'
+        point = self.elements_all[3][angle_type]
+        result = self.group.regularize(point)
+        expected = point
+        self.assertAllClose(result, expected)
 
-                # Note: by default, the rotation vector is inverted by
-                # the function regularize when the angle of the rotation is pi.
-                angle_type = 'with_angle_pi'
-                point = self.elements_all[3][angle_type]
-                result = group.regularize(point)
-                expected = point
-                self.assertAllClose(result, expected)
+        angle_type = 'with_angle_close_pi_high'
+        point = self.elements_all[3][angle_type]
+        result = self.group.regularize(point)
+        expected = point / gs.linalg.norm(point) * gs.pi
+        self.assertAllClose(result, expected)
 
-                angle_type = 'with_angle_close_pi_high'
-                point = self.elements_all[3][angle_type]
-                result = group.regularize(point)
-                expected = point / gs.linalg.norm(point) * gs.pi
-                self.assertAllClose(result, expected)
+        in_pi_2pi = ['with_angle_in_pi_2pi',
+                     'with_angle_close_2pi_low']
 
-                in_pi_2pi = ['with_angle_in_pi_2pi',
-                             'with_angle_close_2pi_low']
+        for angle_type in in_pi_2pi:
+            point = self.elements_all[3][angle_type]
+            point_initial = point
+            angle = gs.linalg.norm(point)
+            new_angle = gs.pi - (angle - gs.pi)
 
-                for angle_type in in_pi_2pi:
-                    point = self.elements_all[3][angle_type]
-                    point_initial = point
-                    angle = gs.linalg.norm(point)
-                    new_angle = gs.pi - (angle - gs.pi)
+            point_initial = point
+            result = self.group.regularize(point)
 
-                    point_initial = point
-                    result = group.regularize(point)
+            expected = - (new_angle / angle) * point_initial
+            self.assertAllClose(result, expected)
 
-                    expected = - (new_angle / angle) * point_initial
-                    self.assertAllClose(result, expected)
+        angle_type = 'with_angle_2pi'
+        point = self.elements_all[3][angle_type]
+        result = self.group.regularize(point)
+        expected = gs.array([0., 0., 0.])
+        self.assertAllClose(result, expected)
 
-                angle_type = 'with_angle_2pi'
-                point = self.elements_all[3][angle_type]
-                result = group.regularize(point)
-                expected = gs.array([0., 0., 0.])
-                self.assertAllClose(result, expected)
+        angle_type = 'with_angle_close_2pi_high'
+        point = self.elements_all[3][angle_type]
+        angle = gs.linalg.norm(point)
+        new_angle = angle - 2 * gs.pi
 
-                angle_type = 'with_angle_close_2pi_high'
-                point = self.elements_all[3][angle_type]
-                angle = gs.linalg.norm(point)
-                new_angle = angle - 2 * gs.pi
-
-                result = group.regularize(point)
-                expected = new_angle * point / angle
-                self.assertAllClose(result, expected)
-
-            else:
-                angle = 0.345
-                point = gs.array([
-                    [gs.cos(angle), -gs.sin(angle)],
-                    [gs.sin(angle), gs.cos(angle)]])
-                result = group.regularize(point)
-                expected = point
-                self.assertAllClose(result, expected)
+        result = self.group.regularize(point)
+        expected = new_angle * point / angle
+        self.assertAllClose(result, expected)
 
     def test_regularize_vectorization(self):
-        for n in self.n_seq:
-            group = self.so[n]
+        n_samples = self.n_samples
+        rot_vecs = self.group.random_uniform(n_samples=n_samples)
+        result = self.group.regularize(rot_vecs)
 
-            n_samples = self.n_samples
-            rot_vecs = group.random_uniform(n_samples=n_samples)
-            result = group.regularize(rot_vecs)
-
-            self.assertAllClose(gs.shape(result), (n_samples, group.dim))
+        self.assertAllClose(gs.shape(result), (n_samples, self.group.dim))
 
     def test_matrix_from_rotation_vector(self):
-        n = 3
-        group = self.so[n]
-
-        rot_vec_0 = group.identity
-        result = group.matrix_from_rotation_vector(rot_vec_0)
+        rot_vec_0 = self.group.identity
+        result = self.group.matrix_from_rotation_vector(rot_vec_0)
         expected = gs.eye(3)
         self.assertAllClose(result, expected)
 
         rot_vec_1 = gs.array([gs.pi / 3., 0., 0.])
-        result = group.matrix_from_rotation_vector(rot_vec_1)
+        result = self.group.matrix_from_rotation_vector(rot_vec_1)
         expected = gs.array([
             [1., 0., 0.],
             [0., 0.5, -gs.sqrt(3.) / 2],
@@ -331,7 +288,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
             gs.eye(3)
             + coef_1 * skew_rot_vec_3
             + coef_2 * gs.matmul(skew_rot_vec_3, skew_rot_vec_3))
-        result = group.matrix_from_rotation_vector(rot_vec_3)
+        result = self.group.matrix_from_rotation_vector(rot_vec_3)
         self.assertAllClose(result, expected)
 
         rot_vec_6 = gs.array([.1, 1.3, -.5])
@@ -342,7 +299,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
 
         coef_1 = gs.sin(angle) / angle
         coef_2 = (1 - gs.cos(angle)) / (angle ** 2)
-        result = group.matrix_from_rotation_vector(rot_vec_6)
+        result = self.group.matrix_from_rotation_vector(rot_vec_6)
         expected = (
             gs.eye(3)
             + coef_1 * skew_rot_vec_6
@@ -350,26 +307,20 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         self.assertAllClose(result, expected)
 
     def test_matrix_from_rotation_vector_vectorization(self):
-        for n in self.n_seq:
-            group = self.so[n]
+        n_samples = self.n_samples
+        rot_vecs = self.group.random_uniform(n_samples=n_samples)
 
-            n_samples = self.n_samples
-            rot_vecs = group.random_uniform(n_samples=n_samples)
+        rot_mats = self.group.matrix_from_rotation_vector(rot_vecs)
 
-            rot_mats = group.matrix_from_rotation_vector(rot_vecs)
-
-            self.assertAllClose(
-                gs.shape(rot_mats), (n_samples, group.n, group.n))
+        self.assertAllClose(
+            gs.shape(rot_mats), (n_samples, self.group.n, self.group.n))
 
     def test_rotation_vector_from_matrix(self):
-        n = 3
-        group = self.so[n]
-
         angle = .12
         rot_mat = gs.array([[1., 0., 0.],
                             [0., gs.cos(angle), -gs.sin(angle)],
                             [0, gs.sin(angle), gs.cos(angle)]])
-        result = group.rotation_vector_from_matrix(rot_mat)
+        result = self.group.rotation_vector_from_matrix(rot_mat)
         expected = .12 * gs.array([1., 0., 0.])
 
         self.assertAllClose(result, expected)
@@ -382,41 +333,23 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         matrix_from_rotation_vector
         is the identity.
         """
-        for n in self.n_seq:
-            group = self.so[n]
-
-            if n == 3:
-                for angle_type in self.elements[3]:
-                    point = self.elements[3][angle_type]
-                    if angle_type in self.angles_close_to_pi[3]:
-                        continue
-
-                    rot_mat = group.matrix_from_rotation_vector(point)
-                    result = group.rotation_vector_from_matrix(rot_mat)
-
-                    expected = group.regularize(point)
-
-                    self.assertAllClose(result, expected)
-
-            else:  # n == 2
-                # TODO(nguigs): bring back a 1d representation of SO2
-                point = gs.array([0.78])
-
-                rot_mat = group.matrix_from_rotation_vector(point)
-                result = group.rotation_vector_from_matrix(rot_mat)
-
-                expected = point
-
-                self.assertAllClose(result, expected)
+        for angle_type in self.elements[3]:
+            point = self.elements[3][angle_type]
+            if angle_type in self.angles_close_to_pi[3]:
+                continue
+    
+            rot_mat = self.group.matrix_from_rotation_vector(point)
+            result = self.group.rotation_vector_from_matrix(rot_mat)
+    
+            expected = self.group.regularize(point)
+    
+            self.assertAllClose(result, expected)
 
     def test_matrix_from_tait_bryan_angles_extrinsic_xyz(self):
-        n = 3
-        group = self.so[n]
-
         tait_bryan_angles = gs.array([0., 0., 0.])
-        result = group.matrix_from_tait_bryan_angles_extrinsic_xyz(
+        result = self.group.matrix_from_tait_bryan_angles_extrinsic_xyz(
             tait_bryan_angles)
-        expected = gs.eye(n)
+        expected = gs.eye(3)
 
         self.assertAllClose(result, expected)
 
@@ -425,7 +358,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         sin_angle = gs.sin(angle)
 
         tait_bryan_angles = gs.array([angle, 0., 0.])
-        result = group.matrix_from_tait_bryan_angles_extrinsic_xyz(
+        result = self.group.matrix_from_tait_bryan_angles_extrinsic_xyz(
             tait_bryan_angles)
         expected = gs.array([[cos_angle, - sin_angle, 0.],
                              [sin_angle, cos_angle, 0.],
@@ -434,7 +367,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         self.assertAllClose(result, expected)
 
         tait_bryan_angles = gs.array([0., angle, 0.])
-        result = group.matrix_from_tait_bryan_angles_extrinsic_xyz(
+        result = self.group.matrix_from_tait_bryan_angles_extrinsic_xyz(
             tait_bryan_angles)
         expected = gs.array([[cos_angle, 0., sin_angle],
                              [0., 1., 0.],
@@ -443,7 +376,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         self.assertAllClose(result, expected)
 
         tait_bryan_angles = gs.array([0., 0., angle])
-        result = group.matrix_from_tait_bryan_angles_extrinsic_xyz(
+        result = self.group.matrix_from_tait_bryan_angles_extrinsic_xyz(
             tait_bryan_angles)
         expected = gs.array([[1., 0., 0.],
                              [0., cos_angle, - sin_angle],
@@ -452,13 +385,10 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         self.assertAllClose(result, expected)
 
     def test_matrix_from_tait_bryan_angles_extrinsic_zyx(self):
-        n = 3
-        group = self.so[n]
-
         tait_bryan_angles = gs.array([0., 0., 0.])
-        result = group.matrix_from_tait_bryan_angles_extrinsic_zyx(
+        result = self.group.matrix_from_tait_bryan_angles_extrinsic_zyx(
             tait_bryan_angles)
-        expected = gs.eye(n)
+        expected = gs.eye(3)
 
         self.assertAllClose(result, expected)
 
@@ -467,7 +397,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         sin_angle = gs.sin(angle)
 
         tait_bryan_angles = gs.array([angle, 0., 0.])
-        result = group.matrix_from_tait_bryan_angles_extrinsic_zyx(
+        result = self.group.matrix_from_tait_bryan_angles_extrinsic_zyx(
             tait_bryan_angles)
         expected = gs.array([[1., 0., 0.],
                              [0., cos_angle, - sin_angle],
@@ -476,7 +406,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         self.assertAllClose(result, expected)
 
         tait_bryan_angles = gs.array([0., angle, 0.])
-        result = group.matrix_from_tait_bryan_angles_extrinsic_zyx(
+        result = self.group.matrix_from_tait_bryan_angles_extrinsic_zyx(
             tait_bryan_angles)
         expected = gs.array([[cos_angle, 0., sin_angle],
                              [0., 1., 0.],
@@ -485,7 +415,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         self.assertAllClose(result, expected)
 
         tait_bryan_angles = gs.array([0., 0., angle])
-        result = group.matrix_from_tait_bryan_angles_extrinsic_zyx(
+        result = self.group.matrix_from_tait_bryan_angles_extrinsic_zyx(
             tait_bryan_angles)
         expected = gs.array([[cos_angle, - sin_angle, 0.],
                              [sin_angle, cos_angle, 0.],
@@ -498,7 +428,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         sin_angle_bis = gs.sin(angle_bis)
 
         tait_bryan_angles = gs.array([angle, angle_bis, 0.])
-        result = group.matrix_from_tait_bryan_angles_extrinsic_zyx(
+        result = self.group.matrix_from_tait_bryan_angles_extrinsic_zyx(
             tait_bryan_angles)
         expected = gs.array([[cos_angle_bis, 0., sin_angle_bis],
                              [sin_angle * sin_angle_bis,
@@ -511,7 +441,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         self.assertAllClose(result, expected)
 
         tait_bryan_angles = gs.array([angle, 0., angle_bis])
-        result = group.matrix_from_tait_bryan_angles_extrinsic_zyx(
+        result = self.group.matrix_from_tait_bryan_angles_extrinsic_zyx(
             tait_bryan_angles)
         expected = gs.array([[cos_angle_bis, - sin_angle_bis, 0.],
                              [cos_angle * sin_angle_bis,
@@ -524,7 +454,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         self.assertAllClose(result, expected)
 
         tait_bryan_angles = gs.array([0., angle, angle_bis])
-        result = group.matrix_from_tait_bryan_angles_extrinsic_zyx(
+        result = self.group.matrix_from_tait_bryan_angles_extrinsic_zyx(
             tait_bryan_angles)
         expected = gs.array([[cos_angle * cos_angle_bis,
                               - cos_angle * sin_angle_bis,
@@ -541,18 +471,15 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         This tests that the rotation matrix computed from the
         Tait-Bryan angles [0, 0, 0] is the identiy as expected.
         """
-        n = 3
-        group = self.so[n]
-
         order = 'xyz'
         extrinsic_or_intrinsic = 'intrinsic'
 
         tait_bryan_angles = gs.array([0., 0., 0.])
-        result = group.matrix_from_tait_bryan_angles(
+        result = self.group.matrix_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
-        expected = gs.eye(n)
+        expected = gs.eye(3)
         self.assertAllClose(result, expected)
 
         angle = gs.pi / 6.
@@ -560,7 +487,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         sin_angle = gs.sin(angle)
 
         tait_bryan_angles = gs.array([angle, 0., 0.])
-        result = group.matrix_from_tait_bryan_angles(
+        result = self.group.matrix_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -571,7 +498,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         self.assertAllClose(result, expected)
 
         tait_bryan_angles = gs.array([0., angle, 0.])
-        result = group.matrix_from_tait_bryan_angles(
+        result = self.group.matrix_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -582,7 +509,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         self.assertAllClose(result, expected)
 
         tait_bryan_angles = gs.array([0., 0., angle])
-        result = group.matrix_from_tait_bryan_angles(
+        result = self.group.matrix_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -597,18 +524,15 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         This tests that the matrix computed from the
         Tait-Bryan angles[0, 0, 0] is [1, 0., 0., 0.] as expected.
         """
-        n = 3
-        group = self.so[n]
-
         order = 'zyx'
         extrinsic_or_intrinsic = 'intrinsic'
 
         tait_bryan_angles = gs.array([0., 0., 0.])
-        result = group.matrix_from_tait_bryan_angles(
+        result = self.group.matrix_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
-        expected = gs.eye(n)
+        expected = gs.eye(3)
 
         self.assertAllClose(result, expected)
 
@@ -617,7 +541,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         sin_angle = gs.sin(angle)
 
         tait_bryan_angles = gs.array([angle, 0., 0.])
-        result = group.matrix_from_tait_bryan_angles(
+        result = self.group.matrix_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -628,7 +552,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         self.assertAllClose(result, expected)
 
         tait_bryan_angles = gs.array([0., angle, 0.])
-        result = group.matrix_from_tait_bryan_angles(
+        result = self.group.matrix_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -639,7 +563,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         self.assertAllClose(result, expected)
 
         tait_bryan_angles = gs.array([0., 0., angle])
-        result = group.matrix_from_tait_bryan_angles(
+        result = self.group.matrix_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -650,13 +574,11 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         self.assertAllClose(result, expected)
 
     def test_tait_bryan_angles_from_matrix_extrinsic_xyz(self):
-        n = 3
-        group = self.so[n]
         extrinsic_or_intrinsic = 'extrinsic'
         order = 'xyz'
 
-        matrix = gs.eye(n)
-        result = group.tait_bryan_angles_from_matrix(
+        matrix = gs.eye(3)
+        result = self.group.tait_bryan_angles_from_matrix(
             matrix, extrinsic_or_intrinsic, order)
         expected = gs.array([0., 0., 0.])
 
@@ -669,7 +591,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         rot_mat = gs.array([[1., 0., 0.],
                             [0., cos_angle, - sin_angle],
                             [0., sin_angle, cos_angle]])
-        result = group.tait_bryan_angles_from_matrix(
+        result = self.group.tait_bryan_angles_from_matrix(
             rot_mat, extrinsic_or_intrinsic, order)
         expected = gs.array([0., 0., angle])
 
@@ -678,7 +600,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         rot_mat = gs.array([[cos_angle, 0., sin_angle],
                             [0., 1., 0.],
                             [- sin_angle, 0., cos_angle]])
-        result = group.tait_bryan_angles_from_matrix(
+        result = self.group.tait_bryan_angles_from_matrix(
             rot_mat, extrinsic_or_intrinsic, order)
         expected = gs.array([0., angle, 0.])
 
@@ -687,20 +609,18 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         rot_mat = gs.array([[cos_angle, - sin_angle, 0.],
                             [sin_angle, cos_angle, 0.],
                             [0., 0., 1.]])
-        result = group.tait_bryan_angles_from_matrix(
+        result = self.group.tait_bryan_angles_from_matrix(
             rot_mat, extrinsic_or_intrinsic, order)
         expected = gs.array([angle, 0., 0.])
 
         self.assertAllClose(result, expected)
 
     def test_tait_bryan_angles_from_matrix_extrinsic_zyx(self):
-        n = 3
-        group = self.so[n]
         extrinsic_or_intrinsic = 'extrinsic'
         order = 'zyx'
 
-        rot_mat = gs.eye(n)
-        result = group.tait_bryan_angles_from_matrix(
+        rot_mat = gs.eye(3)
+        result = self.group.tait_bryan_angles_from_matrix(
             rot_mat, extrinsic_or_intrinsic, order)
         expected = gs.array([0., 0., 0.])
 
@@ -713,7 +633,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         rot_mat = gs.array([[1., 0., 0.],
                             [0., cos_angle, - sin_angle],
                             [0., sin_angle, cos_angle]])
-        result = group.tait_bryan_angles_from_matrix(
+        result = self.group.tait_bryan_angles_from_matrix(
             rot_mat, extrinsic_or_intrinsic, order)
         expected = gs.array([angle, 0., 0.])
 
@@ -722,7 +642,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         rot_mat = gs.array([[cos_angle, 0., sin_angle],
                             [0., 1., 0.],
                             [- sin_angle, 0., cos_angle]])
-        result = group.tait_bryan_angles_from_matrix(
+        result = self.group.tait_bryan_angles_from_matrix(
             rot_mat, extrinsic_or_intrinsic, order)
         expected = gs.array([0., angle, 0.])
 
@@ -731,7 +651,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         rot_mat = gs.array([[cos_angle, - sin_angle, 0.],
                             [sin_angle, cos_angle, 0.],
                             [0., 0., 1.]])
-        result = group.tait_bryan_angles_from_matrix(
+        result = self.group.tait_bryan_angles_from_matrix(
             rot_mat, extrinsic_or_intrinsic, order)
         expected = gs.array([0., 0., angle])
 
@@ -749,7 +669,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                             sin_angle,
                             cos_angle * cos_angle_bis]])
 
-        result = group.tait_bryan_angles_from_matrix(
+        result = self.group.tait_bryan_angles_from_matrix(
             matrix,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -763,7 +683,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                             sin_angle * cos_angle_bis,
                             cos_angle]])
 
-        result = group.tait_bryan_angles_from_matrix(
+        result = self.group.tait_bryan_angles_from_matrix(
             matrix,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -777,7 +697,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                             sin_angle * sin_angle_bis,
                             cos_angle]])
 
-        result = group.tait_bryan_angles_from_matrix(
+        result = self.group.tait_bryan_angles_from_matrix(
             matrix,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -786,13 +706,11 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         self.assertAllClose(result, expected)
 
     def test_tait_bryan_angles_from_matrix_intrinsic_xyz(self):
-        n = 3
-        group = self.so[n]
         extrinsic_or_intrinsic = 'intrinsic'
         order = 'xyz'
 
-        matrix = gs.eye(n)
-        result = group.tait_bryan_angles_from_matrix(
+        matrix = gs.eye(3)
+        result = self.group.tait_bryan_angles_from_matrix(
             matrix, extrinsic_or_intrinsic, order)
         expected = gs.array([0., 0., 0.])
 
@@ -805,7 +723,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         rot_mat = gs.array([[1., 0., 0.],
                             [0., cos_angle, - sin_angle],
                             [0., sin_angle, cos_angle]])
-        result = group.tait_bryan_angles_from_matrix(
+        result = self.group.tait_bryan_angles_from_matrix(
             rot_mat, extrinsic_or_intrinsic, order)
         expected = gs.array([0., 0., angle])
 
@@ -814,7 +732,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         rot_mat = gs.array([[cos_angle, 0., sin_angle],
                             [0., 1., 0.],
                             [- sin_angle, 0., cos_angle]])
-        result = group.tait_bryan_angles_from_matrix(
+        result = self.group.tait_bryan_angles_from_matrix(
             rot_mat, extrinsic_or_intrinsic, order)
         expected = gs.array([0., angle, 0.])
 
@@ -823,20 +741,18 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         rot_mat = gs.array([[cos_angle, - sin_angle, 0.],
                             [sin_angle, cos_angle, 0.],
                             [0., 0., 1.]])
-        result = group.tait_bryan_angles_from_matrix(
+        result = self.group.tait_bryan_angles_from_matrix(
             rot_mat, extrinsic_or_intrinsic, order)
         expected = gs.array([angle, 0., 0.])
 
         self.assertAllClose(result, expected)
 
     def test_tait_bryan_angles_from_matrix_intrinsic_zyx(self):
-        n = 3
-        group = self.so[n]
         extrinsic_or_intrinsic = 'intrinsic'
         order = 'zyx'
 
-        rot_mat = gs.eye(n)
-        result = group.tait_bryan_angles_from_matrix(
+        rot_mat = gs.eye(3)
+        result = self.group.tait_bryan_angles_from_matrix(
             rot_mat, extrinsic_or_intrinsic, order)
         expected = gs.array([0., 0., 0.])
 
@@ -849,7 +765,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         rot_mat = gs.array([[1., 0., 0.],
                             [0., cos_angle, - sin_angle],
                             [0., sin_angle, cos_angle]])
-        result = group.tait_bryan_angles_from_matrix(
+        result = self.group.tait_bryan_angles_from_matrix(
             rot_mat, extrinsic_or_intrinsic, order)
         expected = gs.array([angle, 0., 0.])
 
@@ -858,7 +774,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         rot_mat = gs.array([[cos_angle, 0., sin_angle],
                             [0., 1., 0.],
                             [- sin_angle, 0., cos_angle]])
-        result = group.tait_bryan_angles_from_matrix(
+        result = self.group.tait_bryan_angles_from_matrix(
             rot_mat, extrinsic_or_intrinsic, order)
         expected = gs.array([0., angle, 0.])
 
@@ -867,7 +783,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         rot_mat = gs.array([[cos_angle, - sin_angle, 0.],
                             [sin_angle, cos_angle, 0.],
                             [0., 0., 1.]])
-        result = group.tait_bryan_angles_from_matrix(
+        result = self.group.tait_bryan_angles_from_matrix(
             rot_mat, extrinsic_or_intrinsic, order)
         expected = gs.array([0., 0., angle])
 
@@ -881,20 +797,17 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         tait_bryan_angles_from_rotation_vector
         is the identity.
         """
-        n = 3
-        group = self.so[n]
-
         order = 'xyz'
         extrinsic_or_intrinsic = 'extrinsic'
 
         point = gs.pi / (6. * gs.sqrt(3.)) * gs.array([1., 1., 1.])
-        matrix = group.matrix_from_rotation_vector(point)
+        matrix = self.group.matrix_from_rotation_vector(point)
 
-        tait_bryan_angles = group.tait_bryan_angles_from_matrix(
+        tait_bryan_angles = self.group.tait_bryan_angles_from_matrix(
             matrix,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
-        result = group.matrix_from_tait_bryan_angles(
+        result = self.group.matrix_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -917,9 +830,6 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         tait_bryan_angles_from_rotation_vector
         is the identity.
         """
-        n = 3
-        group = self.so[n]
-
         order = 'zyx'
         extrinsic_or_intrinsic = 'extrinsic'
 
@@ -930,11 +840,11 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         rot_mat = gs.array([[1., 0., 0.],
                             [0., cos_angle, - sin_angle],
                             [0., sin_angle, cos_angle]])
-        tait_bryan_angles = group.tait_bryan_angles_from_matrix(
+        tait_bryan_angles = self.group.tait_bryan_angles_from_matrix(
             rot_mat,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
-        result = group.matrix_from_tait_bryan_angles(
+        result = self.group.matrix_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -949,11 +859,11 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         rot_mat = gs.array([[cos_angle, 0., sin_angle],
                             [0., 1., 0.],
                             [- sin_angle, 0., cos_angle]])
-        tait_bryan_angles = group.tait_bryan_angles_from_matrix(
+        tait_bryan_angles = self.group.tait_bryan_angles_from_matrix(
             rot_mat,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
-        result = group.matrix_from_tait_bryan_angles(
+        result = self.group.matrix_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -969,11 +879,11 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         rot_mat = gs.array([[cos_angle, - sin_angle, 0.],
                             [sin_angle, cos_angle, 0.],
                             [0., 0., 1.]])
-        tait_bryan_angles = group.tait_bryan_angles_from_matrix(
+        tait_bryan_angles = self.group.tait_bryan_angles_from_matrix(
             rot_mat,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
-        result = group.matrix_from_tait_bryan_angles(
+        result = self.group.matrix_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -998,11 +908,11 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                              cos_angle * cos_angle_bis]])
         # This matrix corresponds to tait-bryan angles (angle, angle_bis, 0.)
 
-        tait_bryan_angles = group.tait_bryan_angles_from_matrix(
+        tait_bryan_angles = self.group.tait_bryan_angles_from_matrix(
             rot_mat,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
-        result = group.matrix_from_tait_bryan_angles(
+        result = self.group.matrix_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -1015,13 +925,13 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                             expected))
 
         point = gs.pi / (6. * gs.sqrt(3.)) * gs.array([0., 2., 1.])
-        rot_mat = group.matrix_from_rotation_vector(point)
+        rot_mat = self.group.matrix_from_rotation_vector(point)
 
-        tait_bryan_angles = group.tait_bryan_angles_from_matrix(
+        tait_bryan_angles = self.group.tait_bryan_angles_from_matrix(
             rot_mat,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
-        result = group.matrix_from_tait_bryan_angles(
+        result = self.group.matrix_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -1041,18 +951,15 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         tait_bryan_angles_from_rotation_vector
         is the identity.
         """
-        n = 3
-        group = self.so[n]
-
         order = 'xyz'
         extrinsic_or_intrinsic = 'extrinsic'
 
         tait_bryan_angles = gs.array([0., 0., 0.])
-        matrix = group.matrix_from_tait_bryan_angles(
+        matrix = self.group.matrix_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
-        result = group.tait_bryan_angles_from_matrix(
+        result = self.group.tait_bryan_angles_from_matrix(
             matrix,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -1070,11 +977,11 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         angle = gs.pi / 6.
 
         tait_bryan_angles = gs.array([angle, 0., 0.])
-        matrix = group.matrix_from_tait_bryan_angles(
+        matrix = self.group.matrix_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
-        result = group.tait_bryan_angles_from_matrix(
+        result = self.group.tait_bryan_angles_from_matrix(
             matrix,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -1090,11 +997,11 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                             expected))
 
         tait_bryan_angles = gs.array([0., angle, 0.])
-        matrix = group.matrix_from_tait_bryan_angles(
+        matrix = self.group.matrix_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
-        result = group.tait_bryan_angles_from_matrix(
+        result = self.group.tait_bryan_angles_from_matrix(
             matrix,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -1110,11 +1017,11 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                             expected))
 
         tait_bryan_angles = gs.array([0., 0., angle])
-        matrix = group.matrix_from_tait_bryan_angles(
+        matrix = self.group.matrix_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
-        result = group.tait_bryan_angles_from_matrix(
+        result = self.group.tait_bryan_angles_from_matrix(
             matrix,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -1130,11 +1037,11 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                             expected))
 
         tait_bryan_angles = gs.array([0.1, 0.7, 0.3])
-        matrix = group.matrix_from_tait_bryan_angles(
+        matrix = self.group.matrix_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
-        result = group.tait_bryan_angles_from_matrix(
+        result = self.group.tait_bryan_angles_from_matrix(
             matrix,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -1157,18 +1064,15 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         tait_bryan_angles_from_rotation_vector
         is the identity.
         """
-        n = 3
-        group = self.so[n]
-
         order = 'zyx'
         extrinsic_or_intrinsic = 'extrinsic'
 
         tait_bryan_angles = gs.array([0., 0., 0.])
-        matrix = group.matrix_from_tait_bryan_angles(
+        matrix = self.group.matrix_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
-        result = group.tait_bryan_angles_from_matrix(
+        result = self.group.tait_bryan_angles_from_matrix(
             matrix,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -1186,11 +1090,11 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         angle = gs.pi / 6.
 
         tait_bryan_angles = gs.array([angle, 0., 0.])
-        matrix = group.matrix_from_tait_bryan_angles(
+        matrix = self.group.matrix_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
-        result = group.tait_bryan_angles_from_matrix(
+        result = self.group.tait_bryan_angles_from_matrix(
             matrix,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -1206,11 +1110,11 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                             expected))
 
         tait_bryan_angles = gs.array([0., angle, 0.])
-        matrix = group.matrix_from_tait_bryan_angles(
+        matrix = self.group.matrix_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
-        result = group.tait_bryan_angles_from_matrix(
+        result = self.group.tait_bryan_angles_from_matrix(
             matrix,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -1226,11 +1130,11 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                             expected))
 
         tait_bryan_angles = gs.array([0., 0., angle])
-        matrix = group.matrix_from_tait_bryan_angles(
+        matrix = self.group.matrix_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
-        result = group.tait_bryan_angles_from_matrix(
+        result = self.group.tait_bryan_angles_from_matrix(
             matrix,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -1246,11 +1150,11 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                             expected))
 
         tait_bryan_angles = gs.array([0.3, 0.3, 0.])
-        matrix = group.matrix_from_tait_bryan_angles(
+        matrix = self.group.matrix_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
-        result = group.tait_bryan_angles_from_matrix(
+        result = self.group.tait_bryan_angles_from_matrix(
             matrix,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -1273,9 +1177,6 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         tait_bryan_angles_from_rotation_vector
         is the identity.
         """
-        n = 3
-        group = self.so[n]
-
         order = 'xyz'
         extrinsic_or_intrinsic = 'intrinsic'
 
@@ -1286,11 +1187,11 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         matrix = gs.array([[1., 0., 0.],
                            [0., cos_angle, - sin_angle],
                            [0., sin_angle, cos_angle]])
-        tait_bryan_angles = group.tait_bryan_angles_from_matrix(
+        tait_bryan_angles = self.group.tait_bryan_angles_from_matrix(
             matrix,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
-        result = group.matrix_from_tait_bryan_angles(
+        result = self.group.matrix_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -1298,11 +1199,11 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         matrix = gs.array([[cos_angle, 0., sin_angle],
                            [0., 1., 0.],
                            [- sin_angle, 0., cos_angle]])
-        tait_bryan_angles = group.tait_bryan_angles_from_matrix(
+        tait_bryan_angles = self.group.tait_bryan_angles_from_matrix(
             matrix,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
-        result = group.matrix_from_tait_bryan_angles(
+        result = self.group.matrix_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -1330,11 +1231,11 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         matrix = gs.array([[cos_angle, - sin_angle, 0.],
                            [sin_angle, cos_angle, 0.],
                            [0., 0., 1.]])
-        tait_bryan_angles = group.tait_bryan_angles_from_matrix(
+        tait_bryan_angles = self.group.tait_bryan_angles_from_matrix(
             matrix,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
-        result = group.matrix_from_tait_bryan_angles(
+        result = self.group.matrix_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -1350,13 +1251,13 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                             expected))
 
         point = gs.pi / (6. * gs.sqrt(3.)) * gs.array([1., 1., 1.])
-        matrix = group.matrix_from_rotation_vector(point)
+        matrix = self.group.matrix_from_rotation_vector(point)
 
-        tait_bryan_angles = group.tait_bryan_angles_from_matrix(
+        tait_bryan_angles = self.group.tait_bryan_angles_from_matrix(
             matrix,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
-        result = group.matrix_from_tait_bryan_angles(
+        result = self.group.matrix_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -1380,20 +1281,17 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         tait_bryan_angles_from_rotation_vector
         is the identity.
         """
-        n = 3
-        group = self.so[n]
-
         order = 'zyx'
         extrinsic_or_intrinsic = 'intrinsic'
 
         point = gs.pi / (6. * gs.sqrt(3.)) * gs.array([1., 1., 1.])
-        matrix = group.matrix_from_rotation_vector(point)
+        matrix = self.group.matrix_from_rotation_vector(point)
 
-        tait_bryan_angles = group.tait_bryan_angles_from_matrix(
+        tait_bryan_angles = self.group.tait_bryan_angles_from_matrix(
             matrix,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
-        result = group.matrix_from_tait_bryan_angles(
+        result = self.group.matrix_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -1416,18 +1314,15 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         tait_bryan_angles_from_rotation_vector
         is the identity.
         """
-        n = 3
-        group = self.so[n]
-
         order = 'xyz'
         extrinsic_or_intrinsic = 'intrinsic'
 
         tait_bryan_angles = gs.array([0., 0., 0.])
-        matrix = group.matrix_from_tait_bryan_angles(
+        matrix = self.group.matrix_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
-        result = group.tait_bryan_angles_from_matrix(
+        result = self.group.tait_bryan_angles_from_matrix(
             matrix,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -1445,11 +1340,11 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         angle = gs.pi / 6.
 
         tait_bryan_angles = gs.array([angle, 0., 0.])
-        matrix = group.matrix_from_tait_bryan_angles(
+        matrix = self.group.matrix_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
-        result = group.tait_bryan_angles_from_matrix(
+        result = self.group.tait_bryan_angles_from_matrix(
             matrix,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -1465,11 +1360,11 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                             expected))
 
         tait_bryan_angles = gs.array([0., angle, 0.])
-        matrix = group.matrix_from_tait_bryan_angles(
+        matrix = self.group.matrix_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
-        result = group.tait_bryan_angles_from_matrix(
+        result = self.group.tait_bryan_angles_from_matrix(
             matrix,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -1485,11 +1380,11 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                             expected))
 
         tait_bryan_angles = gs.array([0., 0., angle])
-        matrix = group.matrix_from_tait_bryan_angles(
+        matrix = self.group.matrix_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
-        result = group.tait_bryan_angles_from_matrix(
+        result = self.group.tait_bryan_angles_from_matrix(
             matrix,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -1505,11 +1400,11 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                             expected))
 
         tait_bryan_angles = gs.array([0.1, 0.7, 0.3])
-        matrix = group.matrix_from_tait_bryan_angles(
+        matrix = self.group.matrix_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
-        result = group.tait_bryan_angles_from_matrix(
+        result = self.group.tait_bryan_angles_from_matrix(
             matrix,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -1532,18 +1427,15 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         tait_bryan_angles_from_rotation_vector
         is the identity.
         """
-        n = 3
-        group = self.so[n]
-
         order = 'zyx'
         extrinsic_or_intrinsic = 'intrinsic'
 
         tait_bryan_angles = gs.array([0., 0., 0.])
-        matrix = group.matrix_from_tait_bryan_angles(
+        matrix = self.group.matrix_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
-        result = group.tait_bryan_angles_from_matrix(
+        result = self.group.tait_bryan_angles_from_matrix(
             matrix,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -1561,11 +1453,11 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         angle = gs.pi / 6.
 
         tait_bryan_angles = gs.array([angle, 0., 0.])
-        matrix = group.matrix_from_tait_bryan_angles(
+        matrix = self.group.matrix_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
-        result = group.tait_bryan_angles_from_matrix(
+        result = self.group.tait_bryan_angles_from_matrix(
             matrix,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -1581,11 +1473,11 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                             expected))
 
         tait_bryan_angles = gs.array([0., angle, 0.])
-        matrix = group.matrix_from_tait_bryan_angles(
+        matrix = self.group.matrix_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
-        result = group.tait_bryan_angles_from_matrix(
+        result = self.group.tait_bryan_angles_from_matrix(
             matrix,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -1601,11 +1493,11 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                             expected))
 
         tait_bryan_angles = gs.array([0., 0., angle])
-        matrix = group.matrix_from_tait_bryan_angles(
+        matrix = self.group.matrix_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
-        result = group.tait_bryan_angles_from_matrix(
+        result = self.group.tait_bryan_angles_from_matrix(
             matrix,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -1621,11 +1513,11 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                             expected))
 
         tait_bryan_angles = gs.array([0.1, 0.7, 0.3])
-        matrix = group.matrix_from_tait_bryan_angles(
+        matrix = self.group.matrix_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
-        result = group.tait_bryan_angles_from_matrix(
+        result = self.group.tait_bryan_angles_from_matrix(
             matrix,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -1641,11 +1533,8 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                             expected))
 
     def test_quaternion_from_tait_bryan_angles_intrinsic_xyz(self):
-        n = 3
-        group = self.so[n]
-
         tait_bryan_angles = gs.array([0., 0., 0.])
-        result = group.quaternion_from_tait_bryan_angles_intrinsic_xyz(
+        result = self.group.quaternion_from_tait_bryan_angles_intrinsic_xyz(
             tait_bryan_angles)
         expected = gs.array([1., 0., 0., 0.])
 
@@ -1659,7 +1548,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         sin_half_angle = gs.sin(angle / 2.)
 
         tait_bryan_angles = gs.array([angle, 0., 0.])
-        result = group.quaternion_from_tait_bryan_angles_intrinsic_xyz(
+        result = self.group.quaternion_from_tait_bryan_angles_intrinsic_xyz(
             tait_bryan_angles)
         expected = gs.array([cos_half_angle, 0., 0., sin_half_angle])
 
@@ -1670,7 +1559,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                             expected))
 
         tait_bryan_angles = gs.array([0., angle, 0.])
-        result = group.quaternion_from_tait_bryan_angles_intrinsic_xyz(
+        result = self.group.quaternion_from_tait_bryan_angles_intrinsic_xyz(
             tait_bryan_angles)
         expected = gs.array([cos_half_angle, 0., sin_half_angle, 0.])
 
@@ -1681,7 +1570,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                             expected))
 
         tait_bryan_angles = gs.array([0., 0., angle])
-        result = group.quaternion_from_tait_bryan_angles_intrinsic_xyz(
+        result = self.group.quaternion_from_tait_bryan_angles_intrinsic_xyz(
             tait_bryan_angles)
         expected = gs.array([cos_half_angle, sin_half_angle, 0., 0.])
 
@@ -1692,13 +1581,11 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                             expected))
 
     def test_quaternion_from_tait_bryan_angles_intrinsic_zyx(self):
-        n = 3
-        group = self.so[n]
         extrinsic_or_intrinsic = 'intrinsic'
         order = 'zyx'
 
         tait_bryan_angles = gs.array([0., 0., 0.])
-        result = group.quaternion_from_tait_bryan_angles(
+        result = self.group.quaternion_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -1714,7 +1601,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         sin_half_angle = gs.sin(angle / 2.)
 
         tait_bryan_angles = gs.array([angle, 0., 0.])
-        result = group.quaternion_from_tait_bryan_angles(
+        result = self.group.quaternion_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -1727,7 +1614,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                             expected))
 
         tait_bryan_angles = gs.array([0., angle, 0.])
-        result = group.quaternion_from_tait_bryan_angles(
+        result = self.group.quaternion_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -1740,7 +1627,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                             expected))
 
         tait_bryan_angles = gs.array([0., 0., angle])
-        result = group.quaternion_from_tait_bryan_angles(
+        result = self.group.quaternion_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -1757,14 +1644,11 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         This tests that the Tait-Bryan angles of the quaternion [1, 0, 0, 0],
         is [0, 0, 0] as expected.
         """
-        n = 3
-        group = self.so[n]
-
         order = 'xyz'
         extrinsic_or_intrinsic = 'intrinsic'
 
         quaternion = gs.array([1., 0., 0., 0.])
-        result = group.tait_bryan_angles_from_quaternion(
+        result = self.group.tait_bryan_angles_from_quaternion(
             quaternion,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -1781,7 +1665,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         sin_half_angle = gs.sin(angle / 2.)
 
         quaternion = gs.array([cos_half_angle, sin_half_angle, 0., 0.])
-        result = group.tait_bryan_angles_from_quaternion(
+        result = self.group.tait_bryan_angles_from_quaternion(
             quaternion,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -1794,7 +1678,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                             expected))
 
         quaternion = gs.array([cos_half_angle, 0., sin_half_angle, 0.])
-        result = group.tait_bryan_angles_from_quaternion(
+        result = self.group.tait_bryan_angles_from_quaternion(
             quaternion,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -1807,7 +1691,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                             expected))
 
         quaternion = gs.array([cos_half_angle, 0., 0., sin_half_angle])
-        result = group.tait_bryan_angles_from_quaternion(
+        result = self.group.tait_bryan_angles_from_quaternion(
             quaternion,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -1824,14 +1708,11 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         This tests that the Tait-Bryan angles of the quaternion [1, 0, 0, 0],
         is [0, 0, 0] as expected.
         """
-        n = 3
-        group = self.so[n]
-
         order = 'zyx'
         extrinsic_or_intrinsic = 'intrinsic'
 
         quaternion = gs.array([1., 0., 0., 0.])
-        result = group.tait_bryan_angles_from_quaternion(
+        result = self.group.tait_bryan_angles_from_quaternion(
             quaternion,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -1848,7 +1729,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         sin_half_angle = gs.sin(angle / 2.)
 
         quaternion = gs.array([cos_half_angle, sin_half_angle, 0., 0.])
-        result = group.tait_bryan_angles_from_quaternion(
+        result = self.group.tait_bryan_angles_from_quaternion(
             quaternion,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -1861,7 +1742,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                             expected))
 
         quaternion = gs.array([cos_half_angle, 0., sin_half_angle, 0.])
-        result = group.tait_bryan_angles_from_quaternion(
+        result = self.group.tait_bryan_angles_from_quaternion(
             quaternion,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -1874,7 +1755,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                             expected))
 
         quaternion = gs.array([cos_half_angle, 0., 0., sin_half_angle])
-        result = group.tait_bryan_angles_from_quaternion(
+        result = self.group.tait_bryan_angles_from_quaternion(
             quaternion,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -1891,14 +1772,11 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         This tests that the quaternion computed from the
         Tait-Bryan angles[0, 0, 0] is [1, 0., 0., 0.] as expected.
         """
-        n = 3
-        group = self.so[n]
-
         order = 'xyz'
         extrinsic_or_intrinsic = 'extrinsic'
 
         tait_bryan_angles = gs.array([0., 0., 0.])
-        result = group.quaternion_from_tait_bryan_angles(
+        result = self.group.quaternion_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -1918,14 +1796,11 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         This tests that the quaternion computed from the
         Tait-Bryan angles[0, 0, 0] is [1, 0., 0., 0.] as expected.
         """
-        n = 3
-        group = self.so[n]
-
         order = 'zyx'
         extrinsic_or_intrinsic = 'extrinsic'
 
         tait_bryan_angles = gs.array([0., 0., 0.])
-        result = group.quaternion_from_tait_bryan_angles(
+        result = self.group.quaternion_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -1945,14 +1820,11 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         This tests that the Tait-Bryan angles of the quaternion [1, 0, 0, 0],
         is [0, 0, 0] as expected.
         """
-        n = 3
-        group = self.so[n]
-
         order = 'xyz'
         extrinsic_or_intrinsic = 'extrinsic'
 
         quaternion = gs.array([1., 0., 0., 0.])
-        result = group.tait_bryan_angles_from_quaternion(
+        result = self.group.tait_bryan_angles_from_quaternion(
             quaternion, extrinsic_or_intrinsic='intrinsic', order='zyx')
         expected = gs.array([0., 0., 0.])
 
@@ -1970,14 +1842,11 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         This tests that the Tait-Bryan angles of the quaternion [1, 0, 0, 0],
         is [0, 0, 0] as expected.
         """
-        n = 3
-        group = self.so[n]
-
         order = 'zyx'
         extrinsic_or_intrinsic = 'extrinsic'
 
         quaternion = gs.array([1., 0., 0., 0.])
-        result = group.tait_bryan_angles_from_quaternion(
+        result = self.group.tait_bryan_angles_from_quaternion(
             quaternion, extrinsic_or_intrinsic='intrinsic', order='zyx')
         expected = gs.array([0., 0., 0.])
 
@@ -1995,7 +1864,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         sin_half_angle = gs.sin(angle / 2.)
 
         quaternion = gs.array([cos_half_angle, sin_half_angle, 0., 0.])
-        result = group.tait_bryan_angles_from_quaternion(
+        result = self.group.tait_bryan_angles_from_quaternion(
             quaternion,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -2008,7 +1877,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                             expected))
 
         quaternion = gs.array([cos_half_angle, 0., sin_half_angle, 0.])
-        result = group.tait_bryan_angles_from_quaternion(
+        result = self.group.tait_bryan_angles_from_quaternion(
             quaternion,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -2021,7 +1890,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                             expected))
 
         quaternion = gs.array([cos_half_angle, 0., 0., sin_half_angle])
-        result = group.tait_bryan_angles_from_quaternion(
+        result = self.group.tait_bryan_angles_from_quaternion(
             quaternion,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -2041,24 +1910,21 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         tait_bryan_angles_from_rotation_vector
         is the identity.
         """
-        n = 3
-        group = self.so[n]
-
         order = 'xyz'
         extrinsic_or_intrinsic = 'extrinsic'
 
-        for angle_type in self.elements[n]:
-            point = self.elements[n][angle_type]
-            if angle_type in self.angles_close_to_pi[n]:
+        for angle_type in self.elements[3]:
+            point = self.elements[3][angle_type]
+            if angle_type in self.angles_close_to_pi[3]:
                 continue
 
-            quaternion = group.quaternion_from_rotation_vector(point)
+            quaternion = self.group.quaternion_from_rotation_vector(point)
 
-            tait_bryan_angles = group.tait_bryan_angles_from_quaternion(
+            tait_bryan_angles = self.group.tait_bryan_angles_from_quaternion(
                 quaternion,
                 extrinsic_or_intrinsic=extrinsic_or_intrinsic,
                 order=order)
-            result = group.quaternion_from_tait_bryan_angles(
+            result = self.group.quaternion_from_tait_bryan_angles(
                 tait_bryan_angles,
                 extrinsic_or_intrinsic=extrinsic_or_intrinsic,
                 order=order)
@@ -2077,13 +1943,13 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                                 expected))
 
         point = gs.pi / (6. * gs.sqrt(3.)) * gs.array([1., 1., 1.])
-        quaternion = group.quaternion_from_rotation_vector(point)
+        quaternion = self.group.quaternion_from_rotation_vector(point)
 
-        tait_bryan_angles = group.tait_bryan_angles_from_quaternion(
+        tait_bryan_angles = self.group.tait_bryan_angles_from_quaternion(
             quaternion,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
-        result = group.quaternion_from_tait_bryan_angles(
+        result = self.group.quaternion_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -2109,24 +1975,21 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         tait_bryan_angles_from_rotation_vector
         is the identity.
         """
-        n = 3
-        group = self.so[n]
-
         order = 'xyz'
         extrinsic_or_intrinsic = 'intrinsic'
 
-        for angle_type in self.elements[n]:
-            point = self.elements[n][angle_type]
-            if angle_type in self.angles_close_to_pi[n]:
+        for angle_type in self.elements[3]:
+            point = self.elements[3][angle_type]
+            if angle_type in self.angles_close_to_pi[3]:
                 continue
 
-            quaternion = group.quaternion_from_rotation_vector(point)
+            quaternion = self.group.quaternion_from_rotation_vector(point)
 
-            tait_bryan_angles = group.tait_bryan_angles_from_quaternion(
+            tait_bryan_angles = self.group.tait_bryan_angles_from_quaternion(
                 quaternion,
                 extrinsic_or_intrinsic=extrinsic_or_intrinsic,
                 order=order)
-            result = group.quaternion_from_tait_bryan_angles(
+            result = self.group.quaternion_from_tait_bryan_angles(
                 tait_bryan_angles,
                 extrinsic_or_intrinsic=extrinsic_or_intrinsic,
                 order=order)
@@ -2145,13 +2008,13 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                                 expected))
 
         point = gs.pi / (6 * gs.sqrt(3.)) * gs.array([1., 1., 1.])
-        quaternion = group.quaternion_from_rotation_vector(point)
+        quaternion = self.group.quaternion_from_rotation_vector(point)
 
-        tait_bryan_angles = group.tait_bryan_angles_from_quaternion(
+        tait_bryan_angles = self.group.tait_bryan_angles_from_quaternion(
             quaternion,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
-        result = group.quaternion_from_tait_bryan_angles(
+        result = self.group.quaternion_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -2170,18 +2033,15 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                             expected))
 
     def test_tait_bryan_angles_and_quaternion_intrinsic_xyz(self):
-        n = 3
-        group = self.so[n]
-
         order = 'xyz'
         extrinsic_or_intrinsic = 'intrinsic'
 
         tait_bryan_angles = gs.array([0., 0., 0.])
-        quaternion = group.quaternion_from_tait_bryan_angles(
+        quaternion = self.group.quaternion_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
-        result = group.tait_bryan_angles_from_quaternion(
+        result = self.group.tait_bryan_angles_from_quaternion(
             quaternion,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -2199,11 +2059,11 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         angle = gs.pi / 6.
 
         tait_bryan_angles = gs.array([angle, 0., 0.])
-        quaternion = group.quaternion_from_tait_bryan_angles(
+        quaternion = self.group.quaternion_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
-        result = group.tait_bryan_angles_from_quaternion(
+        result = self.group.tait_bryan_angles_from_quaternion(
             quaternion,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -2219,11 +2079,11 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                             expected))
 
         tait_bryan_angles = gs.array([0., angle, 0.])
-        quaternion = group.quaternion_from_tait_bryan_angles(
+        quaternion = self.group.quaternion_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
-        result = group.tait_bryan_angles_from_quaternion(
+        result = self.group.tait_bryan_angles_from_quaternion(
             quaternion,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -2239,11 +2099,11 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                             expected))
 
         tait_bryan_angles = gs.array([0., 0., angle])
-        quaternion = group.quaternion_from_tait_bryan_angles(
+        quaternion = self.group.quaternion_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
-        result = group.tait_bryan_angles_from_quaternion(
+        result = self.group.tait_bryan_angles_from_quaternion(
             quaternion,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -2259,11 +2119,11 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                             expected))
 
         tait_bryan_angles = gs.array([0.1, 0.7, 0.3])
-        quaternion = group.quaternion_from_tait_bryan_angles(
+        quaternion = self.group.quaternion_from_tait_bryan_angles(
             tait_bryan_angles,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
-        result = group.tait_bryan_angles_from_quaternion(
+        result = self.group.tait_bryan_angles_from_quaternion(
             quaternion,
             extrinsic_or_intrinsic=extrinsic_or_intrinsic,
             order=order)
@@ -2286,27 +2146,24 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         tait_bryan_angles_from_rotation_vector
         is the identity.
         """
-        n = 3
-        group = self.so[n]
-
         order = 'xyz'
 
         for extrinsic_or_intrinsic in ('extrinsic', 'intrinsic'):
-            for angle_type in self.elements[n]:
-                point = self.elements[n][angle_type]
-                if angle_type in self.angles_close_to_pi[n]:
+            for angle_type in self.elements[3]:
+                point = self.elements[3][angle_type]
+                if angle_type in self.angles_close_to_pi[3]:
                     continue
 
-                tait_bryan = group.tait_bryan_angles_from_rotation_vector(
+                tait_bryan = self.group.tait_bryan_angles_from_rotation_vector(
                     point,
                     extrinsic_or_intrinsic=extrinsic_or_intrinsic,
                     order=order)
-                result = group.rotation_vector_from_tait_bryan_angles(
+                result = self.group.rotation_vector_from_tait_bryan_angles(
                     tait_bryan,
                     extrinsic_or_intrinsic=extrinsic_or_intrinsic,
                     order=order)
 
-                expected = group.regularize(point)
+                expected = self.group.regularize(point)
 
                 self.assertTrue(gs.allclose(result, expected, atol=1e-5),
                                 ' for {} Tait-Bryan angles with order {}\n'
@@ -2327,24 +2184,21 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         tait_bryan_angles_from_rotation_vector
         is the identity.
         """
-        n = 3
-        group = self.so[n]
-
         order = 'zyx'
         extrinsic_or_intrinsic = 'extrinsic'
 
-        for angle_type in self.elements[n]:
-            point = self.elements[n][angle_type]
-            if angle_type in self.angles_close_to_pi[n]:
+        for angle_type in self.elements[3]:
+            point = self.elements[3][angle_type]
+            if angle_type in self.angles_close_to_pi[3]:
                 continue
 
-            quaternion = group.quaternion_from_rotation_vector(point)
+            quaternion = self.group.quaternion_from_rotation_vector(point)
 
-            tait_bryan_angles = group.tait_bryan_angles_from_quaternion(
+            tait_bryan_angles = self.group.tait_bryan_angles_from_quaternion(
                 quaternion,
                 extrinsic_or_intrinsic=extrinsic_or_intrinsic,
                 order=order)
-            result = group.quaternion_from_tait_bryan_angles(
+            result = self.group.quaternion_from_tait_bryan_angles(
                 tait_bryan_angles,
                 extrinsic_or_intrinsic=extrinsic_or_intrinsic,
                 order=order)
@@ -2370,24 +2224,21 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         tait_bryan_angles_from_rotation_vector
         is the identity.
         """
-        n = 3
-        group = self.so[n]
-
         order = 'zyx'
         extrinsic_or_intrinsic = 'intrinsic'
 
-        for angle_type in self.elements[n]:
-            point = self.elements[n][angle_type]
-            if angle_type in self.angles_close_to_pi[n]:
+        for angle_type in self.elements[3]:
+            point = self.elements[3][angle_type]
+            if angle_type in self.angles_close_to_pi[3]:
                 continue
 
-            quaternion = group.quaternion_from_rotation_vector(point)
+            quaternion = self.group.quaternion_from_rotation_vector(point)
 
-            tait_bryan_angles = group.tait_bryan_angles_from_quaternion(
+            tait_bryan_angles = self.group.tait_bryan_angles_from_quaternion(
                 quaternion,
                 extrinsic_or_intrinsic=extrinsic_or_intrinsic,
                 order=order)
-            result = group.quaternion_from_tait_bryan_angles(
+            result = self.group.quaternion_from_tait_bryan_angles(
                 tait_bryan_angles,
                 extrinsic_or_intrinsic=extrinsic_or_intrinsic,
                 order=order)
@@ -2406,28 +2257,18 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                                 expected))
 
     def test_rotation_vector_and_rotation_matrix_vectorization(self):
-        for n in self.n_seq:
-            group = self.so[n]
+        rot_vecs = gs.array([
+            [0.3, 0.2, 0.2],
+            [0., -0.4, 0.8],
+            [1.2, 0., 0.],
+            [1.1, 1.1, 0.]])
 
-            if n == 3:
-                rot_vecs = gs.array([
-                    [0.3, 0.2, 0.2],
-                    [0., -0.4, 0.8],
-                    [1.2, 0., 0.],
-                    [1.1, 1.1, 0.]])
-            if n == 2:
-                rot_vecs = gs.array([
-                    [2.],
-                    [1.3],
-                    [0.8],
-                    [0.03]])
+        rot_mats = self.group.matrix_from_rotation_vector(rot_vecs)
+        result = self.group.rotation_vector_from_matrix(rot_mats)
 
-            rot_mats = group.matrix_from_rotation_vector(rot_vecs)
-            result = group.rotation_vector_from_matrix(rot_mats)
+        expected = self.group.regularize(rot_vecs)
 
-            expected = group.regularize(rot_vecs)
-
-            self.assertAllClose(result, expected)
+        self.assertAllClose(result, expected)
 
     def test_rotation_vector_and_rotation_matrix_with_angles_close_to_pi(self):
         """
@@ -2437,17 +2278,14 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         matrix_from_rotation_vector
         is the identity.
         """
-        n = 3
-        group = self.so[n]
-
         angle_types = self.angles_close_to_pi[3]
         for angle_type in angle_types:
             point = self.elements[3][angle_type]
 
-            rot_mat = group.matrix_from_rotation_vector(point)
-            result = group.rotation_vector_from_matrix(rot_mat)
+            rot_mat = self.group.matrix_from_rotation_vector(point)
+            result = self.group.rotation_vector_from_matrix(rot_mat)
 
-            expected = group.regularize(point)
+            expected = self.group.regularize(point)
             inv_expected = - expected
 
             self.assertTrue(
@@ -2455,44 +2293,27 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                 or gs.allclose(result, inv_expected))
 
     def test_quaternion_and_rotation_vector(self):
-        for n in self.n_seq:
-            group = self.so[n]
-            if n == 3:
-                for angle_type in self.elements[3]:
-                    point = self.elements[3][angle_type]
-                    if angle_type in self.angles_close_to_pi[3]:
-                        continue
+        for angle_type in self.elements[3]:
+            point = self.elements[3][angle_type]
+            if angle_type in self.angles_close_to_pi[3]:
+                continue
 
-                    quaternion = group.quaternion_from_rotation_vector(point)
-                    result = group.rotation_vector_from_quaternion(quaternion)
+            quaternion = self.group.quaternion_from_rotation_vector(point)
+            result = self.group.rotation_vector_from_quaternion(quaternion)
 
-                    expected = group.regularize(point)
+            expected = self.group.regularize(point)
 
-                    self.assertAllClose(result, expected)
-
-            else:
-                point = group.random_uniform()
-                self.assertRaises(
-                    ValueError,
-                    lambda: group.quaternion_from_rotation_vector(point))
-                fake_quaternion = gs.random.rand(1, n + 1)
-                self.assertRaises(
-                    ValueError,
-                    lambda: group.rotation_vector_from_quaternion(
-                        fake_quaternion))
+            self.assertAllClose(result, expected)
 
     def test_quaternion_and_rotation_vector_with_angles_close_to_pi(self):
-        n = 3
-        group = self.so[n]
-
         angle_types = self.angles_close_to_pi[3]
         for angle_type in angle_types:
             point = self.elements[3][angle_type]
 
-            quaternion = group.quaternion_from_rotation_vector(point)
-            result = group.rotation_vector_from_quaternion(quaternion)
+            quaternion = self.group.quaternion_from_rotation_vector(point)
+            result = self.group.rotation_vector_from_quaternion(quaternion)
 
-            expected = group.regularize(point)
+            expected = self.group.regularize(point)
             inv_expected = - expected
 
             self.assertTrue(
@@ -2500,98 +2321,75 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                 or gs.allclose(result, inv_expected))
 
     def test_quaternion_and_rotation_vector_vectorization(self):
-        n = 3
-        group = self.so[n]
-
         rot_vecs = gs.array([
             [1.2, 0., 0.9],
             [0.4, -0.5, 0.2],
             [0., 0., 1.9],
             [0.4, -0.12, 0.222]])
-        quaternions = group.quaternion_from_rotation_vector(rot_vecs)
-        result = group.rotation_vector_from_quaternion(quaternions)
+        quaternions = self.group.quaternion_from_rotation_vector(rot_vecs)
+        result = self.group.rotation_vector_from_quaternion(quaternions)
 
-        expected = group.regularize(rot_vecs)
+        expected = self.group.regularize(rot_vecs)
         self.assertAllClose(result, expected)
 
     def test_quaternion_and_matrix(self):
-        for n in self.n_seq:
-            group = self.so[n]
+        for angle_type in self.elements[3]:
+            point = self.elements[3][angle_type]
+            if angle_type in self.angles_close_to_pi[3]:
+                continue
 
-            if n == 3:
-                for angle_type in self.elements[3]:
-                    point = self.elements[3][angle_type]
-                    if angle_type in self.angles_close_to_pi[3]:
-                        continue
+            matrix = self.group.matrix_from_rotation_vector(point)
 
-                    matrix = group.matrix_from_rotation_vector(point)
+            quaternion = self.group.quaternion_from_matrix(matrix)
+            result = self.group.matrix_from_quaternion(quaternion)
 
-                    quaternion = group.quaternion_from_matrix(matrix)
-                    result = group.matrix_from_quaternion(quaternion)
+            expected = matrix
 
-                    expected = matrix
+            self.assertAllClose(result, expected)
 
-                    self.assertAllClose(result, expected)
+        angle = gs.pi / 9.
+        cos_angle = gs.cos(angle)
+        sin_angle = gs.sin(angle)
 
-                angle = gs.pi / 9.
-                cos_angle = gs.cos(angle)
-                sin_angle = gs.sin(angle)
+        angle_bis = gs.pi / 7.
+        cos_angle_bis = gs.cos(angle_bis)
+        sin_angle_bis = gs.sin(angle_bis)
 
-                angle_bis = gs.pi / 7.
-                cos_angle_bis = gs.cos(angle_bis)
-                sin_angle_bis = gs.sin(angle_bis)
+        rot_mat = gs.array([[cos_angle_bis, 0., sin_angle_bis],
+                            [sin_angle * sin_angle_bis,
+                             cos_angle,
+                             - sin_angle * cos_angle_bis],
+                            [- cos_angle * sin_angle_bis,
+                             sin_angle,
+                             cos_angle * cos_angle_bis]])
 
-                rot_mat = gs.array([[cos_angle_bis, 0., sin_angle_bis],
-                                    [sin_angle * sin_angle_bis,
-                                     cos_angle,
-                                     - sin_angle * cos_angle_bis],
-                                    [- cos_angle * sin_angle_bis,
-                                     sin_angle,
-                                     cos_angle * cos_angle_bis]])
+        quaternion = self.group.quaternion_from_matrix(
+            rot_mat)
+        result = self.group.matrix_from_quaternion(
+            quaternion)
 
-                quaternion = group.quaternion_from_matrix(
-                    rot_mat)
-                result = group.matrix_from_quaternion(
-                    quaternion)
+        expected = rot_mat
+        self.assertAllClose(result, expected)
 
-                expected = rot_mat
-                self.assertAllClose(result, expected)
+        point = gs.pi / (6 * gs.sqrt(3.)) * gs.array([0., 2., 1.])
+        rot_mat = self.group.matrix_from_rotation_vector(point)
 
-                point = gs.pi / (6 * gs.sqrt(3.)) * gs.array([0., 2., 1.])
-                rot_mat = group.matrix_from_rotation_vector(point)
+        quaternion = self.group.quaternion_from_matrix(
+            rot_mat)
+        result = self.group.matrix_from_quaternion(
+            quaternion)
 
-                quaternion = group.quaternion_from_matrix(
-                    rot_mat)
-                result = group.matrix_from_quaternion(
-                    quaternion)
-
-                expected = rot_mat
-                self.assertAllClose(result, expected)
-
-            else:
-                rot_vec = group.random_uniform(point_type='vector')
-
-                rot_mat = group.matrix_from_rotation_vector(rot_vec)
-                self.assertRaises(
-                    ValueError,
-                    lambda: group.quaternion_from_matrix(rot_mat))
-                fake_quaternion = gs.random.rand(1, n + 1)
-                self.assertRaises(
-                    ValueError,
-                    lambda: group.matrix_from_quaternion(
-                        fake_quaternion))
+        expected = rot_mat
+        self.assertAllClose(result, expected)
 
     def test_quaternion_and_matrix_with_angles_close_to_pi(self):
-        n = 3
-        group = self.so[n]
-
         angle_types = self.angles_close_to_pi[3]
         for angle_type in angle_types:
             point = self.elements[3][angle_type]
-            matrix = group.matrix_from_rotation_vector(point)
+            matrix = self.group.matrix_from_rotation_vector(point)
 
-            quaternion = group.quaternion_from_matrix(matrix)
-            result = group.matrix_from_quaternion(quaternion)
+            quaternion = self.group.quaternion_from_matrix(matrix)
+            result = self.group.matrix_from_quaternion(quaternion)
 
             expected = matrix
             inv_expected = gs.linalg.inv(matrix)
@@ -2601,165 +2399,96 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                 or gs.allclose(result, inv_expected))
 
     def test_quaternion_and_rotation_vector_and_matrix_vectorization(self):
-        n = 3
-        group = self.so[n]
-
         rot_vecs = gs.array([
             [0.2, 0., -0.3],
             [0.11, 0.11, 0.11],
             [-0.4, 0.2, 0.2],
             [0.66, -0.99, 0.]])
-        rot_mats = group.matrix_from_rotation_vector(rot_vecs)
+        rot_mats = self.group.matrix_from_rotation_vector(rot_vecs)
 
-        quaternions = group.quaternion_from_matrix(rot_mats)
-        result = group.matrix_from_quaternion(quaternions)
+        quaternions = self.group.quaternion_from_matrix(rot_mats)
+        result = self.group.matrix_from_quaternion(quaternions)
 
         expected = rot_mats
         self.assertAllClose(result, expected)
 
     def test_compose(self):
-        for n in self.n_seq:
-            group = self.so[n]
-            if n == 3:
-                for element_type in self.elements[3]:
-                    point = self.elements[3][element_type]
-                    # Composition by identity, on the right
-                    # Expect the original transformation
-                    result = group.compose(point, group.identity)
-                    expected = group.regularize(point)
-                    if element_type not in self.angles_close_to_pi[3]:
-                        self.assertAllClose(result, expected)
+        for element_type in self.elements[3]:
+            point = self.elements[3][element_type]
+            # Composition by identity, on the right
+            # Expect the original transformation
+            result = self.group.compose(point, self.group.identity)
+            expected = self.group.regularize(point)
+            if element_type not in self.angles_close_to_pi[3]:
+                self.assertAllClose(result, expected)
 
-                    else:
-                        inv_expected = - expected
-                        self.assertTrue(
-                            gs.allclose(result, expected)
-                            or gs.allclose(result, inv_expected))
+            else:
+                inv_expected = - expected
+                self.assertTrue(
+                    gs.allclose(result, expected)
+                    or gs.allclose(result, inv_expected))
 
-                    # Composition by identity, on the left
-                    # Expect the original transformation
-                    result = group.compose(group.identity, point)
-                    expected = group.regularize(point)
+                # Composition by identity, on the left
+                # Expect the original transformation
+                result = self.group.compose(self.group.identity, point)
+                expected = self.group.regularize(point)
 
-                    if element_type not in self.angles_close_to_pi[3]:
-                        self.assertAllClose(result, expected)
-                    else:
-                        inv_expected = - expected
-                        self.assertTrue(
-                            gs.allclose(result, expected)
-                            or gs.allclose(result, inv_expected))
-
-            # else:
-            #     angle = 0.986
-            #     point = gs.array([
-            #         [gs.cos(angle), -gs.sin(angle)],
-            #         [gs.sin(angle), gs.cos(angle)]])
-            #
-            #     result = group.compose(point, group.identity)
-            #     expected = group.regularize(point)
-            #     self.assertAllClose(result, expected)
-            #
-            #     result = group.compose(group.identity, point)
-            #     expected = group.regularize(point)
-            #     self.assertAllClose(result, expected)
+                if element_type not in self.angles_close_to_pi[3]:
+                    self.assertAllClose(result, expected)
+                else:
+                    inv_expected = - expected
+                    self.assertTrue(
+                        gs.allclose(result, expected)
+                        or gs.allclose(result, inv_expected))
 
     def test_compose_and_inverse(self):
-        for n in self.n_seq:
-            group = self.so[n]
+        for point in self.elements[3].values():
+            inv_point = self.group.inverse(point)
+            # Compose transformation by its inverse on the right
+            # Expect the self.group identity
+            result = self.group.compose(point, inv_point)
+            expected = self.group.identity
+            self.assertAllClose(result, expected)
 
-            if n == 3:
-                for point in self.elements[3].values():
-                    inv_point = group.inverse(point)
-                    # Compose transformation by its inverse on the right
-                    # Expect the group identity
-                    result = group.compose(point, inv_point)
-                    expected = group.identity
-                    self.assertAllClose(result, expected)
-
-                    # Compose transformation by its inverse on the left
-                    # Expect the group identity
-                    result = group.compose(inv_point, point)
-                    expected = group.identity
-                    self.assertAllClose(result, expected)
-            else:
-                angle = 0.986
-                point = gs.array([
-                    [gs.cos(angle), -gs.sin(angle)],
-                    [gs.sin(angle), gs.cos(angle)]])
-
-                inv_point = group.inverse(point)
-                # Compose transformation by its inverse on the right
-                # Expect the group identity
-                result = group.compose(point, inv_point)
-                expected = group.identity
-                self.assertAllClose(result, expected)
-
-                # Compose transformation by its inverse on the left
-                # Expect the group identity
-                result = group.compose(inv_point, point)
-                expected = group.identity
-                self.assertAllClose(result, expected)
+            # Compose transformation by its inverse on the left
+            # Expect the self.group identity
+            result = self.group.compose(inv_point, point)
+            expected = self.group.identity
+            self.assertAllClose(result, expected)
 
     def test_compose_vectorization(self):
-        point_type = 'vector'
-        for n in self.n_seq:
-            group = self.so[n]
-            group.default_point_type = point_type
+        n_samples = self.n_samples
+        n_points_a = self.group.random_uniform(n_samples=n_samples)
+        n_points_b = self.group.random_uniform(n_samples=n_samples)
+        one_point = self.group.random_uniform(n_samples=1)
 
-            n_samples = self.n_samples
-            n_points_a = group.random_uniform(n_samples=n_samples)
-            n_points_b = group.random_uniform(n_samples=n_samples)
-            one_point = group.random_uniform(n_samples=1)
+        result = self.group.compose(one_point, n_points_a)
+        self.assertAllClose(
+            gs.shape(result), (n_samples, self.group.dim))
 
-            result = group.compose(one_point, n_points_a)
-            if point_type == 'vector':
-                self.assertAllClose(
-                    gs.shape(result), (n_samples, group.dim))
-            if point_type == 'matrix':
-                self.assertAllClose(
-                    gs.shape(result), (n_samples, n, n))
+        result = self.group.compose(n_points_a, one_point)
+        self.assertAllClose(
+            gs.shape(result), (n_samples, self.group.dim))
 
-            result = group.compose(n_points_a, one_point)
-            if point_type == 'vector':
-                self.assertAllClose(
-                    gs.shape(result), (n_samples, group.dim))
-            if point_type == 'matrix':
-                self.assertAllClose(
-                    gs.shape(result), (n_samples, n, n))
-
-            result = group.compose(n_points_a, n_points_b)
-            if point_type == 'vector':
-                self.assertAllClose(
-                    gs.shape(result), (n_samples, group.dim))
-            if point_type == 'matrix':
-                self.assertAllClose(
-                    gs.shape(result), (n_samples, n, n))
+        result = self.group.compose(n_points_a, n_points_b)
+        self.assertAllClose(
+            gs.shape(result), (n_samples, self.group.dim))
 
     def test_inverse_vectorization(self):
-        for n in self.n_seq:
-            group = self.so[n]
+        n_samples = self.n_samples
+        points = self.group.random_uniform(n_samples=n_samples)
+        result = self.group.inverse(points)
 
-            n_samples = self.n_samples
-            points = group.random_uniform(n_samples=n_samples)
-            result = group.inverse(points)
-
-            if n == 3:
-                self.assertAllClose(
-                    gs.shape(result), (n_samples, group.dim))
-            else:
-                self.assertAllClose(
-                    gs.shape(result), (n_samples, n, n))
+        self.assertAllClose(
+            gs.shape(result), (n_samples, self.group.dim))
 
     def test_left_jacobian_through_its_determinant(self):
-        n = 3
-        group = self.so[n]
-
         for angle_type in self.elements[3]:
             point = self.elements[3][angle_type]
-            jacobian = group.jacobian_translation(point=point,
+            jacobian = self.group.jacobian_translation(point=point,
                                                   left_or_right='left')
             result = gs.linalg.det(jacobian)
-            point = group.regularize(point)
+            point = self.group.regularize(point)
             angle = gs.linalg.norm(point)
             if angle_type in ['with_angle_0',
                               'with_angle_close_0',
@@ -2772,24 +2501,18 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
             self.assertAllClose(result, expected)
 
     def test_left_jacobian_vectorization(self):
-        n = 3
-        group = self.so[n]
-
         n_samples = self.n_samples
-        points = group.random_uniform(n_samples=n_samples)
-        jacobians = group.jacobian_translation(
+        points = self.group.random_uniform(n_samples=n_samples)
+        jacobians = self.group.jacobian_translation(
             point=points, left_or_right='left')
         self.assertAllClose(
-            gs.shape(jacobians), (n_samples, group.dim, group.dim))
+            gs.shape(jacobians), (n_samples, self.group.dim, self.group.dim))
 
     def test_exp(self):
         """
         The Riemannian exp and log are inverse functions of each other.
         This test is the inverse of test_log's.
         """
-        n = 3
-        group = self.so[n]
-
         metric = self.metrics_all[3]['canonical']
         theta = gs.pi / 5.
         rot_vec_base_point = theta / gs.sqrt(3.) * gs.array([1., 1., 1.])
@@ -2814,7 +2537,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                     + (1 - phi) / 3 * gs.ones([3, 3])
                     + gs.pi / (10 * gs.sqrt(3.)) * skew)
         inv_jacobian = gs.linalg.inv(jacobian)
-        expected = group.compose(rot_vec_base_point,
+        expected = self.group.compose(rot_vec_base_point,
                                  gs.dot(inv_jacobian, rot_vec_2))
 
         result = metric.exp(
@@ -2822,41 +2545,35 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         self.assertAllClose(result, expected)
 
     def test_exp_vectorization(self):
-        n = 3
-        group = self.so[n]
-
         n_samples = self.n_samples
         for metric_type in self.metrics[3]:
             metric = self.metrics[3][metric_type]
 
-            one_tangent_vec = group.random_uniform(n_samples=1)
-            one_base_point = group.random_uniform(n_samples=1)
-            n_tangent_vec = group.random_uniform(n_samples=n_samples)
-            n_base_point = group.random_uniform(n_samples=n_samples)
+            one_tangent_vec = self.group.random_uniform(n_samples=1)
+            one_base_point = self.group.random_uniform(n_samples=1)
+            n_tangent_vec = self.group.random_uniform(n_samples=n_samples)
+            n_base_point = self.group.random_uniform(n_samples=n_samples)
 
             # Test with the 1 base point, and n tangent vecs
             result = metric.exp(n_tangent_vec, one_base_point)
             self.assertAllClose(
-                gs.shape(result), (n_samples, group.dim))
+                gs.shape(result), (n_samples, self.group.dim))
 
             # Test with the several base point, and one tangent vec
             result = metric.exp(one_tangent_vec, n_base_point)
             self.assertAllClose(
-                gs.shape(result), (n_samples, group.dim))
+                gs.shape(result), (n_samples, self.group.dim))
 
             # Test with the same number n of base point and n tangent vec
             result = metric.exp(n_tangent_vec, n_base_point)
             self.assertAllClose(
-                gs.shape(result), (n_samples, group.dim))
+                gs.shape(result), (n_samples, self.group.dim))
 
     def test_log(self):
         """
         The Riemannian exp and log are inverse functions of each other.
         This test is the inverse of test_exp's.
         """
-        n = 3
-        group = self.so[n]
-
         metric = self.metrics_all[3]['canonical']
         theta = gs.pi / 5.
         rot_vec_base_point = theta / gs.sqrt(3.) * gs.array([1., 1., 1.])
@@ -2881,7 +2598,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                     + gs.pi / (10 * gs.sqrt(3.)) * skew)
         inv_jacobian = gs.linalg.inv(jacobian)
         aux = gs.dot(inv_jacobian, expected)
-        rot_vec_2 = group.compose(rot_vec_base_point,
+        rot_vec_2 = self.group.compose(rot_vec_base_point,
                                   aux)
 
         result = metric.log(base_point=rot_vec_base_point,
@@ -2890,67 +2607,55 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         self.assertAllClose(result, expected)
 
     def test_log_vectorization(self):
-        n = 3
-        group = self.so[n]
-
         n_samples = self.n_samples
         for metric_type in self.metrics[3]:
             metric = self.metrics[3][metric_type]
 
-            one_point = group.random_uniform(n_samples=1)
-            one_base_point = group.random_uniform(n_samples=1)
-            n_point = group.random_uniform(n_samples=n_samples)
-            n_base_point = group.random_uniform(n_samples=n_samples)
+            one_point = self.group.random_uniform(n_samples=1)
+            one_base_point = self.group.random_uniform(n_samples=1)
+            n_point = self.group.random_uniform(n_samples=n_samples)
+            n_base_point = self.group.random_uniform(n_samples=n_samples)
 
             # Test with the 1 base point, and several different points
             result = metric.log(n_point, one_base_point)
             self.assertAllClose(
-                gs.shape(result), (n_samples, group.dim))
+                gs.shape(result), (n_samples, self.group.dim))
 
             # Test with the several base point, and 1 point
             result = metric.log(one_point, n_base_point)
             self.assertAllClose(
-                gs.shape(result), (n_samples, group.dim))
+                gs.shape(result), (n_samples, self.group.dim))
 
             # Test with the same number n of base point and point
             result = metric.log(n_point, n_base_point)
             self.assertAllClose(
-                gs.shape(result), (n_samples, group.dim))
+                gs.shape(result), (n_samples, self.group.dim))
 
     def test_exp_from_identity_vectorization(self):
-        n = 3
-        group = self.so[n]
-
         n_samples = self.n_samples
         metric = self.metrics_all[3]['canonical']
 
-        tangent_vecs = group.random_uniform(n_samples=n_samples)
+        tangent_vecs = self.group.random_uniform(n_samples=n_samples)
         result = metric.exp_from_identity(tangent_vecs)
 
         self.assertAllClose(
-            gs.shape(result), (n_samples, group.dim))
+            gs.shape(result), (n_samples, self.group.dim))
 
     def test_log_from_identity_vectorization(self):
-        n = 3
-        group = self.so[n]
-
         n_samples = self.n_samples
         metric = self.metrics_all[3]['canonical']
 
-        points = group.random_uniform(n_samples=n_samples)
+        points = self.group.random_uniform(n_samples=n_samples)
         result = metric.log_from_identity(points)
 
         self.assertAllClose(
-            gs.shape(result), (n_samples, group.dim))
+            gs.shape(result), (n_samples, self.group.dim))
 
     def test_exp_then_log_from_identity(self):
         """
         This tests that the composition of
         log and exp gives identity.
         """
-        n = 3
-        group = self.so[n]
-
         for metric_type in self.metrics[3]:
             for angle_type in self.elements[3]:
                 if angle_type in self.angles_close_to_pi[3]:
@@ -2961,7 +2666,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
 
                 result = helper.exp_then_log_from_identity(metric, tangent_vec)
 
-                reg_vec = group.regularize_tangent_vec_at_identity(
+                reg_vec = self.group.regularize_tangent_vec_at_identity(
                     tangent_vec=tangent_vec, metric=metric)
                 expected = reg_vec
 
@@ -2972,9 +2677,6 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         This tests that the composition of
         log and exp gives identity.
         """
-        n = 3
-        group = self.so[n]
-
         angle_types = self.angles_close_to_pi[3]
 
         for metric_type in self.metrics[3]:
@@ -2985,7 +2687,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
 
                 result = helper.exp_then_log_from_identity(metric, tangent_vec)
 
-                expected = group.regularize_tangent_vec_at_identity(
+                expected = self.group.regularize_tangent_vec_at_identity(
                     tangent_vec=tangent_vec, metric=metric)
                 inv_expected = - expected
                 self.assertTrue(
@@ -2997,10 +2699,6 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         This tests that the composition of
         log and exp gives identity.
         """
-
-        n = 3
-        group = self.so[n]
-
         for metric_type in self.metrics[3]:
             for angle_type in self.elements[3]:
                 if angle_type in self.angles_close_to_pi[3]:
@@ -3010,7 +2708,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                 point = self.elements[3][angle_type]
 
                 result = helper.log_then_exp_from_identity(metric, point)
-                expected = group.regularize(point)
+                expected = self.group.regularize(point)
 
                 self.assertAllClose(result, expected)
 
@@ -3019,9 +2717,6 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         This tests that the composition of
         log and exp gives identity.
         """
-        n = 3
-        group = self.so[n]
-
         angle_types = self.angles_close_to_pi[3]
 
         for metric_type in self.metrics[3]:
@@ -3031,7 +2726,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                 point = self.elements[3][angle_type]
 
                 result = helper.log_then_exp_from_identity(metric, point)
-                expected = group.regularize(point)
+                expected = self.group.regularize(point)
                 inv_expected = - expected
 
                 self.assertTrue(
@@ -3043,9 +2738,6 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         This tests that the composition of
         log and exp gives identity.
         """
-        n = 3
-        group = self.so[n]
-
         for metric_type in self.metrics[3]:
             for angle_type in self.elements[3]:
                 if angle_type in self.angles_close_to_pi[3]:
@@ -3059,7 +2751,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                                                  tangent_vec=tangent_vec,
                                                  base_point=base_point)
 
-                    reg_tangent_vec = group.regularize_tangent_vec(
+                    reg_tangent_vec = self.group.regularize_tangent_vec(
                         tangent_vec=tangent_vec,
                         base_point=base_point,
                         metric=metric)
@@ -3071,9 +2763,6 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         This tests that the composition of
         log and exp gives identity.
         """
-        n = 3
-        group = self.so[n]
-
         angle_types = self.angles_close_to_pi[3]
         for metric_type in self.metrics[3]:
             for angle_type in angle_types:
@@ -3086,7 +2775,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                                                  tangent_vec=tangent_vec,
                                                  base_point=base_point)
 
-                    reg_tangent_vec = group.regularize_tangent_vec(
+                    reg_tangent_vec = self.group.regularize_tangent_vec(
                         tangent_vec=tangent_vec,
                         base_point=base_point,
                         metric=metric)
@@ -3102,10 +2791,6 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         This tests that the composition of
         log and exp gives identity.
         """
-
-        n = 3
-        group = self.so[n]
-
         for metric_type in self.metrics[3]:
             for angle_type in self.elements[3]:
                 if angle_type in self.angles_close_to_pi[3]:
@@ -3121,7 +2806,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                                                  base_point=base_point,
                                                  point=point)
 
-                    expected = group.regularize(point)
+                    expected = self.group.regularize(point)
                     inv_expected = - expected
 
                     self.assertTrue(
@@ -3133,9 +2818,6 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         This tests that the composition of
         log and exp gives identity.
         """
-        n = 3
-        group = self.so[n]
-
         angle_types = self.angles_close_to_pi[3]
         for metric_type in self.metrics[3]:
             for angle_type in angle_types:
@@ -3148,7 +2830,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                                                  base_point=base_point,
                                                  point=point)
 
-                    expected = group.regularize(point)
+                    expected = self.group.regularize(point)
                     inv_expected = - expected
 
                     self.assertTrue(
@@ -3158,148 +2840,127 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
     def test_group_exp_from_identity_coincides_with_expm(self):
         """Test exponentials."""
         # FIXME: Problem in shapes
-        for n in self.n_seq:
-            group = self.so[n]
-
-            normal_rv = gs.random.rand(gs.array(n ** 2))
-            tangent_sample = gs.reshape(normal_rv, (n, n))
-            tangent_sample = tangent_sample - gs.transpose(tangent_sample)
-            expected = gs.linalg.expm(tangent_sample)
-            tangent_vec = group.vector_from_skew_matrix(tangent_sample)
-            exp = group.exp_from_identity(tangent_vec)
-            result = group.matrix_from_rotation_vector(exp)
-            self.assertAllClose(result, expected)
+        normal_rv = gs.random.rand(gs.array(3 ** 2))
+        tangent_sample = gs.reshape(normal_rv, (3, 3))
+        tangent_sample = tangent_sample - gs.transpose(tangent_sample)
+        expected = gs.linalg.expm(tangent_sample)
+        tangent_vec = self.group.vector_from_skew_matrix(tangent_sample)
+        exp = self.group.exp_from_identity(tangent_vec)
+        result = self.group.matrix_from_rotation_vector(exp)
+        self.assertAllClose(result, expected)
 
     # def test_group_exp_from_identity_coincides_with_expm_for_high_dims(self):
     #     for n in [4, 5, 6, 7, 8, 9, 10]:
-    #         group = SpecialOrthogonal(n=n)
+    #         self.group = SpecialOrthogonal(n=n)
     #
     #         normal_rv = gs.random.rand(gs.array(n ** 2))
-    #         tangent_sample = gs.reshape(normal_rv, (n, n))
+    #         tangent_sample = gs.reshape(normal_rv, (3, 3))
     #         tangent_sample = tangent_sample - gs.transpose(tangent_sample)
     #
     #         result = gs.reshape(
-    #             group.exp_from_identity(
-    #                 tangent_sample, point_type='matrix'), (n, n))
+    #             self.group.exp_from_identity(
+    #                 tangent_sample, point_type='matrix'), (3, 3))
     #
     #         expected = gs.linalg.expm(tangent_sample)
     #
     #         self.assertAllClose(result, expected)
 
     def test_group_exp_from_identity_vectorization(self):
-        n = 3
-        group = self.so[n]
-
         n_samples = self.n_samples
-        tangent_vecs = group.random_uniform(n_samples=n_samples)
-        result = group.exp_from_identity(tangent_vecs)
+        tangent_vecs = self.group.random_uniform(n_samples=n_samples)
+        result = self.group.exp_from_identity(tangent_vecs)
 
         self.assertAllClose(
-            gs.shape(result), (n_samples, group.dim))
+            gs.shape(result), (n_samples, self.group.dim))
 
     def test_group_log_from_identity_vectorization(self):
-        n = 3
-        group = self.so[n]
-
         n_samples = self.n_samples
-        points = group.random_uniform(n_samples=n_samples)
-        result = group.log_from_identity(points)
+        points = self.group.random_uniform(n_samples=n_samples)
+        result = self.group.log_from_identity(points)
 
         self.assertAllClose(
-            gs.shape(result), (n_samples, group.dim))
+            gs.shape(result), (n_samples, self.group.dim))
 
     def test_group_exp_vectorization(self):
-        n = 3
-        group = self.so[n]
-
         n_samples = self.n_samples
         # Test with the 1 base_point, and several different tangent_vecs
-        tangent_vecs = group.random_uniform(n_samples=n_samples)
-        base_point = group.random_uniform(n_samples=1)
-        result = group.exp(tangent_vecs, base_point)
+        tangent_vecs = self.group.random_uniform(n_samples=n_samples)
+        base_point = self.group.random_uniform(n_samples=1)
+        result = self.group.exp(tangent_vecs, base_point)
 
         self.assertAllClose(
-            gs.shape(result), (n_samples, group.dim))
+            gs.shape(result), (n_samples, self.group.dim))
 
         # Test with the same number of base_points and tangent_vecs
-        tangent_vecs = group.random_uniform(n_samples=n_samples)
-        base_points = group.random_uniform(n_samples=n_samples)
-        result = group.exp(tangent_vecs, base_points)
+        tangent_vecs = self.group.random_uniform(n_samples=n_samples)
+        base_points = self.group.random_uniform(n_samples=n_samples)
+        result = self.group.exp(tangent_vecs, base_points)
 
         self.assertAllClose(
-            gs.shape(result), (n_samples, group.dim))
+            gs.shape(result), (n_samples, self.group.dim))
 
         # Test with the several base_points, and 1 tangent_vec
-        tangent_vec = group.random_uniform(n_samples=1)
-        base_points = group.random_uniform(n_samples=n_samples)
-        result = group.exp(tangent_vec, base_points)
+        tangent_vec = self.group.random_uniform(n_samples=1)
+        base_points = self.group.random_uniform(n_samples=n_samples)
+        result = self.group.exp(tangent_vec, base_points)
 
         self.assertAllClose(
-            gs.shape(result), (n_samples, group.dim))
+            gs.shape(result), (n_samples, self.group.dim))
 
     def test_group_log_vectorization(self):
-        n = 3
-        group = self.so[n]
-
         n_samples = self.n_samples
         # Test with the 1 base point, and several different points
-        points = group.random_uniform(n_samples=n_samples)
-        base_point = group.random_uniform(n_samples=1)
-        result = group.log(points, base_point)
+        points = self.group.random_uniform(n_samples=n_samples)
+        base_point = self.group.random_uniform(n_samples=1)
+        result = self.group.log(points, base_point)
 
         self.assertAllClose(
-            gs.shape(result), (n_samples, group.dim))
+            gs.shape(result), (n_samples, self.group.dim))
 
         # Test with the same number of base points and points
-        points = group.random_uniform(n_samples=n_samples)
-        base_points = group.random_uniform(n_samples=n_samples)
-        result = group.log(points, base_points)
+        points = self.group.random_uniform(n_samples=n_samples)
+        base_points = self.group.random_uniform(n_samples=n_samples)
+        result = self.group.log(points, base_points)
 
         self.assertAllClose(
-            gs.shape(result), (n_samples, group.dim))
+            gs.shape(result), (n_samples, self.group.dim))
 
         # Test with the several base points, and 1 point
-        point = group.random_uniform(n_samples=1)
-        base_points = group.random_uniform(n_samples=n_samples)
-        result = group.log(point, base_points)
+        point = self.group.random_uniform(n_samples=1)
+        base_points = self.group.random_uniform(n_samples=n_samples)
+        result = self.group.log(point, base_points)
 
         self.assertAllClose(
-            gs.shape(result), (n_samples, group.dim))
+            gs.shape(result), (n_samples, self.group.dim))
 
     def test_group_exp_then_log_from_identity(self):
         """
-        Test that the group exponential
-        and the group logarithm are inverse.
+        Test that the self.group exponential
+        and the self.group logarithm are inverse.
         Expect their composition to give the identity function.
         """
-        n = 3
-        group = self.so[n]
-
         for angle_type in self.elements[3]:
             if angle_type in self.angles_close_to_pi[3]:
                 continue
             tangent_vec = self.elements[3][angle_type]
             result = helper.group_exp_then_log_from_identity(
-                group=group, tangent_vec=tangent_vec)
-            expected = group.regularize(tangent_vec)
+                group=self.group, tangent_vec=tangent_vec)
+            expected = self.group.regularize(tangent_vec)
             self.assertAllClose(result, expected)
 
     def test_group_exp_then_log_from_identity_with_angles_close_to_pi(self):
         """
-        Test that the group exponential
-        and the group logarithm are inverse.
+        Test that the self.group exponential
+        and the self.group logarithm are inverse.
         Expect their composition to give the identity function.
         """
-        n = 3
-        group = self.so[n]
-
         angle_types = self.angles_close_to_pi[3]
         for angle_type in angle_types:
             tangent_vec = self.elements[3][angle_type]
             result = helper.group_exp_then_log_from_identity(
-                group=group,
+                group=self.group,
                 tangent_vec=tangent_vec)
-            expected = group.regularize(tangent_vec)
+            expected = self.group.regularize(tangent_vec)
             inv_expected = - expected
 
             self.assertTrue(
@@ -3308,37 +2969,32 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
 
     def test_group_log_then_exp_from_identity(self):
         """
-        Test that the group exponential
-        and the group logarithm are inverse.
+        Test that the self.group exponential
+        and the self.group logarithm are inverse.
         Expect their composition to give the identity function.
         """
-        n = 3
-        group = self.so[n]
 
         for angle_type in self.elements[3]:
             point = self.elements[3][angle_type]
             result = helper.group_log_then_exp_from_identity(
-                group=group,
+                group=self.group,
                 point=point)
-            expected = group.regularize(point)
+            expected = self.group.regularize(point)
             self.assertAllClose(result, expected)
 
     def test_group_log_then_exp_from_identity_with_angles_close_to_pi(self):
         """
-        Test that the group exponential
-        and the group logarithm are inverse.
+        Test that the self.group exponential
+        and the self.group logarithm are inverse.
         Expect their composition to give the identity function.
         """
-        n = 3
-        group = self.so[n]
-
         angle_types = self.angles_close_to_pi[3]
         for angle_type in angle_types:
             point = self.elements[3][angle_type]
             result = helper.group_log_then_exp_from_identity(
-                group=group,
+                group=self.group,
                 point=point)
-            expected = group.regularize(point)
+            expected = self.group.regularize(point)
             inv_expected = - expected
 
             self.assertTrue(
@@ -3352,9 +3008,6 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         log and exp gives identity.
 
         """
-        n = 3
-        group = self.so[n]
-
         for angle_type in self.elements[3]:
             if angle_type in self.angles_close_to_pi[3]:
                 continue
@@ -3363,12 +3016,12 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                 base_point = self.elements[3][angle_type_base]
 
                 result = helper.group_exp_then_log(
-                    group=group,
+                    group=self.group,
                     tangent_vec=tangent_vec,
                     base_point=base_point)
 
-                metric = group.left_canonical_metric
-                expected = group.regularize_tangent_vec(
+                metric = self.group.left_canonical_metric
+                expected = self.group.regularize_tangent_vec(
                     tangent_vec=tangent_vec,
                     base_point=base_point,
                     metric=metric)
@@ -3380,9 +3033,6 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         This tests that the composition of
         log and exp gives identity.
         """
-        n = 3
-        group = self.so[n]
-
         angle_types = self.angles_close_to_pi[3]
         for angle_type in angle_types:
             for angle_type_base in self.elements[3]:
@@ -3390,12 +3040,12 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                 base_point = self.elements[3][angle_type_base]
 
                 result = helper.group_exp_then_log(
-                    group=group,
+                    group=self.group,
                     tangent_vec=tangent_vec,
                     base_point=base_point)
 
-                metric = group.left_canonical_metric
-                reg_tangent_vec = group.regularize_tangent_vec(
+                metric = self.group.left_canonical_metric
+                reg_tangent_vec = self.group.regularize_tangent_vec(
                     tangent_vec=tangent_vec,
                     base_point=base_point,
                     metric=metric)
@@ -3411,10 +3061,6 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         This tests that the composition of
         log and exp gives identity.
         """
-
-        n = 3
-        group = self.so[n]
-
         for angle_type in self.elements[3]:
             if angle_type in self.angles_close_to_pi[3]:
                 continue
@@ -3425,10 +3071,10 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                 base_point = self.elements[3][angle_type_base]
 
                 result = helper.group_log_then_exp(
-                    group=group,
+                    group=self.group,
                     point=point,
                     base_point=base_point)
-                expected = group.regularize(point)
+                expected = self.group.regularize(point)
 
                 self.assertAllClose(result, expected, atol=ATOL)
 
@@ -3437,9 +3083,6 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         This tests that the composition of
         log and exp gives identity.
         """
-        n = 3
-        group = self.so[n]
-
         angle_types = self.angles_close_to_pi[3]
         for angle_type in angle_types:
             for angle_type_base in self.elements[3]:
@@ -3447,10 +3090,10 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                 base_point = self.elements[3][angle_type_base]
 
                 result = helper.group_log_then_exp(
-                    group=group,
+                    group=self.group,
                     point=point,
                     base_point=base_point)
-                expected = group.regularize(point)
+                expected = self.group.regularize(point)
                 inv_expected = - expected
 
                 self.assertTrue(
@@ -3458,16 +3101,13 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                     or gs.allclose(result, inv_expected, atol=5e-3))
 
     def test_squared_dist_is_symmetric(self):
-        n = 3
-        group = self.so[n]
-
         for metric in self.metrics[3].values():
             for angle_type_1 in self.elements[3]:
                 for angle_type_2 in self.elements[3]:
                     point_1 = self.elements[3][angle_type_1]
                     point_2 = self.elements[3][angle_type_2]
-                    point_1 = group.regularize(point_1)
-                    point_2 = group.regularize(point_2)
+                    point_1 = self.group.regularize(point_1)
+                    point_2 = self.group.regularize(point_2)
 
                     sq_dist_1_2 = gs.mod(
                         metric.squared_dist(point_1, point_2) + 1e-4,
@@ -3483,16 +3123,13 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         For other metrics, the scaling factor can give
         distances above pi.
         """
-        n = 3
-        group = self.so[n]
-
         metric = self.metrics_all[3]['canonical']
         for angle_type_1 in self.elements[3]:
             for angle_type_2 in self.elements[3]:
                 point_1 = self.elements[3][angle_type_1]
                 point_2 = self.elements[3][angle_type_2]
-                point_1 = group.regularize(point_1)
-                point_2 = group.regularize(point_2)
+                point_1 = self.group.regularize(point_1)
+                point_2 = self.group.regularize(point_2)
 
                 sq_dist = metric.squared_dist(point_1, point_2)
                 diff = sq_dist - gs.pi ** 2
@@ -3500,23 +3137,20 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                                 'sq_dist = {}'.format(sq_dist))
 
     def test_squared_dist_vectorization(self):
-        n = 3
-        group = self.so[n]
-
         n_samples = self.n_samples
         for metric_type in self.metrics[3]:
             metric = self.metrics[3][metric_type]
-            point_id = group.identity
+            point_id = self.group.identity
 
-            one_point_1 = group.random_uniform(n_samples=1)
-            one_point_2 = group.random_uniform(n_samples=1)
-            one_point_1 = group.regularize(one_point_1)
-            one_point_2 = group.regularize(one_point_2)
+            one_point_1 = self.group.random_uniform(n_samples=1)
+            one_point_2 = self.group.random_uniform(n_samples=1)
+            one_point_1 = self.group.regularize(one_point_1)
+            one_point_2 = self.group.regularize(one_point_2)
 
-            n_point_1 = group.random_uniform(n_samples=n_samples)
-            n_point_2 = group.random_uniform(n_samples=n_samples)
-            n_point_1 = group.regularize(n_point_1)
-            n_point_2 = group.regularize(n_point_2)
+            n_point_1 = self.group.random_uniform(n_samples=n_samples)
+            n_point_2 = self.group.random_uniform(n_samples=n_samples)
+            n_point_1 = self.group.regularize(n_point_1)
+            n_point_2 = self.group.regularize(n_point_2)
 
             # Identity and n points 2
             result = metric.squared_dist(point_id, n_point_2)
@@ -3539,23 +3173,20 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
             self.assertAllClose(gs.shape(result), (n_samples,))
 
     def test_dist_vectorization(self):
-        n = 3
-        group = self.so[n]
-
         n_samples = self.n_samples
         for metric_type in self.metrics[3]:
             metric = self.metrics[3][metric_type]
-            point_id = group.identity
+            point_id = self.group.identity
 
-            one_point_1 = group.random_uniform(n_samples=1)
-            one_point_2 = group.random_uniform(n_samples=1)
-            one_point_1 = group.regularize(one_point_1)
-            one_point_2 = group.regularize(one_point_2)
+            one_point_1 = self.group.random_uniform(n_samples=1)
+            one_point_2 = self.group.random_uniform(n_samples=1)
+            one_point_1 = self.group.regularize(one_point_1)
+            one_point_2 = self.group.regularize(one_point_2)
 
-            n_point_1 = group.random_uniform(n_samples=n_samples)
-            n_point_2 = group.random_uniform(n_samples=n_samples)
-            n_point_1 = group.regularize(n_point_1)
-            n_point_2 = group.regularize(n_point_2)
+            n_point_1 = self.group.random_uniform(n_samples=n_samples)
+            n_point_2 = self.group.random_uniform(n_samples=n_samples)
+            n_point_1 = self.group.regularize(n_point_1)
+            n_point_2 = self.group.regularize(n_point_2)
 
             # Identity and n points 2
             result = metric.dist(point_id, n_point_2)
@@ -3578,10 +3209,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
             self.assertAllClose(gs.shape(result), (n_samples,))
 
     def test_geodesic_and_belongs(self):
-        n = 3
-        group = self.so[n]
-
-        initial_point = group.random_uniform()
+        initial_point = self.group.random_uniform()
         initial_tangent_vec = gs.array([2., 0., -1.])
         metric = self.metrics_all[3]['canonical']
         geodesic = metric.geodesic(initial_point=initial_point,
@@ -3589,23 +3217,20 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
 
         t = gs.linspace(start=0., stop=1., num=100)
         points = geodesic(t)
-        result = gs.all(group.belongs(points))
+        result = gs.all(self.group.belongs(points))
         expected = True
         self.assertAllClose(result, expected)
 
     def test_geodesic_subsample(self):
         """Test geodesic."""
         # FIXME
-        # n = 3
-        # group = self.so[n]
-
-        # initial_point = group.random_uniform()
+        # initial_point = self.group.random_uniform()
         # initial_tangent_vec = gs.array([1., 1., 1.])
-        # metric = self.metrics_all[n]['canonical']
+        # metric = self.metrics_all[3]['canonical']
         # geodesic = metric.geodesic(initial_point=initial_point,
         #                            initial_tangent_vec=initial_tangent_vec)
         # n_steps = 100
-        # t = gs.linspace(start=0., stop=1., num=n_steps+1)
+        # t = gs.linself.group(start=0., stop=1., num=n_steps+1)
         # points = geodesic(t)
 
         # tangent_vec_step = initial_tangent_vec / n_steps
@@ -3615,51 +3240,43 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         #     self.assertTrue(gs.allclose(point_step, points[i]))
 
     def test_lie_bracket_at_identity(self):
-        dim = 3
-        space = self.so[dim]
-        base_point = space.identity
+        base_point = self.group.identity
         first_tan = gs.array([0., 0., -1.])
         second_tan = first_tan
 
-        result = space.lie_bracket(
+        result = self.group.lie_bracket(
             first_tan, second_tan, base_point)
-        expected = gs.zeros(dim)
+        expected = gs.zeros(3)
 
         self.assertAllClose(result, expected)
 
         first_tan = gs.array([0., 0., 1.])
         second_tan = gs.array([0., 1., 0.])
 
-        result = space.lie_bracket(
+        result = self.group.lie_bracket(
             first_tan, second_tan, base_point)
         expected = gs.array([-1., 0., 0.])
 
         self.assertAllClose(result, expected)
 
     def test_lie_bracket_vectorization(self):
-        dim = 3
-        space = self.so[dim]
-
-        base_point = gs.array([space.identity, space.identity])
+        base_point = gs.array([self.group.identity, self.group.identity])
         first_tan = gs.array([[0., 0., 1.], [0., 0., 1.]])
         second_tan = gs.array([[0., 0., 1.], [0., 1., 0.]])
 
-        result = space.lie_bracket(
+        result = self.group.lie_bracket(
             first_tan, second_tan, base_point)
         expected = gs.array([gs.zeros(3), gs.array([-1., 0., 0.])])
 
         self.assertAllClose(result, expected)
 
     # def test_lie_bracket_at_non_identity(self):
-    #     dim = 3
-    #     space = self.so[dim]
-    #
     #     base_point = gs.array([
     #         [-1., 0., 0.],
     #         [0., -1., 0.],
     #         [0., 0., 1.]])
-    #     rotation = space.jacobian_translation(base_point)
-    #     first_tan = space.compose(
+    #     rotation = self.group.jacobian_translation(base_point)
+    #     first_tan = self.group.compose(
     #         base_point,
     #         gs.array([
     #             [0., -1., 0.],
@@ -3674,7 +3291,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
     #             [1., 0., 0.]])
     #     )
     #
-    #     result = space.lie_bracket(
+    #     result = self.group.lie_bracket(
     #         first_tan, second_tan, base_point, point_type='matrix')
     #     expected = gs.matmul(
     #         base_point,


### PR DESCRIPTION
This PR adds the vector parametrization of SO(2) and SE(2), following the way the 3-dimensional case is treated.
For SE(2), the focus is on the group structure for now.

The tests for SO(2) follow those of SO(3), this might be a bit of an overkill, but at least it is more or less exhaustive.