### PR TITLE
add abstract class for quotient spaces

### DIFF
--- a/geomstats/_backend/__init__.py
+++ b/geomstats/_backend/__init__.py
@@ -113,6 +113,7 @@ BACKEND_ATTRIBUTES = {
     ],
     'autograd': ['value_and_grad'],
     'linalg': [
+        'cholesky',
         'det',
         'eig',
         'eigh',

--- a/geomstats/_backend/__init__.py
+++ b/geomstats/_backend/__init__.py
@@ -122,7 +122,6 @@ BACKEND_ATTRIBUTES = {
         'inv',
         'logm',
         'norm',
-        'powerm',
         'qr',
         'solve_sylvester',
         'sqrtm',

--- a/geomstats/_backend/numpy/linalg.py
+++ b/geomstats/_backend/numpy/linalg.py
@@ -2,7 +2,6 @@
 
 import autograd.numpy as np
 import autograd.scipy.linalg as asp
-import scipy.linalg
 from autograd.extend import defvjp, primitive
 from autograd.numpy.linalg import (  # NOQA
     cholesky,
@@ -15,39 +14,14 @@ from autograd.numpy.linalg import (  # NOQA
     svd
 )
 
-from .common import to_ndarray
 
 _TOL = 1e-10
 
 
-def _is_symmetric(x, tol=_TOL):
-    new_x = to_ndarray(x, to_ndim=3)
-    return (np.abs(new_x - np.transpose(new_x, axes=(0, 2, 1))) < tol).all()
-
-
-def _expsym(x):
-    eigvals, eigvecs = np.linalg.eigh(x)
-    eigvals = np.exp(eigvals)
-    eigvals = np.vectorize(np.diag, signature='(n)->(n,n)')(eigvals)
-    transp_eigvecs = np.transpose(eigvecs, axes=(0, 2, 1))
-    result = np.matmul(eigvecs, eigvals)
-    result = np.matmul(result, transp_eigvecs)
-    return result
-
-
 @primitive
 def expm(x):
-    ndim = x.ndim
-    new_x = to_ndarray(x, to_ndim=3)
-    if _is_symmetric(new_x):
-        result = _expsym(new_x)
-    else:
-        result = np.vectorize(asp.expm,
-                              signature='(n,m)->(n,m)')(new_x)
-
-    if ndim == 2:
-        return result[0]
-    return result
+    return np.vectorize(
+        asp.expm, signature='(n,m)->(n,m)')(x)
 
 
 def _expm_vjp(_ans, x):
@@ -69,55 +43,8 @@ defvjp(expm, _expm_vjp)
 
 
 def logm(x):
-    ndim = x.ndim
-    new_x = to_ndarray(x, to_ndim=3)
-    if _is_symmetric(new_x):
-        eigvals, eigvecs = np.linalg.eigh(new_x)
-        if (eigvals > 0).all():
-            eigvals = np.log(eigvals)
-            eigvals = np.vectorize(np.diag, signature='(n)->(n,n)')(eigvals)
-            transp_eigvecs = np.transpose(eigvecs, axes=(0, 2, 1))
-            result = np.matmul(eigvecs, eigvals)
-            result = np.matmul(result, transp_eigvecs)
-        else:
-            result = np.vectorize(scipy.linalg.logm,
-                                  signature='(n,m)->(n,m)')(new_x)
-    else:
-        result = np.vectorize(scipy.linalg.logm,
-                              signature='(n,m)->(n,m)')(new_x)
-
-    if ndim == 2:
-        return result[0]
-    return result
-
-
-def powerm(x, power):
-    ndim = x.ndim
-    new_x = to_ndarray(x, to_ndim=3)
-    if _is_symmetric(new_x):
-        eigvals, eigvecs = np.linalg.eigh(new_x)
-        if (eigvals > 0).all():
-            eigvals = eigvals ** power
-            eigvals = np.vectorize(np.diag, signature='(n)->(n,n)')(eigvals)
-            transp_eigvecs = np.transpose(eigvecs, axes=(0, 2, 1))
-            result = np.matmul(eigvecs, eigvals)
-            result = np.matmul(result, transp_eigvecs)
-        else:
-            log_x = np.vectorize(scipy.linalg.logm,
-                                 signature='(n,m)->(n,m)')(new_x)
-            p_log_x = power * log_x
-            result = np.vectorize(scipy.linalg.expm,
-                                  signature='(n,m)->(n,m)')(p_log_x)
-    else:
-        log_x = np.vectorize(scipy.linalg.logm,
-                             signature='(n,m)->(n,m)')(new_x)
-        p_log_x = power * log_x
-        result = np.vectorize(scipy.linalg.expm,
-                              signature='(n,m)->(n,m)')(p_log_x)
-
-    if ndim == 2:
-        return result[0]
-    return result
+    return np.vectorize(
+        asp.logm, signature='(n,m)->(n,m)')(x)
 
 
 def solve_sylvester(a, b, q):
@@ -133,13 +60,13 @@ def solve_sylvester(a, b, q):
                 return eigvecs @ tilde_x @ np.transpose(eigvecs, axes)
 
     return np.vectorize(
-        scipy.linalg.solve_sylvester,
+        asp.solve_sylvester,
         signature='(m,m),(n,n),(m,n)->(m,n)')(a, b, q)
 
 
 def sqrtm(x):
     return np.vectorize(
-        scipy.linalg.sqrtm, signature='(n,m)->(n,m)')(x)
+        asp.sqrtm, signature='(n,m)->(n,m)')(x)
 
 
 def qr(*args, **kwargs):

--- a/geomstats/_backend/numpy/linalg.py
+++ b/geomstats/_backend/numpy/linalg.py
@@ -3,6 +3,7 @@
 import autograd.numpy as np
 import scipy.linalg
 from autograd.numpy.linalg import (  # NOQA
+    cholesky,
     det,
     eig,
     eigh,

--- a/geomstats/_backend/numpy/linalg.py
+++ b/geomstats/_backend/numpy/linalg.py
@@ -2,6 +2,7 @@
 
 import autograd.numpy as np
 import autograd.scipy.linalg as asp
+import scipy.linalg
 from autograd.extend import defvjp, primitive
 from autograd.numpy.linalg import (  # NOQA
     cholesky,
@@ -14,8 +15,14 @@ from autograd.numpy.linalg import (  # NOQA
     svd
 )
 
+from .common import to_ndarray
 
 _TOL = 1e-10
+
+
+def _is_symmetric(x, tol=_TOL):
+    new_x = to_ndarray(x, to_ndim=3)
+    return (np.abs(new_x - np.transpose(new_x, axes=(0, 2, 1))) < tol).all()
 
 
 @primitive
@@ -43,8 +50,26 @@ defvjp(expm, _expm_vjp)
 
 
 def logm(x):
-    return np.vectorize(
-        asp.logm, signature='(n,m)->(n,m)')(x)
+    ndim = x.ndim
+    new_x = to_ndarray(x, to_ndim=3)
+    if _is_symmetric(new_x):
+        eigvals, eigvecs = np.linalg.eigh(new_x)
+        if (eigvals > 0).all():
+            eigvals = np.log(eigvals)
+            eigvals = np.vectorize(np.diag, signature='(n)->(n,n)')(eigvals)
+            transp_eigvecs = np.transpose(eigvecs, axes=(0, 2, 1))
+            result = np.matmul(eigvecs, eigvals)
+            result = np.matmul(result, transp_eigvecs)
+        else:
+            result = np.vectorize(scipy.linalg.logm,
+                                  signature='(n,m)->(n,m)')(new_x)
+    else:
+        result = np.vectorize(scipy.linalg.logm,
+                              signature='(n,m)->(n,m)')(new_x)
+
+    if ndim == 2:
+        return result[0]
+    return result
 
 
 def solve_sylvester(a, b, q):
@@ -60,13 +85,13 @@ def solve_sylvester(a, b, q):
                 return eigvecs @ tilde_x @ np.transpose(eigvecs, axes)
 
     return np.vectorize(
-        asp.solve_sylvester,
+        scipy.linalg.solve_sylvester,
         signature='(m,m),(n,n),(m,n)->(m,n)')(a, b, q)
 
 
 def sqrtm(x):
     return np.vectorize(
-        asp.sqrtm, signature='(n,m)->(n,m)')(x)
+        scipy.linalg.sqrtm, signature='(n,m)->(n,m)')(x)
 
 
 def qr(*args, **kwargs):

--- a/geomstats/_backend/pytorch/linalg.py
+++ b/geomstats/_backend/pytorch/linalg.py
@@ -10,9 +10,13 @@ def _raise_not_implemented_error(*args, **kwargs):
 
 
 eig = _raise_not_implemented_error
+expm = torch.matrix_exp
 logm = _raise_not_implemented_error
 powerm = torch.matrix_power
-expm = torch.matrix_exp
+
+
+def cholesky(a):
+    return torch.cholesky(a, upper=False)
 
 
 def sqrtm(x):

--- a/geomstats/_backend/pytorch/linalg.py
+++ b/geomstats/_backend/pytorch/linalg.py
@@ -11,19 +11,14 @@ def _raise_not_implemented_error(*args, **kwargs):
 
 eig = _raise_not_implemented_error
 logm = _raise_not_implemented_error
-powerm = _raise_not_implemented_error
+powerm = torch.matrix_power
+expm = torch.matrix_exp
 
 
 def sqrtm(x):
     np_sqrtm = np.vectorize(
         scipy.linalg.sqrtm, signature='(n,m)->(n,m)')(x)
     return torch.from_numpy(np_sqrtm)
-
-
-def expm(x):
-    np_expm = np.vectorize(
-        scipy.linalg.expm, signature='(n,m)->(n,m)')(x)
-    return torch.from_numpy(np_expm)
 
 
 def inv(*args, **kwargs):

--- a/geomstats/_backend/pytorch/linalg.py
+++ b/geomstats/_backend/pytorch/linalg.py
@@ -12,7 +12,8 @@ def _raise_not_implemented_error(*args, **kwargs):
 eig = _raise_not_implemented_error
 expm = torch.matrix_exp
 logm = _raise_not_implemented_error
-powerm = torch.matrix_power
+inv = torch.inverse
+det = torch.det
 
 
 def cholesky(a):
@@ -23,10 +24,6 @@ def sqrtm(x):
     np_sqrtm = np.vectorize(
         scipy.linalg.sqrtm, signature='(n,m)->(n,m)')(x)
     return torch.from_numpy(np_sqrtm)
-
-
-def inv(*args, **kwargs):
-    return torch.from_numpy(np.linalg.inv(*args, **kwargs))
 
 
 def eigvalsh(a, **kwargs):
@@ -51,14 +48,10 @@ def svd(x, full_matrices=True, compute_uv=True):
     return torch.svd(x, some=not full_matrices, compute_uv=compute_uv)[1]
 
 
-def det(*args, **kwargs):
-    return torch.from_numpy(np.array(np.linalg.det(*args, **kwargs)))
-
-
-def norm(x, ord=2, axis=None):
+def norm(x, ord=None, axis=None):
     if axis is None:
-        return torch.norm(x, p=ord)
-    return torch.norm(x, p=ord, dim=axis)
+        return torch.linalg.norm(x, ord=ord)
+    return torch.linalg.norm(x, ord=ord, dim=axis)
 
 
 def solve_sylvester(a, b, q):

--- a/geomstats/_backend/pytorch/linalg.py
+++ b/geomstats/_backend/pytorch/linalg.py
@@ -23,7 +23,7 @@ def cholesky(a):
 def sqrtm(x):
     np_sqrtm = np.vectorize(
         scipy.linalg.sqrtm, signature='(n,m)->(n,m)')(x)
-    return torch.from_numpy(np_sqrtm)
+    return torch.as_tensor(np_sqrtm, dtype=x.dtype)
 
 
 def eigvalsh(a, **kwargs):

--- a/geomstats/_backend/tensorflow/linalg.py
+++ b/geomstats/_backend/tensorflow/linalg.py
@@ -66,7 +66,3 @@ def solve_sylvester(a, b, q):
 
 def qr(x, mode='reduced'):
     return tf.linalg.qr(x, full_matrices=(mode == 'complete'))
-
-
-def powerm(x, power):
-    return expm(power * logm(x))

--- a/geomstats/_backend/tensorflow/linalg.py
+++ b/geomstats/_backend/tensorflow/linalg.py
@@ -25,6 +25,10 @@ def eigvalsh(a, **_unused_kwargs):
     return tf.linalg.eigvalsh(a)
 
 
+def cholesky(a, **_unused_kwargs):
+    return tf.linalg.cholesky(a)
+
+
 def logm(x):
     original_type = x.dtype
     x = tf.cast(x, tf.complex64)

--- a/geomstats/geometry/connection.py
+++ b/geomstats/geometry/connection.py
@@ -151,6 +151,9 @@ class Connection:
         step : str, {'euler', 'rk4'}
             Numerical scheme to use for integration.
             Optional, default: 'euler'.
+        max_iter
+        verbose
+        tol
 
         Returns
         -------

--- a/geomstats/geometry/embedded_manifold.py
+++ b/geomstats/geometry/embedded_manifold.py
@@ -21,10 +21,10 @@ class EmbeddedManifold(Manifold):
     """
 
     def __init__(self, dim, embedding_manifold, default_point_type='vector',
-                 default_coords_type='intrinsic'):
+                 default_coords_type='intrinsic', **kwargs):
         super(EmbeddedManifold, self).__init__(
             dim=dim, default_point_type=default_point_type,
-            default_coords_type=default_coords_type)
+            default_coords_type=default_coords_type, **kwargs)
         self.embedding_manifold = embedding_manifold
 
     def intrinsic_to_extrinsic_coords(self, point_intrinsic):

--- a/geomstats/geometry/fiber_bundle.py
+++ b/geomstats/geometry/fiber_bundle.py
@@ -1,10 +1,9 @@
-"""Classes for fiber bundles and quotient metrics."""
+"""Class for (principal) fiber bundles."""
 
 from scipy.optimize import minimize
 
 import geomstats.backend as gs
 from geomstats.geometry.manifold import Manifold
-from geomstats.geometry.riemannian_metric import RiemannianMetric
 
 
 class FiberBundle(Manifold):
@@ -92,12 +91,12 @@ class FiberBundle(Manifold):
 
         Parameters
         ----------
-        point: array-like, shape=[..., {ambient_dim, [n, n]}]
+        point : array-like, shape=[..., {ambient_dim, [n, n]}]
             Point of the total space.
 
         Returns
         -------
-        projection: array-like, shape=[..., {dim, [n, n]}]
+        projection : array-like, shape=[..., {dim, [n, n]}]
             Point of the base manifold.
         """
         return point
@@ -114,12 +113,12 @@ class FiberBundle(Manifold):
 
         Parameters
         ----------
-        point: array-like, shape=[..., {dim, [n, n]}]
+        point : array-like, shape=[..., {dim, [n, n]}]
             Point of the base manifold.
 
         Returns
         -------
-        lift: array-like, shape=[..., {ambient_dim, [n, n]}]
+        lift : array-like, shape=[..., {ambient_dim, [n, n]}]
             Point of the total space.
         """
         return point
@@ -340,141 +339,3 @@ class FiberBundle(Manifold):
                                  'base point (of the base manifold) must be '
                                  'given.')
         return self.horizontal_projection(tangent_vec, point)
-
-
-class QuotientMetric(RiemannianMetric):
-    """Quotient metric.
-
-    Given a (principal) fiber bundle, or more generally a manifold with a
-    Lie group acting on it by the right, the quotient space is the space of
-    orbits under this action. The quotient metric is defined such that the
-    canonical projection is a Riemannian submersion, i.e. it is isometric to
-    the restriction of the metric of the total space to horizontal subspaces.
-
-    Parameters
-    ----------
-    fiber_bundle : FiberBundle
-        Bundle structure to define the quotient.
-    group : LieGroup
-        Group acting on the right.
-        Optional, default : None. In this case the group must be passed to
-        the fiber bundle instance.
-    ambient_metric : RiemannianMetric
-        Metric of the total space.
-        Optional, default : None. In this case, the total space must have a
-        metric as an attribute.
-    """
-
-    def __init__(self, fiber_bundle, group=None, ambient_metric=None):
-        super(QuotientMetric, self).__init__(
-            dim=fiber_bundle.dim,
-            default_point_type=fiber_bundle.default_point_type)
-
-        self.fiber_bundle = fiber_bundle
-        if group is None:
-            group = fiber_bundle.group
-        if ambient_metric is None:
-            ambient_metric = fiber_bundle.total_space.metric
-
-        self.group = group
-        self.ambient_metric = ambient_metric
-
-    def inner_product(
-            self, tangent_vec_a, tangent_vec_b, base_point=None, point=None):
-        """Compute the inner-product of two tangent vectors at a base point.
-
-        Parameters
-        ----------
-        tangent_vec_a : array-like, shape=[..., {dim, [n, n]}]
-            Tangent vector to the quotient manifold.
-        tangent_vec_b : array-like, shape=[..., {dim, [n, n]}]
-            Tangent vector to the quotient manifold.
-        base_point : array-like, shape=[..., {dim, [n, n]}]
-            Point on the quotient manifold.
-            Optional, default: None.
-        point : array-like, shape=[..., {dim, [n, n]}]
-            Point on the total space, lift of `base_point`, i.e. such that
-            `submersion` applied to `point` results in `base_point`.
-            Optional, default: None. In this case, it is computed using the
-            method lift.
-
-        Returns
-        -------
-        inner_product : float, shape=[...]
-            Inner products
-        """
-        if point is None:
-            if base_point is not None:
-                point = self.fiber_bundle.lift(base_point)
-            else:
-                raise ValueError('Either a point (of the total space) or a '
-                                 'base point (of the quotient manifold) must '
-                                 'be given.')
-        horizontal_a = self.fiber_bundle.horizontal_lift(tangent_vec_a, point)
-        horizontal_b = self.fiber_bundle.horizontal_lift(tangent_vec_b, point)
-        return self.ambient_metric.inner_product(
-            horizontal_a, horizontal_b, point)
-
-    def exp(self, tangent_vec, base_point, **kwargs):
-        """Compute the Riemannian exponential of a tangent vector.
-
-        Parameters
-        ----------
-        tangent_vec : array-like, shape=[..., {dim, [n, n]}]
-            Tangent vector to the quotient manifold.
-        base_point : array-like, shape=[..., {dim, [n, n]}]
-            Point on the quotient manifold.
-            Optional, default: None.
-
-        Returns
-        -------
-        exp : array-like, shape=[..., {dim, [n, n]}]
-            Point on the quotient manifold.
-        """
-        lift = self.fiber_bundle.lift(base_point)
-        horizontal_vec = self.fiber_bundle.horizontal_lift(
-            tangent_vec, lift)
-        return self.fiber_bundle.submersion(
-            self.ambient_metric.exp(horizontal_vec, lift))
-
-    def log(self, point, base_point, **kwargs):
-        """Compute the Riemannian logarithm of a point.
-
-        Parameters
-        ----------
-        point : array-like, shape=[..., {dim, [n, n]}]
-            Point on the quotient manifold.
-        base_point : array-like, shape=[..., {dim, [n, n]}]
-            Point on the quotient manifold.
-
-        Returns
-        -------
-        log : array-like, shape=[..., {dim, [n, n]}]
-            Tangent vector at the base point equal to the Riemannian logarithm
-            of point at the base point.
-        """
-        point_fiber = self.fiber_bundle.lift(point)
-        bp_fiber = self.fiber_bundle.lift(base_point)
-        aligned = self.fiber_bundle.align(point_fiber, bp_fiber, **kwargs)
-        return self.fiber_bundle.tangent_submersion(
-            self.ambient_metric.log(aligned, bp_fiber), bp_fiber)
-
-    def squared_dist(self, point_a, point_b, **kwargs):
-        """Squared geodesic distance between two points.
-
-        Parameters
-        ----------
-        point_a : array-like, shape=[...,  {dim, [n, n]}]
-            Point.
-        point_b : array-like, shape=[...,  {dim, [n, n]}]
-            Point.
-
-        Returns
-        -------
-        sq_dist : array-like, shape=[...,]
-            Squared distance.
-        """
-        lift_a = self.fiber_bundle.lift(point_a)
-        lift_b = self.fiber_bundle.lift(point_b)
-        aligned = self.fiber_bundle.align(lift_a, lift_b, **kwargs)
-        return self.ambient_metric.squared_dist(aligned, lift_b)

--- a/geomstats/geometry/general_linear.py
+++ b/geomstats/geometry/general_linear.py
@@ -86,14 +86,15 @@ class GeneralLinear(Matrices):
         samples : array-like, shape=[..., n, n]
             Point sampled on GL(n).
         """
-        samples = gs.random.rand(n_samples, self.n, self.n)
+        samples = gs.random.normal(size=(n_samples, self.n, self.n))
         while True:
             dets = gs.linalg.det(samples)
             indcs = gs.isclose(dets, 0.0, atol=tol)
             num_bad_samples = gs.sum(indcs)
             if num_bad_samples == 0:
                 break
-            new_samples = gs.random.rand(num_bad_samples, self.n, self.n)
+            new_samples = gs.random.normal(
+                size=(num_bad_samples, self.n, self.n))
             samples = self._replace_values(samples, new_samples, indcs)
         if n_samples == 1:
             samples = gs.squeeze(samples, axis=0)

--- a/geomstats/geometry/lie_algebra.py
+++ b/geomstats/geometry/lie_algebra.py
@@ -8,8 +8,8 @@ in that base. This base will be provided in child classes
 """
 import geomstats.backend as gs
 import geomstats.errors
-from ._bch_coefficients import BCH_COEFFICIENTS
 from geomstats.geometry.matrices import Matrices
+from ._bch_coefficients import BCH_COEFFICIENTS
 
 
 class MatrixLieAlgebra(Matrices):

--- a/geomstats/geometry/lie_algebra.py
+++ b/geomstats/geometry/lie_algebra.py
@@ -9,9 +9,10 @@ in that base. This base will be provided in child classes
 import geomstats.backend as gs
 import geomstats.errors
 from ._bch_coefficients import BCH_COEFFICIENTS
+from geomstats.geometry.matrices import Matrices
 
 
-class MatrixLieAlgebra:
+class MatrixLieAlgebra(Matrices):
     """Class implementing matrix Lie algebra related functions.
 
     Parameters
@@ -23,33 +24,12 @@ class MatrixLieAlgebra:
         Lie algebra.
     """
 
-    def __init__(self, dim, n):
+    def __init__(self, dim, n, **kwargs):
+        super(MatrixLieAlgebra, self).__init__(m=n, n=n, **kwargs)
         geomstats.errors.check_integer(dim, 'dim')
         geomstats.errors.check_integer(n, 'n')
         self.dim = dim
-        self.n = n
         self.basis = None
-
-    @staticmethod
-    def lie_bracket(matrix_a, matrix_b):
-        """Compute the Lie_bracket (commutator) of two matrices.
-
-        Notice that inputs have to be given in matrix form, no conversion
-        between basis and matrix representation is attempted.
-
-        Parameters
-        ----------
-        matrix_a : array-like, shape=[..., n, n]
-            Matrix.
-        matrix_b : array-like, shape=[..., n, n]
-            Matrix.
-
-        Returns
-        -------
-        bracket : shape=[..., n, n]
-            Lie bracket.
-        """
-        return gs.matmul(matrix_a, matrix_b) - gs.matmul(matrix_b, matrix_a)
 
     def baker_campbell_hausdorff(self, matrix_a, matrix_b, order=2):
         """Calculate the Baker-Campbell-Hausdorff approximation of given order.
@@ -93,7 +73,7 @@ class MatrixLieAlgebra:
             i_p = BCH_COEFFICIENTS[i, 1] - 1
             i_pp = BCH_COEFFICIENTS[i, 2] - 1
 
-            el.append(self.lie_bracket(el[i_p], el[i_pp]))
+            el.append(self.bracket(el[i_p], el[i_pp]))
             result += (float(BCH_COEFFICIENTS[i, 3]) /
                        float(BCH_COEFFICIENTS[i, 4]) *
                        el[i])

--- a/geomstats/geometry/pre_shape.py
+++ b/geomstats/geometry/pre_shape.py
@@ -429,7 +429,7 @@ class ProcrustesMetric(RiemannianMetric):
 class KendallShapeMetric(ProcrustesMetric):
     """Quotient metric on the shape space.
 
-    The Kendall shape space is obtained by taking the caution of the
+    The Kendall shape space is obtained by taking the quotient of the
     pre-shape space by the space of rotations of the ambient space.
 
     Parameters

--- a/geomstats/geometry/pre_shape.py
+++ b/geomstats/geometry/pre_shape.py
@@ -6,9 +6,10 @@ import geomstats.backend as gs
 from geomstats.algebra_utils import from_vector_to_diagonal_matrix
 from geomstats.errors import check_tf_error
 from geomstats.geometry.embedded_manifold import EmbeddedManifold
+from geomstats.geometry.fiber_bundle import FiberBundle
 from geomstats.geometry.hypersphere import Hypersphere
 from geomstats.geometry.matrices import Matrices, MatricesMetric
-from geomstats.geometry.quotient_manifold import FiberBundle, QuotientMetric
+from geomstats.geometry.quotient_metric import QuotientMetric
 from geomstats.geometry.riemannian_metric import RiemannianMetric
 
 TOLERANCE = 1e-6

--- a/geomstats/geometry/pre_shape.py
+++ b/geomstats/geometry/pre_shape.py
@@ -289,7 +289,7 @@ class PreShapeSpace(EmbeddedManifold):
         return gs.logical_and(is_tangent, is_symmetric)
 
     def align(self, point, base_point):
-        """Realign point to base_point.
+        """Align point to base_point.
 
         Find the optimal rotation R in SO(m) such that the base point and
         R.point are well positioned.

--- a/geomstats/geometry/pre_shape.py
+++ b/geomstats/geometry/pre_shape.py
@@ -8,12 +8,13 @@ from geomstats.errors import check_tf_error
 from geomstats.geometry.embedded_manifold import EmbeddedManifold
 from geomstats.geometry.hypersphere import Hypersphere
 from geomstats.geometry.matrices import Matrices, MatricesMetric
+from geomstats.geometry.quotient_manifold import FiberBundle, QuotientMetric
 from geomstats.geometry.riemannian_metric import RiemannianMetric
 
 TOLERANCE = 1e-6
 
 
-class PreShapeSpace(EmbeddedManifold):
+class PreShapeSpace(EmbeddedManifold, FiberBundle):
     r"""Class for the Kendall pre-shape space.
 
     The pre-shape space is the sphere of the space of centered k-ad of
@@ -40,10 +41,12 @@ class PreShapeSpace(EmbeddedManifold):
     """
 
     def __init__(self, k_landmarks, m_ambient):
+        embedding_manifold = Matrices(k_landmarks, m_ambient)
         super(PreShapeSpace, self).__init__(
             dim=m_ambient * (k_landmarks - 1) - 1,
-            embedding_manifold=Matrices(k_landmarks, m_ambient),
-            default_point_type='matrix')
+            embedding_manifold=embedding_manifold,
+            default_point_type='matrix',
+            total_space=embedding_manifold)
         self.embedding_metric = self.embedding_manifold.metric
         self.k_landmarks = k_landmarks
         self.m_ambient = m_ambient
@@ -243,27 +246,6 @@ class PreShapeSpace(EmbeddedManifold):
 
         return - gs.matmul(base_point, skew)
 
-    @classmethod
-    def horizontal_projection(cls, tangent_vec, base_point):
-        r"""Project to horizontal subspace.
-
-        Compute the horizontal component of a tangent vector :math: `w` at a
-        base point :math: `x` by removing the vertical component.
-
-        Parameters
-        ----------
-        tangent_vec : array-like, shape=[..., k_landmarks, m_ambient]
-            Tangent vector to the pre-shape space at `base_point`.
-        base_point : array-like, shape=[..., k_landmarks, m_ambient]
-            Point on the pre-shape space.
-
-        Returns
-        -------
-        horizontal : array-like, shape=[..., k_landmarks, m_ambient]
-            Horizontal component of `tangent_vec`.
-        """
-        return tangent_vec - cls.vertical_projection(tangent_vec, base_point)
-
     def is_horizontal(self, tangent_vec, base_point, atol=TOLERANCE):
         """Check whether the tangent vector is horizontal at base_point.
 
@@ -288,7 +270,7 @@ class PreShapeSpace(EmbeddedManifold):
         is_symmetric = Matrices.is_symmetric(product, atol)
         return gs.logical_and(is_tangent, is_symmetric)
 
-    def align(self, point, base_point):
+    def align(self, point, base_point, **kwargs):
         """Align point to base_point.
 
         Find the optimal rotation R in SO(m) such that the base point and
@@ -426,7 +408,7 @@ class ProcrustesMetric(RiemannianMetric):
         return log
 
 
-class KendallShapeMetric(ProcrustesMetric):
+class KendallShapeMetric(QuotientMetric):
     """Quotient metric on the shape space.
 
     The Kendall shape space is obtained by taking the quotient of the
@@ -441,100 +423,6 @@ class KendallShapeMetric(ProcrustesMetric):
     """
 
     def __init__(self, k_landmarks, m_ambient):
-        super(KendallShapeMetric, self).__init__(k_landmarks, m_ambient)
-        self.preshape = PreShapeSpace(k_landmarks, m_ambient)
-
-    def inner_product(self, tangent_vec_a, tangent_vec_b, base_point=None):
-        """Compute the inner-product of two tangent vectors at a base point.
-
-        Parameters
-        ----------
-        tangent_vec_a : array-like, shape=[..., k_landmarks, m_ambient]
-            First tangent vector at base point.
-        tangent_vec_b : array-like, shape=[...,k_landmarks, m_ambient]
-            Second tangent vector at base point.
-        base_point : array-like, shape=[..., k_landmarks, m_ambient]
-            Point in the shape space.
-
-        Returns
-        -------
-        inner_prod : array-like, shape=[...,]
-            Inner-product of the two tangent vectors.
-        """
-        horizontal_a = self.preshape.horizontal_projection(
-            tangent_vec_a, base_point)
-        horizontal_b = self.preshape.horizontal_projection(
-            tangent_vec_b, base_point)
-        return super(KendallShapeMetric, self).inner_product(
-            horizontal_a, horizontal_b, base_point)
-
-    def dist(self, point_a, point_b):
-        r"""Geodesic distance between two points.
-
-        The geodesic distance between two points :math: `x, y` corresponds to
-        the Procrustes distance after alignment of the pre-shapes. It is
-        computed with the formula:
-
-        .. math:
-
-                    d(x, y) = arccos(tr(xy^T))
-
-        where tr is the trace operator.
-
-        Parameters
-        ----------
-        point_a : array-like, shape=[..., k_landmarks, m_ambient]
-            Point.
-        point_b : array-like, shape=[..., k_landmarks, m_ambient]
-            Point.
-
-        Returns
-        -------
-        dist : array-like, shape=[...,]
-            Distance.
-        """
-        aligned = self.preshape.align(point_a, point_b)
-        trace = gs.einsum('...ij,...ij->...', aligned, point_b)
-        trace = gs.clip(trace, -1, 1)
-        dist = gs.arccos(trace)
-        return dist
-
-    def exp(self, tangent_vec, base_point):
-        """Compute the Riemannian exponential of a tangent vector.
-
-        Parameters
-        ----------
-        tangent_vec : array-like, shape=[..., k_landmarks, m_ambient]
-            Tangent vector at a base point.
-        base_point : array-like, shape=[..., k_landmarks, m_ambient]
-            Point in the shape space.
-
-        Returns
-        -------
-        exp : array-like, shape=[..., k_landmarks, m_ambient]
-            Point in the shape space equal to the Riemannian exponential
-            of tangent_vec at the base point.
-        """
-        horizontal = self.preshape.horizontal_projection(
-            tangent_vec, base_point)
-        return super(KendallShapeMetric, self).exp(
-            horizontal, base_point)
-
-    def log(self, point, base_point):
-        """Compute the Riemannian logarithm of a point.
-
-        Parameters
-        ----------
-        point : array-like, shape=[..., k_landmarks, m_ambient]
-            Point on the shape space.
-        base_point : array-like, shape=[..., k_landmarks, m_ambient]
-            Point on the shape space.
-
-        Returns
-        -------
-        log : array-like, shape=[..., k_landmarks, m_ambient]
-            Tangent vector at the base point equal to the Riemannian logarithm
-            of point at the base point.
-        """
-        aligned = self.preshape.align(point, base_point)
-        return super(KendallShapeMetric, self).log(aligned, base_point)
+        super(KendallShapeMetric, self).__init__(
+            fiber_bundle=PreShapeSpace(k_landmarks, m_ambient),
+            ambient_metric=ProcrustesMetric(k_landmarks, m_ambient))

--- a/geomstats/geometry/quotient_manifold.py
+++ b/geomstats/geometry/quotient_manifold.py
@@ -35,7 +35,7 @@ class FiberBundle(Manifold):
     """
 
     def __init__(self, total_space, base=None, group=None, group_action=None,
-                 dim=None):
+                 dim=None, **kwargs):
 
         if dim is None:
             if base is not None:
@@ -47,8 +47,7 @@ class FiberBundle(Manifold):
                                  'its dimension, or the group acting on the '
                                  'total space must be provided.')
 
-        super(FiberBundle, self).__init__(
-            dim=dim, default_point_type=total_space.default_point_type)
+        super(FiberBundle, self).__init__(dim=dim, **kwargs)
 
         self.base = base
         self.total_space = total_space
@@ -353,14 +352,17 @@ class QuotientMetric(RiemannianMetric):
 
     def __init__(self, fiber_bundle, group=None, ambient_metric=None):
         super(QuotientMetric, self).__init__(
-            dim=fiber_bundle.dim - group.dim,
+            dim=fiber_bundle.dim,
             default_point_type=fiber_bundle.default_point_type)
 
         self.fiber_bundle = fiber_bundle
         if group is None:
-            self.group = fiber_bundle.group
+            group = fiber_bundle.group
         if ambient_metric is None:
-            self.ambient_metric = fiber_bundle.total_space.metric
+            ambient_metric = fiber_bundle.total_space.metric
+
+        self.group = group
+        self.ambient_metric = ambient_metric
 
     def inner_product(self, tangent_vec_a, tangent_vec_b, base_point=None):
         """Compute the inner-product of two tangent vectors at a base point.

--- a/geomstats/geometry/quotient_manifold.py
+++ b/geomstats/geometry/quotient_manifold.py
@@ -1,4 +1,4 @@
-"""Classes for quotient manifolds and quotient metrics"""
+"""Classes for fiber bundles and quotient metrics."""
 
 from scipy.optimize import minimize
 
@@ -8,7 +8,7 @@ from geomstats.geometry.riemannian_metric import RiemannianMetric
 
 
 class FiberBundle(Manifold):
-    """Class for (principal) fiber bundles
+    """Class for (principal) fiber bundles.
 
     This class implements abstract methods for fiber bundles, or more
     generally manifolds, with a submersion map, or a right Lie group action.
@@ -58,7 +58,7 @@ class FiberBundle(Manifold):
         self.group_action = group_action
 
     def belongs(self, point, atol=1e-6):
-        """Evaluate if a point belongs to the bundle.
+        """Evaluate if a point belongs to the base manifold.
 
         Evaluate if a point belongs to the base manifold when it is given,
         otherwise to the total space.
@@ -86,7 +86,8 @@ class FiberBundle(Manifold):
         This is the projection of the fiber bundle, defined on the total
         space, with values in the base manifold. This map is surjective.
         By default, the base manifold  is not explicit but is identified with a
-        section of the fiber bundle, so the submersion is the identity map.
+        local section of the fiber bundle, so the submersion is the identity
+        map.
 
         Parameters
         ----------
@@ -104,8 +105,8 @@ class FiberBundle(Manifold):
         """Lift a point to total space.
 
         This is a section of the fiber bundle, defined on the base manifold,
-        with values in the total space. It means that lift composed with
-        submersion results in the identity map. By default, the base manifold
+        with values in the total space. It means that submersion applied after
+        lift results in the identity map. By default, the base manifold
         is not explicit but is identified with a section of the fiber bundle,
         so the lift is the identity map.
 
@@ -150,7 +151,9 @@ class FiberBundle(Manifold):
 
         Find the optimal group element g such that the base point and
         point.g are well positioned, meaning that the total space distance is
-        minimized. By default, this is solved by gradient descent.
+        minimized. This also means that the geodesic joining the base point
+        and the aligned point is horizontal. By default, this is solved by a
+        gradient descent in the Lie algebra.
 
         Parameters
         ----------
@@ -182,6 +185,7 @@ class FiberBundle(Manifold):
             identity.shape
 
         def wrap(param):
+            """Wrap a parameter vector to a group element."""
             algebra_elt = gs.array(param, dtype=base_point.dtype)
             algebra_elt = self.group.lie_algebra.matrix_representation(
                 algebra_elt)
@@ -202,9 +206,9 @@ class FiberBundle(Manifold):
     def horizontal_projection(self, tangent_vec, base_point):
         r"""Project to horizontal subspace.
 
-        Compute the horizontal component of a tangent vector :math: `w` at a
-        base point :math: `x` by removing the vertical component,
-        or by a computing a horizontal lift of the tangent projection.
+        Compute the horizontal component of a tangent vector at a
+        base point by removing the vertical component,
+        or by computing a horizontal lift of the tangent projection.
 
         Parameters
         ----------
@@ -303,7 +307,7 @@ class FiberBundle(Manifold):
         """Lift a tangent vector to a horizontal vector in the total space.
 
         It means that horizontal lift is the inverse of the restriction of the
-        tangent submersion to the horizontal space a point, where point must
+        tangent submersion to the horizontal space at point, where point must
         be in the fiber above the base point. By default, the base manifold
         is not explicit but is identified with a horizontal section of the
         fiber bundle, so the horizontal lift is the horizontal projection.
@@ -325,6 +329,13 @@ class FiberBundle(Manifold):
         horizontal_lift : array-like, shape=[..., {ambient_dim, [n, n]}]
             Tangent vector to the total space at point.
         """
+        if point is None:
+            if base_point is not None:
+                point = self.lift(base_point)
+            else:
+                raise ValueError('Either a point (of the total space) or a '
+                                 'base point (of the base manifold) must be '
+                                 'given.')
         return self.horizontal_projection(tangent_vec, point)
 
 

--- a/geomstats/geometry/quotient_manifold.py
+++ b/geomstats/geometry/quotient_manifold.py
@@ -1,0 +1,350 @@
+"""Classes for quotient manifolds and quotient metrics"""
+
+from scipy.optimize import minimize
+
+import geomstats.backend as gs
+from geomstats.geometry.manifold import Manifold
+from geomstats.geometry.riemannian_metric import RiemannianMetric
+
+
+class FiberBundle(Manifold):
+    """Class for (principal) fiber bundles
+
+    This class implements abstract methods for fiber bundles, or more
+    generally manifolds, with a submersion map, or a right Lie group action.
+
+    Parameters
+    ----------
+    total_space : Manifold
+        Total space of the bundle.
+    base : Manifold
+        Base manifold of the bundle.
+        Optional. Default : None.
+    group : LieGroup
+        Group that acts on the total space by the right.
+        Optional. Default : None.
+        Either the group or the group action must be given.
+    group_action : callable
+        Right group action. It must take as input a point of the total space
+        and an element of the group, and return a point of the total space.
+    dim : int
+        Dimension of the base manifold.
+        Optional. If available the dimension of the base manifold is used,
+        or the difference between the dimension of the total space and the
+        group. Either dim, base or group must be given as input.
+    """
+
+    def __init__(self, total_space, base=None, group=None, group_action=None,
+                 dim=None):
+
+        if dim is None:
+            if base is not None:
+                dim = base.dim
+            elif group is not None:
+                dim = total_space.dim - group.dim
+            else:
+                raise ValueError('Either the base manifold, '
+                                 'its dimension, or the group acting on the '
+                                 'total space must be provided.')
+
+        super(FiberBundle, self).__init__(
+            dim=dim, default_point_type=total_space.default_point_type)
+
+        self.base = base
+        self.total_space = total_space
+        self.group = group
+
+        if group_action is None and group is not None:
+            group_action = group.compose
+        self.group_action = group_action
+
+    def belongs(self, point, atol=1e-6):
+        """Evaluate if a point belongs to the bundle.
+
+        Evaluate if a point belongs to the base manifold is given, otherwise
+        to the total space.
+
+        Parameters
+        ----------
+        point : array-like, shape=[..., dim]
+            Point to evaluate.
+        atol : float
+            Absolute tolerance.
+            Optional, default: 1e-6.
+
+        Returns
+        -------
+        belongs : array-like, shape=[...,]
+            Boolean evaluating if point belongs to the manifold.
+        """
+        if self.base is not None:
+            return self.base.belongs(point, atol=atol)
+        return self.total_space.belongs(point, atol=atol)
+
+    def submersion(self, point):
+        """Project a point to base manifold.
+
+        This is the projection of the fiber bundle, defined on the total
+        space, with values in the base manifold. This map is surjective.
+
+        Parameters
+        ----------
+        point: array-like, shape=[..., {ambient_dim, [n, n]}]
+            Point of the total space.
+
+        Returns
+        -------
+        projection: array-like, shape=[..., {dim, [n, n]}]
+            Point of the base manifold.
+        """
+        raise NotImplementedError
+
+    def lift(self, point):
+        """Lift a point to total space.
+
+        This is a section of the fiber bundle, defined on the base manifold,
+        with values in the total space. It means that lift composed with
+        submersion results in the identity map.
+
+        Parameters
+        ----------
+        point: array-like, shape=[..., {dim, [n, n]}]
+            Point of the base manifold.
+
+        Returns
+        -------
+        lift: array-like, shape=[..., {ambient_dim, [n, n]}]
+            Point of the total space.
+        """
+        raise NotImplementedError
+
+    def tangent_submersion(self, tangent_vec, base_point):
+        """Project a tangent vector to base manifold.
+
+        This is the differential of the projection of the fiber bundle,
+        defined on the tangent space of a point of the total space,
+        with values in the tangent space of the projection of this point in the
+        base manifold. This map is surjective.
+
+        Parameters
+        ----------
+        tangent_vec :  array-like, shape=[..., ambient_dim, [n , n]}]
+            Tangent vector to the total space at `base_point`.
+        base_point: array-like, shape=[..., {ambient_dim, [n, n]}]
+            Point of the total space.
+
+        Returns
+        -------
+        projection: array-like, shape=[..., {dim, [n, n]}]
+            Tangent vector to the base manifold.
+        """
+        raise NotImplementedError
+
+    def align(self, point, base_point, max_iter=25, verbose=False, tol=1e-6):
+        """Align point to base_point.
+
+        Find the optimal group element g such that the base point and
+        point.g are well positioned, meaning that the total space distance is
+        minimized. By default, this is solved by gradient descent.
+
+        Parameters
+        ----------
+        point : array-like, shape=[..., {ambient_dim, [n, n]}]
+            Point on the manifold.
+        base_point : array-like, shape=[..., {ambient_dim, [n, n]}]
+            Point on the manifold.
+        max_iter : int
+            Maximum number of gradient steps.
+            Optional, default : 25.
+        verbose : bool
+            Verbosity level.
+            Optional, default : False.
+        tol : float
+            Tolerance for the stopping criterion.
+            Optional, default : 1e-6
+
+        Returns
+        -------
+        aligned : array-like, shape=[..., {ambient_dim, [n, n]}]
+            Action of the optimal g on point.
+        """
+        identity = self.group.identity
+        initial_distance = self.total_space.metric.squared_dist(
+            point, base_point)
+        n_samples = 1 if isinstance(initial_distance, float) else \
+            len(initial_distance)
+        max_shape = (n_samples, ) + identity.shape if n_samples > 1 else \
+            identity.shape
+
+        def objective(param):
+            group_elt = gs.array(param, dtype=base_point.dtype)
+            group_elt = gs.reshape(group_elt, max_shape)
+            aligned = self.group_action(param, group_elt)
+            return self.total_space.metric.squared_dist(aligned, base_point)
+
+        objective_with_grad = gs.autograd.value_and_grad(objective)
+        tangent_vec = gs.flatten(gs.random.rand(*max_shape))
+        res = minimize(
+            objective_with_grad, tangent_vec, method='L-BFGS-B', jac=True,
+            options={'disp': verbose, 'maxiter': max_iter}, tol=tol)
+
+        optimal_group_elt = gs.array(res.x)
+        optimal_group_elt = gs.reshape(
+            optimal_group_elt, max_shape)
+        return self.group_action(optimal_group_elt)(point)
+
+    def horizontal_projection(self, tangent_vec, base_point):
+        r"""Project to horizontal subspace.
+
+        Compute the horizontal component of a tangent vector :math: `w` at a
+        base point :math: `x` by removing the vertical component,
+        or by a computing a horizontal lift of the tangent projection.
+
+        Parameters
+        ----------
+        tangent_vec : array-like, shape=[..., {ambient_dim, [n, n]}]
+            Tangent vector to the total space at `base_point`.
+        base_point : array-like, shape=[..., {ambient_dim, [n, n]}]
+            Point on the total space.
+
+        Returns
+        -------
+        horizontal : array-like, shape=[..., {ambient_dim, [n, n]}]
+            Horizontal component of `tangent_vec`.
+        """
+        try:
+            return tangent_vec - self.vertical_projection(
+                tangent_vec, base_point)
+        except RecursionError:
+            return self.horizontal_lift(
+                self.tangent_submersion(tangent_vec, base_point), base_point)
+
+    def vertical_projection(self, tangent_vec, base_point):
+        r"""Project to vertical subspace.
+
+        Compute the vertical component of a tangent vector :math: `w` at a
+        base point :math: `x` by removing the horizontal component.
+
+        Parameters
+        ----------
+        tangent_vec : array-like, shape=[..., {ambient_dim, [n, n]}]
+            Tangent vector to the total space at `base_point`.
+        base_point : array-like, shape=[..., {ambient_dim, [n, n]}]
+            Point on the total space.
+
+        Returns
+        -------
+        horizontal : array-like, shape=[..., {ambient_dim, [n, n]}]
+            Vertical component of `tangent_vec`.
+        """
+        try:
+            return tangent_vec - self.horizontal_projection(
+                tangent_vec, base_point)
+        except RecursionError:
+            raise NotImplementedError
+
+    def is_horizontal(self, tangent_vec, base_point, atol=1e-6):
+        """Evaluate if the tangent vector is horizontal at base_point.
+
+        Parameters
+        ----------
+        tangent_vec : array-like, shape=[..., {ambient_dim, [n, n]}]
+            Tangent vector.
+        base_point : array-like, shape=[..., {ambient_dim, [n, n]}]
+            Point on the manifold.
+            Optional, default: none.
+        atol : float
+            Absolute tolerance.
+            Optional, default: 1e-6.
+
+        Returns
+        -------
+        is_tangent : bool
+            Boolean denoting if tangent vector is horizontal.
+        """
+        return gs.isclose(
+            tangent_vec, self.horizontal_projection(tangent_vec, base_point),
+            atol=atol)
+
+    def is_vertical(self, tangent_vec, base_point, atol=1e-6):
+        """Evaluate if the tangent vector is vertical at base_point.
+
+        Parameters
+        ----------
+        tangent_vec : array-like, shape=[..., {ambient_dim, [n, n]}]
+            Tangent vector.
+        base_point : array-like, shape=[..., {ambient_dim, [n, n]}]
+            Point on the manifold.
+            Optional, default: none.
+        atol : float
+            Absolute tolerance.
+            Optional, default: 1e-6.
+
+        Returns
+        -------
+        is_tangent : bool
+            Boolean denoting if tangent vector is vertical.
+        """
+        return gs.isclose(
+            tangent_vec, self.vertical_projection(tangent_vec, base_point))
+
+    def horizontal_lift(self, tangent_vec, point=None, base_point=None):
+        """Lift a tangent vector to a horizontal vector in the total space.
+
+        It means that horizontal lift is the inverse of the restriction of the
+        tangent submersion to the horizontal space a point, where point must
+        be in the fiber above the base point.
+
+        Parameters
+        ----------
+        tangent_vec : array-like, shape=[..., {dim, [n, n]}]
+        point: array-like, shape=[..., {ambient_dim, [n, n]}]
+            Point of the total space.
+            Optional, default : None. The `lift` method is used to compute a
+            point at which to compute a tangent vector.
+        base_point : array-like, shape=[..., {dim, [n, n]}]
+            Point of the base space.
+            Optional, default : None. In this case, point must be given,
+            and `submersion` is used to compute the base_point if needed.
+
+        Returns
+        -------
+        horizontal_lift : array-like, shape=[..., {ambient_dim, [n, n]}]
+            Tangent vector to the total space at point.
+        """
+        raise NotImplementedError
+
+
+class QuotientMetric(RiemannianMetric):
+    def __init__(self, fiber_bundle, group, ambient_metric):
+        super(QuotientMetric, self).__init__(
+            dim=fiber_bundle.dim - group.dim,
+            default_point_type=fiber_bundle.default_point_type)
+
+        self.fiber_bundle = fiber_bundle
+        self.group = group
+        self.ambient_metric = ambient_metric
+
+    def inner_product(self, tangent_vec_a, tangent_vec_b, base_point=None):
+        horizontal_a = self.fiber_bundle.horizontal_projection(
+            tangent_vec_a, base_point)
+        horizontal_b = self.fiber_bundle.horizontal_projection(
+            tangent_vec_b, base_point)
+        return self.ambient_metric.inner_product(
+            horizontal_a, horizontal_b, base_point)
+
+    def exp(self, tangent_vec, base_point, **kwargs):
+        lift = self.fiber_bundle.lift(base_point)
+        horizontal_vec = self.fiber_bundle.horizontal_projection(
+            tangent_vec, lift)
+        return self.fiber_bundle.submersion(
+            self.ambient_metric.exp(horizontal_vec, lift))
+
+    def log(self, point, base_point, **kwargs):
+        aligned = self.fiber_bundle.align(point, base_point, **kwargs)
+        return self.fiber_bundle.tangent_submersion(
+            self.ambient_metric.log(aligned, base_point), base_point)
+
+    def squared_dist(self, point_a, point_b, **kwargs):
+        aligned = self.fiber_bundle.align(point_a, point_b, **kwargs)
+        return self.ambient_metric.squared_dist(aligned, point_b)

--- a/geomstats/geometry/quotient_manifold.py
+++ b/geomstats/geometry/quotient_manifold.py
@@ -80,7 +80,8 @@ class FiberBundle(Manifold):
             return self.base.belongs(point, atol=atol)
         return self.total_space.belongs(point, atol=atol)
 
-    def submersion(self, point):
+    @staticmethod
+    def submersion(point):
         """Project a point to base manifold.
 
         This is the projection of the fiber bundle, defined on the total
