### PR TITLE
remove redundant call to variance function

### DIFF
--- a/tests/test_expectation_maximization.py
+++ b/tests/test_expectation_maximization.py
@@ -93,17 +93,17 @@ class TestEM(geomstats.tests.TestCase):
     def test_weighted_frechet_mean(self):
         """Test for weighted mean."""
         data = gs.array([[0.1, 0.2],
-                         [0.25, 0.35],
-                        [-0.1, -0.2],
-                        [-0.4, 0.3]])
-        weights = gs.repeat([0.5], data.shape[0])
+                         [0.25, 0.35]])
+        weights = gs.array([3., 1.])
         mean_o = FrechetMean(
             metric=self.metric,
             point_type='vector')
-        mean_o.fit(data, weights)
-        mean = mean_o.estimate_
-        mean_verdict = [-0.03857, 0.15922]
-        self.assertAllClose(mean, mean_verdict, TOLERANCE)
+        mean_o.fit(data, weights=weights)
+        result = mean_o.estimate_
+        expected = self.metric.exp(
+            weights[1] / gs.sum(weights) * self.metric.log(data[1], data[0]),
+            data[0])
+        self.assertAllClose(result, expected, TOLERANCE)
 
     @geomstats.tests.np_and_pytorch_only
     def test_normalization_factor(self):


### PR DESCRIPTION
The variance function uses `metric.squared_dist`, which can be replaced by `metric.norm(logs)`, where logs have already been computed. This avoids computing the logs twice.
Also fixed `test_weighted_frechet_mean` which was wrong as the `weights` arguments was not used...