### PR TITLE
Visualization H2

### DIFF
--- a/geomstats/geometry/normal_distributions.py
+++ b/geomstats/geometry/normal_distributions.py
@@ -9,36 +9,14 @@ from geomstats.geometry.poincare_half_space import PoincareHalfSpaceMetric
 
 
 class NormalDistributions(PoincareHalfSpace):
-    """Class for the manifold of normal distributions.
+    """Class for the manifold of univariate normal distributions.
 
-    This is upper half-pane.
+    This is upper half-plane.
     """
 
     def __init__(self):
         super(NormalDistributions, self).__init__(dim=2)
         self.metric = FisherRaoMetric()
-
-    def belongs(self, point):
-        """Evaluate if a point belongs to the manifold of normal distributions.
-
-        The statistical manifold of normal distributions is the upper
-        half plane.
-
-        Parameters
-        ----------
-        point : array-like, shape=[..., 2]
-            Point to be checked.
-
-        Returns
-        -------
-        belongs : array-like, shape=[...,]
-            Boolean indicating whether point represents a normal
-            distribution.
-        """
-        point_dim = point.shape[-1]
-        belongs = point_dim == self.dim
-        belongs = gs.logical_and(belongs, gs.all(point[..., -1] > 0))
-        return belongs
 
     @staticmethod
     def random_uniform(n_samples=1, bound=5.):
@@ -62,7 +40,7 @@ class NormalDistributions(PoincareHalfSpace):
         """
         means = -bound + 2 * bound * gs.random.rand(n_samples)
         stds = bound * gs.random.rand(n_samples)
-        return gs.transpose(gs.vstack((means, stds)))
+        return gs.transpose(gs.stack((means, stds)))
 
     def sample(self, point, n_samples=1):
         """Sample from the normal distribution.

--- a/geomstats/geometry/normal_distributions.py
+++ b/geomstats/geometry/normal_distributions.py
@@ -1,0 +1,102 @@
+"""Statistical Manifold of normal distributions with the Fisher metric."""
+
+from scipy.stats import norm
+
+import geomstats.backend as gs
+import geomstats.errors
+from geomstats.geometry.poincare_half_space import PoincareHalfSpace
+from geomstats.geometry.poincare_half_space import PoincareHalfSpaceMetric
+
+
+class NormalDistributions(PoincareHalfSpace):
+    """Class for the manifold of normal distributions.
+
+    This is upper half-pane.
+    """
+
+    def __init__(self):
+        super(NormalDistributions, self).__init__(dim=2)
+        self.metric = FisherRaoMetric()
+
+    def belongs(self, point):
+        """Evaluate if a point belongs to the manifold of normal distributions.
+
+        The statistical manifold of normal distributions is the upper
+        half plane.
+
+        Parameters
+        ----------
+        point : array-like, shape=[..., 2]
+            Point to be checked.
+
+        Returns
+        -------
+        belongs : array-like, shape=[...,]
+            Boolean indicating whether point represents a normal
+            distribution.
+        """
+        point_dim = point.shape[-1]
+        belongs = point_dim == self.dim
+        belongs = gs.logical_and(belongs, gs.all(point[..., -1] > 0))
+        return belongs
+
+    @staticmethod
+    def random_uniform(n_samples=1, bound=5.):
+        """Sample parameters of normal distributions.
+
+        The uniform distribution on [-bound/2, bound/2]x[0, bound] is used.
+
+        Parameters
+        ----------
+        n_samples : int
+            Number of samples.
+            Optional, default: 1.
+        bound : float
+            Side of the square where the normal parameters are sampled.
+            Optional, default: 5.
+
+        Returns
+        -------
+        samples : array-like, shape=[..., 2]
+            Sample of points representing normal distributions.
+        """
+        means = -bound + 2 * bound * gs.random.rand(n_samples)
+        stds = bound * gs.random.rand(n_samples)
+        return gs.transpose(gs.vstack((means, stds)))
+
+    def sample(self, point, n_samples=1):
+        """Sample from the normal distribution.
+
+        Sample from the normal distribution with parameters provided
+        by point.
+
+        Parameters
+        ----------
+        point : array-like, shape=[..., 2]
+            Point representing a normal distribution (location and scale).
+        n_samples : int
+            Number of points to sample with each pair of parameters in point.
+            Optional, default: 1.
+
+        Returns
+        -------
+        samples : array-like, shape=[..., n_samples]
+            Sample from normal distributions.
+        """
+        geomstats.errors.check_belongs(point, self)
+        point = gs.to_ndarray(point, to_ndim=2)
+        samples = []
+        for loc, scale in point:
+            samples.append(gs.array(
+                norm.rvs(loc, scale, size=n_samples)))
+        return samples[0] if len(point) == 1 else gs.stack(samples)
+
+
+class FisherRaoMetric(PoincareHalfSpaceMetric):
+    """Class for the Fisher information metric on normal distributions.
+
+    This is the metric of the Poincare upper half-plane.
+    """
+
+    def __init__(self):
+        super(FisherRaoMetric, self).__init__(dim=2)

--- a/geomstats/geometry/poincare_half_space.py
+++ b/geomstats/geometry/poincare_half_space.py
@@ -36,23 +36,26 @@ class PoincareHalfSpace(Hyperbolic):
         self.metric = PoincareHalfSpaceMetric(self.dim, self.scale)
 
     def belongs(self, point):
-        """Test if a point belongs to the hyperbolic space.
+        """Evaluate if a point belongs to the manifold of normal distributions.
 
-        Test if a point belongs to the hyperbolic space based on
-        the poincare ball representation.
+        The statistical manifold of normal distributions is the upper
+        half plane.
 
         Parameters
         ----------
-        point : array-like, shape=[..., dim]
-            Point to be tested.
+        point : array-like, shape=[..., 2]
+            Point to be checked.
 
         Returns
         -------
         belongs : array-like, shape=[...,]
-            Array of booleans indicating whether the corresponding points
-            belong to the hyperbolic space.
+            Boolean indicating whether point represents a normal
+            distribution.
         """
