### PR TITLE
Add sylvester solve for tf in backend

### DIFF
--- a/geomstats/_backend/numpy/linalg.py
+++ b/geomstats/_backend/numpy/linalg.py
@@ -99,6 +99,17 @@ def powerm(x, power):
 
 
 def solve_sylvester(a, b, q):
+    if a.shape == b.shape:
+        axes = (0, 2, 1) if a.ndim == 3 else (1, 0)
+        if np.all(a == b) and np.all(
+                np.abs(a - np.transpose(a, axes)) < 1e-6):
+            eigvals, eigvecs = eigh(a)
+            if np.all(eigvals >= 1e-6):
+                tilde_q = np.transpose(eigvecs, axes) @ q @ eigvecs
+                tilde_x = tilde_q / (
+                    eigvals[..., :, None] + eigvals[..., None, :])
+                return eigvecs @ tilde_x @ np.transpose(eigvecs, axes)
+
     return np.vectorize(
         scipy.linalg.solve_sylvester,
         signature='(m,m),(n,n),(m,n)->(m,n)')(a, b, q)

--- a/geomstats/_backend/pytorch/linalg.py
+++ b/geomstats/_backend/pytorch/linalg.py
@@ -60,6 +60,16 @@ def norm(x, ord=2, axis=None):
 
 
 def solve_sylvester(a, b, q):
+    if a.shape == b.shape:
+        if torch.all(a == b) and torch.all(
+                torch.abs(a - a.transpose(-2, -1)) < 1e-6):
+            eigvals, eigvecs = eigh(a)
+            if torch.all(eigvals >= 1e-6):
+                tilde_q = eigvecs.transpose(-2, -1) @ q @ eigvecs
+                tilde_x = tilde_q / (
+                    eigvals[..., :, None] + eigvals[..., None, :])
+                return eigvecs @ tilde_x @ eigvecs.transpose(-2, -1)
+
     solution = np.vectorize(
         scipy.linalg.solve_sylvester,
         signature='(m,m),(n,n),(m,n)->(m,n)')(a, b, q)

--- a/geomstats/_backend/tensorflow/linalg.py
+++ b/geomstats/_backend/tensorflow/linalg.py
@@ -46,7 +46,7 @@ def solve_sylvester(a, b, q):
         if tf.reduce_all(a == b) and tf.reduce_all(
                 tf.abs(a - tf.transpose(a, perm=axes)) < 1e-6):
             eigvals, eigvecs = eigh(a)
-            if tf.reduce_all(eigvals >= 0):
+            if tf.reduce_all(eigvals >= 1e-6):
                 tilde_q = tf.transpose(eigvecs, perm=axes) @ q @ eigvecs
                 tilde_x = tilde_q / (
                     eigvals[..., :, None] + eigvals[..., None, :])

--- a/geomstats/_backend/tensorflow/linalg.py
+++ b/geomstats/_backend/tensorflow/linalg.py
@@ -41,8 +41,20 @@ def svd(x, full_matrices=True, compute_uv=True, **kwargs):
 
 
 def solve_sylvester(a, b, q):
+    axes = (0, 2, 1) if a.ndim == 3 else (1, 0)
+    if a.shape == b.shape:
+        if tf.reduce_all(a == b) and tf.reduce_all(
+                tf.abs(a - tf.transpose(a, perm=axes)) < 1e-6):
+            eigvals, eigvecs = eigh(a)
+            if tf.reduce_all(eigvals >= 0):
+                tilde_q = tf.transpose(eigvecs, perm=axes) @ q @ eigvecs
+                tilde_x = tilde_q / (
+                    eigvals[..., :, None] + eigvals[..., None, :])
+                return eigvecs @ tilde_x @ tf.transpose(
+                    eigvecs, perm=axes)
     raise NotImplementedError('solve_sylvester is not implemented in '
-                              'tensorflow')
+                              'tensorflow if a != b or a not Symmetric '
+                              'Semi Definite')
 
 
 def qr(x, mode='reduced'):

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -918,18 +918,17 @@ class TestBackends(geomstats.tests.TestCase):
         self.assertAllClose(result_grad, expected_grad)
 
     def test_choice(self):
-
         x = gs.array([0.1, 0.2, 0.3, 0.4, 0.5])
         a = 4
-
         result = gs.random.choice(x, a)
 
+        result_bool = True
         for i in result:
             if i in x:
-                self.assertTrue(True)
-            else:
-                self.assertTrue(False)
+                continue
+            result_bool = False
 
+        self.assertTrue(result_bool)
         self.assertEqual(len(result), a)
 
     def test_split(self):

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -984,6 +984,7 @@ class TestBackends(geomstats.tests.TestCase):
         self.assertAllClose(result, skew)
 
     def test_sylvester_solve_vectorization(self):
+        gs.random.seed(0)
         mat = gs.random.rand(2, 4, 3)
         spd = gs.matmul(gs.transpose(mat, (0, 2, 1)), mat)
 

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -971,3 +971,27 @@ class TestBackends(geomstats.tests.TestCase):
         s = _np.linalg.svd(np_point, compute_uv=compute_uv)
         s_r = gs.linalg.svd(gs_point, compute_uv=compute_uv)
         self.assertAllClose(s, s_r)
