### PR TITLE
Corrected a + - sign typo in curvature doc-string (connection.py / in…

### DIFF
--- a/geomstats/geometry/connection.py
+++ b/geomstats/geometry/connection.py
@@ -453,11 +453,11 @@ class Connection:
 
     def directional_curvature(
             self, tangent_vec_a, tangent_vec_b, base_point):
-        r"""Compute the directional curvature, better known in relativity as
-        the tidal force operator.
+        """Compute the directional curvature (tidal force operator).
 
-        For two tangent vectors at a base point :math: `X,Y`,
-        the directional curvature is defined by :math: `R_X(Y) = R(X,Y)X`.
+        For two tangent vectors at a base point :math: `X,Y`, the directional
+        curvature, better known in relativity as the tidal force operator,
+        is defined by :math: `R_X(Y) = R(X,Y)X`.
 
         Parameters
         ----------

--- a/geomstats/geometry/connection.py
+++ b/geomstats/geometry/connection.py
@@ -431,7 +431,7 @@ class Connection:
         For three tangent vectors at a base point :math: `X,Y,Z`,
         the curvature is defined by
         :math: `R(X, Y)Z = \nabla_{[X,Y]}Z
-        - \nabla_X\nabla_Y Z + - \nabla_Y\nabla_X Z`.
+        - \nabla_X\nabla_Y Z + \nabla_Y\nabla_X Z`.
 
         Parameters
         ----------
@@ -450,6 +450,31 @@ class Connection:
             Tangent vector at `base_point`.
         """
         raise NotImplementedError('The curvature is not implemented.')
+
+    def directional_curvature(
+            self, tangent_vec_a, tangent_vec_b, base_point):
+        r"""Compute the directional curvature, better known in relativity as
+        the tidal force operator.
+
+        For two tangent vectors at a base point :math: `X,Y`,
+        the directional curvature is defined by :math: `R_X(Y) = R(X,Y)X`.
+
+        Parameters
+        ----------
+        tangent_vec_a : array-like, shape=[..., {dim, [n, n]}]
+            Tangent vector at `base_point`.
+        tangent_vec_b : array-like, shape=[..., {dim, [n, n]}]
+            Tangent vector at `base_point`.
+        base_point :  array-like, shape=[..., {dim, [n, n]}]
+            Point on the group. Optional, default is the identity.
+
+        Returns
+        -------
+        directional_curvature : array-like, shape=[..., {dim, [n, n]}]
+            Tangent vector at `base_point`.
+        """
+        return self.curvature(tangent_vec_a, tangent_vec_b, tangent_vec_a,
+                              base_point)
 
     def geodesic(self, initial_point,
                  end_point=None, initial_tangent_vec=None):

--- a/geomstats/geometry/hypersphere.py
+++ b/geomstats/geometry/hypersphere.py
@@ -679,11 +679,11 @@ class HypersphereMetric(RiemannianMetric):
 
         For three tangent vectors at a base point :math: `x,y,z`,
         the curvature is defined by
-        :math: `R(X, Y)Z = \nabla_{[X,Y]}Z
-        - \nabla_X\nabla_Y Z + - \nabla_Y\nabla_X Z`, where :math: `\nabla`
+        :math: `R(x, y)z = \nabla_{[x,y]}z
+        - \nabla_z\nabla_y z + \nabla_y\nabla_x z`, where :math: `\nabla`
         is the Levi-Civita connection. In the case of the hypersphere,
         we have the closed formula
-        :math: `R(X,Y)Z = \langle X, Z \rangle Y - \langle Y,Z \rangle X`.
+        :math: `R(x,y)z = \langle x, z \rangle y - \langle y,z \rangle x`.
 
         Parameters
         ----------

--- a/geomstats/geometry/invariant_metric.py
+++ b/geomstats/geometry/invariant_metric.py
@@ -278,7 +278,7 @@ class _InvariantMetricMatrix(RiemannianMetric):
         For three tangent vectors at identity :math: `x,y,z`,
         the curvature is defined by
         :math: `R(x, y)z = \nabla_{[x,y]}z
-        - \nabla_x\nabla_y z + - \nabla_y\nabla_x z`.
+        - \nabla_x\nabla_y z + \nabla_y\nabla_x z`.
 
         Parameters
         ----------
@@ -315,7 +315,7 @@ class _InvariantMetricMatrix(RiemannianMetric):
         For three tangent vectors at a base point :math: `x,y,z`,
         the curvature is defined by
         :math: `R(x, y)z = \nabla_{[x,y]}z
-        - \nabla_x\nabla_y z + - \nabla_y\nabla_x z`. It is computed using
+        - \nabla_x\nabla_y z + \nabla_y\nabla_x z`. It is computed using
         the invariance of the connection and its value at identity.
 
         Parameters

--- a/geomstats/geometry/quotient_metric.py
+++ b/geomstats/geometry/quotient_metric.py
@@ -204,4 +204,4 @@ class QuotientMetric(RiemannianMetric):
             horizontal_a, f_bc, point_fiber)
         f_a_f_bc = bundle.tangent_submersion(f_a_f_bc, point_fiber)
 
-        return -(projected_top_curvature + 2 * f_c_f_ab - f_a_f_bc + f_b_f_ac)
+        return projected_top_curvature - 2 * f_c_f_ab + f_a_f_bc - f_b_f_ac

--- a/geomstats/geometry/riemannian_metric.py
+++ b/geomstats/geometry/riemannian_metric.py
@@ -399,9 +399,10 @@ class RiemannianMetric(Connection):
             self, tangent_vec_a, tangent_vec_b, base_point=None):
         """Compute the sectional curvature.
 
-        For two orthonormal tangent vectors at a base point :math: `x,y`,
-        the sectional curvature is defined by :math: `<R(x, y)x,
-        y>`. Non-orthonormal vectors can be given.
+        For two orthonormal tangent vectors :math: `x,y` at a base point,
+        the sectional curvature is defined by :math: `<R(x, y)x, y> =
+        <R_x(y), y>`. For non-orthonormal vectors vectors, it is :math:
+        `<R(x, y)x, y> / \\|x \\wedge y\\|^2`.
 
         Parameters
         ----------

--- a/geomstats/geometry/riemannian_metric.py
+++ b/geomstats/geometry/riemannian_metric.py
@@ -397,7 +397,7 @@ class RiemannianMetric(Connection):
 
     def sectional_curvature(
             self, tangent_vec_a, tangent_vec_b, base_point=None):
-        """Compute the sectional curvature.
+        r"""Compute the sectional curvature.
 
         For two orthonormal tangent vectors :math: `x,y` at a base point,
         the sectional curvature is defined by :math: `<R(x, y)x, y> =

--- a/tests/tests_geomstats/test_pre_shape.py
+++ b/tests/tests_geomstats/test_pre_shape.py
@@ -395,9 +395,10 @@ class TestPreShapeSpace(geomstats.tests.TestCase):
         tidal = kendall.directional_curvature(hor_a, hor_b, base_point)
 
         numerator = kendall.inner_product(tidal, hor_b, base_point)
-        denominator = kendall.inner_product(hor_a, hor_a, base_point) * \
-                      kendall.inner_product(hor_b, hor_b, base_point) - \
-                      kendall.inner_product(hor_a, hor_b, base_point) ** 2
+        denominator = \
+            kendall.inner_product(hor_a, hor_a, base_point) * \
+            kendall.inner_product(hor_b, hor_b, base_point) - \
+            kendall.inner_product(hor_a, hor_b, base_point) ** 2
         condition = ~gs.isclose(denominator, 0.)
         kappa = numerator[condition] / denominator[condition]
         kappa_direct = \
@@ -405,4 +406,3 @@ class TestPreShapeSpace(geomstats.tests.TestCase):
         self.assertAllClose(kappa, kappa_direct)
         result = (kappa > 1.0 - 1e-12)
         self.assertTrue(gs.all(result))
-

--- a/tests/tests_geomstats/test_pre_shape.py
+++ b/tests/tests_geomstats/test_pre_shape.py
@@ -376,3 +376,33 @@ class TestPreShapeSpace(geomstats.tests.TestCase):
             horizontal_a, vertical_b, base_point)
         is_horizontal = space.is_horizontal(result, base_point)
         self.assertTrue(is_horizontal)
