### PR TITLE
Factorize Taylor Approximations

### DIFF
--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -96,6 +96,7 @@ exp = _box_scalar(exp)
 log = _box_scalar(log)
 sin = _box_scalar(sin)
 sinh = _box_scalar(sinh)
+tan = _box_scalar(tan)
 
 
 def to_numpy(x):

--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -5,7 +5,6 @@ from functools import wraps
 import numpy as _np
 import torch
 from torch import (  # NOQA
-    abs,
     acos as arccos,
     arange,
     argmin,
@@ -89,6 +88,7 @@ def _box_scalar(function):
     return wrapper
 
 
+abs = _box_scalar(abs)
 ceil = _box_scalar(ceil)
 cos = _box_scalar(cos)
 cosh = _box_scalar(cosh)

--- a/geomstats/algebra_utils.py
+++ b/geomstats/algebra_utils.py
@@ -26,6 +26,17 @@ INV_TANC_TAYLOR_COEFFS = [1.,
                           - 2. / 945.,
                           - 1. / 4725.]
 
+cos_close_0 = {'function': gs.cos, 'coeffs': COS_TAYLOR_COEFFS}
+sinc_close_0 = {
+    'function': lambda x: gs.sin(x) / x,
+    'coeffs': SINC_TAYLOR_COEFFS}
+inv_sinc_close_0 = {
+    'function': lambda x: x / gs.sin(x),
+    'coeffs': INV_SINC_TAYLOR_COEFFS}
+inv_tanc_close_0 = {
+    'function': lambda x: x / gs.tan(x),
+    'coeffs': INV_TANC_TAYLOR_COEFFS}
+
 
 def from_vector_to_diagonal_matrix(vector):
     """Create diagonal matrices from rows of a matrix.
@@ -48,7 +59,7 @@ def from_vector_to_diagonal_matrix(vector):
 
 
 def taylor_exp_even_func(
-        point, taylor_coefs, function, order=7, tol=EPSILON):
+        point, taylor_function, order=7, tol=EPSILON):
     """
 
     Parameters
@@ -67,9 +78,9 @@ def taylor_exp_even_func(
 
     """
     approx = gs.einsum(
-        'k,k...->...', gs.array(taylor_coefs[:order]),
+        'k,k...->...', gs.array(taylor_function['coeffs'][:order]),
         gs.array([point ** k for k in range(order)]))
     point_ = gs.where(gs.abs(point) <= tol, tol, point)
-    exact = function(gs.sqrt(point_))
+    exact = taylor_function['function'](gs.sqrt(point_))
     result = gs.where(gs.abs(point) < tol, approx, exact)
     return result

--- a/geomstats/algebra_utils.py
+++ b/geomstats/algebra_utils.py
@@ -1,9 +1,30 @@
 """Utility module of reusable algebra routines."""
+import math
 
 import geomstats.backend as gs
 
 
-EPSILON = 1e-8
+EPSILON = 1e-4
+COS_TAYLOR_COEFFS = [1.,
+                     - 1.0 / math.factorial(2),
+                     + 1.0 / math.factorial(4),
+                     - 1.0 / math.factorial(6),
+                     + 1.0 / math.factorial(8)]
+SINC_TAYLOR_COEFFS = [1.,
+                      - 1.0 / math.factorial(3),
+                      + 1.0 / math.factorial(5),
+                      - 1.0 / math.factorial(7),
+                      + 1.0 / math.factorial(9)]
+INV_SINC_TAYLOR_COEFFS = [1,
+                          1. / 6.,
+                          7. / 360.,
+                          31. / 15120.,
+                          127. / 604800.]
+INV_TANC_TAYLOR_COEFFS = [1.,
+                          - 1. / 3.,
+                          - 1. / 45.,
+                          - 2. / 945.,
+                          - 1. / 4725.]
 
 
 def from_vector_to_diagonal_matrix(vector):
@@ -26,11 +47,29 @@ def from_vector_to_diagonal_matrix(vector):
     return diagonals
 
 
-def taylor_exp(point, taylor_coefs, function, order=7, tol=EPSILON):
-    return gs.where(
-        point < tol,
-        gs.einsum(
-            'k,k...->...',
-            gs.array(taylor_coefs[:order]),
-            gs.array([point ** k for k in range(order)])),
-        function(point))
+def taylor_exp_even_func(
+        point, taylor_coefs, function, order=7, tol=EPSILON):
+    """
+
+    Parameters
+    ----------
+    point
+    taylor_coefs
+    function
+    order
+    tol
+    even: bool
+        If True, the Taylor approximation is composed with the square
+        function, so point is considered point^2
+
+    Returns
+    -------
+
+    """
+    approx = gs.einsum(
+        'k,k...->...', gs.array(taylor_coefs[:order]),
+        gs.array([point ** k for k in range(order)]))
+    point_ = gs.where(gs.abs(point) <= tol, tol, point)
+    exact = function(gs.sqrt(point_))
+    result = gs.where(gs.abs(point) < tol, approx, exact)
+    return result

--- a/geomstats/algebra_utils.py
+++ b/geomstats/algebra_utils.py
@@ -4,7 +4,7 @@ import math
 import geomstats.backend as gs
 
 
-EPSILON = 1e-4
+EPSILON = 1e-6
 COS_TAYLOR_COEFFS = [1.,
                      - 1.0 / math.factorial(2),
                      + 1.0 / math.factorial(4),
@@ -15,27 +15,29 @@ SINC_TAYLOR_COEFFS = [1.,
                       + 1.0 / math.factorial(5),
                       - 1.0 / math.factorial(7),
                       + 1.0 / math.factorial(9)]
-INV_SINC_TAYLOR_COEFFS = [1,
-                          1. / 6.,
-                          7. / 360.,
-                          31. / 15120.,
-                          127. / 604800.]
-INV_TANC_TAYLOR_COEFFS = [1.,
-                          - 1. / 3.,
-                          - 1. / 45.,
-                          - 2. / 945.,
-                          - 1. / 4725.]
+INV_SINC_TAYLOR_COEFFS = [1, 1. / 6., 7. / 360., 31. / 15120., 127. / 604800.]
+INV_TANC_TAYLOR_COEFFS = [1., - 1. / 3., - 1. / 45., - 2. / 945., - 1. / 4725.]
+COSC_TAYLOR_COEFFS = [1. / 2.,
+                      - 1.0 / math.factorial(4),
+                      + 1.0 / math.factorial(6),
+                      - 1.0 / math.factorial(8),
+                      + 1. / math.factorial(10)]
+VAR_INV_TAN_TAYLOR_COEFFS = [
+    1. / 12., 1. / 720., 1. / 30240., 1. / 1209600.]
 
 cos_close_0 = {'function': gs.cos, 'coeffs': COS_TAYLOR_COEFFS}
 sinc_close_0 = {
-    'function': lambda x: gs.sin(x) / x,
-    'coeffs': SINC_TAYLOR_COEFFS}
+    'function': lambda x: gs.sin(x) / x, 'coeffs': SINC_TAYLOR_COEFFS}
 inv_sinc_close_0 = {
-    'function': lambda x: x / gs.sin(x),
-    'coeffs': INV_SINC_TAYLOR_COEFFS}
+    'function': lambda x: x / gs.sin(x), 'coeffs': INV_SINC_TAYLOR_COEFFS}
 inv_tanc_close_0 = {
-    'function': lambda x: x / gs.tan(x),
-    'coeffs': INV_TANC_TAYLOR_COEFFS}
+    'function': lambda x: x / gs.tan(x), 'coeffs': INV_TANC_TAYLOR_COEFFS}
+cosc_close_0 = {
+    'function': lambda x: (1 - gs.cos(x)) / x ** 2,
+    'coeffs': COSC_TAYLOR_COEFFS}
+var_inv_tanc_close_0 = {
+    'function': lambda x: (1 - (x / gs.tan(x))) / x ** 2,
+    'coeffs': VAR_INV_TAN_TAYLOR_COEFFS}
 
 
 def from_vector_to_diagonal_matrix(vector):
@@ -59,19 +61,15 @@ def from_vector_to_diagonal_matrix(vector):
 
 
 def taylor_exp_even_func(
-        point, taylor_function, order=7, tol=EPSILON):
-    """
+        point, taylor_function, order=5, tol=EPSILON):
+    """Taylor Approximation of an even function around zero.
 
     Parameters
     ----------
     point
-    taylor_coefs
-    function
+    taylor_function
     order
     tol
-    even: bool
-        If True, the Taylor approximation is composed with the square
-        function, so point is considered point^2
 
     Returns
     -------

--- a/geomstats/algebra_utils.py
+++ b/geomstats/algebra_utils.py
@@ -3,6 +3,9 @@
 import geomstats.backend as gs
 
 
+EPSILON = 1e-8
+
+
 def from_vector_to_diagonal_matrix(vector):
     """Create diagonal matrices from rows of a matrix.
 
@@ -21,3 +24,13 @@ def from_vector_to_diagonal_matrix(vector):
     identity = gs.cast(identity, vector.dtype)
     diagonals = gs.einsum('...i,ij->...ij', vector, identity)
     return diagonals
+
+
+def taylor_exp(point, taylor_coefs, function, order=7, tol=EPSILON):
+    return gs.where(
+        point < tol,
+        gs.einsum(
+            'k,k...->...',
+            gs.array(taylor_coefs[:order]),
+            gs.array([point ** k for k in range(order)])),
+        function(point))

--- a/geomstats/geometry/hypersphere.py
+++ b/geomstats/geometry/hypersphere.py
@@ -445,9 +445,9 @@ class HypersphereMetric(RiemannianMetric):
         norm2 = self.embedding_metric.squared_norm(proj_tangent_vec)
 
         coef_1 = utils.taylor_exp_even_func(
-            norm2, utils.COS_TAYLOR_COEFFS, gs.cos, order=4)
+            norm2, utils.cos_close_0, order=4)
         coef_2 = utils.taylor_exp_even_func(
-            norm2, utils.SINC_TAYLOR_COEFFS, lambda x: gs.sin(x) / x, order=4)
+            norm2, utils.sinc_close_0, order=4)
         exp = (gs.einsum('...,...j->...j', coef_1, base_point)
                + gs.einsum('...,...j->...j', coef_2, proj_tangent_vec))
 
