### PR TITLE
Make geodesic faster and more accurate in Dirichlet Distributions

### DIFF
--- a/geomstats/geometry/dirichlet_distributions.py
+++ b/geomstats/geometry/dirichlet_distributions.py
@@ -403,8 +403,7 @@ class DirichletMetric(RiemannianMetric):
             geod = []
 
             def initialize(point_0, point_1):
-                """Initialize the solution of the boundary value problem.
-                """
+                """Initialize the solution of the boundary value problem."""
                 lin_init = gs.zeros([2 * self.dim, n_steps])
                 lin_init[:self.dim, :] = gs.transpose(
                     gs.linspace(point_0, point_1, n_steps))

--- a/tests/test_dirichlet_distributions.py
+++ b/tests/test_dirichlet_distributions.py
@@ -306,6 +306,5 @@ class TestDirichletDistributions(geomstats.tests.TestCase):
         result = 1 / velocity_norm.min() * (
             velocity_norm.max() - velocity_norm.min())
         expected = 0.
-        print(result)
 
         self.assertAllClose(expected, result, atol=1e-4, rtol=1.)


### PR DESCRIPTION
When boundary conditions are given, the geodesic method for Dirichlet Distributions solves 2 ODEs: first to compute the log, then to compute exp of the log. This is slow and the resulting geodesic does not end at the desired end point. This PR aims to fix this.