### PR TITLE
Kristianeschenburg grassmann belongs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 
 .ipynb_checkpoints
 */.ipynb_checkpoints/*
+*.ipynb
 
 # IPython
 profile_default/

--- a/geomstats/_backend/tensorflow/__init__.py
+++ b/geomstats/_backend/tensorflow/__init__.py
@@ -14,7 +14,7 @@ from tensorflow import (  # NOQA
     asin as arcsin,
     atan2 as arctan2,
     clip_by_value as clip,
-    concat as concatenate,
+    concat,
     cos,
     cosh,
     divide,
@@ -91,6 +91,10 @@ def _raise_not_implemented_error(*args, **kwargs):
 
 def to_numpy(x):
     return x.numpy()
+
+
+def concatenate(x, axis=0, out=None):
+    return concat(x, axis=axis)
 
 
 def convert_to_wider_dtype(tensor_list):

--- a/geomstats/_backend/tensorflow/__init__.py
+++ b/geomstats/_backend/tensorflow/__init__.py
@@ -524,7 +524,7 @@ def vectorize(x, pyfunc, multiple_args=False, dtype=None, **kwargs):
 
 def split(x, indices_or_sections, axis=0):
     if isinstance(indices_or_sections, int):
-        return tf.split(x, indices_or_sections, dim=axis)
+        return tf.split(x, indices_or_sections, axis=axis)
     indices_or_sections = _np.array(indices_or_sections)
     intervals_length = indices_or_sections[1:] - indices_or_sections[:-1]
     last_interval_length = x.shape[axis] - indices_or_sections[-1]

--- a/geomstats/_backend/tensorflow/linalg.py
+++ b/geomstats/_backend/tensorflow/linalg.py
@@ -31,8 +31,10 @@ def logm(x):
 
 
 def svd(x):
+    is_vectorized = x.ndim == 3
+    axis = (0, 2, 1) if is_vectorized else (1, 0)
     s, u, v_t = tf.linalg.svd(x, full_matrices=True)
-    return u, s, tf.transpose(v_t, perm=(0, 2, 1))
+    return u, s, tf.transpose(v_t, perm=axis)
 
 
 def qr(*args, mode='reduced'):

--- a/geomstats/geometry/euclidean.py
+++ b/geomstats/geometry/euclidean.py
@@ -116,9 +116,10 @@ class EuclideanMetric(RiemannianMetric):
         Dimension of the Euclidean space.
     """
 
-    def __init__(self, dim):
+    def __init__(self, dim, default_point_type='vector'):
         super(EuclideanMetric, self).__init__(
-            dim=dim, signature=(dim, 0, 0))
+            dim=dim, signature=(dim, 0, 0),
+            default_point_type=default_point_type)
 
     def inner_product_matrix(self, base_point=None):
         """Compute the inner-product matrix, independent of the base point.

--- a/geomstats/geometry/grassmannian.py
+++ b/geomstats/geometry/grassmannian.py
@@ -96,9 +96,9 @@ class Grassmannian(EmbeddedManifold):
         belongs : bool
         """
 
-        [n_points, n, p] = point.shape
+        n, p = point.shape[-2:]
 
-        return [n == p] * n_points
+        return n == p
 
     @staticmethod
     def _check_symmetric(point):

--- a/geomstats/geometry/grassmannian.py
+++ b/geomstats/geometry/grassmannian.py
@@ -114,7 +114,7 @@ class Grassmannian(EmbeddedManifold):
     def is_tangent(self, vector, base_point=None, atol=TOLERANCE):
         diff = Matrices.mul(
             base_point, vector) + Matrices.mul(vector, base_point) - vector
-        is_close = gs.all(gs.isclose(diff, 0, atol=atol))
+        is_close = gs.all(gs.isclose(diff, 0., atol=atol))
         return gs.logical_and(Matrices.is_symmetric(vector), is_close)
 
     def to_tangent(self, vector, base_point=None):
@@ -229,7 +229,8 @@ class GrassmannianCanonicalMetric(RiemannianMetric):
         ----------
         tangent_vec : array-like, shape=[..., n, n]
             Tangent vector at base point.
-            `vector` is skew-symmetric, in so(n).
+            `tangent_vec` is the bracket of a skew-symmetric matrix with the
+            base_point.
         base_point : array-like, shape=[..., n, n]
             Base point.
             `base_point` is a rank p projector of Gr(n, k).
@@ -241,7 +242,8 @@ class GrassmannianCanonicalMetric(RiemannianMetric):
         """
         expm = gs.linalg.expm
         mul = Matrices.mul
-        return mul(expm(tangent_vec), base_point, expm(-tangent_vec))
+        rot = Matrices.bracket(base_point, -tangent_vec)
+        return mul(expm(rot), base_point, expm(-rot))
 
     def log(self, point, base_point):
         r"""Compute the Riemannian logarithm of point w.r.t. base_point.
@@ -276,4 +278,4 @@ class GrassmannianCanonicalMetric(RiemannianMetric):
         sym2 = 2 * point - id_n
         sym1 = 2 * base_point - id_n
         rot = GLn.mul(sym2, sym1)
-        return GLn.log(rot) / 2
+        return Matrices.bracket(GLn.log(rot) / 2, base_point)

--- a/geomstats/geometry/grassmannian.py
+++ b/geomstats/geometry/grassmannian.py
@@ -59,14 +59,14 @@ class Grassmannian(EmbeddedManifold):
 
         Parameters
         ----------
-        n_samples: int,
+        n_samples : int
             The number of points to sample
             Optional. default: 1.
 
         Returns
         -------
         projectors : array-like, shape=[..., n, n]
-            Points following a uniform distribution
+            Points following a uniform distribution.
 
         References
         ----------
@@ -160,13 +160,12 @@ class Grassmannian(EmbeddedManifold):
 
     @staticmethod
     def _check_square(point):
-        """Check if a point is square.
+        """Check if a point is a square matrix.
 
         Parameters
         ----------
-        point
-        n: Euclidean dimension
-        k: subspace dimension
+        point : array-like, shape=[..., n, n]
+            Matrix.
 
         Returns
         -------

--- a/geomstats/geometry/grassmannian.py
+++ b/geomstats/geometry/grassmannian.py
@@ -5,7 +5,7 @@ import geomstats.errors
 from geomstats.geometry.embedded_manifold import EmbeddedManifold
 from geomstats.geometry.euclidean import EuclideanMetric
 from geomstats.geometry.general_linear import GeneralLinear
-from geomstats.geometry.matrices import Matrices
+from geomstats.geometry.matrices import Matrices, MatricesMetric
 from geomstats.geometry.riemannian_metric import RiemannianMetric
 
 TOLERANCE = 1e-5
@@ -73,8 +73,7 @@ class Grassmannian(EmbeddedManifold):
         .. [Chikuse03] Yasuko Chikuse, Statistics on special manifolds,
         New York: Springer-Verlag. 2003, 10.1007/978-0-387-21540-2
         """
-        points = gs.random.normal(size=n_samples * self.k * self. n)
-        points = gs.reshape(points, (n_samples, self.n, self.k))
+        points = gs.random.normal(size=(n_samples, self. n, self.k))
         full_rank = Matrices.mul(Matrices.transpose(points), points)
         projector = Matrices.mul(
             points,
@@ -194,7 +193,7 @@ class Grassmannian(EmbeddedManifold):
         return gs.sum(s > tolerance, axis=-1) == rank
 
 
-class GrassmannianCanonicalMetric(RiemannianMetric):
+class GrassmannianCanonicalMetric(MatricesMetric, RiemannianMetric):
     """Canonical metric of the Grassmann manifold.
 
     Coincides with the Frobenius metric.
@@ -215,8 +214,7 @@ class GrassmannianCanonicalMetric(RiemannianMetric):
 
         dim = int(p * (n - p))
         super(GrassmannianCanonicalMetric, self).__init__(
-            dim=dim,
-            signature=(dim, 0, 0))
+            m=n, n=n, dim=dim, signature=(dim, 0, 0))
 
         self.n = n
         self.p = p

--- a/geomstats/geometry/matrices.py
+++ b/geomstats/geometry/matrices.py
@@ -250,10 +250,10 @@ class MatricesMetric(EuclideanMetric):
         Integers representing the shapes of the matrices: m x n.
     """
 
-    def __init__(self, m, n):
+    def __init__(self, m, n, **kwargs):
         dimension = m * n
         super(MatricesMetric, self).__init__(
-            dim=dimension)
+            dim=dimension, default_point_type='matrix')
 
     def inner_product(self, tangent_vec_a, tangent_vec_b, base_point=None):
         """Compute Frobenius inner-product of two tan vecs at `base_point`.

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -931,3 +931,10 @@ class TestBackends(geomstats.tests.TestCase):
                 self.assertTrue(False)
 
         self.assertEqual(len(result), a)
+
+    def test_split(self):
+        x = gs.array([0.1, 0.2, 0.3, 0.4])
+        result_1, result_2 = gs.split(x, 2)
+        expected_1, expected_2 = _np.split(x, 2)
+        self.assertAllCloseToNp(result_1, expected_1)
+        self.assertAllCloseToNp(result_2, expected_2)

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -934,7 +934,7 @@ class TestBackends(geomstats.tests.TestCase):
 
     def test_split(self):
         x = gs.array([0.1, 0.2, 0.3, 0.4])
-        result_1, result_2 = gs.split(x, 2)
-        expected_1, expected_2 = _np.split(x, 2)
-        self.assertAllCloseToNp(result_1, expected_1)
-        self.assertAllCloseToNp(result_2, expected_2)
+        result = gs.split(x, 2)
+        expected = _np.split(x, 2)
+        for res, exp in zip(result, expected):
+            self.assertAllClose(res, exp)

--- a/tests/test_grassmannian.py
+++ b/tests/test_grassmannian.py
@@ -94,3 +94,23 @@ class TestGrassmannian(geomstats.tests.TestCase):
         point = self.space.random_uniform()
         result = self.space.belongs(point)
         self.assertTrue(result)
+
+        expected = (self.n,) * 2
+        result_shape = point.shape
+        self.assertAllClose(result_shape, expected)
+
+        n_samples = 5
+        points = self.space.random_uniform(n_samples)
+        result = gs.all(self.space.belongs(points))
+        self.assertTrue(result)
+
+        expected = (n_samples,) + (self.n,) * 2
+        result_shape = points.shape
+        self.assertAllClose(result_shape, expected)
+
+    def test_is_to_tangent(self):
+        base_point = self.space.random_uniform()
+        vector = gs.random.rand(self.n, self.n)
+        tangent_vec = self.space.to_tangent(vector, base_point)
+        result = self.space.is_tangent(tangent_vec, base_point)
+        self.assertTrue(result)

--- a/tests/test_grassmannian.py
+++ b/tests/test_grassmannian.py
@@ -61,7 +61,7 @@ class TestGrassmannian(geomstats.tests.TestCase):
         self.assertTrue(self.space.is_tangent(result, p_xy))
         self.assertAllClose(result, expected)
 
-    @geomstats.tests.np_only
+    @geomstats.tests.np_and_tf_only
     def test_log_vectorized(self):
         tangent_vecs = pi_4 * gs.array([r_y, r_z])
         base_points = gs.array([p_xy, p_xz])
@@ -77,7 +77,7 @@ class TestGrassmannian(geomstats.tests.TestCase):
 
         point = gs.array([p_yz, p_xz])
         result = self.space.belongs(point)
-        self.assertTrue(result.all())
+        self.assertTrue(gs.all(result))
 
         not_a_point = gs.random.rand(3, 2)
         self.assertRaises(ValueError, self.space.belongs, not_a_point)

--- a/tests/test_grassmannian.py
+++ b/tests/test_grassmannian.py
@@ -4,6 +4,7 @@ import geomstats.backend as gs
 import geomstats.tests
 from geomstats.geometry.grassmannian import Grassmannian
 from geomstats.geometry.grassmannian import GrassmannianCanonicalMetric
+from geomstats.geometry.matrices import Matrices
 
 p_xy = gs.array([
     [1., 0., 0.],
@@ -40,24 +41,24 @@ class TestGrassmannian(geomstats.tests.TestCase):
         self.metric = GrassmannianCanonicalMetric(self.n, self.k)
 
     def test_exp_np(self):
+        vec = Matrices.bracket(pi_2 * r_y, gs.array([p_xy, p_yz]))
         result = self.metric.exp(
-            pi_2 * r_y,
-            gs.array([p_xy, p_yz]))
+            vec, gs.array([p_xy, p_yz]))
         expected = gs.array([p_yz, p_xy])
         self.assertAllClose(result, expected)
 
+        vec = Matrices.bracket(
+            pi_2 * gs.array([r_y, r_z]), gs.array([p_xy, p_yz]))
         result = self.metric.exp(
-            pi_2 * gs.array([r_y, r_z]),
-            gs.array([p_xy, p_yz]))
+            vec, gs.array([p_xy, p_yz]))
         expected = gs.array([p_yz, p_xz])
         self.assertAllClose(result, expected)
 
-    @geomstats.tests.np_only
     def test_log(self):
+        expected = Matrices.bracket(pi_4 * r_y, p_xy)
         result = self.metric.log(
-            self.metric.exp(pi_4 * r_y, p_xy),
-            p_xy)
-        expected = pi_4 * r_y
+            self.metric.exp(expected, p_xy), p_xy)
+        self.assertTrue(self.space.is_tangent(result, p_xy))
         self.assertAllClose(result, expected)
 
     @geomstats.tests.np_only

--- a/tests/test_grassmannian.py
+++ b/tests/test_grassmannian.py
@@ -78,6 +78,19 @@ class TestGrassmannian(geomstats.tests.TestCase):
         result = self.space.belongs(point)
         self.assertTrue(result.all())
 
+        not_a_point = gs.random.rand(3, 2)
+        self.assertRaises(ValueError, self.space.belongs, not_a_point)
+
         not_a_point = gs.random.rand(3, 3)
         result = self.space.belongs(not_a_point)
         self.assertTrue(~result)
+
+        point = gs.array([p_xy, not_a_point])
+        result = self.space.belongs(point)
+        expected = gs.array([True, False])
+        self.assertAllClose(result, expected)
+
+    def test_random_and_belongs(self):
+        point = self.space.random_uniform()
+        result = self.space.belongs(point)
+        self.assertTrue(result)

--- a/tests/test_grassmannian.py
+++ b/tests/test_grassmannian.py
@@ -54,6 +54,7 @@ class TestGrassmannian(geomstats.tests.TestCase):
         expected = gs.array([p_yz, p_xz])
         self.assertAllClose(result, expected)
 
+    @geomstats.tests.np_and_tf_only
     def test_log(self):
         expected = Matrices.bracket(pi_4 * r_y, p_xy)
         result = self.metric.log(

--- a/tests/test_grassmannian.py
+++ b/tests/test_grassmannian.py
@@ -68,3 +68,16 @@ class TestGrassmannian(geomstats.tests.TestCase):
         result = self.metric.log(points, base_points)
         expected = tangent_vecs
         self.assertAllClose(result, expected)
+
+    def test_belongs(self):
+        point = p_xy
+        result = self.space.belongs(point)
+        self.assertTrue(result)
+
+        point = gs.array([p_yz, p_xz])
+        result = self.space.belongs(point)
+        self.assertTrue(result.all())
+
+        not_a_point = gs.random.rand(3, 3)
+        result = self.space.belongs(not_a_point)
+        self.assertTrue(~result)


### PR DESCRIPTION
This PR adds tools for the Grassmann Manifold, following up on #572:
- remove hard coded dimension
- add belongs, is_tangent, to_tangent methods
- change exp and log to take and return tangent vectors instead of skew-sym matrices
- add random_uniform method
- change the metric to inherit MatricesMetric so that inner products and norms can be computed with the Frobenius dot prod.

@opeltre