@@ -474,11 +474,9 @@ class HypersphereMetric(RiemannianMetric):
         cos_angle = gs.clip(inner_prod, -1., 1.)
         squared_angle = gs.arccos(cos_angle) ** 2
         coef_1_ = utils.taylor_exp_even_func(
-            squared_angle, utils.INV_SINC_TAYLOR_COEFFS,
-            lambda x: x / gs.sin(x), order=5)
+            squared_angle, utils.inv_sinc_close_0, order=5)
         coef_2_ = utils.taylor_exp_even_func(
-            squared_angle, utils.INV_TANC_TAYLOR_COEFFS,
-            lambda x: x / gs.tan(x), order=5)
+            squared_angle, utils.inv_tanc_close_0, order=5)
         log = (gs.einsum('...,...j->...j', coef_1_, point)
                - gs.einsum('...,...j->...j', coef_2_, base_point))
 

--- a/geomstats/geometry/special_orthogonal.py
+++ b/geomstats/geometry/special_orthogonal.py
@@ -4,7 +4,6 @@ import geomstats.algebra_utils as utils
 import geomstats.backend as gs
 import geomstats.errors
 import geomstats.vectorization
-from geomstats import algebra_utils
 from geomstats.geometry.general_linear import GeneralLinear
 from geomstats.geometry.invariant_metric import BiInvariantMetric
 from geomstats.geometry.lie_group import LieGroup