@@ -101,7 +102,8 @@ class FiberBundle(Manifold):
         """
         return point
 
-    def lift(self, point):
+    @staticmethod
+    def lift(point):
         """Lift a point to total space.
 
         This is a section of the fiber bundle, defined on the base manifold,

--- a/geomstats/geometry/quotient_manifold.py
+++ b/geomstats/geometry/quotient_manifold.py
@@ -377,7 +377,8 @@ class QuotientMetric(RiemannianMetric):
         self.group = group
         self.ambient_metric = ambient_metric
 
-    def inner_product(self, tangent_vec_a, tangent_vec_b, base_point=None):
+    def inner_product(
+            self, tangent_vec_a, tangent_vec_b, base_point=None, point=None):
         """Compute the inner-product of two tangent vectors at a base point.
 
         Parameters
@@ -389,18 +390,28 @@ class QuotientMetric(RiemannianMetric):
         base_point : array-like, shape=[..., {dim, [n, n]}]
             Point on the quotient manifold.
             Optional, default: None.
+        point : array-like, shape=[..., {dim, [n, n]}]
+            Point on the total space, lift of `base_point`, i.e. such that
+            `submersion` applied to `point` results in `base_point`.
+            Optional, default: None. In this case, it is computed using the
+            method lift.
 
         Returns
         -------
         inner_product : float, shape=[...]
             Inner products
         """
