### PR TITLE
Visualisation on SE(2) and Canonical left-invariant metric

### DIFF
--- a/examples/plot_geodesics_se2.py
+++ b/examples/plot_geodesics_se2.py
@@ -14,6 +14,7 @@ from geomstats.geometry.special_euclidean import SpecialEuclidean
 SE2_GROUP = SpecialEuclidean(n=2, point_type='matrix')
 N_STEPS = 40
 METRIC = SE2_GROUP.left_canonical_metric
+SE2_VEC = SpecialEuclidean(n=2, point_type='vector')
 
 
 def main():
@@ -28,12 +29,20 @@ def main():
     group_geo_points = SE2_GROUP.exp(tangent_vec)
     left_geo_points = METRIC.exp(tangent_vec)
 
+    initial_right_vec = gs.array([-theta, 2, 2])
+    right_vec = gs.einsum('t, i-> ti', t, initial_right_vec)
+    right_geo_points = SE2_VEC.right_canonical_metric.exp(right_vec)
+    right_points = SE2_VEC.matrix_from_vector(right_geo_points)
+
     ax = visualization.plot(
         group_geo_points, space='SE2_GROUP', color='black',
         label='Group Geodesics')
     ax = visualization.plot(
         left_geo_points, ax=ax, space='SE2_GROUP', color='green',
         label='Left Geodesics')
+    ax = visualization.plot(
+        right_points, ax=ax, space='SE2_GROUP', color='yellow',
+        label='Right Geodesics')
     ax.set_aspect('equal')
     plt.legend(loc='lower right')
     plt.show()

--- a/examples/plot_geodesics_se2.py
+++ b/examples/plot_geodesics_se2.py
@@ -1,0 +1,35 @@
+"""Plot a geodesic of SE(2).
+
+SE2 is equipped canonical Cartan-Shouten connection. The geodesics correspond
+to one-parameter subgroups.
+"""
+
+import matplotlib.pyplot as plt
+
+import geomstats.backend as gs
+import geomstats.visualization as visualization
+from geomstats.geometry.special_euclidean import SpecialEuclidean
+
+SE2_GROUP = SpecialEuclidean(n=2, point_type='matrix')
+N_STEPS = 40
+
+
+def main():
+    """Plot a geodesic on SE2."""
+    theta = gs.pi / 3
+    initial_tangent_vec = gs.array([
+        [0., - theta, 2.],
+        [theta, 0., 3.],
+        [0., 0., 0.]])
+    t = gs.linspace(-3., 3., N_STEPS)
+    tangent_vec = gs.einsum('t,ij->tij', t, initial_tangent_vec)
+    points = SE2_GROUP.exp(tangent_vec)
+
+    ax = visualization.plot(points, space='SE2_GROUP', color='black')
+    ax.set_aspect('equal')
+    plt.show()
+
+
+if __name__ == '__main__':
+    main()
+

--- a/examples/plot_geodesics_se2.py
+++ b/examples/plot_geodesics_se2.py
@@ -1,7 +1,8 @@
 """Plot a geodesic of SE(2).
 
-SE2 is equipped canonical Cartan-Shouten connection. The geodesics correspond
-to one-parameter subgroups.
+SE2 is equipped with both the canonical Cartan-Shouten connection,
+whose geodesics are the group geodesics, i.e. one parameter subgroups and the
+left invariant canonical metric.
 """
 
 import matplotlib.pyplot as plt
@@ -12,21 +13,29 @@ from geomstats.geometry.special_euclidean import SpecialEuclidean
 
 SE2_GROUP = SpecialEuclidean(n=2, point_type='matrix')
 N_STEPS = 40
+METRIC = SE2_GROUP.left_canonical_metric
 
 
 def main():
-    """Plot a geodesic on SE2."""
+    """Plot a group geodesic on SE2."""
     theta = gs.pi / 3
     initial_tangent_vec = gs.array([
         [0., - theta, 2.],
-        [theta, 0., 3.],
+        [theta, 0., 2.],
         [0., 0., 0.]])
-    t = gs.linspace(-3., 3., N_STEPS)
+    t = gs.linspace(-3., 3., N_STEPS + 1)
     tangent_vec = gs.einsum('t,ij->tij', t, initial_tangent_vec)
-    points = SE2_GROUP.exp(tangent_vec)
+    group_geo_points = SE2_GROUP.exp(tangent_vec)
+    left_geo_points = METRIC.exp(tangent_vec)
 
-    ax = visualization.plot(points, space='SE2_GROUP', color='black')
+    ax = visualization.plot(
+        group_geo_points, space='SE2_GROUP', color='black',
+        label='Group Geodesics')
+    ax = visualization.plot(
+        left_geo_points, ax=ax, space='SE2_GROUP', color='green',
+        label='Left Geodesics')
     ax.set_aspect('equal')
+    plt.legend(loc='lower right')
     plt.show()
 
 

--- a/examples/plot_geodesics_se2.py
+++ b/examples/plot_geodesics_se2.py
@@ -17,7 +17,6 @@ SE2_GROUP = SpecialEuclidean(n=2, point_type='matrix')
 N_STEPS = 40
 LEFT_METRIC = SE2_GROUP.left_canonical_metric
 RIGHT_METRIC = SE2_GROUP.right_canonical_metric
-SE2_VEC = SpecialEuclidean(n=2, point_type='vector')
 
 
 def main():
@@ -31,12 +30,7 @@ def main():
     tangent_vec = gs.einsum('t,ij->tij', t, initial_tangent_vec)
     group_geo_points = SE2_GROUP.exp(tangent_vec)
     left_geo_points = LEFT_METRIC.exp(tangent_vec)
-    right_geo_points_ = RIGHT_METRIC.exp(tangent_vec)
-
-    initial_right_vec = gs.array([theta, 2, 2])
-    right_vec = gs.einsum('t, i-> ti', t, initial_right_vec)
-    right_geo_points = SE2_VEC.right_canonical_metric.exp(right_vec)
-    right_points = SE2_VEC.matrix_from_vector(right_geo_points)
+    right_geo_points = RIGHT_METRIC.exp(tangent_vec)
 
     ax = visualization.plot(
         group_geo_points, space='SE2_GROUP', color='black',
@@ -45,11 +39,8 @@ def main():
         left_geo_points, ax=ax, space='SE2_GROUP', color='yellow',
         label='Left')
     ax = visualization.plot(
-        right_points, ax=ax, space='SE2_GROUP', color='magenta',
-        label='Right')
-    ax = visualization.plot(
-        right_geo_points_, ax=ax, space='SE2_GROUP', color='green',
-        label='Right Integration')
+        right_geo_points, ax=ax, space='SE2_GROUP', color='green',
+        label='Right by Integration')
     ax.set_aspect('equal')
     plt.legend(loc='best')
     plt.show()

--- a/examples/plot_geodesics_se2.py
+++ b/examples/plot_geodesics_se2.py
@@ -20,7 +20,7 @@ RIGHT_METRIC = SE2_GROUP.right_canonical_metric
 
 
 def main():
-    """Plot geodesics on SE2 with different structures."""
+    """Plot geodesics on SE(2) with different structures."""
     theta = gs.pi / 3
     initial_tangent_vec = gs.array([
         [0., - theta, 2.],

--- a/examples/plot_geodesics_se2.py
+++ b/examples/plot_geodesics_se2.py
@@ -1,8 +1,10 @@
 """Plot a geodesic of SE(2).
 
-SE2 is equipped with both the canonical Cartan-Shouten connection,
+SE2 is equipped with the canonical Cartan-Shouten connection,
 whose geodesics are the group geodesics, i.e. one parameter subgroups and the
-left invariant canonical metric.
+left and right invariant canonical metric. In all cases the rotation part is
+the same: it has constant angular velocity. The translation parts differe
+however.
 """
 
 import matplotlib.pyplot as plt
@@ -12,7 +14,7 @@ import geomstats.visualization as visualization
 from geomstats.geometry.special_euclidean import SpecialEuclidean
 
 SE2_GROUP = SpecialEuclidean(n=2, point_type='matrix')
-N_STEPS = 20
+N_STEPS = 40
 LEFT_METRIC = SE2_GROUP.left_canonical_metric
 RIGHT_METRIC = SE2_GROUP.right_canonical_metric
 SE2_VEC = SpecialEuclidean(n=2, point_type='vector')
@@ -25,31 +27,31 @@ def main():
         [0., - theta, 2.],
         [theta, 0., 2.],
         [0., 0., 0.]])
-    t = gs.linspace(-1., 1., N_STEPS + 1)
+    t = gs.linspace(-2., 2., N_STEPS + 1)
     tangent_vec = gs.einsum('t,ij->tij', t, initial_tangent_vec)
     group_geo_points = SE2_GROUP.exp(tangent_vec)
     left_geo_points = LEFT_METRIC.exp(tangent_vec)
     right_geo_points_ = RIGHT_METRIC.exp(tangent_vec)
 
-    initial_right_vec = gs.array([-theta, 2, 2])
+    initial_right_vec = gs.array([theta, 2, 2])
     right_vec = gs.einsum('t, i-> ti', t, initial_right_vec)
     right_geo_points = SE2_VEC.right_canonical_metric.exp(right_vec)
     right_points = SE2_VEC.matrix_from_vector(right_geo_points)
 
     ax = visualization.plot(
         group_geo_points, space='SE2_GROUP', color='black',
-        label='Group Geodesics')
+        label='Group')
     ax = visualization.plot(
-        left_geo_points, ax=ax, space='SE2_GROUP', color='green',
-        label='Left Geodesics')
+        left_geo_points, ax=ax, space='SE2_GROUP', color='yellow',
+        label='Left')
     ax = visualization.plot(
-        right_points, ax=ax, space='SE2_GROUP', color='yellow',
-        label='Right Geodesics')
+        right_points, ax=ax, space='SE2_GROUP', color='magenta',
+        label='Right')
     ax = visualization.plot(
         right_geo_points_, ax=ax, space='SE2_GROUP', color='green',
-        label='Right Geodesics Integration')
+        label='Right Integration')
     ax.set_aspect('equal')