@@ -14,14 +13,6 @@ from geomstats.geometry.symmetric_matrices import SymmetricMatrices
 
 ATOL = 1e-5
 
-TAYLOR_COEFFS_1_AT_0 = [1., 0.,
-                        - 1. / 12., 0.,
-                        - 1. / 720., 0.,
-                        - 1. / 30240., 0.]
-TAYLOR_COEFFS_2_AT_0 = [1. / 12., 0.,
-                        1. / 720., 0.,
-                        1. / 30240., 0.,
-                        1. / 1209600., 0.]
 TAYLOR_COEFFS_1_AT_PI = [0., - gs.pi / 4.,
                          - 1. / 4., - gs.pi / 48.,
                          - 1. / 48., - gs.pi / 480.,
@@ -252,7 +243,7 @@ class _SpecialOrthogonalVectors(LieGroup):
         diag = gs.concatenate((gs.ones(self.n - 1), -gs.ones(1)), axis=0)
         diag = gs.to_ndarray(diag, to_ndim=2)
         diag = gs.to_ndarray(
-            algebra_utils.from_vector_to_diagonal_matrix(diag),
+            utils.from_vector_to_diagonal_matrix(diag),
             to_ndim=3) + self.epsilon
         new_mat_diag_s = gs.tile(diag, [n_mats, 1, 1])
 
@@ -1601,14 +1592,9 @@ class _SpecialOrthogonal3Vectors(_SpecialOrthogonalVectors):
 
         angle = gs.sqrt(squared_angle)
         delta_angle = angle - gs.pi
-        approx_at_pi = (
-            TAYLOR_COEFFS_1_AT_PI[1] * delta_angle +
-            TAYLOR_COEFFS_1_AT_PI[2] * delta_angle ** 2 +
-            TAYLOR_COEFFS_1_AT_PI[3] * delta_angle ** 3 +
-            TAYLOR_COEFFS_1_AT_PI[4] * delta_angle ** 4 +
-            TAYLOR_COEFFS_1_AT_PI[5] * delta_angle ** 5 +
-            TAYLOR_COEFFS_1_AT_PI[6] * delta_angle ** 6)
-
+        approx_at_pi = gs.sum(gs.array([
+            TAYLOR_COEFFS_1_AT_PI[k] * delta_angle ** k for k in range(1, 7)
+        ]))
         coef_1 = utils.taylor_exp_even_func(
             squared_angle / 4, utils.inv_tanc_close_0)
         coef_1 = gs.where(

--- a/geomstats/geometry/special_orthogonal.py
+++ b/geomstats/geometry/special_orthogonal.py
@@ -1,5 +1,6 @@
 """Exposes the `SpecialOrthogonal` group class."""
 
+import geomstats.algebra_utils as utils
 import geomstats.backend as gs
 import geomstats.errors
 import geomstats.vectorization
@@ -621,7 +622,7 @@ class _SpecialOrthogonal3Vectors(_SpecialOrthogonalVectors):
         to be between 0 and pi, following the axis-angle
         representation's convention.
 
-        If the angle angle is between pi and 2pi,
+        If the angle is between pi and 2pi,
         the function computes its complementary in 2pi and
         inverts the direction of the rotation axis.
 
@@ -926,7 +927,6 @@ class _SpecialOrthogonal3Vectors(_SpecialOrthogonalVectors):
 
         return self.regularize(rot_vec)
 
-    @geomstats.vectorization.decorator(['else', 'vector'])
     def matrix_from_rotation_vector(self, rot_vec):
         """Convert rotation vector to rotation matrix.
 
@@ -942,40 +942,19 @@ class _SpecialOrthogonal3Vectors(_SpecialOrthogonalVectors):
         """
         rot_vec = self.regularize(rot_vec)
 
-        angle = gs.linalg.norm(rot_vec, axis=1)
-        angle = gs.to_ndarray(angle, to_ndim=2, axis=1)
-
+        squared_angle = gs.sum(rot_vec ** 2, axis=-1)
         skew_rot_vec = self.skew_matrix_from_vector(rot_vec)
 
-        coef_1 = gs.zeros_like(angle)
-        coef_2 = gs.zeros_like(angle)
+        coef_1 = utils.taylor_exp_even_func(squared_angle, utils.sinc_close_0)
+        coef_2 = utils.taylor_exp_even_func(squared_angle, utils.cosc_close_0)
 
-        # This avoids dividing by 0.
-        mask_0 = gs.isclose(angle, 0.)
-        mask_0_float = gs.cast(mask_0, gs.float32) + self.epsilon
-
-        coef_1 += mask_0_float * (1. - (angle ** 2) / 6.)
-        coef_2 += mask_0_float * (1. / 2. - angle ** 2)
-
-        # This avoids dividing by 0.
-        mask_else = ~mask_0
-        mask_else_float = gs.cast(mask_else, gs.float32) + self.epsilon
-
-        angle += mask_0_float
-
-        coef_1 += mask_else_float * (gs.sin(angle) / angle)
-        coef_2 += mask_else_float * (
-            (1. - gs.cos(angle)) / (angle ** 2))
-
-        coef_1 = gs.squeeze(coef_1, axis=1)
-        coef_2 = gs.squeeze(coef_2, axis=1)
         term_1 = (gs.eye(self.dim)
-                  + gs.einsum('n,njk->njk', coef_1, skew_rot_vec))
+                  + gs.einsum('...,...jk->...jk', coef_1, skew_rot_vec))
 
         squared_skew_rot_vec = gs.einsum(
-            'nij,njk->nik', skew_rot_vec, skew_rot_vec)
+            '...ij,...jk->...ik', skew_rot_vec, skew_rot_vec)
 
