### PR TITLE
Address code review comments for tests on PullbackMetric structure

### DIFF
--- a/geomstats/geometry/pullback_metric.py
+++ b/geomstats/geometry/pullback_metric.py
@@ -1,6 +1,5 @@
 """Classes for the pullback metric."""
 
-import autograd
 import itertools
 import joblib
 
@@ -44,7 +43,7 @@ class PullbackMetric(RiemannianMetric):
         self.embedding_metric = EuclideanMetric(embedding_dim)
         self.immersion = immersion
         if jacobian_immersion is None:
-            jacobian_immersion = autograd.jacobian(immersion)
+            jacobian_immersion = gs.autograd.jacobian(immersion)
         self.jacobian_immersion = jacobian_immersion
         if tangent_immersion is None:
             def _tangent_immersion(v, x):
@@ -98,37 +97,6 @@ class PullbackMetric(RiemannianMetric):
         out = pool(
             pickable_inner_product(i, j) 
             for i, j in itertools.product(range(self.dim), range(self.dim)))
-        print(type(out))
-        print(out)
-       
-        out = gs.array(out)
-        print(out.shape)
 
         metric_mat = gs.reshape(gs.array(out), (-1, self.dim, self.dim))
         return metric_mat[0] if base_point.ndim == 1 else metric_mat
-
-
-        # upper_triangular = gs.stack([
-        #     gs.array_from_sparse(indices, data, shape) for data in vec])
-
-        # return SymmetricMatrices.from_vector(
-        #         gs.array(out))
-
-        # all_lines = []
-        # 
-        # for i in range(self.dim):
-        #     line_i = []
-        #     immersed_basis_element_i = gs.matmul(
-        #         jacobian_immersion, basis_elements[i])
-        #     for j in range(self.dim):
-        #         immersed_basis_element_j = gs.matmul(
-        #             jacobian_immersion, basis_elements[j])
-
-        #         value = self.embedding_metric.inner_product(
-        #             immersed_basis_element_i,
-        #             immersed_basis_element_j,
-        #             base_point=immersed_base_point)
-        #         line_i.append(value)
-        #     all_lines.append(gs.array(line_i))
-
-        # return gs.vstack(all_lines)

--- a/geomstats/geometry/riemannian_metric.py
+++ b/geomstats/geometry/riemannian_metric.py
@@ -1,7 +1,6 @@
 """Riemannian and pseudo-Riemannian metrics."""
 from abc import ABC
 
-import autograd
 import joblib
 
 import geomstats.backend as gs

--- a/geomstats/geometry/riemannian_metric.py
+++ b/geomstats/geometry/riemannian_metric.py
@@ -87,7 +87,7 @@ class RiemannianMetric(Connection, ABC):
         mat : array-like, shape=[..., dim, dim]
             Derivative of inverse of inner-product matrix.
         """
-        metric_derivative = autograd.jacobian(self.metric_matrix)
+        metric_derivative = gs.autograd.jacobian(self.metric_matrix)
         return metric_derivative(base_point)
 
     def christoffels(self, base_point):

--- a/geomstats/geometry/symmetric_matrices.py
+++ b/geomstats/geometry/symmetric_matrices.py
@@ -145,8 +145,6 @@ class SymmetricMatrices(VectorSpace):
         mask = 2 * gs.ones(shape) - gs.eye(mat_dim)
         indices = list(zip(*gs.triu_indices(mat_dim)))
         vec = gs.cast(vec, dtype)
-        print(type(vec))
-        print(vec.shape) 
         upper_triangular = gs.stack([
             gs.array_from_sparse(indices, data, shape) for data in vec])
         mat = Matrices.to_symmetric(upper_triangular) * mask

--- a/geomstats/geometry/symmetric_matrices.py
+++ b/geomstats/geometry/symmetric_matrices.py
@@ -145,6 +145,8 @@ class SymmetricMatrices(VectorSpace):
         mask = 2 * gs.ones(shape) - gs.eye(mat_dim)
         indices = list(zip(*gs.triu_indices(mat_dim)))
         vec = gs.cast(vec, dtype)
+        print(type(vec))
+        print(vec.shape) 
         upper_triangular = gs.stack([
             gs.array_from_sparse(indices, data, shape) for data in vec])
         mat = Matrices.to_symmetric(upper_triangular) * mask

--- a/tests/tests_geomstats/test_pullback_metric.py
+++ b/tests/tests_geomstats/test_pullback_metric.py
@@ -223,11 +223,8 @@ class TestPullbackMetric(geomstats.tests.TestCase):
         """
         base_point = gs.array([0.1, 0.2])
         result = self.pullback_metric.christoffels(base_point=base_point)