-    plt.legend(loc='upper right')
+    plt.legend(loc='best')
     plt.show()
 
 

--- a/examples/plot_geodesics_se2.py
+++ b/examples/plot_geodesics_se2.py
@@ -21,7 +21,7 @@ SE2_VEC = SpecialEuclidean(n=2, point_type='vector')
 
 
 def main():
-    """Plot a group geodesic on SE2."""
+    """Plot geodesics on SE2 with different structures."""
     theta = gs.pi / 3
     initial_tangent_vec = gs.array([
         [0., - theta, 2.],
@@ -57,4 +57,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/examples/plot_geodesics_se2.py
+++ b/examples/plot_geodesics_se2.py
@@ -12,8 +12,9 @@ import geomstats.visualization as visualization
 from geomstats.geometry.special_euclidean import SpecialEuclidean
 
 SE2_GROUP = SpecialEuclidean(n=2, point_type='matrix')
-N_STEPS = 40
-METRIC = SE2_GROUP.left_canonical_metric
+N_STEPS = 20
+LEFT_METRIC = SE2_GROUP.left_canonical_metric
+RIGHT_METRIC = SE2_GROUP.right_canonical_metric
 SE2_VEC = SpecialEuclidean(n=2, point_type='vector')
 
 
@@ -24,10 +25,11 @@ def main():
         [0., - theta, 2.],
         [theta, 0., 2.],
         [0., 0., 0.]])
-    t = gs.linspace(-3., 3., N_STEPS + 1)
+    t = gs.linspace(-1., 1., N_STEPS + 1)
     tangent_vec = gs.einsum('t,ij->tij', t, initial_tangent_vec)
     group_geo_points = SE2_GROUP.exp(tangent_vec)
-    left_geo_points = METRIC.exp(tangent_vec)
+    left_geo_points = LEFT_METRIC.exp(tangent_vec)
+    right_geo_points_ = RIGHT_METRIC.exp(tangent_vec)
 
     initial_right_vec = gs.array([-theta, 2, 2])
     right_vec = gs.einsum('t, i-> ti', t, initial_right_vec)
@@ -43,8 +45,11 @@ def main():
     ax = visualization.plot(
         right_points, ax=ax, space='SE2_GROUP', color='yellow',
         label='Right Geodesics')
+    ax = visualization.plot(
+        right_geo_points_, ax=ax, space='SE2_GROUP', color='green',
+        label='Right Geodesics Integration')
     ax.set_aspect('equal')
-    plt.legend(loc='lower right')
+    plt.legend(loc='upper right')
     plt.show()
 
 

--- a/geomstats/_backend/__init__.py
+++ b/geomstats/_backend/__init__.py
@@ -104,6 +104,7 @@ BACKEND_ATTRIBUTES = {
         'tril',
         'tril_indices',
         'triu_indices',
+        'triu_to_vec',
         'vectorize',
         'vstack',
         'where',

--- a/geomstats/_backend/numpy/__init__.py
+++ b/geomstats/_backend/numpy/__init__.py
@@ -362,3 +362,9 @@ def erf(x):
         np.sqrt(1 - np.exp(-x * x *
                            (4 / np.pi + cst_erf * x * x) /
                            (1 + cst_erf * x * x)))
+
+
+def triu_to_vec(x, k=0):
+    n = x.shape[-1]
+    rows, cols = triu_indices(n, k=k)
+    return x[..., rows, cols]

--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -758,3 +758,9 @@ def vectorize(x, pyfunc, multiple_args=False, **kwargs):
     if multiple_args:
         return stack(list(map(lambda y: pyfunc(*y), zip(*x))))
     return stack(list(map(pyfunc, x)))
+
+
+def triu_to_vec(x, k=0):
+    n = x.shape[-1]
+    rows, cols = triu_indices(n, k=k)
+    return x[..., rows, cols]

--- a/geomstats/_backend/tensorflow/__init__.py
+++ b/geomstats/_backend/tensorflow/__init__.py
@@ -759,3 +759,16 @@ def where(condition, x=None, y=None):
         y = tf.constant(y)
     y = cast(y, x.dtype)
     return tf.where(condition, x, y)
+
+
+def triu_to_vec(x, k=0):
+    n = x.shape[-1]
+    axis = 1 if x.ndim == 3 else 0
+    mask = tf.ones((n, n))
+    mask_a = tf.linalg.band_part(mask, 0, -1)
+    if k > 0:
+        mask_b = tf.linalg.band_part(mask, 0, k - 1)
+    else:
+        mask_b = tf.zeros_like(mask_a)
+    mask = tf.cast(mask_a - mask_b, dtype=tf.bool)
+    return tf.boolean_mask(x, mask, axis=axis)

--- a/geomstats/geometry/connection.py
+++ b/geomstats/geometry/connection.py
@@ -102,7 +102,7 @@ class Connection:
 
         Exponential map at base_point of tangent_vec computed by integration
         of the geodesic equation (initial value problem), using the
-        christoffel symbols
+        christoffel symbols.
 
         Parameters
         ----------

--- a/geomstats/geometry/general_linear.py
+++ b/geomstats/geometry/general_linear.py
@@ -16,8 +16,7 @@ class GeneralLinear(Matrices):
     """
 
     def __init__(self, n, **kwargs):
-        Matrices.__init__(self, n, n)
-
+        super(GeneralLinear, self).__init__(n=n, m=n, **kwargs)
         self.n = n
 
     def belongs(self, point):

--- a/geomstats/geometry/hypersphere.py
+++ b/geomstats/geometry/hypersphere.py
@@ -520,10 +520,11 @@ class HypersphereMetric(RiemannianMetric):
 
     @staticmethod
     def parallel_transport(tangent_vec_a, tangent_vec_b, base_point):
-        """Compute the parallel transport of a tangent vector.
+        r"""Compute the parallel transport of a tangent vector.
 
         Closed-form solution for the parallel transport of a tangent vector a
-        along the geodesic defined by exp_(base_point)(tangent_vec_b).
+        along the geodesic defined by :math: `t \mapsto exp_(base_point)(t*
+        tangent_vec_b)`.
 
         Parameters
         ----------
@@ -538,7 +539,7 @@ class HypersphereMetric(RiemannianMetric):
         Returns
         -------
         transported_tangent_vec: array-like, shape=[..., dim + 1]
-            Transported tangent vector at exp_(base_point)(tangent_vec_b).
+            Transported tangent vector at `exp_(base_point)(tangent_vec_b)`.
         """
         theta = gs.linalg.norm(tangent_vec_b, axis=-1)
         normalized_b = gs.einsum('..., ...i->...i', 1 / theta, tangent_vec_b)

--- a/geomstats/geometry/invariant_metric.py
+++ b/geomstats/geometry/invariant_metric.py
@@ -544,6 +544,7 @@ class _InvariantMetricMatrix(RiemannianMetric):
         """
         group = self.group
         basis = self.lie_algebra.orthonormal_basis(self.metric_mat_at_identity)
+        sign = 1. if (self.left_or_right == 'left') else -1.
 
         def lie_acceleration(point, vector):
             velocity = self.group.tangent_translation_map(
@@ -551,7 +552,7 @@ class _InvariantMetricMatrix(RiemannianMetric):
             coefficients = gs.array([self.structure_constant(
                 vector, basis_vector, vector) for basis_vector in basis])
             acceleration = gs.einsum('i...,ijk->...jk', coefficients, basis)
-            return velocity, acceleration
+            return velocity, sign * acceleration
 
         if base_point is None:
             base_point = group.identity

--- a/geomstats/geometry/invariant_metric.py
+++ b/geomstats/geometry/invariant_metric.py
@@ -495,7 +495,7 @@ class _InvariantMetricMatrix(RiemannianMetric):
 
         return translation_map(value_at_id)
 
-    def exp(self, tangent_vec, base_point, n_steps=10, step='rk4',
+    def exp(self, tangent_vec, base_point=None, n_steps=10, step='rk4',
             **kwargs):
         r"""Compute Riemannian exponential of tan. vector wrt to base point.
 
@@ -551,8 +551,13 @@ class _InvariantMetricMatrix(RiemannianMetric):
             acceleration = gs.einsum('i...,ijk->...jk', coefficients, basis)
             return velocity, acceleration
 
-        left_angular_vel = group.compose(
-            group.inverse(base_point), tangent_vec)
+        if base_point is None:
+            base_point = group.identity
+            left_angular_vel = tangent_vec
+        else:
+            left_angular_vel = group.compose(
+                group.inverse(base_point), tangent_vec)
+
         initial_state = (base_point, group.regularize(left_angular_vel))
         flow, _ = integrate(lie_acceleration, initial_state, n_steps=n_steps,
                             step=step, **kwargs)

--- a/geomstats/geometry/invariant_metric.py
+++ b/geomstats/geometry/invariant_metric.py
@@ -572,7 +572,7 @@ class _InvariantMetricMatrix(RiemannianMetric):
         """
         group = self.group
         basis = self.orthonormal_basis(self.lie_algebra.basis)
-        sign = 1. if self.left_or_right == 'left' else 1.
+        sign = 1. if self.left_or_right == 'left' else -1.
 
         def lie_acceleration(point, vector):
             """Compute the right-hand side of the geodesic equation."""

--- a/geomstats/geometry/lie_algebra.py
+++ b/geomstats/geometry/lie_algebra.py
@@ -137,13 +137,12 @@ class MatrixLieAlgebra:
         return gs.einsum("...i,ijk ->...jk", basis_representation, self.basis)
 
     def reshape_metric_matrix(self, metric_matrix):
-        """Reshape diagonal metric matrix to a symmetric matrix of size n.
+        """Reshape diagonal metric matrix to a matrix of size n.
 
-        Reshape a diagonal metric matrix of size `dim x dim` into a symmetric
-        matrix of size `n x n` where :math: `dim= n (n -1) / 2` is the
-        dimension of the space of skew symmetric matrices. The
-        non-diagonal coefficients in the output matrix correspond to the
-        basis matrices of this space. The diagonal is filled with ones.
+        Reshape a diagonal metric matrix of size `dim x dim` into a
+        matrix of size `n x n` where :math: `n` is the size of matrices
+        representing the Lie algebra. The coefficients in the output matrix
+        correspond to the basis matrices of this space.
         This useful to compute a matrix inner product.
 
         Parameters
@@ -166,7 +165,7 @@ class MatrixLieAlgebra:
     def orthonormal_basis(self, metric_matrix):
         """Orthonormalize the basis with respect to the given metric.
 
-        This corresponds to a renormalization.
+        This corresponds only to a renormalization.
 
         Parameters
         ----------
@@ -178,8 +177,11 @@ class MatrixLieAlgebra:
         basis : array-like, shape=[dim, n, n]
             Orthonormal basis.
         """
-        metric_matrix = self.reshape_metric_matrix(metric_matrix) + gs.eye(
-            self.n)
+        metric_matrix = self.reshape_metric_matrix(metric_matrix)
+
+        # Avoid division by 0
+        metric_matrix = gs.where(
+            metric_matrix == 0., gs.ones_like(metric_matrix), metric_matrix)
         return self.basis / gs.sqrt(2 * metric_matrix)
 
     def projection(self, mat):

--- a/geomstats/geometry/lie_algebra.py
+++ b/geomstats/geometry/lie_algebra.py
@@ -178,11 +178,10 @@ class MatrixLieAlgebra:
             Orthonormal basis.
         """
         metric_matrix = self.reshape_metric_matrix(metric_matrix)
+        norms = gs.sum(
+            metric_matrix * self.basis * self.basis, (-2, -1))
 
-        # Avoid division by 0
-        metric_matrix = gs.where(
-            metric_matrix == 0., gs.ones_like(metric_matrix), metric_matrix)
-        return self.basis / gs.sqrt(2 * metric_matrix)
+        return gs.einsum('i, ikl->ikl', 1. / gs.sqrt(norms), self.basis)
 
     def projection(self, mat):
         """Project a matrix to the Lie Algebra.

--- a/geomstats/geometry/lie_group.py
+++ b/geomstats/geometry/lie_group.py
@@ -85,8 +85,8 @@ class LieGroup(Manifold):
     """
 
     def __init__(
-            self, dim, default_point_type='vector', lie_algebra=None,
-            **kwargs):
+            self, dim, default_point_type='vector',
+            lie_algebra=None, **kwargs):
         super(LieGroup, self).__init__(
             dim=dim, default_point_type=default_point_type, **kwargs)
 