-        term_2 = gs.einsum('n,njk->njk', coef_2, squared_skew_rot_vec)
+        term_2 = gs.einsum('...,...jk->...jk', coef_2, squared_skew_rot_vec)
 
         return term_1 + term_2
 
@@ -1618,76 +1597,38 @@ class _SpecialOrthogonal3Vectors(_SpecialOrthogonalVectors):
             left_or_right, 'left_or_right', ['left', 'right'])
 
         point = self.regularize(point)
-        point = gs.to_ndarray(point, to_ndim=2)
-        n_points, _ = point.shape
+        squared_angle = gs.sum(point ** 2, axis=-1)
 
-        angle = gs.linalg.norm(point, axis=-1)
-        angle = gs.expand_dims(angle, axis=-1)
-
-        coef_1 = gs.zeros([n_points, 1])
-        coef_2 = gs.zeros([n_points, 1])
-
-        # This avoids dividing by 0.
-        mask_0 = gs.isclose(angle, 0.)
-        mask_0_float = gs.cast(mask_0, gs.float32) + self.epsilon
-
-        coef_1 += mask_0_float * (
-            TAYLOR_COEFFS_1_AT_0[0]
-            + TAYLOR_COEFFS_1_AT_0[2] * angle ** 2
-            + TAYLOR_COEFFS_1_AT_0[4] * angle ** 4
-            + TAYLOR_COEFFS_1_AT_0[6] * angle ** 6)
-
-        coef_2 += mask_0_float * (
-            TAYLOR_COEFFS_2_AT_0[0]
-            + TAYLOR_COEFFS_2_AT_0[2] * angle ** 2
-            + TAYLOR_COEFFS_2_AT_0[4] * angle ** 4
-            + TAYLOR_COEFFS_2_AT_0[6] * angle ** 6)
-
-        # This avoids dividing by 0.
-        mask_pi = gs.isclose(angle, gs.pi)
-        mask_pi_float = gs.cast(mask_pi, gs.float32) + self.epsilon
-
+        angle = gs.sqrt(squared_angle)
         delta_angle = angle - gs.pi