-        return point[..., -1] > 0
+        point_dim = point.shape[-1]
+        belongs = point_dim == self.dim
+        belongs = gs.logical_and(belongs, point[..., -1] > 0)
+        return belongs
 
 
 class PoincareHalfSpaceMetric(RiemannianMetric):

--- a/tests/test_normal_distributions.py
+++ b/tests/test_normal_distributions.py
@@ -1,0 +1,60 @@
+"""Unit tests for the manifold of normal distributions."""
+
+import warnings
+
+import geomstats.backend as gs
+import geomstats.tests
+from geomstats.geometry.normal_distributions import FisherRaoMetric
+from geomstats.geometry.normal_distributions import NormalDistributions
+
+
+class TestNormalDistributions(geomstats.tests.TestCase):
+    def setUp(self):
+        warnings.simplefilter('ignore', category=UserWarning)
+        self.normal = NormalDistributions()
+        self.metric = FisherRaoMetric()
+        self.n_samples = 10
+        self.dim = self.normal.dim
+
+    def test_random_uniform_and_belongs(self):
+        """Test random_uniform and belongs.
+
+        Test that the random uniform method samples
+        on the normal distribution space.
+        """
+        point = self.normal.random_uniform()
+        result = self.normal.belongs(point)
+        expected = True
+        self.assertAllClose(expected, result)
+
+    def test_random_uniform_and_belongs_vectorization(self):
+        """Test random_uniform and belongs.
+
+        Test that the random uniform method samples
+        on the normal distribution space.
+        """
+        n_samples = self.n_samples
+        point = self.normal.random_uniform(n_samples)
+        result = self.normal.belongs(point)
+        expected = gs.array([True] * n_samples)
+        self.assertAllClose(expected, result)
+
+    def test_random_uniform(self):
+        """Test random_uniform.
+
+        Test that the random uniform method samples points of the right shape
+        """
+        point = self.normal.random_uniform(self.n_samples)
+        self.assertAllClose(gs.shape(point), (self.n_samples, self.dim))
+
+    def test_sample(self):
+        """Test samples.
+        """
+        n_points = self.n_samples
+        n_samples = 100
+        points = self.normal.random_uniform(n_points)
+        samples = self.normal.sample(points, n_samples)
+        result = samples.shape
+        expected = (n_points, n_samples)
+
+        self.assertAllClose(result, expected)


### PR DESCRIPTION
Authorize points to be given in Poincare half plane coordinates in ```visualization``` for ```space=H2_poincare_half_plane```, and make it the default representation, instead of the extrinsic coordinates. I would be in favour of doing the same for the other representations, as I think it is more natural for the user to give the points' coordinates in the appropriate representation.