--- a/geomstats/geometry/manifold.py
+++ b/geomstats/geometry/manifold.py
@@ -27,7 +27,8 @@ class Manifold:
 
     def __init__(
             self, dim, default_point_type='vector',
-            default_coords_type='intrinsic'):
+            default_coords_type='intrinsic', **kwargs):
+        super(Manifold, self).__init__(**kwargs)
         geomstats.errors.check_integer(dim, 'dim')
         geomstats.errors.check_parameter_accepted_values(
             default_point_type, 'default_point_type', ['vector', 'matrix'])

--- a/geomstats/geometry/matrices.py
+++ b/geomstats/geometry/matrices.py
@@ -6,7 +6,6 @@ import geomstats.backend as gs
 import geomstats.errors
 from geomstats.algebra_utils import from_vector_to_diagonal_matrix
 from geomstats.geometry.euclidean import EuclideanMetric
-from geomstats.geometry.manifold import Manifold
 
 
 TOLERANCE = 1e-5

--- a/geomstats/geometry/matrices.py
+++ b/geomstats/geometry/matrices.py
@@ -12,7 +12,7 @@ from geomstats.geometry.manifold import Manifold
 TOLERANCE = 1e-5
 
 
-class Matrices(Manifold):
+class Matrices:
     """Class for the space of matrices (m, n).
 
     Parameters
@@ -21,8 +21,8 @@ class Matrices(Manifold):
         Integers representing the shapes of the matrices: m x n.
     """
 
-    def __init__(self, m, n):
-        super(Matrices, self).__init__(dim=m * n, default_point_type='matrix')
+    def __init__(self, m, n, **kwargs):
+        super(Matrices, self).__init__(**kwargs)
         geomstats.errors.check_integer(n, 'n')
         geomstats.errors.check_integer(m, 'm')
         self.m = m

--- a/geomstats/geometry/matrices.py
+++ b/geomstats/geometry/matrices.py
@@ -22,12 +22,11 @@ class Matrices(Manifold):
     """
 
     def __init__(self, m, n):
-        super(Matrices, self).__init__(dim=m * n)
+        super(Matrices, self).__init__(dim=m * n, default_point_type='matrix')
         geomstats.errors.check_integer(n, 'n')
         geomstats.errors.check_integer(m, 'm')
         self.m = m
         self.n = n
-        self.default_point_type = 'matrix'
         self.metric = MatricesMetric(m, n)
 
     def belongs(self, point):

--- a/geomstats/geometry/skew_symmetric_matrices.py
+++ b/geomstats/geometry/skew_symmetric_matrices.py
@@ -110,5 +110,4 @@ class SkewSymmetricMatrices(MatrixLieAlgebra):
                 matrix_representation[..., 1, 0]])
             return gs.transpose(vec)
 
-        rows, cols = gs.triu_indices(self.n, k=1)
-        return matrix_representation[..., rows, cols]
+        return gs.triu_to_vec(matrix_representation, k=1)

--- a/geomstats/geometry/skew_symmetric_matrices.py
+++ b/geomstats/geometry/skew_symmetric_matrices.py
@@ -91,6 +91,7 @@ class SkewSymmetricMatrices(MatrixLieAlgebra):
         old_shape = gs.shape(matrix_representation)
         as_vector = gs.reshape(
             matrix_representation, (-1, old_shape[-2] * old_shape[-1]))
+        as_vector = gs.squeeze(as_vector)
         upper_tri_indices = gs.reshape(
             gs.arange(0, self.n ** 2), (self.n, self.n)
         )[gs.triu_indices(self.n, k=1)]

--- a/geomstats/geometry/skew_symmetric_matrices.py
+++ b/geomstats/geometry/skew_symmetric_matrices.py
@@ -25,14 +25,27 @@ class SkewSymmetricMatrices(MatrixLieAlgebra):
         dimension = int(n * (n - 1) / 2)
         super(SkewSymmetricMatrices, self).__init__(dimension, n)
 
-        self.basis = gs.zeros((dimension, n, n))
-
-        basis = []
-        for row in gs.arange(n - 1):
-            for col in gs.arange(row + 1, n):
-                basis.append(gs.array_from_sparse(
-                    [(row, col), (col, row)], [1., -1.], (n, n)))
-        self.basis = gs.stack(basis)
+        if n == 2:
+            self.basis = gs.array([[[0., -1.], [1., 0.]]])
+        elif n == 3:
+            self.basis = gs.array([
+                [[0., 0., 0.],
+                 [0., 0., -1.],
+                 [0., 1., 0.]],
+                [[0., 0., 1.],
+                 [0., 0., 0.],
+                 [-1., 0., 0.]],
+                [[0., -1., 0.],
+                 [1., 0., 0.],
+                 [0., 0., 0.]]])
+        else:
+            self.basis = gs.zeros((dimension, n, n))
+            basis = []
+            for row in gs.arange(n - 1):
+                for col in gs.arange(row + 1, n):
+                    basis.append(gs.array_from_sparse(
+                        [(row, col), (col, row)], [1., -1.], (n, n)))
+            self.basis = gs.stack(basis)
 
     def belongs(self, mat, atol=TOLERANCE):
         """Evaluate if mat is a skew-symmetric matrix.

