### PR TITLE
Speedup  from_vector function

### DIFF
--- a/geomstats/_backend/__init__.py
+++ b/geomstats/_backend/__init__.py
@@ -116,6 +116,7 @@ BACKEND_ATTRIBUTES = {
         'triu_indices',
         'triu_to_vec',
         'vectorize',
+        'vec_to_sym',
         'vstack',
         'where',
         'zeros',

--- a/geomstats/_backend/numpy/__init__.py
+++ b/geomstats/_backend/numpy/__init__.py
@@ -408,9 +408,12 @@ def mat_from_diag_triu_tril(diag, tri_upp, tri_low):
     return mat
 
 def vec_to_sym(vec, mat_dim):
-    shape = (vec.shape[0] , ) + (mat_dim, mat_dim)  
+    shape = (mat_dim, mat_dim)  
+    shape = (vec.shape[0],) + shape if vec.ndim>1 else shape
     mat = np.zeros(shape)
-    i, j = np.triu_indices(mat_dim , k=0)
-    mat[... , i, j] = vec
-    sym = 0.5 * ( mat + np.tranpose(mat, [0,2,1]))
+    i, = np.diag_indices(mat_dim, ndim=1)
+    j, k = np.tril_indices(mat_dim)
+    mat[... , j, k] = vec
+    sym = mat+ mat.swapaxes(-1,-2)
+    sym[..., i, i] *= 0.5
     return sym

--- a/geomstats/_backend/numpy/__init__.py
+++ b/geomstats/_backend/numpy/__init__.py
@@ -406,3 +406,11 @@ def mat_from_diag_triu_tril(diag, tri_upp, tri_low):
     mat[..., j, k] = tri_upp
     mat[..., k, j] = tri_low
     return mat
+
+def vec_to_sym(vec, mat_dim):
+    shape = (vec.shape[0] , ) + (mat_dim, mat_dim)  
+    mat = np.zeros(shape)
+    i, j = np.triu_indices(mat_dim , k=0)
+    mat[... , i, j] = vec
+    sym = 0.5 * ( mat + np.tranpose(mat, [0,2,1]))
+    return sym

--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -804,3 +804,12 @@ def mat_from_diag_triu_tril(diag, tri_upp, tri_low):
     mat[..., j, k] = tri_upp
     mat[..., k, j] = tri_low
     return mat
+
+
+def vec_to_sym(vec, mat_dim):
+    shape = (vec.shape[0] , ) + (mat_dim, mat_dim)  
+    mat = torch.zeros(shape)
+    i, j = triu_indices(mat_dim , k=0)
+    mat[... , i, j] = vec
+    sym = 0.5 * ( mat + torch.permute(mat, [0,2,1]))
+    return sym

--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -807,9 +807,12 @@ def mat_from_diag_triu_tril(diag, tri_upp, tri_low):
 
 
 def vec_to_sym(vec, mat_dim):
-    shape = (vec.shape[0] , ) + (mat_dim, mat_dim)  
+    shape = (mat_dim, mat_dim)  
+    shape = (vec.shape[0],) + shape if vec.ndim>1 else shape
     mat = torch.zeros(shape)
-    i, j = triu_indices(mat_dim , k=0)
-    mat[... , i, j] = vec
-    sym = 0.5 * ( mat + torch.permute(mat, [0,2,1]))
+    i, i = gs.diag_indices(mat_dim)
+    j, k = gs.tril_indices(mat_dim)
+    mat[... , j, k] = vec
+    sym = mat+ mat.swapaxes(-1,-2)
+    sym[..., i, i] *= 0.5
     return sym

--- a/geomstats/_backend/tensorflow/__init__.py
+++ b/geomstats/_backend/tensorflow/__init__.py
@@ -811,8 +811,11 @@ def vec_to_triu(vec , strict=True):
     tril : array_like, shape=[..., k, k] where
         k is (1 + sqrt(1 + 8 * n)) / 2
     """
-    n = vec.shape[-1]
-    triu_shape = vec.shape + (n, )
+     if strict:
+      n = vec.shape[-1]
+      triu_shape = vec.shape + (n, )
+    else:
+      triu_shape = shape
     _ones = tf.ones(triu_shape)
     vec = tf.reshape(vec, [-1])
     mask_a = tf.linalg.band_part(_ones, 0, -1)
@@ -840,8 +843,11 @@ def vec_to_tril(vec, strict=True):
     tril : array_like, shape=[..., k, k] where
         k is (1 + sqrt(1 + 8 * n)) / 2
     """
-    n = vec.shape[-1]
-    tril_shape = vec.shape + (n, )
+    if strict:
+      n = vec.shape[-1]
+      tril_shape = vec.shape + (n, )
+    else:
+      tril_shape = shape
     _ones = tf.ones(tril_shape)
     vec = tf.reshape(vec, [-1])
     mask_a = tf.linalg.band_part(_ones, -1, 0)
@@ -879,7 +885,11 @@ def mat_from_diag_triu_tril(diag, tri_upp, tri_low):
     mat = tf.linalg.set_diag(triu_tril_mat, diag)
     return mat
 
-def vec_to_sym(vec):
-    triu = vec_to_triu(vec)
-    sym = 1/2 * (triu + tf.linalg.tranpose(triu)) 
+def vec_to_sym(vec, mat_dim):
+    shape = (mat_dim, mat_dim)  
+    shape = (vec.shape[0],) + shape if vec.ndim>1 else shape
+    triu = vec_to_triu(vec , strict = False , shape=shape)
+    tril = vec_to_tril(vec , strict = False , shape=shape)
+    diag = tf.linalg.band_part(triu, 0, 0)
+    sym = triu + tril - diag
     return sym

--- a/geomstats/_backend/tensorflow/__init__.py
+++ b/geomstats/_backend/tensorflow/__init__.py
@@ -799,8 +799,8 @@ def tile(x, multiples):
     return tf.tile(x_reshape, multiples)
 
 
-def vec_to_triu(vec):
-    """Take vec and forms strictly upper traingular matrix.
+def vec_to_triu(vec , strict=True):
+    """Take vec and forms (strictly) upper traingular matrix.
 
     Parameters
     ---------
@@ -816,8 +816,11 @@ def vec_to_triu(vec):
     _ones = tf.ones(triu_shape)
     vec = tf.reshape(vec, [-1])
     mask_a = tf.linalg.band_part(_ones, 0, -1)
-    mask_b = tf.linalg.band_part(_ones, 0, 0)
-    mask = tf.subtract(mask_a, mask_b)
+    if strict:
+        mask_b = tf.linalg.band_part(_ones, 0, 0)
+        mask = tf.subtract(mask_a, mask_b)
+    else :
+        mask= mask_a
     non_zero = tf.not_equal(mask, tf.constant(0.0))
     indices = tf.where(non_zero)
     sparse = tf.SparseTensor(indices, values=vec, dense_shape=triu_shape)
@@ -825,8 +828,8 @@ def vec_to_triu(vec):
     return triu
 
 
-def vec_to_tril(vec):
-    """Take vec and forms strictly lower triangular matrix.
+def vec_to_tril(vec, strict=True):
+    """Take vec and forms (strictly) lower triangular matrix.
 
     Parameters
     ---------
@@ -842,8 +845,11 @@ def vec_to_tril(vec):
     _ones = tf.ones(tril_shape)
     vec = tf.reshape(vec, [-1])
     mask_a = tf.linalg.band_part(_ones, -1, 0)
-    mask_b = tf.linalg.band_part(_ones, 0, 0)
-    mask = tf.subtract(mask_a, mask_b)
+    if strict:
+        mask_b = tf.linalg.band_part(_ones, 0, 0)
+        mask = tf.subtract(mask_a, mask_b)
+    else :
+        mask= mask_a
     non_zero = tf.not_equal(mask, tf.constant(0.0))
     indices = tf.where(non_zero)
     sparse = tf.SparseTensor(indices, values=vec, dense_shape=tril_shape)
@@ -872,3 +878,8 @@ def mat_from_diag_triu_tril(diag, tri_upp, tri_low):
     triu_tril_mat = triu_mat + tril_mat
     mat = tf.linalg.set_diag(triu_tril_mat, diag)
     return mat
+
+def vec_to_sym(vec):
+    triu = vec_to_triu(vec)
+    sym = 1/2 * (triu + tf.linalg.tranpose(triu)) 
+    return sym

--- a/geomstats/geometry/symmetric_matrices.py
+++ b/geomstats/geometry/symmetric_matrices.py
@@ -118,7 +118,6 @@ class SymmetricMatrices(VectorSpace):
         return gs.triu_to_vec(mat)
 
     @staticmethod
-    @geomstats.vectorization.decorator(['vector', 'else'])
     def from_vector(vec, dtype=gs.float32):
         """Convert a vector into a symmetric matrix.
 
@@ -141,13 +140,7 @@ class SymmetricMatrices(VectorSpace):
             raise ValueError('Invalid input dimension, it must be of the form'
                              '(n_samples, n * (n + 1) / 2)')
         mat_dim = int(mat_dim)
-        shape = (mat_dim, mat_dim)
-        mask = 2 * gs.ones(shape) - gs.eye(mat_dim)
-        indices = list(zip(*gs.triu_indices(mat_dim)))
-        vec = gs.cast(vec, dtype)
-        upper_triangular = gs.stack([
-            gs.array_from_sparse(indices, data, shape) for data in vec])
-        mat = Matrices.to_symmetric(upper_triangular) * mask
+        mat = gs.vec_to_sym(vec, mat_dim)
         return mat
 
     @classmethod


### PR DESCRIPTION
This PR speeds up SymmetricMatrices's `from_vector` using backend functions I have written for log normal sampling. For numpy,  this obtains 500x speedup (110 seconds to 0.220 seconds) on data with shape (100000, 6)