### PR TITLE
Fix tangent PCA with pytorch

### DIFF
--- a/geomstats/_backend/pytorch/linalg.py
+++ b/geomstats/_backend/pytorch/linalg.py
@@ -39,8 +39,14 @@ def eigh(*args, **kwargs):
     return eigvals, eigvecs
 
 
-def svd(*args, full_matrices=True, **kwargs):
-    return torch.svd(*args, some=not full_matrices, **kwargs)
+def svd(x, full_matrices=True, compute_uv=True):
+    is_vectorized = x.ndim == 3
+    axis = (0, 2, 1) if is_vectorized else (1, 0)
+    if compute_uv:
+        u, s, v_t = torch.svd(
+            x, some=not full_matrices, compute_uv=compute_uv)
+        return u, s, v_t.permute(axis)
+    return torch.svd(x, some=not full_matrices, compute_uv=compute_uv)[1]
 
 
 def det(*args, **kwargs):

--- a/geomstats/_backend/pytorch/linalg.py
+++ b/geomstats/_backend/pytorch/linalg.py
@@ -39,11 +39,8 @@ def eigh(*args, **kwargs):
     return eigvals, eigvecs
 
 
-def svd(*args, **kwargs):
-    svds = np.linalg.svd(*args, **kwargs)
-    return (torch.from_numpy(svds[0]),
-            torch.from_numpy(svds[1]),
-            torch.from_numpy(svds[2]))
+def svd(*args, full_matrices=True, **kwargs):
+    return torch.svd(*args, some=not full_matrices, **kwargs)
 
 
 def det(*args, **kwargs):

--- a/geomstats/_backend/tensorflow/linalg.py
+++ b/geomstats/_backend/tensorflow/linalg.py
@@ -30,10 +30,11 @@ def logm(x):
     return tf_logm
 
 
-def svd(x):
+def svd(x, full_matrices=True, compute_uv=True, **kwargs):
     is_vectorized = x.ndim == 3
     axis = (0, 2, 1) if is_vectorized else (1, 0)
-    s, u, v_t = tf.linalg.svd(x, full_matrices=True)
+    s, u, v_t = tf.linalg.svd(
+        x, full_matrices=full_matrices, compute_uv=compute_uv)
     return u, s, tf.transpose(v_t, perm=axis)
 
 

--- a/geomstats/_backend/tensorflow/linalg.py
+++ b/geomstats/_backend/tensorflow/linalg.py
@@ -33,9 +33,11 @@ def logm(x):
 def svd(x, full_matrices=True, compute_uv=True, **kwargs):
     is_vectorized = x.ndim == 3
     axis = (0, 2, 1) if is_vectorized else (1, 0)
-    s, u, v_t = tf.linalg.svd(
-        x, full_matrices=full_matrices, compute_uv=compute_uv)
-    return u, s, tf.transpose(v_t, perm=axis)
+    if compute_uv:
+        s, u, v_t = tf.linalg.svd(
+            x, full_matrices=full_matrices, compute_uv=compute_uv)
+        return u, s, tf.transpose(v_t, perm=axis)
+    return tf.linalg.svd(x, compute_uv=compute_uv)
 
 
 def qr(*args, mode='reduced'):

--- a/geomstats/geometry/matrices.py
+++ b/geomstats/geometry/matrices.py
@@ -127,6 +127,12 @@ class Matrices(Manifold):
         axes = (0, 2, 1) if is_vectorized else (1, 0)
         return gs.transpose(mat, axes)
 
+    @staticmethod
+    def is_square(mat):
+        n = mat.shape[-1]
+        m = mat.shape[-2]
+        return m == n
+
     @classmethod
     def is_symmetric(cls, mat, atol=TOLERANCE):
         """Check if a matrix is symmetric.
@@ -144,6 +150,10 @@ class Matrices(Manifold):
         is_sym : array-like, shape=[...,]
             Boolean evaluating if the matrix is symmetric.
         """
+        is_square = cls.is_square(mat)
+        if not is_square:
+            is_vectorized = (gs.ndim(gs.array(mat)) == 3)
+            return gs.array([False] * len(mat)) if is_vectorized else False
         return cls.equal(mat, cls.transpose(mat), atol)
 
     @classmethod

--- a/geomstats/geometry/matrices.py
+++ b/geomstats/geometry/matrices.py
@@ -129,6 +129,18 @@ class Matrices(Manifold):
 
     @staticmethod
     def is_square(mat):