--- a/geomstats/geometry/skew_symmetric_matrices.py
+++ b/geomstats/geometry/skew_symmetric_matrices.py
@@ -101,6 +101,15 @@ class SkewSymmetricMatrices(MatrixLieAlgebra):
         basis_representation : array-like, shape=[..., dim]
             Representation in the basis.
         """
+        if self.n == 2:
+            return matrix_representation[..., 1, 0][..., None]
+        if self.n == 3:
+            vec = gs.stack([
+                matrix_representation[..., 2, 1],
+                matrix_representation[..., 0, 2],
+                matrix_representation[..., 1, 0]])
+            return gs.transpose(vec)
+
         old_shape = gs.shape(matrix_representation)
         as_vector = gs.reshape(
             matrix_representation, (-1, old_shape[-2] * old_shape[-1]))

--- a/geomstats/geometry/skew_symmetric_matrices.py
+++ b/geomstats/geometry/skew_symmetric_matrices.py
@@ -110,11 +110,5 @@ class SkewSymmetricMatrices(MatrixLieAlgebra):
                 matrix_representation[..., 1, 0]])
             return gs.transpose(vec)
 
-        old_shape = gs.shape(matrix_representation)
-        as_vector = gs.reshape(
-            matrix_representation, (-1, old_shape[-2] * old_shape[-1]))
-        as_vector = gs.squeeze(as_vector)
-        upper_tri_indices = gs.reshape(
-            gs.arange(0, self.n ** 2), (self.n, self.n)
-        )[gs.triu_indices(self.n, k=1)]
-        return as_vector[..., upper_tri_indices]
+        rows, cols = gs.triu_indices(self.n, k=1)
+        return matrix_representation[..., rows, cols]

--- a/geomstats/geometry/special_euclidean.py
+++ b/geomstats/geometry/special_euclidean.py
@@ -83,18 +83,12 @@ class _SpecialEuclideanMatrices(GeneralLinear, LieGroup):
     """
 
     def __init__(self, n):
-        super(_SpecialEuclideanMatrices, self).__init__(
-            default_point_type='matrix', n=n + 1)
+        super().__init__(
+            n=n + 1, dim=int((n * (n + 1)) / 2), default_point_type='matrix',
+            lie_algebra=SpecialEuclideanMatrixLieAlgebra(n=n))
         self.rotations = SpecialOrthogonal(n=n)
         self.translations = Euclidean(dim=n)
         self.n = n
-        self.dim = int((n * (n + 1)) / 2)
-        translation_mask = gs.hstack([
-            gs.ones((self.n,) * 2), 2 * gs.ones((self.n, 1))])
-        translation_mask = gs.concatenate(
-            [translation_mask, gs.zeros((1, self.n + 1))], axis=0)
-        self.translation_mask = translation_mask
-        self.lie_algebra = SpecialEuclideanMatrixLieAlgebra(n=n)
 
         self.left_canonical_metric = \
             SpecialEuclideanMatrixCannonicalLeftMetric(group=self)
@@ -1058,22 +1052,3 @@ class SpecialEuclideanMatrixLieAlgebra(MatrixLieAlgebra):
             matrix_representation[:, :self.n, :self.n])
         translation_part = matrix_representation[:, :-1, self.n]
         return gs.concatenate([skew_part, translation_part], axis=-1)
-
-    def orthonormal_basis(self, metric_matrix):
-        """Orthonormalize the basis with respect to the given metric.
-
-        This corresponds to a renormalization.
-
-        Parameters
-        ----------
-        metric_matrix : array-like, shape=[dim, dim]
-            Matrix of a metric.
-
-        Returns
-        -------
-        basis : array-like, shape=[dim, n, n]
-            Orthonormal basis.
-        """
-        metric_matrix = self.reshape_metric_matrix(metric_matrix) + gs.eye(
-            self.n + 1)
-        return self.basis / gs.sqrt(2 * metric_matrix)

--- a/geomstats/geometry/special_euclidean.py
+++ b/geomstats/geometry/special_euclidean.py
@@ -1153,6 +1153,6 @@ class SpecialEuclideanMatrixLieAlgebra(MatrixLieAlgebra):
             Representation in the basis.
         """
         skew_part = self.skew.basis_representation(
-            matrix_representation[:, :self.n, :self.n])
-        translation_part = matrix_representation[:, :-1, self.n]
-        return gs.concatenate([skew_part, translation_part], axis=-1)
+            matrix_representation[..., :self.n, :self.n])
+        translation_part = matrix_representation[..., :-1, self.n]
+        return gs.concatenate([skew_part, translation_part[..., :]], axis=-1)

--- a/geomstats/geometry/special_euclidean.py
+++ b/geomstats/geometry/special_euclidean.py
@@ -127,9 +127,8 @@ class _SpecialEuclideanMatrices(GeneralLinear, LieGroup):
 
         belongs = gs.logical_and(belongs, all_but_last_zeros)
 
-        last_term = point[..., self.n:, self.n:]
-        belongs = gs.logical_and(
-            belongs, gs.all(last_term == 1, axis=(-2, -1)))
+        last_term = point[..., self.n, self.n]
+        belongs = gs.logical_and(belongs, gs.isclose(last_term, 1.))
 
         if point.ndim == 2:
             return gs.squeeze(belongs)

--- a/geomstats/geometry/special_euclidean.py
+++ b/geomstats/geometry/special_euclidean.py
@@ -876,12 +876,55 @@ class _SpecialEuclidean3Vectors(_SpecialEuclideanVectors):
 
 
 class SpecialEuclideanMatrixCannonicalLeftMetric(_InvariantMetricMatrix):
+    """Class for the canonical left-invariant metric on SE(n).
+
+    The canonical left-invariant metric is defined by endowing the tangent
+    space at the identity with the Frobenius inned-product, and to define the
+    metric at any point by left-translation. This results in a direct product
+    metric between rotations and translations, whose geodesics are therefore
+    easily computable with the matrix exponential and straight lines.
+
+    Parameters
+    ----------
+    group : SpecialEuclidean
+        Instance of the class SpecialEuclidean with `point_type='matrix'`.
+    """
+
     def __init__(self, group):
+        if (
+                not isinstance(group, _SpecialEuclideanMatrices)
+                or group.default_point_type != 'matrix'):
+            raise ValueError('group must be an instance of the '
+                             'SpecialEclidean class with `point_type=matrix`.')
         super(SpecialEuclideanMatrixCannonicalLeftMetric, self).__init__(
             group=group)
         self.n = group.n
 
     def exp(self, tangent_vec, base_point=None, **kwargs):
+        """Exponential map associated to the cannonical metric.
+
+        Exponential map at `base_point` of `tangent_vec`. The geodesics of this
+        metric correspond to a direct product metric between rotation and
+        translation: the translation part is a straight line, while the
+        rotation part has constant angular velocity (which corresponds to one-
+        parameter subgroups of the rotation group).
+
+        Parameters
+        ----------
+        tangent_vec : array-like, shape=[..., n + 1, n + 1]
+            Tangent vector at the base point.
+        base_point : array-like, shape=[..., n + 1, n + 1]
+            Point on the manifold.
+
+        Returns
+        -------
+        exp : array-like, shape=[..., n + 1, n + 1]
+            Point on the manifold.
+
+        See Also
+        --------
+        examples.plot_geodesics_se2
+        """
         group = self.group
         if base_point is None:
             base_point = group.identity
@@ -889,8 +932,8 @@ class SpecialEuclideanMatrixCannonicalLeftMetric(_InvariantMetricMatrix):
         rotation = base_point[..., :self.n, :self.n]
         rotation_exp = GeneralLinear.exp(inf_rotation, rotation)
         translation_exp = (
-                tangent_vec[..., :self.n, self.n]
-                + base_point[..., :self.n, self.n])
+            tangent_vec[..., :self.n, self.n]
+            + base_point[..., :self.n, self.n])
 
         exp = gs.concatenate(
             (rotation_exp, translation_exp[..., None]), axis=-1)
@@ -900,12 +943,40 @@ class SpecialEuclideanMatrixCannonicalLeftMetric(_InvariantMetricMatrix):
         return exp
 
     def log(self, point, base_point=None, **kwargs):
+        """Compute logarithm map associated to the canonical metric.
+
+        Log map at `base_point` of `point`. The geodesics of this
+        metric correspond to a direct product metric between rotation and
+        translation: the translation part is a straight line, while the
+        rotation part has constant angular velocity (which corresponds to one-
+        parameter subgroups of the rotation group).
+
+        Parameters
+        ----------
+        point : array-like, shape=[..., n + 1, n + 1]
+            Point on the manifold.
+        base_point : array-like, shape=[..., n + 1, n + 1]
+            Point on the manifold.
+
+        Returns
+        -------
+        tangent_vec : array-like, shape=[..., n + 1, n + 1]
+            Tangent vector at the base point.
+
+        References
+        ----------
+        [Zefran98]  Zefran, M., V. Kumar, and C.B. Croke.
+                    “On the Generation of Smooth Three-Dimensional Rigid Body
+                    Motions.” IEEE Transactions on Robotics and Automation 14,
+                    no. 4 (August 1998): 576–89.
+                    https://doi.org/10.1109/70.704225.
+        """
         max_shape = point.shape if point.ndim == 3 else base_point.shape
         rotation_bp = base_point[..., :self.n, :self.n]
         rotation_p = point[..., :self.n, :self.n]
         rotation_log = GeneralLinear.log(rotation_p, rotation_bp)
         translation_log = (
-                point[..., :self.n, self.n] - base_point[..., :self.n, self.n])
+            point[..., :self.n, self.n] - base_point[..., :self.n, self.n])
 
         log = gs.concatenate(
             (rotation_log, translation_log[..., None]), axis=-1)
@@ -916,12 +987,36 @@ class SpecialEuclideanMatrixCannonicalLeftMetric(_InvariantMetricMatrix):
         return log
 
     def parallel_transport(self, tangent_vec_a, tangent_vec_b, base_point):
+        r"""Compute the parallel transport of a tangent vector.
+
+        Closed-form solution for the parallel transport of a tangent vector a
+        along the geodesic defined by :math: `t \mapsto exp_(base_point)(t*
+        tangent_vec_b)`. As the special Euclidean group endowed with its
+        canonical left-invariant metric is a symmetric space, parallel
+        transport is achieved by a geodesic symmetry, or equivalently, one step
+         of the pole ladder scheme.
+
+        Parameters
+        ----------
+        tangent_vec_a : array-like, shape=[..., n + 1, n + 1]
+            Tangent vector at base point to be transported.
+        tangent_vec_b : array-like, shape=[..., n + 1, n + 1]
+            Tangent vector at base point, along which the parallel transport
+            is computed.
+        base_point : array-like, shape=[..., n + 1, n + 1]
+            Point on the hypersphere.
+
+        Returns
+        -------
+        transported_tangent_vec: array-like, shape=[..., n + 1, n + 1]
+            Transported tangent vector at `exp_(base_point)(tangent_vec_b)`.
+        """
         point = self.exp(tangent_vec_a, base_point)
         midpoint = self.exp(1. / 2. * tangent_vec_b, base_point)
         next_point = self.exp(tangent_vec_b, base_point)
         first_sym = self.exp(- self.log(point, midpoint), midpoint)
         transported_vec = - self.log(first_sym, next_point)
-        return transported_vec, next_point
+        return transported_vec
 
 
 class SpecialEuclidean(_SpecialEuclidean2Vectors,

--- a/geomstats/geometry/special_euclidean.py
+++ b/geomstats/geometry/special_euclidean.py
@@ -935,11 +935,8 @@ class SpecialEuclideanMatrixCannonicalLeftMetric(_InvariantMetricMatrix):
             tangent_vec[..., :self.n, self.n]
             + base_point[..., :self.n, self.n])
 
-        exp = gs.concatenate(
-            (rotation_exp, translation_exp[..., None]), axis=-1)
-        last_line = gs.zeros(tangent_vec.shape)
-        last_line = gs.assignment(last_line, 1., (-1, -1), axis=0)[..., -1]
-        exp = gs.concatenate((exp, last_line[..., None, :]), axis=-2)
+        exp = homogeneous_representation(
+            rotation_exp, translation_exp, tangent_vec.shape, 1.)
         return exp
 
     def log(self, point, base_point=None, **kwargs):
@@ -978,12 +975,8 @@ class SpecialEuclideanMatrixCannonicalLeftMetric(_InvariantMetricMatrix):
         translation_log = (
             point[..., :self.n, self.n] - base_point[..., :self.n, self.n])
 
-        log = gs.concatenate(
-            (rotation_log, translation_log[..., None]), axis=-1)
-        last_line = gs.zeros(max_shape)
-        last_line = gs.assignment(last_line, 0., (-1, -1), axis=0)[..., -1]
-        log = gs.concatenate((log, last_line[..., None, :]), axis=-2)
-
+        log = homogeneous_representation(
+            rotation_log, translation_log, max_shape, 0.)
         return log
 
     def parallel_transport(self, tangent_vec_a, tangent_vec_b, base_point):

--- a/geomstats/geometry/special_orthogonal.py
+++ b/geomstats/geometry/special_orthogonal.py
@@ -406,10 +406,7 @@ class _SpecialOrthogonal2Vectors(_SpecialOrthogonalVectors):
         skew_mat : array-like, shape=[..., n, n]
             Skew-symmetric matrix.
         """