-        horizontal_a = self.fiber_bundle.horizontal_lift(
-            tangent_vec_a, base_point)
-        horizontal_b = self.fiber_bundle.horizontal_lift(
-            tangent_vec_b, base_point)
+        if point is None:
+            if base_point is not None:
+                point = self.fiber_bundle.lift(base_point)
+            else:
+                raise ValueError('Either a point (of the total space) or a '
+                                 'base point (of the quotient manifold) must '
+                                 'be given.')
+        horizontal_a = self.fiber_bundle.horizontal_lift(tangent_vec_a, point)
+        horizontal_b = self.fiber_bundle.horizontal_lift(tangent_vec_b, point)
         return self.ambient_metric.inner_product(
-            horizontal_a, horizontal_b, base_point)
+            horizontal_a, horizontal_b, point)
 
     def exp(self, tangent_vec, base_point, **kwargs):
         """Compute the Riemannian exponential of a tangent vector.

--- a/geomstats/geometry/quotient_manifold.py
+++ b/geomstats/geometry/quotient_manifold.py
@@ -455,7 +455,7 @@ class QuotientMetric(RiemannianMetric):
         bp_fiber = self.fiber_bundle.lift(base_point)
         aligned = self.fiber_bundle.align(point_fiber, bp_fiber, **kwargs)
         return self.fiber_bundle.tangent_submersion(
-            self.ambient_metric.log(aligned, base_point), base_point)
+            self.ambient_metric.log(aligned, bp_fiber), bp_fiber)
 
     def squared_dist(self, point_a, point_b, **kwargs):
         """Squared geodesic distance between two points.

