### PR TITLE
From vector to lower or upper diagonal

### DIFF
--- a/geomstats/algebra_utils.py
+++ b/geomstats/algebra_utils.py
@@ -92,11 +92,12 @@ def from_vector_to_diagonal_matrix(vector, num_diag=0):
         3-dimensional array where the `i`-th n-by-n array `diagonals[i, :, :]`
         is a diagonal matrix containing the `i`-th row of `vector`.
     """
-    num_lines = gs.shape(vector)[-2]
     num_columns = gs.shape(vector)[-1]
     identity = gs.eye(num_columns)
     identity = gs.cast(identity, vector.dtype)
     diagonals = gs.einsum('...i,ij->...ij', vector, identity)
+    vector = gs.to_ndarray(vector, to_ndim=3)
+    num_lines = gs.shape(vector)[-2]
     if num_diag > 0:
         left_zeros = gs.zeros((num_lines, num_columns, num_diag))
         lower_zeros = gs.zeros((num_lines, num_diag, num_columns + num_diag))
@@ -108,7 +109,7 @@ def from_vector_to_diagonal_matrix(vector, num_diag=0):
         upper_zeros = gs.zeros((num_lines, num_diag, num_columns + num_diag))
         diagonals = gs.concatenate((diagonals, right_zeros), axis=2)
         diagonals = gs.concatenate((upper_zeros, diagonals), axis=1)
-    return diagonals
+    return gs.squeeze(diagonals)
 
 
 def taylor_exp_even_func(

--- a/geomstats/algebra_utils.py
+++ b/geomstats/algebra_utils.py
@@ -96,8 +96,7 @@ def from_vector_to_diagonal_matrix(vector, num_diag=0):
     identity = gs.eye(num_columns)
     identity = gs.cast(identity, vector.dtype)
     diagonals = gs.einsum('...i,ij->...ij', vector, identity)
-    vector = gs.to_ndarray(vector, to_ndim=3)
-    num_lines = gs.shape(vector)[-2]
+    num_lines = 1 if gs.ndim(vector) == 1 else gs.shape(vector)[-2]
     if num_diag > 0:
         left_zeros = gs.zeros((num_lines, num_columns, num_diag))
         lower_zeros = gs.zeros((num_lines, num_diag, num_columns + num_diag))

--- a/geomstats/algebra_utils.py
+++ b/geomstats/algebra_utils.py
@@ -96,7 +96,8 @@ def from_vector_to_diagonal_matrix(vector, num_diag=0):
     identity = gs.eye(num_columns)
     identity = gs.cast(identity, vector.dtype)
     diagonals = gs.einsum('...i,ij->...ij', vector, identity)
-    num_lines = 1 if gs.ndim(vector) == 1 else gs.shape(vector)[-2]
+    diagonals = gs.to_ndarray(diagonals, to_ndim=3)
+    num_lines = diagonals.shape[0]
     if num_diag > 0:
         left_zeros = gs.zeros((num_lines, num_columns, num_diag))
         lower_zeros = gs.zeros((num_lines, num_diag, num_columns + num_diag))
@@ -108,7 +109,7 @@ def from_vector_to_diagonal_matrix(vector, num_diag=0):
         upper_zeros = gs.zeros((num_lines, num_diag, num_columns + num_diag))
         diagonals = gs.concatenate((diagonals, right_zeros), axis=2)
         diagonals = gs.concatenate((upper_zeros, diagonals), axis=1)
-    return gs.squeeze(diagonals)
+    return gs.squeeze(diagonals) if gs.ndim(vector) == 1 else diagonals
 
 
 def taylor_exp_even_func(

--- a/tests/tests_geomstats/test_algebra_utils.py
+++ b/tests/tests_geomstats/test_algebra_utils.py
@@ -49,3 +49,27 @@ class TestAlgebraUtils(geomstats.tests.TestCase):
         points = gs.concatenate([north_pole[None, :], points])
         result = utils.rotate_points(points, end_point)
         self.assertAllClose(result[0], end_point)
+
+    def test_from_vector_to_diagonal_matrix(self):
+        vec = gs.array([[1., 2., 3.], [4., 5., 6.]])
+        mat_diag = utils.from_vector_to_diagonal_matrix(vec, 0)
+        expected = gs.array([
+            [[1., 0., 0.], [0., 2., 0.], [0., 0., 3.]],
+            [[4., 0., 0.], [0., 5., 0.], [0., 0., 6.]]])
+        self.assertAllClose(mat_diag, expected)
+
+        mat_plus = utils.from_vector_to_diagonal_matrix(vec, 1)
+        expected = gs.array([
+            [[0., 1., 0., 0.], [0., 0., 2., 0.],
+             [0., 0., 0., 3.], [0., 0., 0., 0.]],
+            [[0., 4., 0., 0.], [0., 0., 5., 0.],
+             [0., 0., 0., 6.], [0., 0., 0., 0.]]])
+        self.assertAllClose(mat_plus, expected)
+
+        mat_minus = utils.from_vector_to_diagonal_matrix(vec, - 1)
+        expected = gs.array([
+            [[0., 0., 0., 0.], [1., 0., 0., 0.],
+             [0., 2., 0., 0.], [0., 0., 3., 0.]],
+            [[0., 0., 0., 0.], [4., 0., 0., 0.],
+             [0., 5., 0., 0.], [0., 0., 6., 0.]]])
+        self.assertAllClose(mat_minus, expected)

--- a/tests/tests_geomstats/test_algebra_utils.py
+++ b/tests/tests_geomstats/test_algebra_utils.py
@@ -51,6 +51,12 @@ class TestAlgebraUtils(geomstats.tests.TestCase):
         self.assertAllClose(result[0], end_point)
 
     def test_from_vector_to_diagonal_matrix(self):
+        vec = gs.array([1., 2., 3.])
+        mat_diag = utils.from_vector_to_diagonal_matrix(vec, -1)
+        result = mat_diag.shape
+        expected = (4, 4)
+        self.assertAllClose(result, expected)
+
         vec = gs.array([[1., 2., 3.], [4., 5., 6.]])
         mat_diag = utils.from_vector_to_diagonal_matrix(vec, 0)
         expected = gs.array([


### PR DESCRIPTION
This PR adds a `num_diag` argument to `from_vector_to_diagonal_matrix` to transform a vector into a lower diagonal (`num_diag < 0`) or upper diagonal (`num_diag > 0`), just like [np.diag](https://numpy.org/doc/stable/reference/generated/numpy.diag.html). When `num_diag=0` the function is the same as before.