-        coef_1 += mask_pi_float * (
-            TAYLOR_COEFFS_1_AT_PI[1] * delta_angle
-            + TAYLOR_COEFFS_1_AT_PI[2] * delta_angle ** 2
-            + TAYLOR_COEFFS_1_AT_PI[3] * delta_angle ** 3
-            + TAYLOR_COEFFS_1_AT_PI[4] * delta_angle ** 4
-            + TAYLOR_COEFFS_1_AT_PI[5] * delta_angle ** 5
-            + TAYLOR_COEFFS_1_AT_PI[6] * delta_angle ** 6)
+        approx_at_pi = (
+            TAYLOR_COEFFS_1_AT_PI[1] * delta_angle +
+            TAYLOR_COEFFS_1_AT_PI[2] * delta_angle ** 2 +
+            TAYLOR_COEFFS_1_AT_PI[3] * delta_angle ** 3 +
+            TAYLOR_COEFFS_1_AT_PI[4] * delta_angle ** 4 +
+            TAYLOR_COEFFS_1_AT_PI[5] * delta_angle ** 5 +
+            TAYLOR_COEFFS_1_AT_PI[6] * delta_angle ** 6)
 
-        angle += mask_0_float
-        coef_2 += mask_pi_float * ((1 - coef_1) / angle ** 2)
+        coef_1 = utils.taylor_exp_even_func(
+            squared_angle / 4, utils.inv_tanc_close_0)
+        coef_1 = gs.where(
+            -delta_angle < utils.EPSILON, approx_at_pi, coef_1)
 
-        # This avoids dividing by 0.
-        mask_else = ~mask_0 & ~mask_pi
-        mask_else_float = gs.cast(mask_else, gs.float32) + self.epsilon
+        coef_2 = utils.taylor_exp_even_func(
+            squared_angle, utils.var_inv_tanc_close_0, order=4)
+        squared_angle_ = gs.where(
+            squared_angle < utils.EPSILON, utils.EPSILON, squared_angle)
+        coef_2 = gs.where(
+            squared_angle < utils.EPSILON,
+            coef_2, (1 - coef_1) / squared_angle_)
 