-        basis = gs.array([[0., 1.], [-1., 0.]])
-        skew_mat = gs.einsum('...i,kl->...kl', vec, basis)
-
-        return skew_mat
+        return SkewSymmetricMatrices(2).matrix_representation(vec)
 
     @staticmethod
     def vector_from_skew_matrix(skew_mat):
@@ -428,8 +425,7 @@ class _SpecialOrthogonal2Vectors(_SpecialOrthogonalVectors):
         vec : array-like, shape=[..., dim]
             Vector.
         """
-        vec = skew_mat[..., 0, 1]
-        return vec[..., None]
+        return SkewSymmetricMatrices(2).basis_representation(skew_mat)
 
     def rotation_vector_from_matrix(self, rot_mat):
         r"""Convert rotation matrix (in 2D) to rotation vector (axis-angle).
@@ -467,7 +463,7 @@ class _SpecialOrthogonal2Vectors(_SpecialOrthogonalVectors):
         cos_term = gs.cos(rot_vec)
         cos_matrix = gs.einsum('...l,ij->...ij', cos_term, gs.eye(2))
         sin_term = gs.sin(rot_vec)
-        sin_matrix = self.skew_matrix_from_vector(-sin_term)
+        sin_matrix = self.skew_matrix_from_vector(sin_term)
         return cos_matrix + sin_matrix
 
     def compose(self, point_a, point_b):
@@ -739,18 +735,7 @@ class _SpecialOrthogonal3Vectors(_SpecialOrthogonalVectors):
         skew_mat : array-like, shape=[..., n, n]
             Skew-symmetric matrix.
         """
-        basis = gs.array([
-            [[0., 0., 0.],
-             [0., 0., -1.],
-             [0., 1., 0.]],
-            [[0., 0., 1.],
-             [0., 0., 0.],
-             [-1., 0., 0.]],
-            [[0., -1., 0.],
-             [1., 0., 0.],
-             [0., 0., 0.]]])
-        skew = gs.einsum('...n,njk->...jk', vec, basis)
-        return skew
+        return SkewSymmetricMatrices(3).matrix_representation(vec)
 
     @staticmethod
     def vector_from_skew_matrix(skew_mat):
@@ -769,10 +754,7 @@ class _SpecialOrthogonal3Vectors(_SpecialOrthogonalVectors):
         vec : array-like, shape=[..., dim]
             Vector.
         """
-        vec = gs.stack([
-            skew_mat[..., 2, 1], skew_mat[..., 0, 2], skew_mat[..., 1, 0]])
-
-        return gs.transpose(vec)
+        return SkewSymmetricMatrices(3).basis_representation(skew_mat)
 
     @geomstats.vectorization.decorator(['else', 'matrix', 'output_point'])
     def rotation_vector_from_matrix(self, rot_mat):

--- a/geomstats/geometry/special_orthogonal.py
+++ b/geomstats/geometry/special_orthogonal.py
@@ -30,8 +30,8 @@ class _SpecialOrthogonalMatrices(GeneralLinear, LieGroup):
 
     def __init__(self, n):
         super(_SpecialOrthogonalMatrices, self).__init__(
-            dim=int((n * (n - 1)) / 2), default_point_type='matrix', n=n)
-        self.lie_algebra = SkewSymmetricMatrices(n=n)
+            dim=int((n * (n - 1)) / 2), default_point_type='matrix', n=n,
+            lie_algebra=SkewSymmetricMatrices(n=n))
         self.bi_invariant_metric = BiInvariantMetric(group=self)
         self.dim = int((n * (n - 1)) / 2)
 

--- a/geomstats/geometry/special_orthogonal.py
+++ b/geomstats/geometry/special_orthogonal.py
@@ -263,9 +263,6 @@ class _SpecialOrthogonalVectors(LieGroup):
         ----------
         tangent_vec : array-like, shape=[..., dimension]
             Tangent vector at base point.
-        point_type : str, {'vector', 'matrix'}
-            Point type.
-            Optional, default: self.default_point_type.
 
         Returns
         -------

--- a/geomstats/geometry/special_orthogonal.py
+++ b/geomstats/geometry/special_orthogonal.py
@@ -112,7 +112,6 @@ class _SpecialOrthogonalMatrices(GeneralLinear, LieGroup):
         rotation_mat, _ = gs.linalg.qr(random_mat)
         return rotation_mat
 
-    @geomstats.vectorization.decorator(['else', 'vector'])
     def skew_matrix_from_vector(self, vec):
         """Get the skew-symmetric matrix derived from the vector.
 
@@ -128,17 +127,25 @@ class _SpecialOrthogonalMatrices(GeneralLinear, LieGroup):
         skew_mat : array-like, shape=[..., n, n]
             Skew-symmetric matrix.
         """
-        n_vecs, vec_dim = gs.shape(vec)
+        return self.lie_algebra.matrix_representation(vec)
 
-        mat_dim = gs.cast(
-            ((1. + gs.sqrt(1. + 8. * vec_dim)) / 2.), gs.int32)
-        skew_mat = gs.zeros((n_vecs,) + (self.n,) * 2)
-        upper_triangle_indices = gs.triu_indices(mat_dim, k=1)
+    def vector_from_skew_matrix(self, skew_mat):
+        """Derive a vector from the skew-symmetric matrix.
 
-        for i in range(n_vecs):
-            skew_mat[i][upper_triangle_indices] = vec[i]
-            skew_mat[i] = skew_mat[i] - gs.transpose(skew_mat[i])
-        return skew_mat
+        In 3D, compute the vector defining the cross product
+        associated to the skew-symmetric matrix skew mat.
+
+        Parameters
+        ----------
+        skew_mat : array-like, shape=[..., n, n]
+            Skew-symmetric matrix.
+
+        Returns
+        -------
+        vec : array-like, shape=[..., dim]
+            Vector.
+        """
+        return SkewSymmetricMatrices(self.n).basis_representation(skew_mat)
 
 
 class _SpecialOrthogonalVectors(LieGroup):
