### PR TITLE
Add versions for matplotlib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 autograd==1.3
 jupyter
 joblib==0.14.1
-matplotlib
+matplotlib>=3.4.2
 numpy>=1.18.1
 pandas
 scikit-learn>=0.22.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 autograd==1.3
 jupyter
 joblib==0.14.1
-matplotlib>=3.4.2
+matplotlib>=3.3.4
 numpy>=1.18.1
 pandas
 scikit-learn>=0.22.1


### PR DESCRIPTION
Add newer versions for requirements of matplotlib: plotting geodesics on the sphere errors if users have an older version of matplotlib.