-        # This avoids division by 0.
-        angle += mask_pi_float
-        coef_1 += mask_else_float * ((angle / 2) / gs.tan(angle / 2))
-        coef_2 += mask_else_float * ((1 - coef_1) / angle ** 2)
-        jacobian = gs.zeros((n_points, self.dim, self.dim))
-        n_points_tensor = gs.array(n_points)
-        for i in range(n_points):
-            # This avoids dividing by 0.
-            mask_i_float = (
-                gs.get_mask_i_float(i, n_points_tensor)
-                + self.epsilon)
+        outer_ = gs.einsum('...i,...j->...ij', point, point)
+        sign = - 1. if left_or_right == 'right' else 1.
 
-            sign = - 1.
-            if left_or_right == 'left':
-                sign = + 1.
-
-            jacobian_i = (
-                coef_1[i] * gs.eye(self.dim)
-                + coef_2[i] * gs.outer(point[i], point[i])
-                + sign * self.skew_matrix_from_vector(point[i]) / 2.)
-
-            jacobian += gs.einsum('n,ij->nij', mask_i_float, jacobian_i)
-
-        return jacobian[0] if (len(point) == 1 or point.ndim == 1) \
-            else jacobian
+        return (
+            gs.einsum('...,...ij->...ij', coef_1, gs.eye(self.dim))
+            + gs.einsum('...,...ij->...ij', coef_2, outer_)
+            + sign * self.skew_matrix_from_vector(point) / 2.)
 
     def random_uniform(self, n_samples=1):
         """Sample in SO(3) with the uniform distribution.

--- a/tests/test_algebra_utils.py
+++ b/tests/test_algebra_utils.py
@@ -1,0 +1,33 @@
+import math
+
+import geomstats.algebra_utils as utils
+import geomstats.backend as gs
+import geomstats.tests
+
+
+class TestTaylorExp(geomstats.tests.TestCase):
+    def setUp(self):
+        self.functions = [
+            math.cos,
+            lambda x: math.sin(x) / x,
+            lambda x: x / math.sin(x),
+            lambda x: x / math.tan(x)]
+        self.coefs = [
+            utils.COS_TAYLOR_COEFFS,
+            utils.SINC_TAYLOR_COEFFS,
+            utils.INV_SINC_TAYLOR_COEFFS,
+            utils.INV_TANC_TAYLOR_COEFFS]
+        self.names = [
+            'cos',
+            'sinc',
+            'inv_sinc',
+            'inv_tanc']
+
+    def test_all(self):
+        for function, coef, name in zip(
+                self.functions, self.coefs, self.names):
+            for exponent in range(2, 10, 2):
+                x = 10 ** (-exponent)
+                result = utils.taylor_exp_even_func(x, coef, function, order=5)
+                expected = function(gs.sqrt(x))
+                self.assertAllClose(result, expected, atol=1e-15)

--- a/tests/test_algebra_utils.py
+++ b/tests/test_algebra_utils.py
@@ -1,5 +1,6 @@
+import math
+
 import geomstats.algebra_utils as utils
-import geomstats.backend as gs
 import geomstats.tests
 
 
@@ -9,14 +10,17 @@ class TestTaylorExp(geomstats.tests.TestCase):
             utils.cos_close_0,
             utils.sinc_close_0,
             utils.inv_sinc_close_0,
-            utils.inv_tanc_close_0]
+            utils.inv_tanc_close_0,
+            utils.cosc_close_0]
+        self.functions[4]['function'] = lambda x: (1 - math.cos(x)) / x ** 2
+        # self.functions[5]['function'] = (
+        #     lambda x: (1 - (x / math.tan(x))) / x ** 2)
 
     def test_all(self):
-        for taylor_function, coef in zip(
-                self.functions, self.coefs):
-            for exponent in range(2, 10, 2):
+        for taylor_function in self.functions:
+            for exponent in range(4, 12, 2):
                 x = 10 ** (-exponent)
+                expected = taylor_function['function'](math.sqrt(x))
                 result = utils.taylor_exp_even_func(
-                    x, taylor_function, order=5)
-                expected = taylor_function['function'](gs.sqrt(x))
+                    x, taylor_function, order=4)
                 self.assertAllClose(result, expected, atol=1e-15)

--- a/tests/test_algebra_utils.py
+++ b/tests/test_algebra_utils.py
@@ -1,5 +1,3 @@
-import math
-
 import geomstats.algebra_utils as utils
 import geomstats.backend as gs
 import geomstats.tests
@@ -8,26 +6,17 @@ import geomstats.tests
 class TestTaylorExp(geomstats.tests.TestCase):
     def setUp(self):
         self.functions = [
-            math.cos,
-            lambda x: math.sin(x) / x,
-            lambda x: x / math.sin(x),
-            lambda x: x / math.tan(x)]
-        self.coefs = [
-            utils.COS_TAYLOR_COEFFS,
-            utils.SINC_TAYLOR_COEFFS,
-            utils.INV_SINC_TAYLOR_COEFFS,
-            utils.INV_TANC_TAYLOR_COEFFS]
-        self.names = [
-            'cos',
-            'sinc',
-            'inv_sinc',
-            'inv_tanc']
+            utils.cos_close_0,
+            utils.sinc_close_0,
+            utils.inv_sinc_close_0,
+            utils.inv_tanc_close_0]
 
     def test_all(self):
-        for function, coef, name in zip(
-                self.functions, self.coefs, self.names):
+        for taylor_function, coef in zip(
+                self.functions, self.coefs):
             for exponent in range(2, 10, 2):
                 x = 10 ** (-exponent)
-                result = utils.taylor_exp_even_func(x, coef, function, order=5)
-                expected = function(gs.sqrt(x))
+                result = utils.taylor_exp_even_func(
+                    x, taylor_function, order=5)
+                expected = taylor_function['function'](gs.sqrt(x))
                 self.assertAllClose(result, expected, atol=1e-15)

--- a/tests/test_algebra_utils.py
+++ b/tests/test_algebra_utils.py
@@ -13,8 +13,6 @@ class TestTaylorExp(geomstats.tests.TestCase):
             utils.inv_tanc_close_0,
             utils.cosc_close_0]
         self.functions[4]['function'] = lambda x: (1 - math.cos(x)) / x ** 2
-        # self.functions[5]['function'] = (
-        #     lambda x: (1 - (x / math.tan(x))) / x ** 2)
 
     def test_all(self):
         for taylor_function in self.functions:

--- a/tests/test_hypersphere.py
+++ b/tests/test_hypersphere.py
@@ -296,7 +296,7 @@ class TestHypersphere(geomstats.tests.TestCase):
         # Edge case: tangent vector has norm < epsilon
         base_point = gs.array([10., -2., -.5, 34., 3.])
         base_point = base_point / gs.linalg.norm(base_point)
-        vector = 1e-10 * gs.array([.06, -51., 6., 5., 3.])
+        vector = 1e-9 * gs.array([.06, -51., 6., 5., 3.])
         vector = self.space.to_tangent(
             vector=vector, base_point=base_point)
 
@@ -304,7 +304,6 @@ class TestHypersphere(geomstats.tests.TestCase):
         result = self.metric.log(point=exp, base_point=base_point)
         expected = self.space.to_tangent(
             vector=vector, base_point=base_point)
-
         self.assertAllClose(result, expected, atol=1e-8)
 
     def test_squared_norm_and_squared_dist(self):
@@ -503,6 +502,7 @@ class TestHypersphere(geomstats.tests.TestCase):
             initial_point=initial_point[:2],
             end_point=initial_point[2:])
         t = gs.linspace(start=0., stop=1., num=n_geodesic_points)
+        print(t)
         points = geodesic(t)
         result = points[-1]
         expected = initial_point[2:]

--- a/tests/test_hypersphere.py
+++ b/tests/test_hypersphere.py
@@ -148,7 +148,6 @@ class TestHypersphere(geomstats.tests.TestCase):
         point = point / gs.linalg.norm(point)
 
         log = self.metric.log(point=point, base_point=base_point)
-        print(log == base_point - point)
         result = self.metric.exp(tangent_vec=log, base_point=base_point)
         expected = point
 

--- a/tests/test_hypersphere.py
+++ b/tests/test_hypersphere.py
@@ -144,10 +144,11 @@ class TestHypersphere(geomstats.tests.TestCase):
         base_point = gs.array([1., 2., 3., 4., 6.])
         base_point = base_point / gs.linalg.norm(base_point)
         point = (base_point
-                 + 1e-12 * gs.array([-1., -2., 1., 1., .1]))
+                 + 1e-4 * gs.array([-1., -2., 1., 1., .1]))
         point = point / gs.linalg.norm(point)
 
         log = self.metric.log(point=point, base_point=base_point)
+        print(log == base_point - point)
         result = self.metric.exp(tangent_vec=log, base_point=base_point)
         expected = point
 
@@ -245,6 +246,21 @@ class TestHypersphere(geomstats.tests.TestCase):
         result = self.metric.log(n_points, n_base_points)
         self.assertAllClose(gs.shape(result), (n_samples, dim))
 
+    def test_exp_log_are_inverse(self):
+        initial_point = self.space.random_uniform(2)
+        end_point = self.space.random_uniform(2)
+        vec = self.space.metric.log(point=end_point, base_point=initial_point)
+        result = self.space.metric.exp(vec, initial_point)
+        self.assertAllClose(end_point, result)
+
+    def test_log_extreme_case(self):
+        initial_point = self.space.random_uniform(2)
+        vec = 1e-4 * gs.random.rand(*initial_point.shape)
+        vec = self.space.to_tangent(vec, initial_point)
+        point = self.space.metric.exp(vec, base_point=initial_point)
+        result = self.space.metric.log(point, initial_point)
+        self.assertAllClose(vec, result)
+
     def test_exp_and_log_and_projection_to_tangent_space_general_case(self):
         """Test Log and Exp.
 