+
+    def test_sylvester_solve(self):
+        mat = gs.random.rand(4, 3)
+        spd = gs.matmul(gs.transpose(mat), mat)
+
+        mat = gs.random.rand(3, 3)
+        skew = mat - gs.transpose(mat)
+        solution = gs.linalg.solve_sylvester(spd, spd, skew)
+        result = gs.matmul(spd, solution)
+        result += gs.matmul(solution, spd)
+
+        self.assertAllClose(result, skew)
+
+    def test_sylvester_solve_vectorization(self):
+        mat = gs.random.rand(2, 4, 3)
+        spd = gs.matmul(gs.transpose(mat, (0, 2, 1)), mat)
+
+        mat = gs.random.rand(2, 3, 3)
+        skew = mat - gs.transpose(mat, (0, 2, 1))
+        solution = gs.linalg.solve_sylvester(spd, spd, skew)
+        result = gs.matmul(spd, solution)
+        result += gs.matmul(solution, spd)
+
+        self.assertAllClose(result, skew)

--- a/tests/test_pre_shape.py
+++ b/tests/test_pre_shape.py
@@ -101,7 +101,6 @@ class TestPreShapeSpace(geomstats.tests.TestCase):
         expected = gs.array([True, False])
         self.assertAllClose(result, expected)
 
-    @geomstats.tests.np_and_pytorch_only
     def test_vertical_projection(self):
         vector = gs.random.rand(self.k_landmarks, self.m_ambient)
         point = self.space.random_uniform()
@@ -116,7 +115,6 @@ class TestPreShapeSpace(geomstats.tests.TestCase):
         result = Matrices.transpose(tmp_result) - tmp_result
         self.assertAllClose(result, expected)
 
-    @geomstats.tests.np_and_pytorch_only
     def test_vertical_projection_vectorization(self):
         vector = gs.random.rand(
             self.n_samples, self.k_landmarks, self.m_ambient)
@@ -132,7 +130,6 @@ class TestPreShapeSpace(geomstats.tests.TestCase):
         result = Matrices.transpose(tmp_result) - tmp_result
         self.assertAllClose(result, expected)
 
-    @geomstats.tests.np_and_pytorch_only
     def test_horizontal_projection(self):
         vector = gs.random.rand(self.k_landmarks, self.m_ambient)
         point = self.space.random_uniform()
@@ -144,7 +141,6 @@ class TestPreShapeSpace(geomstats.tests.TestCase):
 
         self.assertAllClose(result, expected)
 
-    @geomstats.tests.np_and_pytorch_only
     def test_horizontal_projection_vectorized(self):
         vector = gs.random.rand(
             self.n_samples, self.k_landmarks, self.m_ambient)
@@ -157,7 +153,6 @@ class TestPreShapeSpace(geomstats.tests.TestCase):
 
         self.assertAllClose(result, expected)
 
-    @geomstats.tests.np_and_pytorch_only
     def test_horizontal_and_is_tangent(self):
         vector = gs.random.rand(self.k_landmarks, self.m_ambient)
         point = self.space.random_uniform()
@@ -265,7 +260,6 @@ class TestPreShapeSpace(geomstats.tests.TestCase):
         expected = gs.stack([base_point] * self.n_samples)
         self.assertAllClose(exp, expected)
 
-    @geomstats.tests.np_and_pytorch_only
     def test_kendall_inner_product_shape(self):
         vector = gs.random.rand(
             self.n_samples, self.k_landmarks, self.m_ambient)
@@ -274,7 +268,6 @@ class TestPreShapeSpace(geomstats.tests.TestCase):
         inner = self.shape_metric.inner_product(tan, tan, point)
         self.assertAllClose(inner.shape, (self.n_samples,))
 
-    @geomstats.tests.np_and_pytorch_only
     def test_kendall_log_and_exp(self):
         point, base_point = self.space.random_uniform(2)
         expected = self.space.align(point, base_point)
@@ -285,7 +278,6 @@ class TestPreShapeSpace(geomstats.tests.TestCase):
         exp = self.shape_metric.exp(log, base_point)
         self.assertAllClose(exp, expected)
 
-    @geomstats.tests.np_and_pytorch_only
     def test_kendall_exp_and_log(self):
         base_point = self.space.random_uniform()
         vector = gs.random.rand(self.k_landmarks, self.m_ambient)
@@ -304,7 +296,6 @@ class TestPreShapeSpace(geomstats.tests.TestCase):
         expected = 0.
         self.assertAllClose(result, expected)
 
-    @geomstats.tests.np_and_pytorch_only
     def test_dist(self):
         point, base_point = self.space.random_uniform(2)
         result = self.shape_metric.dist(point, base_point)
@@ -312,7 +303,6 @@ class TestPreShapeSpace(geomstats.tests.TestCase):
         expected = self.shape_metric.norm(log, base_point)
         self.assertAllClose(result, expected)
 
-    @geomstats.tests.np_and_pytorch_only
     def test_dist_vectorization(self):
         point = self.space.random_uniform(self.n_samples)
         base_point = self.space.random_uniform(self.n_samples)


### PR DESCRIPTION
In the particular case where A=B is a Symmetric Non-Negative Definite matrix, the solution to AX + XB = Q can be computed with an eigenvalue decomposition of A. It turns out that this is much faster than vectorizing the scipy solver.
This allows to extend all the methods in the Kendall shape spaces to run with tensorflow, and could be used in #889.