### PR TITLE
Dimension of Kendall shape metric

### DIFF
--- a/geomstats/geometry/_my_manifold.py
+++ b/geomstats/geometry/_my_manifold.py
@@ -80,7 +80,7 @@ class MyManifold(Manifold):
         return belongs
 
     # Another example of method of MyManifold.
-    def is_tangent(self, vector, base_point=None):
+    def is_tangent(self, vector, base_point, atol=gs.atol):
         """Check whether vector is tangent to the manifold at base_point.
 
         In what follows, the ellipsis ... indicates either nothing
@@ -96,7 +96,8 @@ class MyManifold(Manifold):
             Vector.
         base_point : array-like, shape=[..., dim]
             Point on the manifold.
-            Optional, default: None.
+        atol : float
+            Absolute tolerance threshold
 
         Returns
         -------

--- a/geomstats/geometry/_my_manifold.py
+++ b/geomstats/geometry/_my_manifold.py
@@ -80,7 +80,7 @@ class MyManifold(Manifold):
         return belongs
 
     # Another example of method of MyManifold.
-    def is_tangent(self, vector, base_point, atol=gs.atol):
+    def is_tangent(self, vector, base_point=None, atol=gs.atol):
         """Check whether vector is tangent to the manifold at base_point.
 
         In what follows, the ellipsis ... indicates either nothing
@@ -96,6 +96,7 @@ class MyManifold(Manifold):
             Vector.
         base_point : array-like, shape=[..., dim]
             Point on the manifold.
+            Optional, default: None.
         atol : float
             Absolute tolerance threshold
 

--- a/geomstats/geometry/euclidean.py
+++ b/geomstats/geometry/euclidean.py
@@ -38,13 +38,15 @@ class Euclidean(Manifold):
         return identity
     identity = property(get_identity)
 
-    def belongs(self, point):
+    def belongs(self, point, atol=gs.atol):
         """Evaluate if a point belongs to the Euclidean space.
 
         Parameters
         ----------
         point : array-like, shape=[..., dim]
             Point to evaluate.
+        atol : float
+            Unused.
 
         Returns
         -------
@@ -100,6 +102,47 @@ class Euclidean(Manifold):
         if not self.belongs(tangent_vec):
             raise ValueError('The update must be of the same dimension')
         return tangent_vec + base_point
+
+    def is_tangent(self, vector, base_point=None, atol=gs.atol):
+        """Check whether the vector is tangent at base_point.
+
+        In the Euclidean space, tangent spaces are identified with the
+        manifold itself.
+
+        Parameters
+        ----------
+        vector : array-like, shape=[..., dim]
+            Vector.
+        base_point : array-like, shape=[..., dim]
+            Point on the manifold.
+        atol : float
+            Unused.
+
+        Returns
+        -------
+        is_tangent : bool
+            Boolean denoting if vector is a tangent vector at the base point.
+        """
+        return self.belongs(vector)
+
+    def to_tangent(self, vector, base_point=None):
+        """Project a vector to a tangent space of the manifold.
+
+        In a Euclidean space this is just the identity.
+
+        Parameters
+        ----------
+        vector : array-like, shape=[..., dim]
+            Vector.
+        base_point : array-like, shape=[..., dim]
+            Point on the manifold.
+
+        Returns
+        -------
+        tangent_vec : array-like, shape=[..., dim]
+            Tangent vector at base point.
+        """
+        return vector
 
 
 class EuclideanMetric(RiemannianMetric):

--- a/geomstats/geometry/grassmannian.py
+++ b/geomstats/geometry/grassmannian.py
@@ -155,7 +155,7 @@ class Grassmannian(EmbeddedManifold):
         is_close = gs.all(gs.isclose(diff, 0., atol=atol))
         return gs.logical_and(Matrices.is_symmetric(vector), is_close)
 
-    def to_tangent(self, vector, base_point=None):
+    def to_tangent(self, vector, base_point):
         """Project a vector to a tangent space of the manifold.
 
         Compute the bracket (commutator) of the base_point with