--- a/geomstats/geometry/quotient_metric.py
+++ b/geomstats/geometry/quotient_metric.py
@@ -1,0 +1,141 @@
+"""Classes for fiber bundles and quotient metrics."""
+
+from geomstats.geometry.riemannian_metric import RiemannianMetric
+
+
+class QuotientMetric(RiemannianMetric):
+    """Quotient metric.
+
+    Given a (principal) fiber bundle, or more generally a manifold with a
+    Lie group acting on it by the right, the quotient space is the space of
+    orbits under this action. The quotient metric is defined such that the
+    canonical projection is a Riemannian submersion, i.e. it is isometric to
+    the restriction of the metric of the total space to horizontal subspaces.
+
+    Parameters
+    ----------
+    fiber_bundle : geomstats.geometry.fiber_bundle.FiberBundle
+        Bundle structure to define the quotient.
+    group : LieGroup
+        Group acting on the right.
+        Optional, default : None. In this case the group must be passed to
+        the fiber bundle instance.
+    ambient_metric : RiemannianMetric
+        Metric of the total space.
+        Optional, default : None. In this case, the total space must have a
+        metric as an attribute.
+    """
+
+    def __init__(self, fiber_bundle, group=None, ambient_metric=None):
+        super(QuotientMetric, self).__init__(
+            dim=fiber_bundle.dim,
+            default_point_type=fiber_bundle.default_point_type)
+
+        self.fiber_bundle = fiber_bundle
+        if group is None:
+            group = fiber_bundle.group
+        if ambient_metric is None:
+            ambient_metric = fiber_bundle.total_space.metric
+
+        self.group = group
+        self.ambient_metric = ambient_metric
+
+    def inner_product(
+            self, tangent_vec_a, tangent_vec_b, base_point=None, point=None):
+        """Compute the inner-product of two tangent vectors at a base point.
+
+        Parameters
+        ----------
+        tangent_vec_a : array-like, shape=[..., {dim, [n, n]}]
+            Tangent vector to the quotient manifold.
+        tangent_vec_b : array-like, shape=[..., {dim, [n, n]}]
+            Tangent vector to the quotient manifold.
+        base_point : array-like, shape=[..., {dim, [n, n]}]
+            Point on the quotient manifold.
+            Optional, default: None.
+        point : array-like, shape=[..., {dim, [n, n]}]
+            Point on the total space, lift of `base_point`, i.e. such that
+            `submersion` applied to `point` results in `base_point`.
+            Optional, default: None. In this case, it is computed using the
+            method lift.
+
+        Returns
+        -------
+        inner_product : float, shape=[...]
+            Inner products
+        """
+        if point is None:
+            if base_point is not None:
+                point = self.fiber_bundle.lift(base_point)
+            else:
+                raise ValueError('Either a point (of the total space) or a '
+                                 'base point (of the quotient manifold) must '
+                                 'be given.')
+        horizontal_a = self.fiber_bundle.horizontal_lift(tangent_vec_a, point)
+        horizontal_b = self.fiber_bundle.horizontal_lift(tangent_vec_b, point)
+        return self.ambient_metric.inner_product(
+            horizontal_a, horizontal_b, point)
+
+    def exp(self, tangent_vec, base_point, **kwargs):
+        """Compute the Riemannian exponential of a tangent vector.
+
+        Parameters
+        ----------
+        tangent_vec : array-like, shape=[..., {dim, [n, n]}]
+            Tangent vector to the quotient manifold.
+        base_point : array-like, shape=[..., {dim, [n, n]}]
+            Point on the quotient manifold.
+            Optional, default: None.
+
+        Returns
+        -------
+        exp : array-like, shape=[..., {dim, [n, n]}]
+            Point on the quotient manifold.
+        """
+        lift = self.fiber_bundle.lift(base_point)
+        horizontal_vec = self.fiber_bundle.horizontal_lift(
+            tangent_vec, lift)
+        return self.fiber_bundle.submersion(
+            self.ambient_metric.exp(horizontal_vec, lift))
+
+    def log(self, point, base_point, **kwargs):
+        """Compute the Riemannian logarithm of a point.
+
+        Parameters
+        ----------
+        point : array-like, shape=[..., {dim, [n, n]}]
+            Point on the quotient manifold.
+        base_point : array-like, shape=[..., {dim, [n, n]}]
+            Point on the quotient manifold.
+
+        Returns
+        -------
+        log : array-like, shape=[..., {dim, [n, n]}]
+            Tangent vector at the base point equal to the Riemannian logarithm
+            of point at the base point.
+        """
+        point_fiber = self.fiber_bundle.lift(point)
+        bp_fiber = self.fiber_bundle.lift(base_point)
+        aligned = self.fiber_bundle.align(point_fiber, bp_fiber, **kwargs)
+        return self.fiber_bundle.tangent_submersion(
+            self.ambient_metric.log(aligned, bp_fiber), bp_fiber)
+
+    def squared_dist(self, point_a, point_b, **kwargs):
+        """Squared geodesic distance between two points.
+
+        Parameters
+        ----------
+        point_a : array-like, shape=[...,  {dim, [n, n]}]
+            Point.
+        point_b : array-like, shape=[...,  {dim, [n, n]}]
+            Point.
+
+        Returns
+        -------
+        sq_dist : array-like, shape=[...,]
+            Squared distance.
+        """
+        lift_a = self.fiber_bundle.lift(point_a)
+        lift_b = self.fiber_bundle.lift(point_b)
+        aligned = self.fiber_bundle.align(lift_a, lift_b, **kwargs)
+        return self.ambient_metric.squared_dist(aligned, lift_b)