@@ -296,15 +312,13 @@ class TestHypersphere(geomstats.tests.TestCase):
         # Edge case: tangent vector has norm < epsilon
         base_point = gs.array([10., -2., -.5, 34., 3.])
         base_point = base_point / gs.linalg.norm(base_point)
-        vector = 1e-9 * gs.array([.06, -51., 6., 5., 3.])
+        vector = 1e-4 * gs.array([.06, -51., 6., 5., 3.])
         vector = self.space.to_tangent(
             vector=vector, base_point=base_point)
 
         exp = self.metric.exp(tangent_vec=vector, base_point=base_point)
         result = self.metric.log(point=exp, base_point=base_point)
-        expected = self.space.to_tangent(
-            vector=vector, base_point=base_point)
-        self.assertAllClose(result, expected, atol=1e-8)
+        self.assertAllClose(result, vector, atol=1e-7)
 
     def test_squared_norm_and_squared_dist(self):
         """
@@ -502,7 +516,6 @@ class TestHypersphere(geomstats.tests.TestCase):
             initial_point=initial_point[:2],
             end_point=initial_point[2:])
         t = gs.linspace(start=0., stop=1., num=n_geodesic_points)
-        print(t)
         points = geodesic(t)
         result = points[-1]
         expected = initial_point[2:]

--- a/tests/test_product_manifold.py
+++ b/tests/test_product_manifold.py
@@ -61,7 +61,7 @@ class TestProductManifold(geomstats.tests.TestCase):
         base_point = self.space_matrix.random_uniform(n_samples)
         logs = self.space_matrix.metric.log(expected, base_point)
         result = self.space_matrix.metric.exp(logs, base_point)
-        self.assertAllClose(result, expected)
+        self.assertAllClose(result, expected, atol=1e-5)
 
     @geomstats.tests.np_only
     def test_dist_log_exp_norm_vector(self):


### PR DESCRIPTION
This PR factorizes Taylor approximations around 0. This avoids the use of masks, assignments and calls to to_ndarray, and thus should improve readability of the code. Furthermore, the accuracy should be slightly improved as:
```python
import geomstats.backend as gs
from geomstats.geometry.hypersphere import Hypersphere
space = Hypersphere(2)
base_point = space.random_uniform()
vect = space.to_tangent(gs.array([1.0, 0, 0]), base_point)
point = space.metric.exp(1e-6 * vect, base_point)
log = space.metric.log(point, base_point)
```
currently returns log=0. It is not longer the case with this factorization, and even works for much smaller vectors. The same could be applied to hyperbolic geometry and the special euclidean group in a future PR.