### PR TITLE
install from docs/requirements.doc.txt as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 install:
   - pip install --upgrade pip setuptools wheel
   - |
-    for req in ci-requirements.txt dev-requirements.txt opt-requirements.txt requirements.txt; do
+    for req in ci-requirements.txt dev-requirements.txt opt-requirements.txt requirements.txt docs/requirements.doc.txt; do
       pip install -q -r $req
     done
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 install:
   - pip install --upgrade pip setuptools wheel
   - |
-    for req in ci-requirements.txt dev-requirements.txt opt-requirements.txt requirements.txt docs/requirements.doc.txt; do
+    for req in ci-requirements.txt dev-requirements.txt opt-requirements.txt requirements.txt; do
       pip install -q -r $req
     done
 before_script:

--- a/ci-requirements.txt
+++ b/ci-requirements.txt
@@ -5,3 +5,4 @@ nbsphinx_link
 pandoc
 sphinx
 sphinx_rtd_theme
+sphinx_gallery

--- a/ci-requirements.txt
+++ b/ci-requirements.txt
@@ -4,5 +4,6 @@ nbsphinx
 nbsphinx_link
 pandoc
 sphinx
-sphinx_rtd_theme
 sphinx_gallery
+sphinx_rtd_theme
+


### PR DESCRIPTION
Travis.yml is not installing requirements from  docs/requirements.doc.txt. This will fix the 'build-failing' because the sphinx-gallery is added as dependency in  docs/requirements.doc.txt