### PR TITLE
remove seaborn style

### DIFF
--- a/geomstats/visualization.py
+++ b/geomstats/visualization.py
@@ -24,7 +24,6 @@ IMPLEMENTED = ['SO3_GROUP', 'SE3_GROUP', 'S1', 'S2',
 
 
 def tutorial_matplotlib():
-    plt.style.use('seaborn')
     fontsize = 12
     matplotlib.rc('font', size=fontsize)
     matplotlib.rc('text')


### PR DESCRIPTION
Seaborn changes the default matplotlib plotting style, by setting a grey background, which is not very nice IMO (you can see the difference on the notebooks). It will be better for the paper with plain white background.