### PR TITLE
Factorize gradient computation in the backends

### DIFF
--- a/geomstats/_backend/__init__.py
+++ b/geomstats/_backend/__init__.py
@@ -110,6 +110,7 @@ BACKEND_ATTRIBUTES = {
         'zeros',
         'zeros_like'
     ],
+    'autograd': ['value_and_grad'],
     'linalg': [
         'det',
         'eig',

--- a/geomstats/_backend/numpy/__init__.py
+++ b/geomstats/_backend/numpy/__init__.py
@@ -1,5 +1,6 @@
 """Numpy based computation backend."""
 
+import autograd # NOQA
 import autograd.numpy as np
 from autograd.numpy import (  # NOQA
     abs,
@@ -93,7 +94,6 @@ from autograd.numpy import (  # NOQA
 from autograd.scipy.special import polygamma # NOQA
 from scipy.sparse import coo_matrix
 
-from . import autograd # NOQA
 from . import linalg  # NOQA
 from . import random  # NOQA
 from .common import to_ndarray  # NOQA

--- a/geomstats/_backend/numpy/__init__.py
+++ b/geomstats/_backend/numpy/__init__.py
@@ -93,6 +93,7 @@ from autograd.numpy import (  # NOQA
 from autograd.scipy.special import polygamma # NOQA
 from scipy.sparse import coo_matrix
 
+from . import autograd # NOQA
 from . import linalg  # NOQA
 from . import random  # NOQA
 from .common import to_ndarray  # NOQA

--- a/geomstats/_backend/numpy/autograd.py
+++ b/geomstats/_backend/numpy/autograd.py
@@ -1,0 +1,1 @@
+from autograd import value_and_grad # NOQA

--- a/geomstats/_backend/numpy/autograd.py
+++ b/geomstats/_backend/numpy/autograd.py
@@ -1,1 +1,0 @@
-from autograd import value_and_grad # NOQA

--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -61,6 +61,7 @@ from torch import (  # NOQA
     zeros_like
 )
 
+from . import autograd # NOQA
 from . import linalg  # NOQA
 from . import random  # NOQA
 

--- a/geomstats/_backend/pytorch/autograd.py
+++ b/geomstats/_backend/pytorch/autograd.py
@@ -1,0 +1,14 @@
+import numpy as np
+import torch
+
+
+def value_and_grad(objective):
+    def objective_with_grad(velocity):
+        """Create helpful objective func wrapper for autograd comp."""
+        if isinstance(velocity, np.ndarray):
+            velocity = torch.from_numpy(velocity)
+        vel = velocity.clone().detach().requires_grad_(True)
+        loss = objective(vel)
+        loss.backward()
+        return loss.detach().numpy(), vel.grad.detach().numpy()
+    return objective_with_grad

--- a/geomstats/_backend/pytorch/autograd.py
+++ b/geomstats/_backend/pytorch/autograd.py
@@ -3,8 +3,22 @@ import torch
 
 
 def value_and_grad(objective):
+    """'Returns a function that returns both value and gradient.
+
+    Suitable for use in scipy.optimize
+
+    Parameters
+    ----------
+    objective : callable
+        Function to compute the gradient. It must be real-valued.
+
+    Returns
+    -------
+    objective_with_grad : callable
+        Function that takes the argument of the objective function as input
+        and returns both value and grad at the input.
+    '"""
     def objective_with_grad(velocity):
-        """Create helpful objective func wrapper for autograd comp."""
         if isinstance(velocity, np.ndarray):
             velocity = torch.from_numpy(velocity)
         vel = velocity.clone().detach().requires_grad_(True)

--- a/geomstats/_backend/tensorflow/__init__.py
+++ b/geomstats/_backend/tensorflow/__init__.py
@@ -59,7 +59,7 @@ from tensorflow import (  # NOQA
 )
 
 
-
+from . import autograd # NOQA
 from . import linalg  # NOQA
 from . import random  # NOQA
 

--- a/geomstats/_backend/tensorflow/autograd.py
+++ b/geomstats/_backend/tensorflow/autograd.py
@@ -1,0 +1,13 @@
+import numpy as np
+import tensorflow as tf
+
+
+def value_and_grad(objective):
+    def objective_with_grad(velocity):
+        if isinstance(velocity, np.ndarray):
+            velocity = tf.Variable(velocity)
+        with tf.GradientTape() as t:
+            t.watch(velocity)
+            loss = objective(velocity)
+        return loss.numpy(), t.gradient(loss, velocity).numpy()
+    return objective_with_grad

--- a/geomstats/_backend/tensorflow/autograd.py
+++ b/geomstats/_backend/tensorflow/autograd.py
@@ -3,6 +3,21 @@ import tensorflow as tf
 
 
 def value_and_grad(objective):
+    """'Returns a function that returns both value and gradient.
+
+    Suitable for use in scipy.optimize
+
+    Parameters
+    ----------
+    objective : callable
+        Function to compute the gradient. It must be real-valued.
+
+    Returns
+    -------
+    objective_with_grad : callable
+        Function that takes the argument of the objective function as input
+        and returns both value and grad at the input.
+    '"""
     def objective_with_grad(velocity):
         if isinstance(velocity, np.ndarray):
             velocity = tf.Variable(velocity)

--- a/geomstats/geometry/connection.py
+++ b/geomstats/geometry/connection.py
@@ -170,7 +170,7 @@ class Connection:
             return 1. / n_samples * gs.sum(loss)
 
         objective_with_grad = gs.autograd.value_and_grad(objective)
-        tangent_vec = gs.random.rand(sum(gs.shape(base_point)))
+        tangent_vec = gs.random.rand(*gs.flatten(base_point).shape)
         res = minimize(
             objective_with_grad, tangent_vec, method='L-BFGS-B', jac=True,
             options={'disp': False, 'maxiter': 25})

--- a/geomstats/geometry/connection.py
+++ b/geomstats/geometry/connection.py
@@ -1,8 +1,6 @@
 """Affine connections."""
 
-import autograd
 from scipy.optimize import minimize
-from torch.optim.lbfgs import LBFGS
 
 import geomstats.backend as gs
 import geomstats.errors
@@ -158,9 +156,6 @@ class Connection:
         tangent_vec : array-like, shape=[..., dim]
             Tangent vector at the base point.
         """
-        n_samples = geomstats.vectorization.get_n_points(
-            base_point, point_type='vector')
-
         def objective(velocity):
             """Define the objective function."""
             velocity = gs.array(velocity)
@@ -168,7 +163,7 @@ class Connection:
             velocity = gs.reshape(velocity, base_point.shape)
             delta = self.exp(velocity, base_point, n_steps, step) - point
             loss = 1. / self.dim * gs.sum(delta ** 2, axis=-1)
-            return 1. / n_samples * gs.sum(loss)
+            return gs.sum(loss)
 
         objective_with_grad = gs.autograd.value_and_grad(objective)
         tangent_vec = gs.random.rand(*gs.flatten(base_point).shape)

--- a/geomstats/geometry/connection.py
+++ b/geomstats/geometry/connection.py
@@ -164,6 +164,7 @@ class Connection:
         def objective(velocity):
             """Define the objective function."""
             velocity = gs.array(velocity)
+            velocity = gs.cast(velocity, dtype=base_point.dtype)
             velocity = gs.reshape(velocity, base_point.shape)
             delta = self.exp(velocity, base_point, n_steps, step) - point
             loss = 1. / self.dim * gs.sum(delta ** 2, axis=-1)

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -896,3 +896,23 @@ class TestBackends(geomstats.tests.TestCase):
 
         with self.assertRaises((ValueError, RuntimeError)):
             gs.broadcast_arrays(gs.array([1, 2]), gs.array([3, 4, 5]))
+
+    def test_value_and_grad(self):
+        n = 10
+        vector = gs.ones(n)
+        result_loss, result_grad = gs.autograd.value_and_grad(
+            lambda v: gs.sum(v ** 2))(vector)
+        expected_loss = n
+        expected_grad = 2 * vector
+        self.assertAllClose(result_loss, expected_loss)
+        self.assertAllClose(result_grad, expected_grad)
+
+    def test_value_and_grad_numpy_input(self):
+        n = 10
+        vector = _np.ones(n)
+        result_loss, result_grad = gs.autograd.value_and_grad(
+            lambda v: gs.sum(v ** 2))(vector)
+        expected_loss = n
+        expected_grad = 2 * vector
+        self.assertAllClose(result_loss, expected_loss)
+        self.assertAllClose(result_grad, expected_grad)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -94,7 +94,7 @@ class TestConnection(geomstats.tests.TestCase):
 
             self.assertAllClose(result, expected, rtol=rtol, atol=atol)
 
-    @geomstats.tests.np_only
+    @geomstats.tests.np_and_pytorch_only
     def test_exp_connection_metric(self):
         point = gs.array([gs.pi / 2, 0])
         vector = gs.array([0.25, 0.5])
@@ -109,7 +109,7 @@ class TestConnection(geomstats.tests.TestCase):
 
         self.assertAllClose(result, expected, rtol=1e-6)
 
-    @geomstats.tests.np_only
+    @geomstats.tests.np_and_pytorch_only
     def test_exp_connection_metric_vectorization(self):
         point = gs.array([[gs.pi / 2, 0], [gs.pi / 6, gs.pi / 4]])
         vector = gs.array([[0.25, 0.5], [0.30, 0.2]])
@@ -124,7 +124,7 @@ class TestConnection(geomstats.tests.TestCase):
 
         self.assertAllClose(result, expected, rtol=1e-6)
 
-    @geomstats.tests.np_only
+    @geomstats.tests.np_and_pytorch_only
     def test_log_connection_metric(self):
         base_point = gs.array([gs.pi / 3, gs.pi / 4])
         point = gs.array([1.0, gs.pi / 2])
@@ -139,7 +139,7 @@ class TestConnection(geomstats.tests.TestCase):
 
         self.assertAllClose(result, expected, rtol=1e-5, atol=1e-5)
 
-    @geomstats.tests.np_only
+    @geomstats.tests.np_and_pytorch_only
     def test_log_connection_metric_vectorization(self):
         base_point = gs.array([[gs.pi / 3, gs.pi / 4], [gs.pi / 2, gs.pi / 4]])
         point = gs.array([[1.0, gs.pi / 2], [gs.pi / 6, gs.pi / 3]])

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -94,7 +94,6 @@ class TestConnection(geomstats.tests.TestCase):
 
             self.assertAllClose(result, expected, rtol=rtol, atol=atol)
 
-    @geomstats.tests.np_and_pytorch_only
     def test_exp_connection_metric(self):
         point = gs.array([gs.pi / 2, 0])
         vector = gs.array([0.25, 0.5])
@@ -109,7 +108,6 @@ class TestConnection(geomstats.tests.TestCase):
 
         self.assertAllClose(result, expected, rtol=1e-6)
 
-    @geomstats.tests.np_and_pytorch_only
     def test_exp_connection_metric_vectorization(self):
         point = gs.array([[gs.pi / 2, 0], [gs.pi / 6, gs.pi / 4]])
         vector = gs.array([[0.25, 0.5], [0.30, 0.2]])
@@ -124,7 +122,6 @@ class TestConnection(geomstats.tests.TestCase):
 
         self.assertAllClose(result, expected, rtol=1e-6)
 
-    @geomstats.tests.np_and_pytorch_only
     def test_log_connection_metric(self):
         base_point = gs.array([gs.pi / 3, gs.pi / 4])
         point = gs.array([1.0, gs.pi / 2])
@@ -139,7 +136,6 @@ class TestConnection(geomstats.tests.TestCase):
 
         self.assertAllClose(result, expected, rtol=1e-5, atol=1e-5)
 
-    @geomstats.tests.np_and_pytorch_only
     def test_log_connection_metric_vectorization(self):
         base_point = gs.array([[gs.pi / 3, gs.pi / 4], [gs.pi / 2, gs.pi / 4]])
         point = gs.array([[1.0, gs.pi / 2], [gs.pi / 6, gs.pi / 3]])


### PR DESCRIPTION
This PR adds an autograd module to the backend so that automatic differentiation can be used with all backends. This is a proof of concept that it works for the computation of the log on the sphere using Christoffel symbols (already existed before but with numpy only).
For the gradient descent, the scipy solver is used, so we go back and forth between torch/tensorflow tensors and numpy arrays, but it remains simpler than using torch/tensorflow optimizers.