-        print("!")
         expected = self.sphere_metric.christoffels(point=base_point)
         self.assertAllClose(result, expected)
-
-        print("HELLO")
 
         base_point = gs.array([0.7, 0.233])
         result = self.pullback_metric.christoffels(base_point=base_point)

--- a/tests/tests_geomstats/test_pullback_metric.py
+++ b/tests/tests_geomstats/test_pullback_metric.py
@@ -55,7 +55,6 @@ class TestPullbackMetric(geomstats.tests.TestCase):
         result = self.sphere.spherical_to_extrinsic(point)
         self.assertAllClose(result, expected)
 
-    @geomstats.tests.np_only
     def test_jacobian_immersion(self):
         def _expected_jacobian_immersion(point):
             theta = point[..., 0]
@@ -82,7 +81,6 @@ class TestPullbackMetric(geomstats.tests.TestCase):
         expected = _expected_jacobian_immersion(base_point)
         self.assertAllClose(result, expected)
 
-    @geomstats.tests.np_only
     def test_tangent_immersion(self):
         point = gs.array([gs.pi / 2., gs.pi / 2.])
 
@@ -112,7 +110,6 @@ class TestPullbackMetric(geomstats.tests.TestCase):
         expected = gs.array([0., 1., 0.])
         self.assertAllClose(result, expected)
 
-    @geomstats.tests.np_only
     def test_metric_matrix(self):
         def _expected_metric_matrix(point):
             theta = point[..., 0]
@@ -137,7 +134,6 @@ class TestPullbackMetric(geomstats.tests.TestCase):
         expected = _expected_metric_matrix(base_point)
         self.assertAllClose(result, expected)
 
-    @geomstats.tests.np_only
     def test_inverse_metric_matrix(self):
         def _expected_inverse_metric_matrix(point):
             theta = point[..., 0]
@@ -159,7 +155,6 @@ class TestPullbackMetric(geomstats.tests.TestCase):
         expected = _expected_inverse_metric_matrix(base_point)
         self.assertAllClose(result, expected)
 
-    @geomstats.tests.np_only
     def test_inner_product_and_sphere_inner_product(self):
         """Test consistency between sphere's inner-products.
 
@@ -211,7 +206,7 @@ class TestPullbackMetric(geomstats.tests.TestCase):
             base_point=immersed_base_point)
         self.assertAllClose(result, expected)
 
-    @geomstats.tests.np_only
+    @geomstats.tests.np_and_tf_only
     def test_christoffels_and_sphere_christoffels(self):
         """Test consistency between sphere's christoffels.
 
@@ -231,7 +226,6 @@ class TestPullbackMetric(geomstats.tests.TestCase):
         expected = self.sphere_metric.christoffels(point=base_point)
         self.assertAllClose(result, expected)
 
-    @geomstats.tests.np_only
     def test_exp_and_sphere_exp(self):
         """Test consistency between sphere's Riemannian exp.
 
@@ -272,7 +266,7 @@ class TestPullbackMetric(geomstats.tests.TestCase):
 
         self.assertAllClose(result, expected, atol=1e-1)
 
-    @geomstats.tests.np_only
+    @geomstats.tests.np_and_pytorch_only
     def test_parallel_transport_and_sphere_parallel_transport(self):
         """Test consistency between sphere's parallel transports.
 

--- a/tests/tests_geomstats/test_pullback_metric.py
+++ b/tests/tests_geomstats/test_pullback_metric.py
@@ -223,8 +223,11 @@ class TestPullbackMetric(geomstats.tests.TestCase):
         """
         base_point = gs.array([0.1, 0.2])
         result = self.pullback_metric.christoffels(base_point=base_point)
+        print("!")
         expected = self.sphere_metric.christoffels(point=base_point)
         self.assertAllClose(result, expected)
+
+        print("HELLO")
 
         base_point = gs.array([0.7, 0.233])
         result = self.pullback_metric.christoffels(base_point=base_point)


### PR DESCRIPTION
This PR:
- uses joblib in the computation of the metric_matrix (couldn't use Symmetric.to_matrix since it uses scipy internally which does not handle ArrayBox structure from autograd)
- used gs.autograd instead of autograd to make it compatible with torch and tf backends