### PR TITLE
Update on requirements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
       - name: install dependencies [pip]
         run:  |
           pip install --upgrade pip setuptools wheel
-          for req in ci-requirements.txt dev-requirements.txt opt-requirements.txt requirements.txt; do
+          for req in ci-requirements.txt dev-requirements.txt doc-requirements.txt opt-requirements.txt requirements.txt; do
             pip install -q -r $req
           done  
           pip install -e .      

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ jobs:
       - name: install dependencies [pip]
         run:  |
           pip install --upgrade pip setuptools wheel
-          for req in ci-requirements.txt dev-requirements.txt opt-requirements.txt requirements.txt; do
+          for req in ci-requirements.txt dev-requirements.txt doc-requirements.txt opt-requirements.txt requirements.txt; do
             pip install -q -r $req
           done  
           pip install -e .      

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -1,0 +1,1 @@
+jupyter

--- a/opt-requirements.txt
+++ b/opt-requirements.txt
@@ -1,3 +1,3 @@
-tensorflow>=2.1.2; python_version < '3.8'
+tensorflow>=2.2
 tensorflow-probability>=0.9
-torch==1.8.1
+torch>=1.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-autograd==1.3
-joblib==0.14.1
+autograd>=1.3
+joblib>=0.14.1
 matplotlib>=3.3.4
 numpy>=1.18.1
-pandas
+pandas>=1.3.2
 scikit-learn>=0.22.1
 scipy>=1.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ autograd>=1.3
 joblib>=0.14.1
 matplotlib>=3.3.4
 numpy>=1.18.1
-pandas>=1.2.4
+pandas>=1.1.5
 scikit-learn>=0.22.1
 scipy>=1.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ autograd>=1.3
 joblib>=0.14.1
 matplotlib>=3.3.4
 numpy>=1.18.1
-pandas>=1.3.2
+pandas>=1.2.4
 scikit-learn>=0.22.1
 scipy>=1.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 autograd==1.3
-jupyter
 joblib==0.14.1
 matplotlib>=3.3.4
 numpy>=1.18.1

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,6 @@ if __name__ == '__main__':
             'Topic :: Scientific/Engineering :: Mathematics',
             'License :: OSI Approved :: BSD License',
             'Programming Language :: Python :: 3',
-            'Programming Language :: Python :: 3.5',
             'Programming Language :: Python :: 3.6',
             'Programming Language :: Python :: 3.7',
             'Programming Language :: Python :: 3.8'


### PR DESCRIPTION
This PR:
- puts `jupyter` requirement outside of the main `requirements.txt`, see issue #1093 
- puts >= signs in requirements.txt
- puts >= signs in opt-requirements.txt
- bump tensorflow version >= 2.2 to have it work with python 3.8
- removes python version 3.5 in the setup.py since we do not test it anymore