@@ -292,6 +299,42 @@ class _SpecialOrthogonalVectors(LieGroup):
         """
         return self.regularize(point)
 
+    def skew_matrix_from_vector(self, vec):
+        """Get the skew-symmetric matrix derived from the vector.
+
+        In 3D, compute the skew-symmetric matrix,known as the cross-product of
+        a vector, associated to the vector `vec`.
+
+        Parameters
+        ----------
+        vec : array-like, shape=[..., dim]
+            Vector.
+
+        Returns
+        -------
+        skew_mat : array-like, shape=[..., n, n]
+            Skew-symmetric matrix.
+        """
+        return SkewSymmetricMatrices(self.n).matrix_representation(vec)
+
+    def vector_from_skew_matrix(self, skew_mat):
+        """Derive a vector from the skew-symmetric matrix.
+
+        In 3D, compute the vector defining the cross product
+        associated to the skew-symmetric matrix skew mat.
+
+        Parameters
+        ----------
+        skew_mat : array-like, shape=[..., n, n]
+            Skew-symmetric matrix.
+
+        Returns
+        -------
+        vec : array-like, shape=[..., dim]
+            Vector.
+        """
+        return SkewSymmetricMatrices(self.n).basis_representation(skew_mat)
+
 
 class _SpecialOrthogonal2Vectors(_SpecialOrthogonalVectors):
     """Class for the special orthogonal group SO(2) in vector representation.
@@ -383,46 +426,6 @@ class _SpecialOrthogonal2Vectors(_SpecialOrthogonalVectors):
             Regularized tangent vector.
         """
         return self.regularize_tangent_vec_at_identity(tangent_vec)
-
-    @staticmethod
-    def skew_matrix_from_vector(vec):
-        """Get the skew-symmetric matrix derived from the vector.
-
-        In 3D, compute the skew-symmetric matrix,known as the cross-product of
-        a vector, associated to the vector `vec`.
-
-        In nD, fill a skew-symmetric matrix with the values of the vector.
-
-        Parameters
-        ----------
-        vec : array-like, shape=[..., dim]
-            Vector.
-
-        Returns
-        -------
-        skew_mat : array-like, shape=[..., n, n]
-            Skew-symmetric matrix.
-        """
-        return SkewSymmetricMatrices(2).matrix_representation(vec)
-
-    @staticmethod
-    def vector_from_skew_matrix(skew_mat):
-        """Derive a vector from the skew-symmetric matrix.
-
-        In 3D, compute the vector defining the cross product
-        associated to the skew-symmetric matrix skew mat.
-
-        Parameters
-        ----------
-        skew_mat : array-like, shape=[..., n, n]
-            Skew-symmetric matrix.
-
-        Returns
-        -------
-        vec : array-like, shape=[..., dim]
-            Vector.
-        """
-        return SkewSymmetricMatrices(2).basis_representation(skew_mat)
 
     def rotation_vector_from_matrix(self, rot_mat):
         r"""Convert rotation matrix (in 2D) to rotation vector (axis-angle).
@@ -714,44 +717,6 @@ class _SpecialOrthogonal3Vectors(_SpecialOrthogonalVectors):
             base_point, left_or_right=metric.left_or_right)(tangent_vec_at_id)
 
         return regularized_tangent_vec
-
-    @staticmethod
-    def skew_matrix_from_vector(vec):
-        """Get the skew-symmetric matrix derived from the vector.
-
-        In 3D, compute the skew-symmetric matrix,known as the cross-product of
-        a vector, associated to the vector `vec`.
-
-        Parameters
-        ----------
-        vec : array-like, shape=[..., dim]
-            Vector.
-
-        Returns
-        -------
-        skew_mat : array-like, shape=[..., n, n]
-            Skew-symmetric matrix.
-        """
-        return SkewSymmetricMatrices(3).matrix_representation(vec)
-
-    @staticmethod
-    def vector_from_skew_matrix(skew_mat):
-        """Derive a vector from the skew-symmetric matrix.
-
-        In 3D, compute the vector defining the cross product
-        associated to the skew-symmetric matrix skew mat.
-
-        Parameters
-        ----------
-        skew_mat : array-like, shape=[..., n, n]
-            Skew-symmetric matrix.
-
-        Returns
-        -------
-        vec : array-like, shape=[..., dim]
-            Vector.
-        """
-        return SkewSymmetricMatrices(3).basis_representation(skew_mat)
 
     @geomstats.vectorization.decorator(['else', 'matrix', 'output_point'])
     def rotation_vector_from_matrix(self, rot_mat):

--- a/geomstats/geometry/symmetric_matrices.py
+++ b/geomstats/geometry/symmetric_matrices.py
@@ -57,7 +57,6 @@ class SymmetricMatrices(EmbeddedManifold):
     basis = property(get_basis)
 
     @staticmethod