+
+    def test_kendall_directional_curvature(self):
+        space = self.space
+        kendall = KendallShapeMetric(m_ambient=self.m_ambient,
+                                     k_landmarks=self.k_landmarks)
+        n_samples = 4 * self.k_landmarks * self.m_ambient
+        base_point = self.space.random_point(1)
+
+        vec_a = gs.random.rand(n_samples, self.k_landmarks, self.m_ambient)
+        tg_vec_a = space.to_tangent(space.center(vec_a), base_point)
+        hor_a = space.horizontal_projection(tg_vec_a, base_point)
+
+        vec_b = gs.random.rand(n_samples, self.k_landmarks, self.m_ambient)
+        tg_vec_b = space.to_tangent(space.center(vec_b), base_point)
+        hor_b = space.horizontal_projection(tg_vec_b, base_point)
+
+        tidal = kendall.directional_curvature(hor_a, hor_b, base_point)
+
+        numerator = kendall.inner_product(tidal, hor_b, base_point)
+        denominator = kendall.inner_product(hor_a, hor_a, base_point) * \
+                      kendall.inner_product(hor_b, hor_b, base_point) - \
+                      kendall.inner_product(hor_a, hor_b, base_point) ** 2
+        condition = ~gs.isclose(denominator, 0.)
+        kappa = numerator[condition] / denominator[condition]
+        kappa_direct = \
+            kendall.sectional_curvature(hor_a, hor_b, base_point)[condition]
+        self.assertAllClose(kappa, kappa_direct)
+        result = (kappa > 1.0 - 1e-12)
+        self.assertTrue(gs.all(result))
+


### PR DESCRIPTION
…variant_metric.py)

Edited the sectional_curvature doc-string in riemannian_metric.py to display the full formula with non-orthonormal vectors
Added directional_curvature (or tidal operator) in connection.py
Corrected a sign error for top_curvature in quotient_metric.py curvature
Added a unit-test for the sectional curvature of Kendal shape metric in test_pre_shape.py. It add code coverage for the directional_curvature by verifying that the formula gives the same results as sectional_curvature and it verifies that the sectional curvature is greater than the one of the top space (1 in this case because we are on the sphere). A sufficient number of samples is needed to cover statistically all 2-planes.