### PR TITLE
Add break condition to calculation of log on Stiefel manifold

### DIFF
--- a/geomstats/geometry/stiefel.py
+++ b/geomstats/geometry/stiefel.py
@@ -380,6 +380,9 @@ class StiefelCanonicalMetric(RiemannianMetric):
 
             matrix_c = matrix_lv[:, p:2 * p, p:2 * p]
 
+            if gs.linalg.norm(matrix_c) < tol:
+                break
+
             matrix_phi = gs.linalg.expm(-matrix_c)
 
             aux_matrix = gs.matmul(
@@ -389,9 +392,6 @@ class StiefelCanonicalMetric(RiemannianMetric):
                 [matrix_v[:, :, 0:p],
                  aux_matrix],
                 axis=2)
-
-            if gs.linalg.norm(matrix_c) < tol:
-                break
 
         matrix_xv = gs.matmul(base_point, matrix_lv[:, 0:p, 0:p])
         matrix_qv = gs.matmul(matrix_q, matrix_lv[:, p:2 * p, 0:p])

--- a/geomstats/geometry/stiefel.py
+++ b/geomstats/geometry/stiefel.py
@@ -298,12 +298,6 @@ class StiefelCanonicalMetric(RiemannianMetric):
         """
         matrix_w = gs.concatenate([matrix_m, matrix_n], axis=1)
 
-        matrix_v = gs.zeros((
-            matrix_w.shape[0],
-            max(matrix_w.shape[1], matrix_w.shape[2]),
-            max(matrix_w.shape[1], matrix_w.shape[2])
-        ))
-
         matrix_v, _ = gs.linalg.qr(matrix_w, mode='complete')
 
         return matrix_v

--- a/geomstats/geometry/stiefel.py
+++ b/geomstats/geometry/stiefel.py
@@ -329,7 +329,7 @@ class StiefelCanonicalMetric(RiemannianMetric):
         return matrix_v
 
     @geomstats.vectorization.decorator(['else', 'matrix', 'matrix', 'else'])
-    def log(self, point, base_point, max_iter=30):
+    def log(self, point, base_point, max_iter=30, tol=1e-7):
         """Compute the Riemannian logarithm of a point.
 
         Based on [ZR2017]_.
@@ -347,6 +347,13 @@ class StiefelCanonicalMetric(RiemannianMetric):
             Point in the Stiefel manifold.
         base_point : array-like, shape=[..., n, p]
             Point in the Stiefel manifold.
+        max_iter: int
+            Maximum number of iterations to perform during the algorithm.
+            Optional, default: 30.
+        tol: float
+            Tolerance to reach convergence. The matrix 2-norm is used as
+            criterion.
+            Optional, default: 1e-7.
 
         Returns
         -------
@@ -373,9 +380,6 @@ class StiefelCanonicalMetric(RiemannianMetric):
 
             matrix_c = matrix_lv[:, p:2 * p, p:2 * p]
 
-            # TODO (nina): Add break condition
-            # of the form: if gs.all(gs.less_equal(norm_matrix_c, tol)):
-
             matrix_phi = gs.linalg.expm(-matrix_c)
 
             aux_matrix = gs.matmul(
@@ -385,6 +389,9 @@ class StiefelCanonicalMetric(RiemannianMetric):
                 [matrix_v[:, :, 0:p],
                  aux_matrix],
                 axis=2)
+
+            if gs.linalg.norm(matrix_c) < tol:
+                break
 
         matrix_xv = gs.matmul(base_point, matrix_lv[:, 0:p, 0:p])
         matrix_qv = gs.matmul(matrix_q, matrix_lv[:, p:2 * p, 0:p])

--- a/geomstats/geometry/stiefel.py
+++ b/geomstats/geometry/stiefel.py
@@ -329,7 +329,7 @@ class StiefelCanonicalMetric(RiemannianMetric):
         return matrix_v
 
     @geomstats.vectorization.decorator(['else', 'matrix', 'matrix', 'else'])
-    def log(self, point, base_point, max_iter=30, tol=1e-7):
+    def log(self, point, base_point, max_iter=30, tol=1e-6):
         """Compute the Riemannian logarithm of a point.
 
         Based on [ZR2017]_.
@@ -353,7 +353,7 @@ class StiefelCanonicalMetric(RiemannianMetric):
         tol: float
             Tolerance to reach convergence. The matrix 2-norm is used as
             criterion.
-            Optional, default: 1e-7.
+            Optional, default: 1e-6.
 
         Returns
         -------
@@ -380,7 +380,9 @@ class StiefelCanonicalMetric(RiemannianMetric):
 
             matrix_c = matrix_lv[:, p:2 * p, p:2 * p]
 
-            if gs.linalg.norm(matrix_c) < tol:
+            norm_matrix_c = gs.linalg.norm(matrix_c)
+
+            if gs.less_equal(norm_matrix_c, tol):
                 break
 
             matrix_phi = gs.linalg.expm(-matrix_c)


### PR DESCRIPTION
Theorem 3.1 in the reference below provides a method for determining the Riemannian logarithm on the Stiefel manifold. It involves solving a matrix equation via an iterative approach, and provides a break condition in the form of a certain matrix norm being sufficiently small. This (modest) PR implements that break condition and closes Issue [#711](https://github.com/geomstats/geomstats/issues/711).

- [R. Zimmermann. A Matrix-Algebraic Algorithm for the Riemannian Logarithm on the
Stiefel Manifold under the Canonical Metric.](https://arxiv.org/pdf/1604.05054.pdf)