-    @geomstats.vectorization.decorator(['matrix'])
     def to_vector(mat):
         """Convert a symmetric matrix into a vector.
 
@@ -74,14 +73,9 @@ class SymmetricMatrices(EmbeddedManifold):
         if not gs.all(Matrices.is_symmetric(mat)):
             logging.warning('non-symmetric matrix encountered.')
         mat = Matrices.to_symmetric(mat)
-        _, dim, _ = mat.shape
-        indices_i, indices_j = gs.triu_indices(dim)
-        vec = []
-        for i, j in zip(indices_i, indices_j):
-            vec.append(mat[:, i, j])
-        vec = gs.stack(vec, axis=1)
-
-        return vec
+        dim = mat.shape[-1]
+        rows, cols = gs.triu_indices(dim)
+        return mat[..., rows, cols]
 
     @staticmethod
     @geomstats.vectorization.decorator(['vector', 'else'])

--- a/geomstats/geometry/symmetric_matrices.py
+++ b/geomstats/geometry/symmetric_matrices.py
@@ -45,13 +45,18 @@ class SymmetricMatrices(EmbeddedManifold):
 
     def get_basis(self):
         """Compute the basis of the vector space of symmetric matrices."""
-        basis = [
-            gs.array_from_sparse([
-                (row, col), (col, row)], [1., 1.], (self.n, self.n))
-            for row in gs.arange(self.n)
-            for col in gs.arange(row, self.n)]
-        basis = gs.stack(
-            basis) * (gs.ones((self.n, self.n)) - 1. / 2 * gs.eye(self.n))
+        basis = []
+        for row in gs.arange(self.n):
+            for col in gs.arange(row, self.n):
+                if row == col:
+                    indices = [(row, row)]
+                    values = [1.]
+                else:
+                    indices = [(row, col), (col, row)]
+                    values = [1., 1.]
+                basis.append(gs.array_from_sparse(
+                    indices, values, (self.n, ) * 2))
+        basis = gs.stack(basis)
         return basis
 
     basis = property(get_basis)
@@ -73,9 +78,7 @@ class SymmetricMatrices(EmbeddedManifold):
         if not gs.all(Matrices.is_symmetric(mat)):
             logging.warning('non-symmetric matrix encountered.')
         mat = Matrices.to_symmetric(mat)
-        dim = mat.shape[-1]
-        rows, cols = gs.triu_indices(dim)
-        return mat[..., rows, cols]
+        return gs.triu_to_vec(mat)
 
     @staticmethod
     @geomstats.vectorization.decorator(['vector', 'else'])

--- a/geomstats/visualization.py
+++ b/geomstats/visualization.py
@@ -13,6 +13,7 @@ from mpl_toolkits.mplot3d import Axes3D  # NOQA
 
 SE3_GROUP = SpecialEuclidean(n=3, point_type='vector')
 SE2_GROUP = SpecialEuclidean(n=2, point_type='matrix')
+SE2_VECT = SpecialEuclidean(n=2, point_type='vector')
 SO3_GROUP = SpecialOrthogonal(n=3, point_type='vector')
 S1 = Hypersphere(dim=1)
 S2 = Hypersphere(dim=2)
@@ -467,11 +468,11 @@ class SpecialEuclidean2:
         return ax
 
     def add_points(self, points):
+        if self.point_type == 'vector':
+            points = SE2_VECT.matrix_from_vector(points)
         if not gs.all(SE2_GROUP.belongs(points)):
             raise ValueError(
                 'Points do not belong to SE2.')
-        if self.point_type == 'vector':
-            points = SE2_GROUP.matrix_from_vector(points)
         if not isinstance(points, list):
             points = list(points)
         self.points.extend(points)

--- a/geomstats/visualization.py
+++ b/geomstats/visualization.py
@@ -13,7 +13,7 @@ from mpl_toolkits.mplot3d import Axes3D  # NOQA
 
 SE3_GROUP = SpecialEuclidean(n=3, point_type='vector')
 SE2_GROUP = SpecialEuclidean(n=2, point_type='matrix')
-SO3_GROUP = SpecialOrthogonal(n=3, point_type='vector')
+# SO3_GROUP = SpecialOrthogonal(n=3, point_type='vector')
 S1 = Hypersphere(dim=1)
 S2 = Hypersphere(dim=2)
 H2 = Hyperboloid(dim=2)
@@ -479,21 +479,13 @@ class SpecialEuclidean2:
     def draw(self, ax, **kwargs):
         points = gs.array(self.points)
         translation = points[..., :2, 2]
-        min_y = min(translation[..., 1])
-        max_y = max(translation[..., 1])
-        max_x = max(translation[..., 0])
-        min_x = min(translation[..., 0])
-        y_lims = [min_y - 1., max_y + 1.]
-        x_lims = [min_x - 1., max_x + 1.]
-        ax = self.set_ax(ax, x_lims, y_lims)
-
         frame_1 = points[:, :2, 0]
         frame_2 = points[:, :2, 1]
         ax.quiver(translation[:, 0], translation[:, 1], frame_1[:, 0],
                   frame_1[:, 1], width=0.005, color='b')
         ax.quiver(translation[:, 0], translation[:, 1], frame_2[:, 0],
                   frame_2[:, 1], width=0.005, color='r')
-        ax.scatter(translation[:, 0], translation[:, 1], **kwargs)
+        ax.scatter(translation[:, 0], translation[:, 1], s=16, **kwargs)
 
 
 def convert_to_trihedron(point, space=None):

--- a/geomstats/visualization.py
+++ b/geomstats/visualization.py
@@ -451,6 +451,7 @@ class KleinDisk:
 
 class SpecialEuclidean2:
     """Class used to plot points in the 2d special euclidean group."""
+
     def __init__(self, points=None, point_type='matrix'):
         self.points = []
         self.point_type = point_type

--- a/geomstats/visualization.py
+++ b/geomstats/visualization.py
@@ -13,7 +13,7 @@ from mpl_toolkits.mplot3d import Axes3D  # NOQA
 
 SE3_GROUP = SpecialEuclidean(n=3, point_type='vector')
 SE2_GROUP = SpecialEuclidean(n=2, point_type='matrix')
-# SO3_GROUP = SpecialOrthogonal(n=3, point_type='vector')
+SO3_GROUP = SpecialOrthogonal(n=3, point_type='vector')
 S1 = Hypersphere(dim=1)
 S2 = Hypersphere(dim=2)
 H2 = Hyperboloid(dim=2)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -16,6 +16,7 @@ import examples.plot_expectation_maximization_manifolds as plot_em_manifolds
 import examples.plot_geodesics_h2 as plot_geodesics_h2
 import examples.plot_geodesics_poincare_polydisk as plot_geodesics_poincare_polydisk # NOQA
 import examples.plot_geodesics_s2 as plot_geodesics_s2
+import examples.plot_geodesics_se2 as plot_geodesics_se2
 import examples.plot_geodesics_se3 as plot_geodesics_se3
 import examples.plot_geodesics_so3 as plot_geodesics_so3
 import examples.plot_grid_h2 as plot_grid_h2
@@ -177,3 +178,7 @@ class TestExamples(geomstats.tests.TestCase):
     @staticmethod
     def test_plot_pole_ladder_s2():
         plot_pole_ladder_s2.main()
+
+    @staticmethod
+    def test_plot_geodesics_se2():
+        plot_geodesics_se2.main()

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -180,5 +180,6 @@ class TestExamples(geomstats.tests.TestCase):
         plot_pole_ladder_s2.main()
 
     @staticmethod
+    @geomstats.tests.np_and_pytorch_only
     def test_plot_geodesics_se2():
         plot_geodesics_se2.main()

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -180,6 +180,5 @@ class TestExamples(geomstats.tests.TestCase):
         plot_pole_ladder_s2.main()
 
     @staticmethod
-    @geomstats.tests.np_and_pytorch_only
     def test_plot_geodesics_se2():
         plot_geodesics_se2.main()

--- a/tests/test_invariant_metric.py
+++ b/tests/test_invariant_metric.py
@@ -732,7 +732,7 @@ class TestInvariantMetric(geomstats.tests.TestCase):
         lie_algebra = group.lie_algebra
         metric = InvariantMetric(group=group)
         canonical_metric = group.left_canonical_metric
-        basis = lie_algebra.orthonormal_basis(metric.metric_mat_at_identity)
+        basis = metric.orthonormal_basis(lie_algebra.basis)
 
         vector = gs.random.rand(len(basis))
         tangent_vec = gs.einsum('...j,jkl->...kl', vector, basis)

--- a/tests/test_invariant_metric.py
+++ b/tests/test_invariant_metric.py
@@ -557,23 +557,23 @@ class TestInvariantMetric(geomstats.tests.TestCase):
         metric = InvariantMetric(group=group)
         basis = metric.orthonormal_basis(group.lie_algebra.basis)
         x, y, z = basis
-        result = metric.structure_constant(-z, y, -x)
+        result = metric.structure_constant(x, y, z)
         expected = 2. ** .5 / 2.
         self.assertAllClose(result, expected)
 
-        result = -metric.structure_constant(y, -z, -x)
+        result = -metric.structure_constant(y, x, z)
         self.assertAllClose(result, expected)
 
-        result = metric.structure_constant(y, -x, -z)
+        result = metric.structure_constant(y, z, x)
         self.assertAllClose(result, expected)
 
-        result = -metric.structure_constant(-x, y, -z)
+        result = -metric.structure_constant(z, y, x)
         self.assertAllClose(result, expected)
 
-        result = metric.structure_constant(-x, -z, y)
+        result = metric.structure_constant(z, x, y)
         self.assertAllClose(result, expected)
 
-        result = -metric.structure_constant(-z, -x, y)
+        result = -metric.structure_constant(x, z, y)
         self.assertAllClose(result, expected)
 
         result = metric.structure_constant(x, x, z)
@@ -596,13 +596,13 @@ class TestInvariantMetric(geomstats.tests.TestCase):
         group = self.matrix_so3
         metric = InvariantMetric(group=group)
         x, y, z = metric.orthonormal_basis(group.lie_algebra.basis)
-        result = metric.connection(-z, y)
-        expected = -1. / 2 ** .5 / 2. * x
+        result = metric.connection(x, y)
+        expected = 1. / 2 ** .5 / 2. * z
         self.assertAllClose(result, expected)
 
         point = group.random_uniform()
         translation_map = group.tangent_translation_map(point)
-        tan_a = translation_map(-z)
+        tan_a = translation_map(x)
         tan_b = translation_map(y)
         result = metric.connection(tan_a, tan_b, point)
         expected = translation_map(expected)
@@ -619,7 +619,7 @@ class TestInvariantMetric(geomstats.tests.TestCase):
 
         point = group.random_uniform()
         translation_map = group.tangent_translation_map(point)
-        tan_a = translation_map(-z)
+        tan_a = translation_map(x)
         tan_b = translation_map(y)
         result = metric.sectional_curvature(tan_a, tan_b, point)
         self.assertAllClose(result, expected)

--- a/tests/test_lie_algebra.py
+++ b/tests/test_lie_algebra.py
@@ -29,7 +29,6 @@ class TestLieAlgebra(geomstats.tests.TestCase):
         expected = True
         self.assertAllClose(result, expected)
 
-    @geomstats.tests.np_and_pytorch_only
     def test_basis_and_matrix_representation(self):
         n_samples = 2
         expected = gs.random.rand(n_samples * self.dim)

--- a/tests/test_lie_algebra.py
+++ b/tests/test_lie_algebra.py
@@ -5,7 +5,8 @@ import geomstats.tests
 from geomstats.algebra_utils import from_vector_to_diagonal_matrix
 from geomstats.geometry.invariant_metric import InvariantMetric
 from geomstats.geometry.skew_symmetric_matrices import SkewSymmetricMatrices
-from geomstats.geometry.special_orthogonal import SpecialOrthogonal
+from geomstats.geometry.special_euclidean import SpecialEuclidean, \
+    SpecialOrthogonal
 
 
 class TestLieAlgebra(geomstats.tests.TestCase):
@@ -59,3 +60,26 @@ class TestLieAlgebra(geomstats.tests.TestCase):
 
         result = metric.inner_product_at_identity(basis[1], basis[1])
         self.assertAllClose(result, 1.)
+
+    def test_orthonormal_basis_se3(self):
+        group = SpecialEuclidean(3)
+        lie_algebra = group.lie_algebra
+        metric = InvariantMetric(group=group)
+        basis = lie_algebra.orthonormal_basis(metric.metric_mat_at_identity)
+        for i, x in enumerate(basis):
+            for y in basis[i:]:
+                result = metric.inner_product_at_identity(x, y)
+                expected = 0. if gs.any(x != y) else 1.
+                self.assertAllClose(result, expected)
+
+        metric_mat = from_vector_to_diagonal_matrix(
+            gs.arange(1, group.dim + 1))
+        metric = InvariantMetric(
+            group=group,
+            metric_mat_at_identity=metric_mat)
+        basis = lie_algebra.orthonormal_basis(metric.metric_mat_at_identity)
+        for i, x in enumerate(basis):
+            for y in basis[i:]:
+                result = metric.inner_product_at_identity(x, y)
+                expected = 0. if gs.any(x != y) else 1.
+                self.assertAllClose(result, expected)

--- a/tests/test_skew_symmetric_matrices.py
+++ b/tests/test_skew_symmetric_matrices.py
@@ -68,3 +68,12 @@ class TestSkewSymmetricMatrices(geomstats.tests.TestCase):
             shape = gs.shape(skew.basis_representation(skew.basis))
             dim = int(n * (n - 1) / 2)
             self.assertEqual(shape, (dim, dim))
+
+    @geomstats.tests.np_and_pytorch_only
+    def test_matrix_and_basis_representation(self):
+        for n in self.n_seq:
+            skew = self.skew[n]
+            vec = gs.random.rand(skew.dim)
+            mat = skew.matrix_representation(vec)
+            result = skew.basis_representation(mat)
+            self.assertAllClose(result, vec)

--- a/tests/test_skew_symmetric_matrices.py
+++ b/tests/test_skew_symmetric_matrices.py
@@ -61,15 +61,13 @@ class TestSkewSymmetricMatrices(geomstats.tests.TestCase):
             )
             self.assertAllClose(expected, result)
 
-    @geomstats.tests.np_and_pytorch_only
     def test_basis_representation_is_correctly_vectorized(self):
         for n in self.n_seq:
             skew = self.skew[n]
             shape = gs.shape(skew.basis_representation(skew.basis))
             dim = int(n * (n - 1) / 2)
-            self.assertEqual(shape, (dim, dim))
+            self.assertAllClose(shape, (dim, dim))
 
-    @geomstats.tests.np_and_pytorch_only
     def test_matrix_and_basis_representation(self):
         for n in self.n_seq:
             skew = self.skew[n]

--- a/tests/test_skew_symmetric_matrices.py
+++ b/tests/test_skew_symmetric_matrices.py
@@ -7,7 +7,7 @@ from geomstats.geometry.skew_symmetric_matrices import SkewSymmetricMatrices
 
 class TestSkewSymmetricMatrices(geomstats.tests.TestCase):
     def setUp(self):
-        self.n_seq = [3, 4, 5, 6, 7, 8, 9, 10]
+        self.n_seq = [2, 3, 4, 5, 6, 7, 8, 9, 10]
         self.skew = {n: SkewSymmetricMatrices(n=n) for n in self.n_seq}
 
     def test_basis_is_skew_symmetric(self):
@@ -25,7 +25,7 @@ class TestSkewSymmetricMatrices(geomstats.tests.TestCase):
             self.assertEqual(int(n * (n - 1) / 2), skew.dim)
 
     def test_bch_up_to_fourth_order_works(self):
-        for n in self.n_seq:
+        for n in self.n_seq[1:]:
             skew = self.skew[n]
             first_base = skew.basis[0]
             second_base = skew.basis[1]

--- a/tests/test_special_euclidean.py
+++ b/tests/test_special_euclidean.py
@@ -291,3 +291,12 @@ class TestSpecialEuclidean(geomstats.tests.TestCase):
         tangent_vec = self.group.lie_algebra.projection(vec)
         result = self.group.lie_algebra.belongs(tangent_vec)
         self.assertTrue(gs.all(result))
+
+    def test_basis_representation(self):
+        vec = gs.random.rand(self.n_samples, self.group.dim)
+        tangent_vec = self.group.lie_algebra.matrix_representation(vec)
+        result = self.group.lie_algebra.basis_representation(tangent_vec)
+        self.assertAllClose(result, vec)
+
+        result = self.group.lie_algebra.basis_representation(tangent_vec[0])
+        self.assertAllClose(result, vec[0])

--- a/tests/test_special_euclidean.py
+++ b/tests/test_special_euclidean.py
@@ -164,6 +164,29 @@ class TestSpecialEuclidean(geomstats.tests.TestCase):
             expected = point_a + point_b * last_line_0
             self.assertAllClose(result, expected)
 
+    def test_left_exp_coincides(self):
+        vector_group = SpecialEuclidean(n=2, point_type='vector')
+        theta = gs.pi / 3
+        initial_vec = gs.array([theta, 2., 2.])
+        initial_matrix_vec = self.group.lie_algebra.matrix_representation(
+            initial_vec)
+        vector_exp = vector_group.left_canonical_metric.exp(initial_vec)
+        result = self.group.left_canonical_metric.exp(initial_matrix_vec)
+        expected = vector_group.matrix_from_vector(vector_exp)
+        self.assertAllClose(result, expected)
+
+    def test_right_exp_coincides(self):
+        vector_group = SpecialEuclidean(n=2, point_type='vector')
+        theta = gs.pi / 2
+        initial_vec = gs.array([theta, 1., 1.])
+        initial_matrix_vec = self.group.lie_algebra.matrix_representation(
+            initial_vec)
+        vector_exp = vector_group.right_canonical_metric.exp(initial_vec)
+        result = self.group.right_canonical_metric.exp(
+            initial_matrix_vec, n_steps=20)
+        expected = vector_group.matrix_from_vector(vector_exp)
+        self.assertAllClose(result, expected)
+
     def test_basis_belongs(self):
         lie_algebra = self.group.lie_algebra
         result = lie_algebra.belongs(lie_algebra.basis)

--- a/tests/test_special_euclidean.py
+++ b/tests/test_special_euclidean.py
@@ -2,9 +2,9 @@
 
 import geomstats.backend as gs
 import geomstats.tests
-from geomstats.geometry.special_euclidean import SpecialEuclidean, \
-    SpecialEuclideanMatrixLieAlgebra,\
-    SpecialEuclideanMatrixCannonicalLeftMetric
+from geomstats.geometry.special_euclidean import SpecialEuclidean,\
+    SpecialEuclideanMatrixCannonicalLeftMetric,\
+    SpecialEuclideanMatrixLieAlgebra
 
 
 class TestSpecialEuclidean(geomstats.tests.TestCase):

--- a/tests/test_special_euclidean.py
+++ b/tests/test_special_euclidean.py
@@ -183,7 +183,7 @@ class TestSpecialEuclidean(geomstats.tests.TestCase):
             initial_vec)
         vector_exp = vector_group.right_canonical_metric.exp(initial_vec)
         result = self.group.right_canonical_metric.exp(
-            initial_matrix_vec, n_steps=20)
+            initial_matrix_vec, n_steps=25)
         expected = vector_group.matrix_from_vector(vector_exp)
         self.assertAllClose(result, expected)
 
@@ -250,6 +250,7 @@ class TestSpecialEuclidean(geomstats.tests.TestCase):
         result = self.group.belongs(exp)
         self.assertTrue(result)
 
+    @geomstats.tests.np_and_tf_only
     def test_log_and_is_tan(self):
         exp = self.group.left_canonical_metric.exp(
             self.tangent_vec, self.point)
@@ -267,6 +268,7 @@ class TestSpecialEuclidean(geomstats.tests.TestCase):
         result = self.group.is_tangent(log, self.point[0])
         self.assertTrue(result)
 
+    @geomstats.tests.np_and_tf_only
     def test_exp_log(self):
         exp = self.group.left_canonical_metric.exp(
             self.tangent_vec, self.point)
@@ -278,6 +280,7 @@ class TestSpecialEuclidean(geomstats.tests.TestCase):
         result = self.group.left_canonical_metric.log(exp, self.point[0])
         self.assertAllClose(result, self.tangent_vec[0])
 
+    @geomstats.tests.np_and_tf_only
     def test_parallel_transport(self):
         metric = self.group.left_canonical_metric
         tan_a = self.tangent_vec

--- a/tests/test_special_euclidean.py
+++ b/tests/test_special_euclidean.py
@@ -220,13 +220,12 @@ class TestSpecialEuclidean(geomstats.tests.TestCase):
         result = self.group.lie_algebra.belongs(vec)
         self.assertAllClose(result, expected)
 
-    @geomstats.tests.np_and_pytorch_only
     def test_basis_representation_is_correctly_vectorized(self):
         for n in range(2, 5):
             algebra = SpecialEuclideanMatrixLieAlgebra(n)
             shape = gs.shape(algebra.basis_representation(algebra.basis))
             dim = int(n * (n + 1) / 2)
-            self.assertEqual(shape, (dim, dim))
+            self.assertAllClose(shape, (dim, dim))
 
     def test_left_metric_wrong_group(self):
         group = self.group.rotations

--- a/tests/test_symmetric_matrices.py
+++ b/tests/test_symmetric_matrices.py
@@ -37,7 +37,6 @@ class TestSymmetricMatrices(geomstats.tests.TestCase):
         expected = False
         self.assertAllClose(result, expected)
 
-    @geomstats.tests.np_and_pytorch_only
     def test_basis(self):
         """Test of belongs method."""
         sym_n = SymmetricMatrices(2)
@@ -75,7 +74,6 @@ class TestSymmetricMatrices(geomstats.tests.TestCase):
         result = gs.matmul(result, gs.transpose(result, (0, 2, 1)))
         self.assertAllClose(result, expected)
 
-    @geomstats.tests.np_and_pytorch_only
     def test_vector_from_symmetric_matrix_and_symmetric_matrix_from_vector(
             self):
         """Test for matrix to vector and vector to matrix conversions."""
@@ -95,7 +93,6 @@ class TestSymmetricMatrices(geomstats.tests.TestCase):
 
         self.assertTrue(gs.allclose(result_2, expected_2))
 
-    @geomstats.tests.np_and_pytorch_only
     def test_vector_and_symmetric_matrix_vectorization(self):
         """Test of vectorization."""
         n_samples = 5

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -69,7 +69,8 @@ class TestVisualization(geomstats.tests.TestCase):
         points = self.H2.random_uniform(self.n_samples)
         visualization.plot(points, space='H2_klein_disk')
 
-    def test_plot_points_se2(self):
+    @staticmethod
+    def test_plot_points_se2():
         points = SpecialEuclidean(n=2, point_type='vector').random_uniform(4)
         visu = visualization.SpecialEuclidean2(points, point_type='vector')
         ax = visu.set_ax()

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -68,3 +68,9 @@ class TestVisualization(geomstats.tests.TestCase):
     def test_plot_points_h2_klein_disk(self):
         points = self.H2.random_uniform(self.n_samples)
         visualization.plot(points, space='H2_klein_disk')
+
+    def test_plot_points_se2(self):
+        points = SpecialEuclidean(n=2, point_type='vector').random_uniform(4)
+        visu = visualization.SpecialEuclidean2(points, point_type='vector')
+        ax = visu.set_ax()
+        visu.draw(ax)


### PR DESCRIPTION
This PR continues #878, #884 and #886. It
- adds a module for visualisation of SE(2) in the plane
- adds a class for the left-invariant metric on matrix SE(n). It is a product metric with closed-form formulas. It is checked that they coincide with the vector implementations.
- adds an example where the geodesics with the different structures are plotted.
- Harmonize 2 and 3 dimensional bases of the space of skew symmetric matrices with conventions