### PR TITLE
Fix vectorization of geodesic

### DIFF
--- a/geomstats/geometry/connection.py
+++ b/geomstats/geometry/connection.py
@@ -532,9 +532,8 @@ class Connection:
         n_initial_conditions = initial_tangent_vec.shape[0]
 
         if n_initial_conditions > 1 and len(initial_point) == 1:
-            initial_point = gs.tile(
-                initial_point, n_initial_conditions).reshape(
-                n_initial_conditions, *initial_point.shape)
+            initial_point = gs.stack(
+                [initial_point[0]] * n_initial_conditions)
 
         def path(t):
             """Generate parameterized function for geodesic curve.
@@ -544,7 +543,8 @@ class Connection:
             t : array-like, shape=[n_points,]
                 Times at which to compute points of the geodesics.
             """
-            t = gs.array(t, gs.float32)
+            t = gs.array(t)
+            t = gs.cast(t, initial_tangent_vec.dtype)
             t = gs.to_ndarray(t, to_ndim=1)
             if point_type == 'vector':
                 tangent_vecs = gs.einsum(

--- a/geomstats/geometry/connection.py
+++ b/geomstats/geometry/connection.py
@@ -502,8 +502,8 @@ class Connection:
         path : callable
             Time parameterized geodesic curve. If a batch of initial
             conditions is passed, the output array's first dimension
-            represents time, and the second corresponds to the different
-            initial conditions.
+            represents the different initial conditions, and the second
+            corresponds to time.
         """
         point_type = self.default_point_type
 
@@ -556,9 +556,9 @@ class Connection:
             points_at_time_t = [
                 self.exp(tv, pt) for tv,
                 pt in zip(tangent_vecs, initial_point)]
-            points_at_time_t = gs.stack(points_at_time_t, axis=1)
+            points_at_time_t = gs.stack(points_at_time_t, axis=0)
 
-            return points_at_time_t[:, 0] if n_initial_conditions == 1 else \
+            return points_at_time_t[0] if n_initial_conditions == 1 else \
                 points_at_time_t
         return path
 

--- a/geomstats/geometry/connection.py
+++ b/geomstats/geometry/connection.py
@@ -531,6 +531,11 @@ class Connection:
                 initial_tangent_vec, to_ndim=3)
         n_initial_conditions = initial_tangent_vec.shape[0]
 
+        if n_initial_conditions > 1 and len(initial_point) == 1:
+            initial_point = gs.tile(
+                initial_point, n_initial_conditions).reshape(
+                n_initial_conditions, *initial_point.shape)
+
         def path(t):
             """Generate parameterized function for geodesic curve.
 

--- a/tests/tests_geomstats/test_connection.py
+++ b/tests/tests_geomstats/test_connection.py
@@ -13,7 +13,7 @@ from geomstats.geometry.special_orthogonal import SpecialOrthogonal
 class TestConnection(geomstats.tests.TestCase):
     def setUp(self):
         warnings.simplefilter('ignore', category=UserWarning)
-
+        gs.random.seed(0)
         self.dim = 4
         self.euc_metric = EuclideanMetric(dim=self.dim)
 
@@ -185,7 +185,7 @@ class TestConnection(geomstats.tests.TestCase):
             initial_tangent_vec=initial_tangent_vec)
         t = gs.linspace(start=0., stop=1., num=n_geodesic_points)
         points = geodesic(t)
-        result = points[-1]
+        result = points[:, -1]
         expected = self.hypersphere.metric.exp(vector, initial_point)
         self.assertAllClose(expected, result)
 
@@ -212,7 +212,7 @@ class TestConnection(geomstats.tests.TestCase):
             initial_tangent_vec=initial_tangent_vec)
         t = gs.linspace(start=0., stop=1., num=n_geodesic_points)
         points = geodesic(t)
-        result = points[-1]
+        result = points[:, -1]
         expected = space.bi_invariant_metric.exp(
             initial_tangent_vec, initial_point)
         self.assertAllClose(result, expected)

--- a/tests/tests_geomstats/test_connection.py
+++ b/tests/tests_geomstats/test_connection.py
@@ -255,19 +255,19 @@ class TestConnection(geomstats.tests.TestCase):
         geo = metric.geodesic(initial_point, initial_tangent_vec)
         path = geo(time)
         result = path.shape
-        expected = (10, 2, 3)
+        expected = (2, 10, 3)
         self.assertAllClose(result, expected)
 
         geo = metric.geodesic(initial_point, end_point=end_point)
         path = geo(time)
         result = path.shape
-        expected = (10, 2, 3)
+        expected = (2, 10, 3)
         self.assertAllClose(result, expected)
 
         geo = metric.geodesic(initial_point, end_point=end_point[0])
         path = geo(time)
         result = path.shape
-        expected = (10, 2, 3)
+        expected = (2, 10, 3)
         self.assertAllClose(result, expected)
 
         initial_tangent_vec = space.to_tangent(
@@ -275,5 +275,5 @@ class TestConnection(geomstats.tests.TestCase):
         geo = metric.geodesic(initial_point[0], initial_tangent_vec)
         path = geo(time)
         result = path.shape
-        expected = (10, 2, 3)
+        expected = (2, 10, 3)
         self.assertAllClose(result, expected)

--- a/tests/tests_geomstats/test_connection.py
+++ b/tests/tests_geomstats/test_connection.py
@@ -241,3 +241,39 @@ class TestConnection(geomstats.tests.TestCase):
                 initial_point=initial_point,
                 initial_tangent_vec=initial_tangent_vec,
                 end_point=end_point))
+
+    def test_geodesic_vectorization(self):
+        space = Hypersphere(2)
+        metric = space.metric
+        initial_point = space.random_uniform(2)
+        vector = gs.random.rand(2, 3)
+        initial_tangent_vec = space.to_tangent(
+            vector=vector, base_point=initial_point)
+        end_point = space.random_uniform(2)
+        time = gs.linspace(0, 1, 10)
+
+        geo = metric.geodesic(initial_point, initial_tangent_vec)
+        path = geo(time)
+        result = path.shape
+        expected = (10, 2, 3)
+        self.assertAllClose(result, expected)
+
+        geo = metric.geodesic(initial_point, end_point=end_point)
+        path = geo(time)
+        result = path.shape
+        expected = (10, 2, 3)
+        self.assertAllClose(result, expected)
+
+        geo = metric.geodesic(initial_point, end_point=end_point[0])
+        path = geo(time)
+        result = path.shape
+        expected = (10, 2, 3)
+        self.assertAllClose(result, expected)
+
+        initial_tangent_vec = space.to_tangent(
+            vector=vector, base_point=initial_point[0])
+        geo = metric.geodesic(initial_point[0], initial_tangent_vec)
+        path = geo(time)
+        result = path.shape
+        expected = (10, 2, 3)
+        self.assertAllClose(result, expected)

--- a/tests/tests_geomstats/test_hypersphere.py
+++ b/tests/tests_geomstats/test_hypersphere.py
@@ -527,7 +527,7 @@ class TestHypersphere(geomstats.tests.TestCase):
             end_point=initial_point[2:])
         t = gs.linspace(start=0., stop=1., num=n_geodesic_points)
         points = geodesic(t)
-        result = points[-1]
+        result = points[:, -1]
         expected = initial_point[2:]
         self.assertAllClose(expected, result)
 


### PR DESCRIPTION
The previous method `geodesic` did not work when only one base_point was passed.
I am wondering whether the shape of the output should be `(n_initial_conditions, n_times, {dim, [n, n]})` or  `(n_times, n_initial_conditions, {dim, [n, n]})`? So far the second option is returned