--- a/geomstats/geometry/skew_symmetric_matrices.py
+++ b/geomstats/geometry/skew_symmetric_matrices.py
@@ -2,8 +2,10 @@
 
 This is the Lie algebra of the Special Orthogonal Group.
 As basis we choose the matrices with a single 1 on the upper triangular part
-of the matrices (and a -1 in its lower triangular part).
+of the matrices (and a -1 in its lower triangular part), except in dim 2 and
+3 to match usual conventions.
 """
+
 import geomstats.backend as gs
 from geomstats.geometry.lie_algebra import MatrixLieAlgebra
 

--- a/geomstats/geometry/skew_symmetric_matrices.py
+++ b/geomstats/geometry/skew_symmetric_matrices.py
@@ -6,7 +6,6 @@ of the matrices (and a -1 in its lower triangular part).
 """
 import geomstats.backend as gs
 from geomstats.geometry.lie_algebra import MatrixLieAlgebra
-from geomstats.geometry.matrices import Matrices
 
 
 TOLERANCE = 1e-8
@@ -22,8 +21,8 @@ class SkewSymmetricMatrices(MatrixLieAlgebra):
     """
 
     def __init__(self, n):
-        dimension = int(n * (n - 1) / 2)
-        super(SkewSymmetricMatrices, self).__init__(dimension, n)
+        dim = int(n * (n - 1) / 2)
+        super(SkewSymmetricMatrices, self).__init__(dim, n)
 
         if n == 2:
             self.basis = gs.array([[[0., -1.], [1., 0.]]])
@@ -39,7 +38,7 @@ class SkewSymmetricMatrices(MatrixLieAlgebra):
                  [1., 0., 0.],
                  [0., 0., 0.]]])
         else:
-            self.basis = gs.zeros((dimension, n, n))
+            self.basis = gs.zeros((dim, n, n))
             basis = []
             for row in gs.arange(n - 1):
                 for col in gs.arange(row + 1, n):
@@ -63,10 +62,12 @@ class SkewSymmetricMatrices(MatrixLieAlgebra):
         belongs : array-like, shape=[...,]
             Boolean evaluating if matrix is skew symmetric.
         """
