### PR TITLE
Add environment.yml for conda

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,6 +94,14 @@ backends:
 
     pip3 install -r dev-requirements.txt -r opt-requirements.txt
 
+To add the `requirements.txt` into a conda environment, you can use the
+`enviroment.yml` file as follows:
+
+::
+
+   conda env create --file environment.yml 
+
+
 Choose the backend
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -101,6 +101,9 @@ To add the `requirements.txt` into a conda environment, you can use the
 
    conda env create --file environment.yml 
 
+Note that this only installs the minimum requirements. To add the optional,
+development, continuous integration and documentation requirements, 
+refer to the files *-requirements.txt.
 
 Choose the backend
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -103,7 +103,7 @@ To add the `requirements.txt` into a conda environment, you can use the
 
 Note that this only installs the minimum requirements. To add the optional,
 development, continuous integration and documentation requirements, 
-refer to the files *-requirements.txt.
+refer to the files `*-requirements.txt`.
 
 Choose the backend
 ------------------

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,15 @@
+name: geomstats-3.8
+channels:
+  - conda-forge
+dependencies:
+  - jupyter
+  - joblib==0.14.1
+  - matplotlib>=3.3.4
+  - numpy>=1.18.1
+  - pandas
+  - pip
+  - python=3.8
+  - scikit-learn>=0.22.1
+  - scipy>=1.4.1
+  - pip:
+    - autograd==1.3

--- a/environment.yml
+++ b/environment.yml
@@ -2,8 +2,6 @@ name: geomstats-3.8
 channels:
   - conda-forge
 dependencies:
-  - jupyter
-  - joblib==0.14.1
   - matplotlib>=3.3.4
   - numpy>=1.18.1
   - pandas
@@ -12,4 +10,4 @@ dependencies:
   - scikit-learn>=0.22.1
   - scipy>=1.4.1
   - pip:
-    - autograd==1.3
+    - autograd>=1.3


### PR DESCRIPTION
This PR:
- adds an `environment.yml` file so that users can easily install the requirements for geomstats into a conda environment,
- adds an explanation into the README about it.