+        """Check if a matrix is square.
+
+        Parameters
+        ----------
+        mat : array-like, shape=[..., m, n]
+            Matrix.
+
+        Returns
+        -------
+        is_square : array-like, shape=[...,]
+            Boolean evaluating if the matrix is square.
+        """
         n = mat.shape[-1]
         m = mat.shape[-2]
         return m == n

--- a/geomstats/learning/pca.py
+++ b/geomstats/learning/pca.py
@@ -184,14 +184,14 @@ class TangentPCA(_BasePCA):
         tangent_vecs = self.metric.log(X, base_point=self.base_point_fit)
         if self.point_type == 'matrix':
             if Matrices.is_symmetric(tangent_vecs).all():
-                X = SymmetricMatrices.to_vector(
-                    tangent_vecs)
+                X = SymmetricMatrices.to_vector(tangent_vecs)
             else:
                 X = gs.reshape(tangent_vecs, (len(X), - 1))
         else:
             X = tangent_vecs
-
-        return super(TangentPCA, self).transform(X)
+        X = X - self.mean_
+        X_transformed = gs.matmul(X, gs.transpose(self.components_))
+        return X_transformed
 
     def inverse_transform(self, X):
         """Low-dimensional reconstruction of X.
@@ -256,9 +256,6 @@ class TangentPCA(_BasePCA):
         else:
             X = tangent_vecs
 
-        X = check_array(X, dtype=[gs.float64, gs.float32], ensure_2d=True,
-                        copy=self.copy)
-
         if self.n_components is None:
             n_components = min(X.shape)
         else:
@@ -285,7 +282,7 @@ class TangentPCA(_BasePCA):
         self.mean_ = gs.mean(X, axis=0)
         X -= self.mean_
 
-        U, S, V = linalg.svd(X, full_matrices=False)
+        U, S, V = gs.linalg.svd(X, full_matrices=False)
         # flip eigenvectors' sign to enforce deterministic output
         U, V = svd_flip(U, V)
 
@@ -295,7 +292,7 @@ class TangentPCA(_BasePCA):
         explained_variance_ = (S ** 2) / (n_samples - 1)
         total_var = explained_variance_.sum()
         explained_variance_ratio_ = explained_variance_ / total_var
-        singular_values_ = S.copy()  # Store the singular values.
+        singular_values_ = gs.copy(S)  # Store the singular values.
 
         # Postprocess the number of components required
         if n_components == 'mle':

--- a/geomstats/learning/pca.py
+++ b/geomstats/learning/pca.py
@@ -3,12 +3,10 @@
 import numbers
 from math import log
 
-from scipy import linalg
 from scipy.special import gammaln
 from sklearn.decomposition._base import _BasePCA
 from sklearn.utils.extmath import stable_cumsum
 from sklearn.utils.extmath import svd_flip
-from sklearn.utils.validation import check_array
 
 import geomstats.backend as gs
 from geomstats.geometry.matrices import Matrices

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -9,7 +9,6 @@ import warnings
 import numpy as _np
 import scipy.linalg
 
-import geomstats.algebra_utils as utils
 import geomstats.backend as gs
 import geomstats.tests
 from geomstats.geometry.special_orthogonal import SpecialOrthogonal

--- a/tests/test_matrices.py
+++ b/tests/test_matrices.py
@@ -65,10 +65,13 @@ class TestMatrices(geomstats.tests.TestCase):
         self.assertAllClose(tr(a), b)
         self.assertAllClose(tr(ar([a, b])), ar([b, a]))
 
-    @geomstats.tests.np_only
     def test_is_symmetric(self):
-        sym_mat = gs.array([[1., 2.],
-                            [2., 1.]])
+        not_squared = gs.array([[1., 2.], [2., 1.], [3., 1.]])
+        result = self.space.is_symmetric(not_squared)
+        expected = False
+        self.assertAllClose(result, expected)
+
+        sym_mat = gs.array([[1., 2.], [2., 1.]])
         result = self.space.is_symmetric(sym_mat)
         expected = gs.array(True)
         self.assertAllClose(result, expected)


### PR DESCRIPTION
Address #861 

Use native SVD of each back-end
remove check array from sklearn because it returns a numpy array, whichever backend
Works with pytorch but not tensorflow because of another sklearn function.