-        return Matrices(self.n, self.n).is_skew_symmetric(mat=mat, atol=atol)
+        is_skew = self.is_skew_symmetric(mat=mat, atol=atol)
+        return gs.logical_and(
+            is_skew, super(SkewSymmetricMatrices, self).belongs(mat))
 
-    @staticmethod
-    def projection(mat):
+    @classmethod
+    def projection(cls, mat):
         r"""Compute the skew-symmetric component of a matrix.
 
         The skew-symmetric part of a matrix :math: `X` is defined by
@@ -83,7 +84,7 @@ class SkewSymmetricMatrices(MatrixLieAlgebra):
         skew_sym : array-like, shape=[..., n, n]
             Skew-symmetric matrix.
         """
-        return Matrices.to_skew_symmetric(mat)
+        return cls.to_skew_symmetric(mat)
 
     def basis_representation(self, matrix_representation):
         """Calculate the coefficients of given matrix in the basis.

--- a/geomstats/geometry/spd_matrices.py
+++ b/geomstats/geometry/spd_matrices.py
@@ -383,9 +383,49 @@ class SPDMatrices(SymmetricMatrices, EmbeddedManifold):
         return cls.apply_func_to_eigvals(mat, gs.log, check_positive=True)
 
     def is_tangent(self, vector, base_point=None, atol=TOLERANCE):
+        """Check whether the vector is tangent at base_point.
+
+        A "vector" is tangent to the manifold of SPD matrices if it is a
+        symmetric matrix.
+
+        Parameters
+        ----------
+        vector : array-like, shape=[..., n, n]
+            Matrix.
+        base_point : array-like, shape=[..., n, n]
+            Point on the manifold.
+            Optional, default: None.
+        atol : float
+            Absolute tolerance.
+            Optional, default: 1e-6.
+
+        Returns
+        -------
+        is_tangent : bool
+            Boolean denoting if vector is a tangent vector at the base point.
+        """
         return super(SPDMatrices, self).belongs(vector, atol)
 
     def to_tangent(self, vector, base_point=None):
+        """Project a vector to a tangent space of the manifold.
+
+        A "vector" is tangent to the manifold of SPD matrices if it is a
+        symmetric matrix, so the symmetric component of the input matrix is
+        returned.
+
+        Parameters
+        ----------
+        vector : array-like, shape=[..., n, n]
+            Matrix.
+        base_point : array-like, shape=[..., n, n]
+            Point on the manifold.
+            Optional, default: None.
+
+        Returns
+        -------
+        tangent_vec : array-like, shape=[..., n, n]
+            Tangent vector at base point.
+        """
         return super(SPDMatrices, self).projection(vector)
 
 

--- a/geomstats/geometry/spd_matrices.py
+++ b/geomstats/geometry/spd_matrices.py
@@ -931,7 +931,7 @@ class SPDMetricEuclidean(RiemannianMetric):
         exp_domain : array-like, shape=[..., 2]
             Interval of time where the geodesic is defined.
         """
-        invsqrt_base_point = gs.linalg.powerm(base_point, -.5)
+        invsqrt_base_point = SymmetricMatrices.powerm(base_point, -.5)
 
         reduced_vec = gs.matmul(invsqrt_base_point, tangent_vec)
         reduced_vec = gs.matmul(reduced_vec, invsqrt_base_point)

--- a/geomstats/geometry/spd_matrices.py
+++ b/geomstats/geometry/spd_matrices.py
@@ -723,14 +723,16 @@ class SPDMetricBuresWasserstein(RiemannianMetric):
         """
         eigvals, eigvecs = gs.linalg.eigh(base_point)
         transp_eigvecs = Matrices.transpose(eigvecs)
-        rotated_tangent_vec_a = Matrices.mul(transp_eigvecs, tangent_vec_a,
-                                             eigvecs)
-        rotated_tangent_vec_b = Matrices.mul(transp_eigvecs, tangent_vec_b,
-                                             eigvecs)
-        coefficients = 1 / (eigvals[..., :, None] + eigvals[..., None, :])
+        rotated_tangent_vec_a = Matrices.mul(
+            transp_eigvecs, tangent_vec_a, eigvecs)
+        rotated_tangent_vec_b = Matrices.mul(
+            transp_eigvecs, tangent_vec_b, eigvecs)
 
-        result = gs.sum(coefficients * rotated_tangent_vec_a *
-                        rotated_tangent_vec_b, axis=(-2, -1)) / 2
+        coefficients = 1 / (eigvals[..., :, None] + eigvals[..., None, :])
+        result = gs.sum(
+            coefficients * rotated_tangent_vec_a * rotated_tangent_vec_b,
+            axis=(-2, -1)) / 2
+
         return result
 
     def exp(self, tangent_vec, base_point):
@@ -754,13 +756,12 @@ class SPDMetricBuresWasserstein(RiemannianMetric):
                                            eigvecs)
         coefficients = 1 / (eigvals[..., :, None] + eigvals[..., None, :])
         rotated_sylvester = rotated_tangent_vec * coefficients
-        rotated_hessian = gs.einsum('...ij,...j->...ij',
-                                    rotated_sylvester, eigvals)
+        rotated_hessian = gs.einsum(
+            '...ij,...j->...ij', rotated_sylvester, eigvals)
         rotated_hessian = Matrices.mul(rotated_hessian, rotated_sylvester)
         hessian = Matrices.mul(eigvecs, rotated_hessian, transp_eigvecs)
 
-        result = base_point + tangent_vec + hessian
-        return result
+        return base_point + tangent_vec + hessian
 
     def log(self, point, base_point):
         """Compute the Bures-Wasserstein logarithm map.
@@ -785,8 +786,7 @@ class SPDMetricBuresWasserstein(RiemannianMetric):
         sqrt_product = gs.linalg.sqrtm(product)
         transp_sqrt_product = Matrices.transpose(sqrt_product)
 
-        result = sqrt_product + transp_sqrt_product - 2 * base_point
-        return result
+        return sqrt_product + transp_sqrt_product - 2 * base_point
 
     def squared_dist(self, point_a, point_b):
         """Compute the Bures-Wasserstein squared distance.
@@ -811,8 +811,7 @@ class SPDMetricBuresWasserstein(RiemannianMetric):
         trace_b = gs.trace(point_b)
         trace_prod = gs.trace(sqrt_product)
 
-        result = trace_a + trace_b - 2 * trace_prod
-        return result
+        return trace_a + trace_b - 2 * trace_prod
 
 
 class SPDMetricEuclidean(RiemannianMetric):

--- a/geomstats/geometry/spd_matrices.py
+++ b/geomstats/geometry/spd_matrices.py
@@ -385,6 +385,9 @@ class SPDMatrices(SymmetricMatrices, EmbeddedManifold):
     def is_tangent(self, vector, base_point=None, atol=TOLERANCE):
         return super(SPDMatrices, self).belongs(vector, atol)
 
+    def to_tangent(self, vector, base_point=None):
+        return super(SPDMatrices, self).projection(vector)
+
 
 class SPDMetricAffine(RiemannianMetric):
     """Class for the affine-invariant metric on the SPD manifold."""

--- a/geomstats/geometry/spd_matrices.py
+++ b/geomstats/geometry/spd_matrices.py
@@ -382,6 +382,9 @@ class SPDMatrices(SymmetricMatrices, EmbeddedManifold):
         """
         return cls.apply_func_to_eigvals(mat, gs.log, check_positive=True)
 
+    def is_tangent(self, vector, base_point=None, atol=TOLERANCE):
+        return super(SPDMatrices, self).belongs(vector, atol)
+
 
 class SPDMetricAffine(RiemannianMetric):
     """Class for the affine-invariant metric on the SPD manifold."""

--- a/geomstats/geometry/symmetric_matrices.py
+++ b/geomstats/geometry/symmetric_matrices.py
@@ -63,6 +63,18 @@ class SymmetricMatrices(EmbeddedManifold):
 
     @staticmethod
     def projection(point):
+        """Make a matrix symmetric, by averaging with its transpose.
+
+        Parameters
+        ----------
+        point : array-like, shape=[..., n, n]
+            Matrix.
+
+        Returns
+        -------
+        sym : array-like, shape=[..., n, n]
+            Symmetric matrix.
+        """
         return Matrices.to_symmetric(point)
 
     @staticmethod

--- a/geomstats/geometry/symmetric_matrices.py
+++ b/geomstats/geometry/symmetric_matrices.py
@@ -62,6 +62,10 @@ class SymmetricMatrices(EmbeddedManifold):
     basis = property(get_basis)
 
     @staticmethod