--- a/geomstats/geometry/grassmannian.py
+++ b/geomstats/geometry/grassmannian.py
@@ -128,7 +128,7 @@ class Grassmannian(EmbeddedManifold):
             Matrices.transpose(points))
         return projector[0] if n_samples == 1 else projector
 
-    def is_tangent(self, vector, base_point=None, atol=gs.atol):
+    def is_tangent(self, vector, base_point, atol=gs.atol):
         r"""Check if a vector is tangent to the manifold at the base point.
 
         Check if the (n,n)-matrix :math: `Y` is symmetric and verifies the

--- a/geomstats/geometry/hyperboloid.py
+++ b/geomstats/geometry/hyperboloid.py
@@ -147,7 +147,7 @@ class Hyperboloid(Hyperbolic, EmbeddedManifold):
         tangent_vec = vector - gs.einsum('...,...j->...j', coef, base_point)
         return tangent_vec
 
-    def is_tangent(self, vector, base_point=None, atol=gs.atol):
+    def is_tangent(self, vector, base_point, atol=gs.atol):
         """Check whether the vector is tangent at base_point.
 
         Parameters
@@ -156,7 +156,6 @@ class Hyperboloid(Hyperbolic, EmbeddedManifold):
             Vector.
         base_point : array-like, shape=[..., dim + 1]
             Point on the manifold.
-            Optional, default: none.
         atol : float
             Absolute tolerance.
             Optional, default: backend atol.

--- a/geomstats/geometry/hypersphere.py
+++ b/geomstats/geometry/hypersphere.py
@@ -138,7 +138,7 @@ class _Hypersphere(EmbeddedManifold):
 
         return tangent_vec
 
-    def is_tangent(self, vector, base_point=None, atol=gs.atol):
+    def is_tangent(self, vector, base_point, atol=gs.atol):
         """Check whether the vector is tangent at base_point.
 
         Parameters
@@ -147,7 +147,6 @@ class _Hypersphere(EmbeddedManifold):
             Vector.
         base_point : array-like, shape=[..., dim]
             Point on the manifold.
-            Optional, default: none.
         atol : float
             Absolute tolerance.
             Optional, default: backend atol.

--- a/geomstats/geometry/invariant_metric.py
+++ b/geomstats/geometry/invariant_metric.py
@@ -187,7 +187,7 @@ class _InvariantMetricMatrix(RiemannianMetric):
                        Geonger International Publishing, 2020.
                        https://doi.org/10.1007/978-3-030-46040-2.
         """
