### PR TITLE
Adding kmeans initialization for EM algorithm on Poincare Ball

### DIFF
--- a/geomstats/learning/expectation_maximization.py
+++ b/geomstats/learning/expectation_maximization.py
@@ -306,7 +306,7 @@ class RiemannianEM(TransformerMixin, ClusterMixin, BaseEstimator):
             self.means = centroids
             self.variances = gs.zeros(self.n_gaussians)
 
-            labeled_data = gs.transpose(gs.vstack([labels, data.T]))
+            labeled_data = gs.transpose(gs.vstack([labels, gs.transpose(data)]))
             for label, centroid in enumerate(centroids):
                 label_mask = gs.where(labeled_data[:, 0] == label)
                 grouped_by_label = labeled_data[label_mask][:, 1:]

--- a/geomstats/learning/expectation_maximization.py
+++ b/geomstats/learning/expectation_maximization.py
@@ -308,7 +308,8 @@ class RiemannianEM(TransformerMixin, ClusterMixin, BaseEstimator):
 
             labeled_data = gs.vstack([labels, data.T]).T
             for label, centroid in enumerate(centroids):
-                grouped_by_label = labeled_data[gs.where(labeled_data[:, 0]== label)][:,1:]
+                label_mask = gs.where(labeled_data[:, 0] == label)
+                grouped_by_label = labeled_data[label_mask][:,1:]
                 v = variance(grouped_by_label, centroid, self.metric)
                 self.variances[label] = v
         else:

--- a/geomstats/learning/expectation_maximization.py
+++ b/geomstats/learning/expectation_maximization.py
@@ -306,7 +306,7 @@ class RiemannianEM(TransformerMixin, ClusterMixin, BaseEstimator):
             self.means = centroids
             self.variances = gs.zeros(self.n_gaussians)
 
-            labeled_data = gs.vstack([labels, data.T]).T
+            labeled_data = gs.transpose(gs.vstack([labels, data.T]))
             for label, centroid in enumerate(centroids):
                 label_mask = gs.where(labeled_data[:, 0] == label)
                 grouped_by_label = labeled_data[label_mask][:, 1:]

--- a/geomstats/learning/expectation_maximization.py
+++ b/geomstats/learning/expectation_maximization.py
@@ -9,8 +9,8 @@ from geomstats.geometry.poincare_ball \
     import PoincareBall
 from geomstats.learning._template import TransformerMixin
 from geomstats.learning.frechet_mean import FrechetMean
-from geomstats.learning.kmeans import RiemannianKMeans
 from geomstats.learning.frechet_mean import variance
+from geomstats.learning.kmeans import RiemannianKMeans
 
 EM_CONV_RATE = 1e-4
 MINIMUM_EPOCHS = 10

--- a/geomstats/learning/expectation_maximization.py
+++ b/geomstats/learning/expectation_maximization.py
@@ -309,7 +309,7 @@ class RiemannianEM(TransformerMixin, ClusterMixin, BaseEstimator):
             labeled_data = gs.vstack([labels, data.T]).T
             for label, centroid in enumerate(centroids):
                 label_mask = gs.where(labeled_data[:, 0] == label)
-                grouped_by_label = labeled_data[label_mask][:,1:]
+                grouped_by_label = labeled_data[label_mask][:, 1:]
                 v = variance(grouped_by_label, centroid, self.metric)
                 self.variances[label] = v
         else:

--- a/geomstats/learning/expectation_maximization.py
+++ b/geomstats/learning/expectation_maximization.py
@@ -293,7 +293,7 @@ class RiemannianEM(TransformerMixin, ClusterMixin, BaseEstimator):
             Gaussian mixture model: means, variances and mixture_coefficients.
         """
         self._dimension = data.shape[-1]
-        if self.initialisation_method == "kmeans":
+        if self.initialisation_method == 'kmeans':
             kmeans = RiemannianKMeans(metric=self.metric,
                                       n_clusters=self.n_gaussians,
                                       init='random',
@@ -306,7 +306,8 @@ class RiemannianEM(TransformerMixin, ClusterMixin, BaseEstimator):
             self.means = centroids
             self.variances = gs.zeros(self.n_gaussians)
 
-            labeled_data = gs.transpose(gs.vstack([labels, gs.transpose(data)]))
+            labeled_data = gs.vstack([labels, gs.transpose(data)])
+            labeled_data = gs.transpose(labeled_data)
             for label, centroid in enumerate(centroids):
                 label_mask = gs.where(labeled_data[:, 0] == label)
                 grouped_by_label = labeled_data[label_mask][:, 1:]

--- a/tests/test_expectation_maximization.py
+++ b/tests/test_expectation_maximization.py
@@ -50,6 +50,18 @@ class TestEM(geomstats.tests.TestCase):
         self.assertTrue((variances < 1).all() and (variances > 0).all())
         self.assertTrue(self.space.belongs(means).all())
 
+        gmm_learning = RiemannianEM(
+            metric=self.metric,
+            n_gaussians=self.n_gaussian,
+            initialisation_method="kmeans",
+            mean_method=self.mean_method)
+
+        means, variances, coefficients = gmm_learning.fit(self.data)
+
+        self.assertTrue((coefficients < 1).all() and (coefficients > 0).all())
+        self.assertTrue((variances < 1).all() and (variances > 0).all())
+        self.assertTrue(self.space.belongs(means).all())
+
     @geomstats.tests.np_only
     def test_weighted_frechet_mean(self):
         """Test for weighted mean."""

--- a/tests/test_expectation_maximization.py
+++ b/tests/test_expectation_maximization.py
@@ -53,7 +53,7 @@ class TestEM(geomstats.tests.TestCase):
         gmm_learning = RiemannianEM(
             metric=self.metric,
             n_gaussians=self.n_gaussian,
-            initialisation_method="kmeans",
+            initialisation_method='kmeans',
             mean_method=self.mean_method)
 
         means, variances, coefficients = gmm_learning.fit(self.data)


### PR DESCRIPTION
The current implementation for EM on the Poincare ball in the RiemannianEM class only allows for random initialization of the cluster centroids. This PR adds the option for performing Riemannian  KMeans instead for initialization.

This should close issue #791