+    def projection(point):
+        return Matrices.to_symmetric(point)
+
+    @staticmethod
     def to_vector(mat):
         """Convert a symmetric matrix into a vector.
 

--- a/opt-requirements.txt
+++ b/opt-requirements.txt
@@ -1,2 +1,2 @@
 tensorflow>=2.1.2; python_version < '3.8'
-torch==1.4.0
+torch==1.7.1

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -11,6 +11,7 @@ import scipy.linalg
 
 import geomstats.backend as gs
 import geomstats.tests
+from geomstats.geometry.spd_matrices import SPDMatrices
 from geomstats.geometry.special_orthogonal import SpecialOrthogonal
 
 
@@ -1001,3 +1002,9 @@ class TestBackends(geomstats.tests.TestCase):
         result = gs.linalg.eigvalsh(mat, UPLO='U')
         expected = _np.linalg.eigvalsh(mat)
         self.assertAllCloseToNp(result, expected)
+
+    def test_cholesky(self):
+        mat = SPDMatrices(3).random_uniform(2)
+        result = gs.linalg.cholesky(mat)
+        expected = _np.linalg.cholesky(mat)
+        self.assertAllClose(result, expected)

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -185,46 +185,6 @@ class TestBackends(geomstats.tests.TestCase):
 
         self.assertAllClose(result, expected)
 
-    @geomstats.tests.np_and_tf_only
-    def test_powerm_diagonal(self):
-        power = .5
-        point = gs.array([[1., 0., 0.],
-                          [0., 4., 0.],
-                          [0., 0., 9.]])
-        result = gs.linalg.powerm(point, power)
-        expected = gs.array([[1., 0., 0.],
-                             [0., 2., 0.],
-                             [0., 0., 3.]])
-
-        self.assertAllClose(result, expected)
-
-    @geomstats.tests.np_and_tf_only
-    def test_powerm(self):
-        power = 2.4
-        point = gs.array([[1., 0., 0.],
-                          [0., 2.5, 1.5],
-                          [0., 1.5, 2.5]])
-        result = gs.linalg.powerm(point, power)
-        result = gs.linalg.powerm(result, 1 / power)
-        expected = point
-
-        self.assertAllClose(result, expected)
-
-    @geomstats.tests.np_only
-    def test_powerm_vectorization(self):
-        power = 2.4
-        points = gs.array([[[1., 0., 0.],
-                            [0., 4., 0.],
-                            [0., 0., 9.]],
-                           [[1., 0., 0.],
-                            [0., 2.5, 1.5],
-                            [0., 1.5, 2.5]]])
-        result = gs.linalg.powerm(points, power)
-        result = gs.linalg.powerm(result, 1. / power)
-        expected = points
-
-        self.assertAllClose(result, expected)
-
     @geomstats.tests.tf_only
     def test_vstack(self):
         import tensorflow as tf
@@ -985,6 +945,15 @@ class TestBackends(geomstats.tests.TestCase):
 
         self.assertAllClose(result, skew)
 
+    @geomstats.tests.np_and_pytorch_only
+    def test_general_sylvester_solve(self):
+        a = gs.array([[-3., -2., 0.], [-1., -1., 3.], [3., -5., -1.]])
+        b = gs.array([[1.]])
+        q = gs.array([[1.], [2.], [3.]])
+        sol = gs.linalg.solve_sylvester(a, b, q)
+        result = gs.matmul(a, sol) + gs.matmul(sol, b)
+        self.assertAllClose(result, q)
+
     def test_sylvester_solve_vectorization(self):
         gs.random.seed(0)
         mat = gs.random.rand(2, 4, 3)
@@ -1010,7 +979,7 @@ class TestBackends(geomstats.tests.TestCase):
         expected = _np.linalg.cholesky(mat)
         self.assertAllClose(result, expected)
 
-    @geomstats.tests.np_only
+    @geomstats.tests.np_and_pytorch_only
     def test_expm_backward(self):
         mat = gs.array([[0, 1, .5], [-1, 0, 0.2], [-.5, -.2, 0]])
 

--- a/tests/test_invariant_metric.py
+++ b/tests/test_invariant_metric.py
@@ -704,7 +704,7 @@ class TestInvariantMetric(geomstats.tests.TestCase):
         result = metric.exp(
             tangent_vec, identity, n_steps=100, step='rk4')
         expected = group.exp(tangent_vec, identity)
-        self.assertAllClose(expected, result)
+        self.assertAllClose(expected, result, atol=1e-5)
 
         result = metric.exp(
             tangent_vec, identity, n_steps=100, step='rk2')
@@ -738,7 +738,7 @@ class TestInvariantMetric(geomstats.tests.TestCase):
         result = metric.exp(
             tangent_vec, identity, n_steps=100, step='rk4')
         expected = canonical_metric.exp(tangent_vec, identity)
-        self.assertAllClose(expected, result)
+        self.assertAllClose(expected, result, atol=1e-5)
 
         result = metric.exp(
             tangent_vec, identity, n_steps=100, step='rk2')

--- a/tests/test_quotient_manifold.py
+++ b/tests/test_quotient_manifold.py
@@ -52,6 +52,12 @@ class TestQuotientSpace(geomstats.tests.TestCase):
         result = self.bundle.belongs(point)
         self.assertTrue(result)
 
+    def test_lift_and_submersion(self):
+        point = self.base.random_uniform()
+        mat = self.bundle.lift(point)
+        result = self.bundle.submersion(mat)
+        self.assertAllClose(result, point)
+
     def test_tangent_submersion(self):
         mat = self.bundle.total_space.random_uniform()
         point = self.bundle.submersion(mat)
@@ -108,3 +114,44 @@ class TestQuotientSpace(geomstats.tests.TestCase):
         result = self.bundle.is_horizontal(
             point[1] - aligned, point[1], atol=1e-5)
         self.assertTrue(result)
+
+    def test_inner_product(self):
+        gs.random.seed(12)
+        mat = self.bundle.total_space.random_uniform() + gs.eye(3)
+        point = self.bundle.submersion(mat)
+        tangent_vecs = GeneralLinear.to_symmetric(
+            self.bundle.total_space.random_uniform(2)) / 10
+        result = self.quotient_metric.inner_product(
+            tangent_vecs[0], tangent_vecs[1], point=mat)
+        expected = self.base_metric.inner_product(
+            tangent_vecs[0], tangent_vecs[1], point)
+        self.assertAllClose(result, expected)
+
+    def test_exp(self):
+        mat = self.bundle.total_space.random_uniform()
+        point = self.bundle.submersion(mat)
+        tangent_vec = GeneralLinear.to_symmetric(
+            self.bundle.total_space.random_uniform()) / 5
+
+        result = self.quotient_metric.exp(tangent_vec, point)
+        expected = self.base_metric.exp(tangent_vec, point)
+        self.assertAllClose(result, expected)
+
+    def test_log(self):
+        gs.random.seed(0)
+        mats = self.bundle.total_space.random_uniform(2) + gs.eye(3)
+        points = self.bundle.submersion(mats)
+
+        result = self.quotient_metric.log(points[1], points[0], tol=1e-10)
+        expected = self.base_metric.log(points[1], points[0])
+        self.assertAllClose(result, expected, atol=1e-5)
+
+    def test_squared_dist(self):
+        gs.random.seed(1)
+        mats = self.bundle.total_space.random_uniform(2) + gs.eye(3)
+        points = self.bundle.submersion(mats)
+
+        result = self.quotient_metric.squared_dist(
+            points[1], points[0], tol=1e-10)
+        expected = self.base_metric.squared_dist(points[1], points[0])
+        self.assertAllClose(result, expected, atol=1e-5)

--- a/tests/test_quotient_manifold.py
+++ b/tests/test_quotient_manifold.py
@@ -6,8 +6,8 @@ from geomstats.geometry.general_linear import GeneralLinear
 from geomstats.geometry.matrices import MatricesMetric
 from geomstats.geometry.spd_matrices import SPDMatrices, \
     SPDMetricBuresWasserstein
-from geomstats.geometry.special_orthogonal import SpecialOrthogonal
 from geomstats.geometry.quotient_manifold import FiberBundle, QuotientMetric
+from geomstats.geometry.special_orthogonal import SpecialOrthogonal
 
 
 class TestQuotientSpace(geomstats.tests.TestCase):

--- a/tests/test_quotient_manifold.py
+++ b/tests/test_quotient_manifold.py
@@ -10,7 +10,7 @@ from geomstats.geometry.special_orthogonal import SpecialOrthogonal
 from geomstats.geometry.quotient_manifold import FiberBundle, QuotientMetric
 
 
-class TestPreShapeSpace(geomstats.tests.TestCase):
+class TestQuotientSpace(geomstats.tests.TestCase):
     def setUp(self):
         n = 3
         self.base = SPDMatrices(n)
@@ -100,8 +100,11 @@ class TestPreShapeSpace(geomstats.tests.TestCase):
         result = self.bundle.is_vertical(horizontal, mat)
         self.assertTrue(result)
 
-    def test_squared_dist(self):
-        point = self.base.random_uniform(2)
-        result = self.quotient_metric.squared_dist(point[0], point[1])
-        expected = self.base_metric.squared_dist(point[0], point[1])
-        self.assertAllClose(result, expected)
+    def test_align(self):
+        gs.random.seed(1230)
+        point = self.bundle.total_space.random_uniform(2)
+        aligned = self.bundle.align(
+            point[0], point[1], tol=1e-10)
+        result = self.bundle.is_horizontal(
+            point[1] - aligned, point[1], atol=1e-5)
+        self.assertTrue(result)

--- a/tests/test_quotient_manifold.py
+++ b/tests/test_quotient_manifold.py
@@ -39,6 +39,7 @@ class TestQuotientSpace(geomstats.tests.TestCase):
         self.bundle.submersion = submersion
         self.bundle.tangent_submersion = tangent_submersion
         self.bundle.horizontal_lift = horizontal_lift
+        self.bundle.lift = gs.linalg.cholesky
 
     def test_belongs(self):
         point = self.base.random_uniform()
@@ -94,10 +95,9 @@ class TestQuotientSpace(geomstats.tests.TestCase):
 
     def test_is_vertical(self):
         mat = self.bundle.total_space.random_uniform()
-        tangent_vec = GeneralLinear.to_symmetric(
-            self.bundle.total_space.random_uniform())
-        horizontal = self.bundle.vertical_projection(tangent_vec, mat)
-        result = self.bundle.is_vertical(horizontal, mat)
+        tangent_vec = self.bundle.total_space.random_uniform()
+        vertical = self.bundle.vertical_projection(tangent_vec, mat)
+        result = self.bundle.is_vertical(vertical, mat)
         self.assertTrue(result)
 
     def test_align(self):

--- a/tests/test_quotient_manifold.py
+++ b/tests/test_quotient_manifold.py
@@ -12,6 +12,7 @@ from geomstats.geometry.special_orthogonal import SpecialOrthogonal
 
 class TestQuotientSpace(geomstats.tests.TestCase):
     def setUp(self):
+        gs.random.seed(1230)
         n = 3
         self.base = SPDMatrices(n)
         self.base_metric = SPDMetricBuresWasserstein(n)
@@ -107,7 +108,6 @@ class TestQuotientSpace(geomstats.tests.TestCase):
         self.assertTrue(result)
 
     def test_align(self):
-        gs.random.seed(1230)
         point = self.bundle.total_space.random_uniform(2)
         aligned = self.bundle.align(
             point[0], point[1], tol=1e-10)

--- a/tests/test_quotient_manifold.py
+++ b/tests/test_quotient_manifold.py
@@ -4,9 +4,9 @@ import geomstats.backend as gs
 import geomstats.tests
 from geomstats.geometry.general_linear import GeneralLinear
 from geomstats.geometry.matrices import MatricesMetric
+from geomstats.geometry.quotient_manifold import FiberBundle, QuotientMetric
 from geomstats.geometry.spd_matrices import SPDMatrices, \
     SPDMetricBuresWasserstein
-from geomstats.geometry.quotient_manifold import FiberBundle, QuotientMetric
 from geomstats.geometry.special_orthogonal import SpecialOrthogonal
 
 

--- a/tests/test_quotient_manifold.py
+++ b/tests/test_quotient_manifold.py
@@ -1,0 +1,107 @@
+"""Unit tests for the quotient space."""
+
+import geomstats.backend as gs
+import geomstats.tests
+from geomstats.geometry.general_linear import GeneralLinear
+from geomstats.geometry.matrices import MatricesMetric
+from geomstats.geometry.spd_matrices import SPDMatrices, \
+    SPDMetricBuresWasserstein
+from geomstats.geometry.special_orthogonal import SpecialOrthogonal
+from geomstats.geometry.quotient_manifold import FiberBundle, QuotientMetric
+
+
+class TestPreShapeSpace(geomstats.tests.TestCase):
+    def setUp(self):
+        n = 3
+        self.base = SPDMatrices(n)
+        self.base_metric = SPDMetricBuresWasserstein(n)
+        self.group = SpecialOrthogonal(n)
+        self.bundle = FiberBundle(
+            GeneralLinear(n), base=self.base, group=self.group)
+        self.quotient_metric = QuotientMetric(
+            self.bundle, ambient_metric=MatricesMetric(n, n))
+
+        def submersion(point):
+            return GeneralLinear.mul(point, GeneralLinear.transpose(point))
+
+        def tangent_submersion(tangent_vec, base_point):
+            product = GeneralLinear.mul(
+                base_point, GeneralLinear.transpose(tangent_vec))
+            return 2 * GeneralLinear.to_symmetric(product)
+
+        def horizontal_lift(tangent_vec, point, base_point=None):
+            if base_point is None:
+                base_point = submersion(point)
+            sylvester = gs.linalg.solve_sylvester(
+                base_point, base_point, tangent_vec)
+            return GeneralLinear.mul(sylvester, point)
+
+        self.bundle.submersion = submersion
+        self.bundle.tangent_submersion = tangent_submersion
+        self.bundle.horizontal_lift = horizontal_lift
+
+    def test_belongs(self):
+        point = self.base.random_uniform()
+        result = self.bundle.belongs(point)
+        self.assertTrue(result)
+
+    def test_submersion(self):
+        mat = self.bundle.total_space.random_uniform()
+        point = self.bundle.submersion(mat)
+        result = self.bundle.belongs(point)
+        self.assertTrue(result)
+
+    def test_tangent_submersion(self):
+        mat = self.bundle.total_space.random_uniform()
+        point = self.bundle.submersion(mat)
+        vec = self.bundle.total_space.random_uniform()
+        tangent_vec = self.bundle.tangent_submersion(vec, point)
+        result = self.base.is_tangent(tangent_vec, point)
+        self.assertTrue(result)
+
+    def test_horizontal_projection(self):
+        mat = self.bundle.total_space.random_uniform()
+        vec = self.bundle.total_space.random_uniform()
+        horizontal_vec = self.bundle.horizontal_projection(vec, mat)
+        product = GeneralLinear.mul(horizontal_vec, GeneralLinear.inverse(mat))
+        is_horizontal = GeneralLinear.is_symmetric(product)
+        self.assertTrue(is_horizontal)
+
+    def test_vertical_projection(self):
+        mat = self.bundle.total_space.random_uniform()
+        vec = self.bundle.total_space.random_uniform()
+        vertical_vec = self.bundle.vertical_projection(vec, mat)
+
+        result = self.bundle.tangent_submersion(vertical_vec, mat)
+        expected = gs.zeros_like(result)
+        self.assertAllClose(result, expected)
+
+    def test_horizontal_lift_and_tangent_submersion(self):
+        mat = self.bundle.total_space.random_uniform()
+        tangent_vec = GeneralLinear.to_symmetric(
+            self.bundle.total_space.random_uniform())
+        horizontal = self.bundle.horizontal_lift(tangent_vec, mat)
+        result = self.bundle.tangent_submersion(horizontal, mat)
+        self.assertAllClose(result, tangent_vec)
+
+    def test_is_horizontal(self):
+        mat = self.bundle.total_space.random_uniform()
+        tangent_vec = GeneralLinear.to_symmetric(
+            self.bundle.total_space.random_uniform())
+        horizontal = self.bundle.horizontal_lift(tangent_vec, mat)
+        result = self.bundle.is_horizontal(horizontal, mat)
+        self.assertTrue(result)
+
+    def test_is_vertical(self):
+        mat = self.bundle.total_space.random_uniform()
+        tangent_vec = GeneralLinear.to_symmetric(
+            self.bundle.total_space.random_uniform())
+        horizontal = self.bundle.vertical_projection(tangent_vec, mat)
+        result = self.bundle.is_vertical(horizontal, mat)
+        self.assertTrue(result)
+
+    def test_squared_dist(self):
+        point = self.base.random_uniform(2)
+        result = self.quotient_metric.squared_dist(point[0], point[1])
+        expected = self.base_metric.squared_dist(point[0], point[1])
+        self.assertAllClose(result, expected)

--- a/tests/test_quotient_metric.py
+++ b/tests/test_quotient_metric.py
@@ -2,17 +2,18 @@
 
 import geomstats.backend as gs
 import geomstats.tests
+from geomstats.geometry.fiber_bundle import FiberBundle
 from geomstats.geometry.general_linear import GeneralLinear
 from geomstats.geometry.matrices import MatricesMetric
-from geomstats.geometry.quotient_manifold import FiberBundle, QuotientMetric
+from geomstats.geometry.quotient_metric import QuotientMetric
 from geomstats.geometry.spd_matrices import SPDMatrices, \
     SPDMetricBuresWasserstein
 from geomstats.geometry.special_orthogonal import SpecialOrthogonal
 
 
-class TestQuotientSpace(geomstats.tests.TestCase):
+class TestQuotientMetric(geomstats.tests.TestCase):
     def setUp(self):
-        gs.random.seed(1230)
+        gs.random.seed(0)
         n = 3
         self.base = SPDMatrices(n)
         self.base_metric = SPDMetricBuresWasserstein(n)
@@ -82,7 +83,7 @@ class TestQuotientSpace(geomstats.tests.TestCase):
 
         result = self.bundle.tangent_submersion(vertical_vec, mat)
         expected = gs.zeros_like(result)
-        self.assertAllClose(result, expected)
+        self.assertAllClose(result, expected, atol=1e-5)
 
     def test_horizontal_lift_and_tangent_submersion(self):
         mat = self.bundle.total_space.random_uniform()
@@ -116,8 +117,7 @@ class TestQuotientSpace(geomstats.tests.TestCase):
         self.assertTrue(result)
 
     def test_inner_product(self):
-        gs.random.seed(12)
-        mat = self.bundle.total_space.random_uniform() + gs.eye(3)
+        mat = self.bundle.total_space.random_uniform()
         point = self.bundle.submersion(mat)
         tangent_vecs = GeneralLinear.to_symmetric(
             self.bundle.total_space.random_uniform(2)) / 10
@@ -138,17 +138,15 @@ class TestQuotientSpace(geomstats.tests.TestCase):
         self.assertAllClose(result, expected)
 
     def test_log(self):
-        gs.random.seed(0)
-        mats = self.bundle.total_space.random_uniform(2) + gs.eye(3)
+        mats = self.bundle.total_space.random_uniform(2)
         points = self.bundle.submersion(mats)
 
         result = self.quotient_metric.log(points[1], points[0], tol=1e-10)
         expected = self.base_metric.log(points[1], points[0])
-        self.assertAllClose(result, expected, atol=1e-5)
+        self.assertAllClose(result, expected, atol=3e-4)
 
     def test_squared_dist(self):
-        gs.random.seed(1)
-        mats = self.bundle.total_space.random_uniform(2) + gs.eye(3)
+        mats = self.bundle.total_space.random_uniform(2)
         points = self.bundle.submersion(mats)
 
         result = self.quotient_metric.squared_dist(

--- a/tests/test_skew_symmetric_matrices.py
+++ b/tests/test_skew_symmetric_matrices.py
@@ -44,19 +44,17 @@ class TestSkewSymmetricMatrices(geomstats.tests.TestCase):
             self.assertAllClose(expected, result)
 
             expected = (
-                    expected
-                    + 1.0 / 12.0 * skew.bracket(first_base, lb_first_second)
-                    - 1.0 / 12.0 * skew.bracket(second_base, lb_first_second)
+                expected
+                + 1.0 / 12.0 * skew.bracket(first_base, lb_first_second)
+                - 1.0 / 12.0 * skew.bracket(second_base, lb_first_second)
             )
             result = skew.baker_campbell_hausdorff(
                 first_base, second_base, order=3
             )
             self.assertAllClose(expected, result)
 
-            expected = expected - 1.0 / 24.0 * skew.bracket(second_base,
-                                                            skew.bracket(
-                                                                first_base,
-                                                                lb_first_second))
+            expected = expected - 1.0 / 24.0 * skew.bracket(
+                second_base, skew.bracket(first_base, lb_first_second))
             result = skew.baker_campbell_hausdorff(
                 first_base, second_base, order=4
             )
@@ -78,7 +76,7 @@ class TestSkewSymmetricMatrices(geomstats.tests.TestCase):
             self.assertAllClose(result, vec)
 
     def test_belongs(self):
-        mat = gs.array([[0, -1], [1, 0]])
+        mat = gs.array([[0., -1.], [1., 0.]])
         result = self.skew[2].belongs(mat)
         self.assertTrue(result)
 

--- a/tests/test_skew_symmetric_matrices.py
+++ b/tests/test_skew_symmetric_matrices.py
@@ -36,7 +36,7 @@ class TestSkewSymmetricMatrices(geomstats.tests.TestCase):
             )
             self.assertAllClose(expected, result)
 
-            lb_first_second = skew.lie_bracket(first_base, second_base)
+            lb_first_second = skew.bracket(first_base, second_base)
             expected = expected + 0.5 * lb_first_second
             result = skew.baker_campbell_hausdorff(
                 first_base, second_base, order=2
@@ -44,18 +44,19 @@ class TestSkewSymmetricMatrices(geomstats.tests.TestCase):
             self.assertAllClose(expected, result)
 
             expected = (
-                expected
-                + 1.0 / 12.0 * skew.lie_bracket(first_base, lb_first_second)
-                - 1.0 / 12.0 * skew.lie_bracket(second_base, lb_first_second)
+                    expected
+                    + 1.0 / 12.0 * skew.bracket(first_base, lb_first_second)
+                    - 1.0 / 12.0 * skew.bracket(second_base, lb_first_second)
             )
             result = skew.baker_campbell_hausdorff(
                 first_base, second_base, order=3
             )
             self.assertAllClose(expected, result)
 
-            expected = expected - 1.0 / 24.0 * skew.lie_bracket(
-                second_base, skew.lie_bracket(first_base, lb_first_second)
-            )
+            expected = expected - 1.0 / 24.0 * skew.bracket(second_base,
+                                                            skew.bracket(
+                                                                first_base,
+                                                                lb_first_second))
             result = skew.baker_campbell_hausdorff(
                 first_base, second_base, order=4
             )
@@ -75,3 +76,11 @@ class TestSkewSymmetricMatrices(geomstats.tests.TestCase):
             mat = skew.matrix_representation(vec)
             result = skew.basis_representation(mat)
             self.assertAllClose(result, vec)
+
+    def test_belongs(self):
+        mat = gs.array([[0, -1], [1, 0]])
+        result = self.skew[2].belongs(mat)
+        self.assertTrue(result)
+
+        result = self.skew[3].belongs(mat)
+        self.assertFalse(result)

--- a/tests/test_spd_matrices.py
+++ b/tests/test_spd_matrices.py
@@ -435,10 +435,8 @@ class TestSPDMatrices(geomstats.tests.TestCase):
         n_points = 10
         t = gs.linspace(start=0., stop=1., num=n_points)
         points = geodesic(t)
-        result = self.space.belongs(points)
-        expected = gs.array([True] * n_points)
-
-        self.assertAllClose(result, expected)
+        result = self.space.belongs(points, atol=1e-5)
+        self.assertTrue(gs.all(result))
 
     def test_squared_dist_is_symmetric(self):
         """Test of SPDMetricAffine.squared_dist (power=1) and is_symmetric."""

--- a/tests/test_spd_matrices.py
+++ b/tests/test_spd_matrices.py
@@ -548,3 +548,9 @@ class TestSPDMatrices(geomstats.tests.TestCase):
         expected = metric.squared_norm(vector=log, base_point=point_a)
 
         self.assertAllClose(result, expected, atol=1e-5)
+
+    def test_to_tangent_and_is_tangent(self):
+        mat = gs.random.rand(3, 3)
+        projection = self.space.to_tangent(mat)
+        result = self.space.is_tangent(projection)
+        self.assertTrue(result)

--- a/tests/test_special_orthogonal3.py
+++ b/tests/test_special_orthogonal3.py
@@ -2719,7 +2719,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
                         base_point=base_point,
                         metric=metric)
                     expected = reg_tangent_vec
-                    self.assertAllClose(result, expected, atol=1e-4)
+                    self.assertAllClose(result, expected, rtol=1e-3, atol=1e-3)
 
     def test_exp_then_log_with_angles_close_to_pi(self):
         """