-        basis = self.orthonormal_basis(self.lie_algebra.basis)
+        basis = self.normal_basis(self.lie_algebra.basis)
         return - gs.einsum(
             'i...,ijk->...jk',
             gs.array([
@@ -567,7 +567,7 @@ class _InvariantMetricMatrix(RiemannianMetric):
                      480–98. https://doi.org/10.2991/jnmp.2004.11.4.5.
         """
         group = self.group
-        basis = self.orthonormal_basis(self.lie_algebra.basis)
+        basis = self.normal_basis(self.lie_algebra.basis)
         sign = 1. if self.left_or_right == 'left' else -1.
 
         def lie_acceleration(point, vector):

--- a/geomstats/geometry/lie_group.py
+++ b/geomstats/geometry/lie_group.py
@@ -470,7 +470,7 @@ class LieGroup(Manifold):
         is_tangent = self.lie_algebra.belongs(tangent_vec_at_id, atol)
         return is_tangent
 
-    def to_tangent(self, vector, base_point=None):
+    def to_tangent(self, vector, base_point):
         """Project a vector onto the tangent space at a base point.
 
         Parameters

--- a/geomstats/geometry/lie_group.py
+++ b/geomstats/geometry/lie_group.py
@@ -470,7 +470,7 @@ class LieGroup(Manifold):
         is_tangent = self.lie_algebra.belongs(tangent_vec_at_id, atol)
         return is_tangent
 
-    def to_tangent(self, vector, base_point):
+    def to_tangent(self, vector, base_point=None):
         """Project a vector onto the tangent space at a base point.
 
         Parameters
@@ -479,6 +479,7 @@ class LieGroup(Manifold):
             Vector to project. Its shape must match the shape of base_point.
         base_point : array-like, shape=[..., {dim, [n, n]}], optional
             Point of the group.
+            Optional, default: identity.
 
         Returns
         -------

--- a/geomstats/geometry/manifold.py
+++ b/geomstats/geometry/manifold.py
@@ -75,7 +75,7 @@ class Manifold:
         raise NotImplementedError(
             'is_tangent is not implemented.')
 
-    def to_tangent(self, vector, base_point=None):
+    def to_tangent(self, vector, base_point):
         """Project a vector to a tangent space of the manifold.
 
         Parameters

--- a/geomstats/geometry/manifold.py
+++ b/geomstats/geometry/manifold.py
@@ -53,7 +53,7 @@ class Manifold:
         """
         raise NotImplementedError('belongs is not implemented.')
 
-    def is_tangent(self, vector, base_point=None, atol=gs.atol):
+    def is_tangent(self, vector, base_point, atol=gs.atol):
         """Check whether the vector is tangent at base_point.
 
         Parameters
@@ -62,7 +62,6 @@ class Manifold:
             Vector.
         base_point : array-like, shape=[..., dim]
             Point on the manifold.
-            Optional, default: none.
         atol : float
             Absolute tolerance.
             Optional, default: backend atol.

--- a/geomstats/geometry/pre_shape.py
+++ b/geomstats/geometry/pre_shape.py
@@ -205,7 +205,7 @@ class PreShapeSpace(EmbeddedManifold, FiberBundle):
 
         return tangent_vec
 
-    def is_tangent(self, vector, base_point=None, atol=gs.atol):
+    def is_tangent(self, vector, base_point, atol=gs.atol):
         """Check whether the vector is tangent at base_point.
 
         Parameters

--- a/geomstats/geometry/pre_shape.py
+++ b/geomstats/geometry/pre_shape.py
@@ -174,7 +174,7 @@ class PreShapeSpace(EmbeddedManifold, FiberBundle):
         mean = gs.mean(point, axis=-2)
         return point - mean[..., None, :]
 
-    def to_tangent(self, vector, base_point=None):
+    def to_tangent(self, vector, base_point):
         """Project a vector to the tangent space.
 
         Project a vector in the embedding matrix space
@@ -528,5 +528,7 @@ class KendallShapeMetric(QuotientMetric):
     """
 
     def __init__(self, k_landmarks, m_ambient):
+        bundle = PreShapeSpace(k_landmarks, m_ambient)
         super(KendallShapeMetric, self).__init__(
-            fiber_bundle=PreShapeSpace(k_landmarks, m_ambient))
+            fiber_bundle=bundle,
+            dim=bundle.dim - int(m_ambient * (m_ambient - 1) / 2))

--- a/geomstats/geometry/quotient_metric.py
+++ b/geomstats/geometry/quotient_metric.py
@@ -27,9 +27,11 @@ class QuotientMetric(RiemannianMetric):
         metric as an attribute.
     """
 
-    def __init__(self, fiber_bundle: FiberBundle):
+    def __init__(self, fiber_bundle: FiberBundle, dim: int = None):
+        if dim is None:
+            dim = fiber_bundle.dim
         super(QuotientMetric, self).__init__(
-            dim=fiber_bundle.dim,
+            dim=dim,
             default_point_type=fiber_bundle.default_point_type)
 
         self.fiber_bundle = fiber_bundle

--- a/geomstats/geometry/riemannian_metric.py
+++ b/geomstats/geometry/riemannian_metric.py
@@ -375,10 +375,10 @@ class RiemannianMetric(Connection):
 
         return closest_neighbor_index
 
-    def orthonormal_basis(self, basis, base_point=None):
-        """Orthonormalize the basis with respect to the metric.
+    def normal_basis(self, basis, base_point=None):
+        """Normalize the basis with respect to the metric.
 
-        This corresponds to a renormalization.
+        This corresponds to a renormalization of each basis vector.
 
         Parameters
         ----------
@@ -389,7 +389,7 @@ class RiemannianMetric(Connection):
         Returns
         -------
         basis : array-like, shape=[dim, n, n]
-            Orthonormal basis.
+            Normal basis.
         """
         norms = self.squared_norm(basis, base_point)
 

--- a/geomstats/geometry/special_orthogonal.py
+++ b/geomstats/geometry/special_orthogonal.py
@@ -337,7 +337,7 @@ class _SpecialOrthogonalVectors(LieGroup):
         """
         return SkewSymmetricMatrices(self.n).basis_representation(skew_mat)
 
-    def to_tangent(self, vector, base_point=None):
+    def to_tangent(self, vector, base_point):
         return self.regularize_tangent_vec(vector, base_point)
 
     def regularize_tangent_vec_at_identity(

--- a/geomstats/geometry/special_orthogonal.py
+++ b/geomstats/geometry/special_orthogonal.py
@@ -337,7 +337,7 @@ class _SpecialOrthogonalVectors(LieGroup):
         """
         return SkewSymmetricMatrices(self.n).basis_representation(skew_mat)
 
-    def to_tangent(self, vector, base_point):
+    def to_tangent(self, vector, base_point=None):
         return self.regularize_tangent_vec(vector, base_point)
 
     def regularize_tangent_vec_at_identity(

--- a/geomstats/geometry/stiefel.py
+++ b/geomstats/geometry/stiefel.py
@@ -152,7 +152,7 @@ class Stiefel(EmbeddedManifold):
         aux = Matrices.mul(Matrices.transpose(base_point), vector)
         return Matrices.is_skew_symmetric(aux, atol=1e-5)
 
-    def to_tangent(self, vector, base_point=None):
+    def to_tangent(self, vector, base_point):
         """Project a vector to a tangent space of the manifold.
 
         Inspired by the method of Pymanopt.

--- a/geomstats/geometry/stiefel.py
+++ b/geomstats/geometry/stiefel.py
@@ -127,7 +127,7 @@ class Stiefel(EmbeddedManifold):
 
         return samples
 
-    def is_tangent(self, vector, base_point=None, atol=EPSILON):
+    def is_tangent(self, vector, base_point, atol=EPSILON):
         """Check whether the vector is tangent at base_point.
 
         A matrix :math: `X` is tangent to the Stiefel manifold at a point
@@ -139,7 +139,6 @@ class Stiefel(EmbeddedManifold):
             Vector.
         base_point : array-like, shape=[..., n, p]
             Point on the manifold.
-            Optional, default: none.
         atol : float
             Absolute tolerance.
             Optional, default: 1e-6.

--- a/tests/tests_geomstats/test_euclidean.py
+++ b/tests/tests_geomstats/test_euclidean.py
@@ -33,6 +33,16 @@ class TestEuclidean(geomstats.tests.TestCase):
 
         self.assertAllClose(result, expected)
 
+    def test_is_tangent(self):
+        vector = self.space.random_point()
+        result = self.space.is_tangent(vector)
+        self.assertTrue(result)
+
+    def test_to_tangent(self):
+        vector = self.space.random_point()
+        result = self.space.to_tangent(vector)
+        self.assertAllClose(result, vector)
+
     def test_squared_norm_vectorization(self):
         n_samples = self.n_samples
         n_points = gs.array([

--- a/tests/tests_geomstats/test_hypersphere.py
+++ b/tests/tests_geomstats/test_hypersphere.py
@@ -9,7 +9,7 @@ from geomstats.geometry.hypersphere import Hypersphere
 from geomstats.geometry.matrices import Matrices
 
 MEAN_ESTIMATION_TOL = 1e-3
-KAPPA_ESTIMATION_TOL = 1e-2
+KAPPA_ESTIMATION_TOL = 3e-2
 ONLINE_KMEANS_TOL = 2e-2
 
 

--- a/tests/tests_geomstats/test_hypersphere.py
+++ b/tests/tests_geomstats/test_hypersphere.py
@@ -9,7 +9,7 @@ from geomstats.geometry.hypersphere import Hypersphere
 from geomstats.geometry.matrices import Matrices
 from geomstats.learning.frechet_mean import FrechetMean
 
-MEAN_ESTIMATION_TOL = 1e-3
+MEAN_ESTIMATION_TOL = 5e-3
 KAPPA_ESTIMATION_TOL = 3e-2
 ONLINE_KMEANS_TOL = 2e-2
 

--- a/tests/tests_geomstats/test_invariant_metric.py
+++ b/tests/tests_geomstats/test_invariant_metric.py
@@ -554,7 +554,7 @@ class TestInvariantMetric(geomstats.tests.TestCase):
     def test_structure_constant(self):
         group = self.matrix_so3
         metric = InvariantMetric(group=group)
-        basis = metric.orthonormal_basis(group.lie_algebra.basis)
+        basis = metric.normal_basis(group.lie_algebra.basis)
         x, y, z = basis
         result = metric.structure_constant(x, y, z)
         expected = 2. ** .5 / 2.
@@ -582,7 +582,7 @@ class TestInvariantMetric(geomstats.tests.TestCase):
     def test_dual_adjoint(self):
         group = self.matrix_so3
         metric = InvariantMetric(group=group)
-        basis = metric.orthonormal_basis(group.lie_algebra.basis)
+        basis = metric.normal_basis(group.lie_algebra.basis)
         for x in basis:
             for y in basis:
                 for z in basis:
@@ -594,7 +594,7 @@ class TestInvariantMetric(geomstats.tests.TestCase):
     def test_connection(self):
         group = self.matrix_so3
         metric = InvariantMetric(group=group)
-        x, y, z = metric.orthonormal_basis(group.lie_algebra.basis)
+        x, y, z = metric.normal_basis(group.lie_algebra.basis)
         result = metric.connection(x, y)
         expected = 1. / 2 ** .5 / 2. * z
         self.assertAllClose(result, expected)
@@ -610,7 +610,7 @@ class TestInvariantMetric(geomstats.tests.TestCase):
     def test_sectional_curvature(self):
         group = self.matrix_so3
         metric = InvariantMetric(group=group)
-        x, y, z = metric.orthonormal_basis(group.lie_algebra.basis)
+        x, y, z = metric.normal_basis(group.lie_algebra.basis)
 
         result = metric.sectional_curvature(x, y)
         expected = 1. / 8
@@ -635,7 +635,7 @@ class TestInvariantMetric(geomstats.tests.TestCase):
     def test_curvature(self):
         group = self.matrix_so3
         metric = InvariantMetric(group=group)
-        x, y, z = metric.orthonormal_basis(group.lie_algebra.basis)
+        x, y, z = metric.normal_basis(group.lie_algebra.basis)
 
         result = metric.curvature_at_identity(x, y, x)
         expected = 1. / 8 * y
@@ -661,7 +661,7 @@ class TestInvariantMetric(geomstats.tests.TestCase):
     def test_curvature_derivative_at_identity(self):
         group = self.matrix_so3
         metric = InvariantMetric(group=group)
-        basis = metric.orthonormal_basis(group.lie_algebra.basis)
+        basis = metric.normal_basis(group.lie_algebra.basis)
 
         result = True
         for x in basis:
@@ -678,7 +678,7 @@ class TestInvariantMetric(geomstats.tests.TestCase):
     def test_curvature_derivative(self):
         group = self.matrix_so3
         metric = InvariantMetric(group=group)
-        x, y, z = metric.orthonormal_basis(group.lie_algebra.basis)
+        x, y, z = metric.normal_basis(group.lie_algebra.basis)
         result = metric.curvature_derivative(
             x, y, z, x)
         expected = gs.zeros_like(x)
@@ -697,7 +697,7 @@ class TestInvariantMetric(geomstats.tests.TestCase):
     def test_integrated_exp_at_id(self):
         group = self.matrix_so3
         metric = InvariantMetric(group=group)
-        basis = metric.orthonormal_basis(group.lie_algebra.basis)
+        basis = metric.normal_basis(group.lie_algebra.basis)
 
         vector = gs.random.rand(2, len(basis))
         tangent_vec = gs.einsum('...j,jkl->...kl', vector, basis)
@@ -731,7 +731,7 @@ class TestInvariantMetric(geomstats.tests.TestCase):
         lie_algebra = group.lie_algebra
         metric = InvariantMetric(group=group)
         canonical_metric = group.left_canonical_metric
-        basis = metric.orthonormal_basis(lie_algebra.basis)
+        basis = metric.normal_basis(lie_algebra.basis)
 
         vector = gs.random.rand(len(basis))
         tangent_vec = gs.einsum('...j,jkl->...kl', vector, basis)
@@ -750,7 +750,7 @@ class TestInvariantMetric(geomstats.tests.TestCase):
         lie_algebra = group.lie_algebra
         metric = InvariantMetric(group=group)
         canonical_metric = group.left_canonical_metric
-        basis = metric.orthonormal_basis(lie_algebra.basis)
+        basis = metric.normal_basis(lie_algebra.basis)
         point = group.random_point()
 
         vector = gs.random.rand(len(basis))

--- a/tests/tests_geomstats/test_lie_algebra.py
+++ b/tests/tests_geomstats/test_lie_algebra.py
@@ -41,7 +41,7 @@ class TestLieAlgebra(geomstats.tests.TestCase):
         group = SpecialOrthogonal(3)
         lie_algebra = SkewSymmetricMatrices(3)
         metric = InvariantMetric(group=group)
-        basis = metric.orthonormal_basis(lie_algebra.basis)
+        basis = metric.normal_basis(lie_algebra.basis)
         result = metric.inner_product_at_identity(basis[0], basis[1])
         self.assertAllClose(result, 0.)
 
@@ -53,7 +53,7 @@ class TestLieAlgebra(geomstats.tests.TestCase):
         metric = InvariantMetric(
             group=group,
             metric_mat_at_identity=metric_mat)
-        basis = metric.orthonormal_basis(lie_algebra.basis)
+        basis = metric.normal_basis(lie_algebra.basis)
         result = metric.inner_product_at_identity(basis[0], basis[1])
         self.assertAllClose(result, 0.)
 
@@ -64,7 +64,7 @@ class TestLieAlgebra(geomstats.tests.TestCase):
         group = SpecialEuclidean(3)
         lie_algebra = group.lie_algebra
         metric = InvariantMetric(group=group)
-        basis = metric.orthonormal_basis(lie_algebra.basis)
+        basis = metric.normal_basis(lie_algebra.basis)
         for i, x in enumerate(basis):
             for y in basis[i:]:
                 result = metric.inner_product_at_identity(x, y)
@@ -76,7 +76,7 @@ class TestLieAlgebra(geomstats.tests.TestCase):
         metric = InvariantMetric(
             group=group,
             metric_mat_at_identity=metric_mat)
-        basis = metric.orthonormal_basis(lie_algebra.basis)
+        basis = metric.normal_basis(lie_algebra.basis)
         for i, x in enumerate(basis):
             for y in basis[i:]:
                 result = metric.inner_product_at_identity(x, y)


### PR DESCRIPTION
- Fix dimension in KendallShapeMetric
- In most cases `base_point` is not optional in `is_tangent` and `to_tangent`, and a missing argument error is much more informative than one raised by manipulating None