@@ -2810,7 +2810,7 @@ class TestSpecialOrthogonal3(geomstats.tests.TestCase):
         tangent_vec = self.group.vector_from_skew_matrix(tangent_sample)
         exp = self.group.exp_from_identity(tangent_vec)
         result = self.group.matrix_from_rotation_vector(exp)
-        self.assertAllClose(result, expected)
+        self.assertAllClose(result, expected, atol=1e-5)
 
     # def test_group_exp_from_identity_coincides_with_expm_for_high_dims(self):
     #     for n in [4, 5, 6, 7, 8, 9, 10]:

--- a/tests/test_symmetric_matrices.py
+++ b/tests/test_symmetric_matrices.py
@@ -114,3 +114,9 @@ class TestSymmetricMatrices(geomstats.tests.TestCase):
         result = self.space.from_vector(vector_2)
         expected = gs.array([[1., 2., 3.], [2., 4., 5.], [3., 5., 6.]])
         self.assertAllClose(result, expected)
+
+    def test_projection_and_belongs(self):
+        mat = gs.random.rand(3, 3)
+        projection = self.space.projection(mat)
+        result = self.space.belongs(projection)
+        self.assertTrue(result)


### PR DESCRIPTION
This PR defines an abstract class for fiber bundles and quotient metrics. There are different scenarios depending on the available methods (whether the submersion is explicitly defined or not). This is tested in two different cases: 
- kendall shape space: the quotient space is abstract and computations are carried out in a section of the total space
- Bures Wasserstein metric on spd: everything is explicit
@ythanwerdas 