### PR TITLE
Add unit tests for geodesic regression on SE2

### DIFF
--- a/examples/geodesic_regression_hypersphere.py
+++ b/examples/geodesic_regression_hypersphere.py
@@ -64,7 +64,7 @@ def main():
     variance_ = variance(y, estimator.estimate_, metric=METRIC)
     r2 = 1 - rss / variance_
 
-    # Fit Geodesic Regression
+    # Fit geodesic regression
     gr = GeodesicRegression(
         SPACE, center_X=False, method='extrinsic', verbose=True)
     gr.fit(X, y, compute_training_score=True)

--- a/examples/geodesic_regression_se2.py
+++ b/examples/geodesic_regression_se2.py
@@ -23,6 +23,7 @@ METRIC = SPACE.left_canonical_metric
 METRIC.default_point_type = 'matrix'
 gs.random.seed(0)
 
+
 def main():
     r"""Compute and visualize a geodesic regression on the SE(2).
 
@@ -81,6 +82,7 @@ def main():
     print(f'MSE on the intercept: {mse_intercept:.2e}')
     print(f'MSE on the initial velocity beta: {mse_beta:.2e}')
     print(f'Determination coefficient: R^2={r2_hat:.2f}')
+    print(f'True R^2: {r2:.2f}')
 
     # Plot
     fitted_data = gr.predict(X)
@@ -94,12 +96,12 @@ def main():
     regressed_geodesic = path(
         gs.linspace(min(X), max(X), 100))
 
-    i = 10
     sphere_visu.draw_points(ax, y, marker='o', c='black')
     sphere_visu.draw_points(ax, fitted_data, marker='o', c='gray')
     sphere_visu.draw_points(
         ax, gs.array([intercept]), marker='x', c='r')
-    sphere_visu.draw_points(ax, gs.array([intercept_hat]), marker='o', c='green')
+    sphere_visu.draw_points(
+        ax, gs.array([intercept_hat]), marker='o', c='green')
 
     ax.plot(
         regressed_geodesic[:, 0, 2],

--- a/examples/geodesic_regression_se2.py
+++ b/examples/geodesic_regression_se2.py
@@ -23,76 +23,89 @@ METRIC = SPACE.left_canonical_metric
 METRIC.default_point_type = 'matrix'
 gs.random.seed(0)
 
-# Generate noise-free data
-n_samples = 20
-X = gs.random.normal(size=(n_samples, ))
-X -= gs.mean(X)
+def main():
+    r"""Compute and visualize a geodesic regression on the SE(2).
 
-intercept = SPACE.random_point()
-coef = SPACE.to_tangent(5. * gs.random.rand(3, 3), intercept)
-y = METRIC.exp(X[:, None, None] * coef[None], intercept)
+    The generative model of the data is:
+    :math:`Z = Exp_{\beta_0}(\beta_1.X)` and :math:`Y = Exp_Z(\epsilon)`
+    where:
+    - :math:`Exp` denotes the Riemannian exponential,
+    - :math:`\beta_0` is called the intercept,
+    - :math:`\beta_1` is called the coefficient,
+    - :math:`\epsilon \sim N(0, 1)` is a standard Gaussian noise,
+    - :math:`X` is the input, :math:`Y` is the target.
+    """
+    # Generate noise-free data
+    n_samples = 20
+    X = gs.random.normal(size=(n_samples, ))
+    X -= gs.mean(X)
 
-# Generate normal noise
-normal_noise = gs.random.normal(size=(n_samples, 3))
-normal_noise = SPACE.lie_algebra.matrix_representation(normal_noise)
-noise = SPACE.tangent_translation_map(y)(normal_noise) / gs.pi / 2
+    intercept = SPACE.random_point()
+    coef = SPACE.to_tangent(5. * gs.random.rand(3, 3), intercept)
+    y = METRIC.exp(X[:, None, None] * coef[None], intercept)
 
-rss = gs.sum(METRIC.squared_norm(noise, y)) / n_samples
+    # Generate normal noise in the Lie algebra
+    normal_noise = gs.random.normal(size=(n_samples, 3))
+    normal_noise = SPACE.lie_algebra.matrix_representation(normal_noise)
+    noise = SPACE.tangent_translation_map(y)(normal_noise) / gs.pi
 
-# Add noise
-y = METRIC.exp(noise, y)
+    rss = gs.sum(METRIC.squared_norm(noise, y)) / n_samples
 
-# True noise level and R2
-estimator = FrechetMean(METRIC)
-estimator.fit(y)
-variance_ = variance(y, estimator.estimate_, metric=METRIC)
-r2 = 1 - rss / variance_
+    # Add noise
+    y = METRIC.exp(noise, y)
 
-gr = GeodesicRegression(
-    SPACE, metric=METRIC, center_X=False, method='riemannian',
-    verbose=True, max_iter=100, learning_rate=.1, initialization='frechet')
-gr.fit(X, y, compute_training_score=True)
+    # True noise level and R2
+    estimator = FrechetMean(METRIC)
+    estimator.fit(y)
+    variance_ = variance(y, estimator.estimate_, metric=METRIC)
+    r2 = 1 - rss / variance_
 
-gr = GeodesicRegression(
-    SPACE, metric=METRIC, center_X=False, method='extrinsic',
-    verbose=True, max_iter=100, learning_rate=.1, initialization='random')
-gr.fit(X, y, compute_training_score=True)
+    # Fit geodesic regression
+    gr = GeodesicRegression(
+        SPACE, metric=METRIC, center_X=False, method='riemannian',
+        verbose=True, max_iter=100, learning_rate=.1, initialization='frechet')
+    gr.fit(X, y, compute_training_score=True)
 
-intercept_hat, beta_hat = gr.intercept_, gr.coef_
+    intercept_hat, beta_hat = gr.intercept_, gr.coef_
 
-# Measure Mean Squared Error
-mse_intercept = METRIC.squared_dist(intercept_hat, intercept)
-mse_beta = METRIC.squared_norm(
-    METRIC.parallel_transport(beta_hat, METRIC.log(intercept_hat, intercept),
-                              intercept_hat) - coef, intercept)
+    # Measure Mean Squared Error
+    mse_intercept = METRIC.squared_dist(intercept_hat, intercept)
+    mse_beta = METRIC.squared_norm(
+        METRIC.parallel_transport(
+            beta_hat, METRIC.log(intercept_hat, intercept), intercept_hat)
+        - coef, intercept)
 
-# Measure goodness of fit
-r2_hat = gr.training_score_
+    # Measure goodness of fit
+    r2_hat = gr.training_score_
 
-print(f'MSE on the intercept: {mse_intercept:.2e}')
-print(f'MSE on the initial velocity beta: {mse_beta:.2e}')
-print(f'Determination coefficient: R^2={r2_hat:.2f}')
+    print(f'MSE on the intercept: {mse_intercept:.2e}')
+    print(f'MSE on the initial velocity beta: {mse_beta:.2e}')
+    print(f'Determination coefficient: R^2={r2_hat:.2f}')
 
-# Plot
-fitted_data = gr.predict(X)
-fig = plt.figure(figsize=(8, 8))
-ax = fig.add_subplot(111)
-sphere_visu = visualization.SpecialEuclidean2()
-ax = sphere_visu.set_ax(ax=ax)
+    # Plot
+    fitted_data = gr.predict(X)
+    fig = plt.figure(figsize=(8, 8))
+    ax = fig.add_subplot(111)
+    sphere_visu = visualization.SpecialEuclidean2()
+    ax = sphere_visu.set_ax(ax=ax)
 
-path = METRIC.geodesic(
-    initial_point=intercept_hat, initial_tangent_vec=beta_hat)
-regressed_geodesic = path(
-    gs.linspace(min(X), max(X), 100))
+    path = METRIC.geodesic(
+        initial_point=intercept_hat, initial_tangent_vec=beta_hat)
+    regressed_geodesic = path(
+        gs.linspace(min(X), max(X), 100))
 
-i = 10
-sphere_visu.draw_points(ax, y, marker='o', c='black')
-sphere_visu.draw_points(ax, fitted_data, marker='o', c='gray')
-sphere_visu.draw_points(
-    ax, gs.array([intercept]), marker='x', c='r')
-sphere_visu.draw_points(ax, gs.array([intercept_hat]), marker='o', c='green')
+    i = 10
+    sphere_visu.draw_points(ax, y, marker='o', c='black')
+    sphere_visu.draw_points(ax, fitted_data, marker='o', c='gray')
+    sphere_visu.draw_points(
+        ax, gs.array([intercept]), marker='x', c='r')
+    sphere_visu.draw_points(ax, gs.array([intercept_hat]), marker='o', c='green')
 
-ax.plot(
-    regressed_geodesic[:, 0, 2],
-    regressed_geodesic[:, 1, 2], c='gray')
-plt.show()
+    ax.plot(
+        regressed_geodesic[:, 0, 2],
+        regressed_geodesic[:, 1, 2], c='gray')
+    plt.show()
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/geodesic_regression_se2.py
+++ b/examples/geodesic_regression_se2.py
@@ -1,0 +1,98 @@
+r"""Compute and visualize a geodesic regression on SE(2).
+
+The generative model of the data is:
+:math:`Z = Exp_{\beta_0}(\beta_1.X)` and :math:`Y = Exp_Z(\epsilon)`
+where:
+- :math:`Exp` denotes the Riemannian exponential,
+- :math:`\beta_0` is called the intercept,
+- :math:`\beta_1` is called the coefficient,
+- :math:`\epsilon \sim N(0, 1)` is a standard Gaussian noise,
+- :math:`X` is called the input, :math:`Y` is called the y.
+"""
+
+import matplotlib.pyplot as plt
+
+import geomstats.backend as gs
+import geomstats.visualization as visualization
+from geomstats.geometry.special_euclidean import SpecialEuclidean
+from geomstats.learning.frechet_mean import FrechetMean, variance
+from geomstats.learning.geodesic_regression import GeodesicRegression
+
+SPACE = SpecialEuclidean(2)
+METRIC = SPACE.left_canonical_metric
+METRIC.default_point_type = 'matrix'
+gs.random.seed(0)
+
+# Generate noise-free data
+n_samples = 20
+X = gs.random.normal(size=(n_samples, ))
+X -= gs.mean(X)
+
+intercept = SPACE.random_point()
+coef = SPACE.to_tangent(5. * gs.random.rand(3, 3), intercept)
+y = METRIC.exp(X[:, None, None] * coef[None], intercept)
+
+# Generate normal noise
+normal_noise = gs.random.normal(size=(n_samples, 3))
+normal_noise = SPACE.lie_algebra.matrix_representation(normal_noise)
+noise = SPACE.tangent_translation_map(y)(normal_noise) / gs.pi / 2
+
+rss = gs.sum(METRIC.squared_norm(noise, y)) / n_samples
+
+# Add noise
+y = METRIC.exp(noise, y)
+
+# True noise level and R2
+estimator = FrechetMean(METRIC)
+estimator.fit(y)
+variance_ = variance(y, estimator.estimate_, metric=METRIC)
+r2 = 1 - rss / variance_
+
+gr = GeodesicRegression(
+    SPACE, metric=METRIC, center_X=False, method='riemannian',
+    verbose=True, max_iter=100, learning_rate=.1, initialization='frechet')
+gr.fit(X, y, compute_training_score=True)
+
+gr = GeodesicRegression(
+    SPACE, metric=METRIC, center_X=False, method='extrinsic',
+    verbose=True, max_iter=100, learning_rate=.1, initialization='random')
+gr.fit(X, y, compute_training_score=True)
+
+intercept_hat, beta_hat = gr.intercept_, gr.coef_
+
+# Measure Mean Squared Error
+mse_intercept = METRIC.squared_dist(intercept_hat, intercept)
+mse_beta = METRIC.squared_norm(
+    METRIC.parallel_transport(beta_hat, METRIC.log(intercept_hat, intercept),
+                              intercept_hat) - coef, intercept)
+
+# Measure goodness of fit
+r2_hat = gr.training_score_
+
+print(f'MSE on the intercept: {mse_intercept:.2e}')
+print(f'MSE on the initial velocity beta: {mse_beta:.2e}')
+print(f'Determination coefficient: R^2={r2_hat:.2f}')
+
+# Plot
+fitted_data = gr.predict(X)
+fig = plt.figure(figsize=(8, 8))
+ax = fig.add_subplot(111)
+sphere_visu = visualization.SpecialEuclidean2()
+ax = sphere_visu.set_ax(ax=ax)
+
+path = METRIC.geodesic(
+    initial_point=intercept_hat, initial_tangent_vec=beta_hat)
+regressed_geodesic = path(
+    gs.linspace(min(X), max(X), 100))
+
+i = 10
+sphere_visu.draw_points(ax, y, marker='o', c='black')
+sphere_visu.draw_points(ax, fitted_data, marker='o', c='gray')
+sphere_visu.draw_points(
+    ax, gs.array([intercept]), marker='x', c='r')
+sphere_visu.draw_points(ax, gs.array([intercept_hat]), marker='o', c='green')
+
+ax.plot(
+    regressed_geodesic[:, 0, 2],
+    regressed_geodesic[:, 1, 2], c='gray')
+plt.show()

--- a/geomstats/_backend/autograd/autodiff.py
+++ b/geomstats/_backend/autograd/autodiff.py
@@ -41,30 +41,39 @@ def custom_gradient(*grad_funcs):
     """
     def decorator(func):
         wrapped_function = primitive(func)
+
+        def wrapped_grad_func(i, ans, *args, **kwargs):
+            grads = grad_funcs[i](*args, **kwargs)
+            if isinstance(grads, float):
+                return lambda g: g * grads
+            if grads.ndim == 2:
+                return lambda g: g[..., None] * grads
+            if grads.ndim == 3:
+                return lambda g: g[..., None, None] * grads
+            return lambda g: g * grads
+
         if len(grad_funcs) == 1:
             defvjp(
                 wrapped_function,
                 lambda ans, *args, **kwargs:
-                    lambda g: g * grad_funcs[0](*args, **kwargs))
+                    wrapped_grad_func(0, ans, *args, **kwargs))
         elif len(grad_funcs) == 2:
+
             defvjp(
                 wrapped_function,
                 lambda ans, *args, **kwargs:
-                    lambda g: anp.einsum(
-                        "...k,...->...",
-                        g,
-                        grad_funcs[0](*args, **kwargs)),
+                    wrapped_grad_func(0, ans, *args, **kwargs),
                 lambda ans, *args, **kwargs:
-                    lambda g: g * grad_funcs[1](*args, **kwargs))
+                    wrapped_grad_func(1, ans, *args, **kwargs))
         elif len(grad_funcs) == 3:
             defvjp(
                 wrapped_function,
                 lambda ans, *args, **kwargs:
-                lambda g: g * grad_funcs[0](*args, **kwargs),
+                    lambda g: g * grad_funcs[0](*args, **kwargs),
                 lambda ans, *args, **kwargs:
-                lambda g: g * grad_funcs[1](*args, **kwargs),
+                    lambda g: g * grad_funcs[1](*args, **kwargs),
                 lambda ans, *args, **kwargs:
-                lambda g: g * grad_funcs[2](*args, **kwargs))
+                    lambda g: g * grad_funcs[2](*args, **kwargs))
         else:
             raise NotImplementedError(
                 "custom_gradient is not yet implemented "

--- a/geomstats/_backend/autograd/autodiff.py
+++ b/geomstats/_backend/autograd/autodiff.py
@@ -50,7 +50,10 @@ def custom_gradient(*grad_funcs):
             defvjp(
                 wrapped_function,
                 lambda ans, *args, **kwargs:
-                    lambda g: anp.einsum("...k,...->...", g, grad_funcs[0](*args, **kwargs)),
+                    lambda g: anp.einsum(
+                        "...k,...->...",
+                        g,
+                        grad_funcs[0](*args, **kwargs)),
                 lambda ans, *args, **kwargs:
                     lambda g: g * grad_funcs[1](*args, **kwargs))
         elif len(grad_funcs) == 3:

--- a/geomstats/_backend/autograd/autodiff.py
+++ b/geomstats/_backend/autograd/autodiff.py
@@ -69,11 +69,11 @@ def custom_gradient(*grad_funcs):
             defvjp(
                 wrapped_function,
                 lambda ans, *args, **kwargs:
-                    lambda g: g * grad_funcs[0](*args, **kwargs),
+                    wrapped_grad_func(0, ans, *args, **kwargs),
                 lambda ans, *args, **kwargs:
-                    lambda g: g * grad_funcs[1](*args, **kwargs),
+                    wrapped_grad_func(1, ans, *args, **kwargs),
                 lambda ans, *args, **kwargs:
-                    lambda g: g * grad_funcs[2](*args, **kwargs))
+                    wrapped_grad_func(2, ans, *args, **kwargs))
         else:
             raise NotImplementedError(
                 "custom_gradient is not yet implemented "

--- a/geomstats/_backend/autograd/autodiff.py
+++ b/geomstats/_backend/autograd/autodiff.py
@@ -1,6 +1,6 @@
 """Wrapper around autograd functions to be consistent with backends."""
 
-
+import autograd.numpy as anp
 from autograd import elementwise_grad as _elementwise_grad
 from autograd import jacobian as _jacobian
 from autograd import value_and_grad as _value_and_grad
@@ -50,7 +50,7 @@ def custom_gradient(*grad_funcs):
             defvjp(
                 wrapped_function,
                 lambda ans, *args, **kwargs:
-                    lambda g: g * grad_funcs[0](*args, **kwargs),
+                    lambda g: anp.einsum("...k,...->...", g, grad_funcs[0](*args, **kwargs)),
                 lambda ans, *args, **kwargs:
                     lambda g: g * grad_funcs[1](*args, **kwargs))
         elif len(grad_funcs) == 3:

--- a/geomstats/_backend/autograd/random.py
+++ b/geomstats/_backend/autograd/random.py
@@ -1,7 +1,7 @@
 """Autograd based random backend."""
 
 from autograd.numpy.random import (  # NOQA
-    choice,
+    default_rng,
     normal,
     multivariate_normal,
     rand,
@@ -9,3 +9,7 @@ from autograd.numpy.random import (  # NOQA
     seed,
     uniform
 )
+
+
+def choice(*args, **kwargs):
+    return default_rng().choice(*args, **kwargs)

--- a/geomstats/_backend/numpy/autodiff.py
+++ b/geomstats/_backend/numpy/autodiff.py
@@ -18,7 +18,7 @@ def detach(x):
     return x
 
 
-def value_and_grad(func):
+def value_and_grad(*args, **kwargs):
     """Return an error when using automatic differentiation with numpy."""
     raise RuntimeError(
         "Automatic differentiation is not supported with numpy backend. "

--- a/geomstats/_backend/numpy/random.py
+++ b/geomstats/_backend/numpy/random.py
@@ -1,7 +1,7 @@
 """Numpy based random backend."""
 
 from numpy.random import (  # NOQA
-    choice,
+    default_rng,
     normal,
     multivariate_normal,
     rand,
@@ -9,3 +9,7 @@ from numpy.random import (  # NOQA
     seed,
     uniform
 )
+
+
+def choice(*args, **kwargs):
+    return default_rng().choice(*args, **kwargs)

--- a/geomstats/_backend/tensorflow/autodiff.py
+++ b/geomstats/_backend/tensorflow/autodiff.py
@@ -36,10 +36,13 @@ def custom_gradient(*grad_funcs):
                 for grad_fun in grad_funcs:
                     grad_func_val = tf.convert_to_tensor(
                         grad_fun(*args, **kwargs))
+                    print("some shapes")
+                    print(upstream.shape)
+                    print(grad_func_val.shape)
                     grad_vals.append(
                         tf.squeeze(
                             tf.einsum(
-                                "...,...->...", upstream, grad_func_val))
+                                "...k,...->...", upstream, grad_func_val))
                     )
                 return tuple(grad_vals)
 

--- a/geomstats/_backend/tensorflow/autodiff.py
+++ b/geomstats/_backend/tensorflow/autodiff.py
@@ -36,9 +36,6 @@ def custom_gradient(*grad_funcs):
                 for grad_fun in grad_funcs:
                     grad_func_val = tf.convert_to_tensor(
                         grad_fun(*args, **kwargs))
-                    print("some shapes")
-                    print(upstream.shape)
-                    print(grad_func_val.shape)
                     grad_vals.append(
                         tf.squeeze(
                             tf.einsum(

--- a/geomstats/geometry/special_euclidean.py
+++ b/geomstats/geometry/special_euclidean.py
@@ -28,16 +28,6 @@ PI8 = PI * PI7
 
 ATOL = 1e-5
 
-TAYLOR_COEFFS_1_AT_0 = [+ 1. / 2., 0.,
-                        - 1. / 24., 0.,
-                        + 1. / 720., 0.,
-                        - 1. / 40320.]
-
-TAYLOR_COEFFS_2_AT_0 = [+ 1. / 6., 0.,
-                        - 1. / 120., 0.,
-                        + 1. / 5040., 0.,
-                        - 1. / 362880.]
-
 
 def _squared_dist_grad_point_a(point_a, point_b, metric):
     """Compute gradient of squared_dist wrt point_a.
@@ -1192,7 +1182,7 @@ class SpecialEuclideanMatrixCannonicalLeftMetric(_InvariantMetricMatrix):
         dist = super().squared_dist(point_a, point_b)
         return dist
 
-    def squared_dist(self, point_a, point_b):
+    def squared_dist(self, point_a, point_b, **kwargs):
         """Squared geodesic distance between two points.
 
         Parameters

--- a/geomstats/geometry/special_orthogonal.py
+++ b/geomstats/geometry/special_orthogonal.py
@@ -72,7 +72,7 @@ class _SpecialOrthogonalMatrices(MatrixLieGroup, EmbeddedManifold):
             Rotation matrix.
         """
         aux_mat = self.submersion(point)
-        aux_mat = Matrices.mul(Matrices.transpose(point), point)
+        # aux_mat = Matrices.mul(Matrices.transpose(point), point)
         inv_sqrt_mat = SymmetricMatrices.powerm(aux_mat, - 1 / 2)
         rotation_mat = Matrices.mul(point, inv_sqrt_mat)
         det = gs.linalg.det(rotation_mat)

--- a/geomstats/learning/geodesic_regression.py
+++ b/geomstats/learning/geodesic_regression.py
@@ -254,7 +254,7 @@ class GeodesicRegression(BaseEstimator):
                     self.metric, verbose=self.verbose).fit(y).estimate_
                 return mean, gs.zeros(shape)
             if init == 'data':
-                return y[gs.random.randint(len(y))],  gs.random.normal(
+                return gs.random.choice(y, 1)[0],  gs.random.normal(
                     size=shape)
             if init == 'warm_start':
                 if self.intercept_ is not None:

--- a/tests/tests_geomstats/test_autodiff.py
+++ b/tests/tests_geomstats/test_autodiff.py
@@ -338,4 +338,4 @@ class TestAutodiff(geomstats.tests.TestCase):
 
         loss, grad = func_with_grad(const_point_b)
         self.assertAllClose(loss, 0.)
-        self.assertAllClose(grad, 0.)
+        self.assertAllClose(grad, gs.zeros_like(grad))

--- a/tests/tests_geomstats/test_autodiff.py
+++ b/tests/tests_geomstats/test_autodiff.py
@@ -326,8 +326,8 @@ class TestAutodiff(geomstats.tests.TestCase):
             return const_metric.squared_dist(x, const_point_b)
 
         arg_point_a = space.random_point()
-        result_value, result_grad = gs.autodiff.value_and_grad(
-            func)(arg_point_a)
+        func_with_grad = gs.autodiff.value_and_grad(func)
+        result_value, result_grad = func_with_grad(arg_point_a)
         expected_value = const_metric.squared_dist(
             arg_point_a, const_point_b)
         expected_grad = -2 * const_metric.log(
@@ -335,3 +335,7 @@ class TestAutodiff(geomstats.tests.TestCase):
 
         self.assertAllClose(result_value, expected_value)
         self.assertAllClose(result_grad, expected_grad)
+
+        loss, grad = func_with_grad(const_point_b)
+        self.assertAllClose(loss, 0.)
+        self.assertAllClose(grad, 0.)

--- a/tests/tests_geomstats/test_examples.py
+++ b/tests/tests_geomstats/test_examples.py
@@ -7,6 +7,7 @@ import warnings
 
 import examples.empirical_frechet_mean_uncertainty_sn as empirical_frechet_mean_uncertainty_sn  # NOQA
 import examples.geodesic_regression_hypersphere as geodesic_regression_hypersphere  # NOQA
+import examples.geodesic_regression_se2 as geodesic_regression_se2
 import examples.gradient_descent_s2 as gradient_descent_s2
 import examples.kalman_filter as kalman_filter
 import examples.learning_graph_structured_data_h2 as learning_gsd_h2
@@ -67,6 +68,11 @@ class TestExamples(geomstats.tests.TestCase):
     @geomstats.tests.autograd_tf_and_torch_only
     def test_geodesic_regression_hypersphere():
         geodesic_regression_hypersphere.main()
+
+    @staticmethod
+    @geomstats.tests.autograd_and_tf_only
+    def test_geodesic_regression_se2():
+        geodesic_regression_se2.main()
 
     @staticmethod
     @geomstats.tests.np_and_autograd_only

--- a/tests/tests_geomstats/test_geodesic_regression.py
+++ b/tests/tests_geomstats/test_geodesic_regression.py
@@ -131,6 +131,7 @@ class TestGeodesicRegression(geomstats.tests.TestCase):
             verbose=True,
             max_iter=50,
             learning_rate=0.1,
+            regularization=0,
         )
 
         def loss_of_param(param):
@@ -224,7 +225,7 @@ class TestGeodesicRegression(geomstats.tests.TestCase):
     @geomstats.tests.autograd_tf_and_torch_only
     def test_loss_minimization_extrinsic_hypersphere(self):
         """Minimize loss from noiseless data."""
-        gr = GeodesicRegression(self.sphere)
+        gr = GeodesicRegression(self.sphere, regularization=0)
 
         def loss_of_param(param):
             return gr._loss(
@@ -337,7 +338,8 @@ class TestGeodesicRegression(geomstats.tests.TestCase):
             verbose=True,
             max_iter=50,
             learning_rate=0.1,
-            initialization='random'
+            initialization='random',
+            regularization=0.9,
         )
 
         gr.fit(self.X_sphere, self.y_sphere, compute_training_score=True)
@@ -346,7 +348,7 @@ class TestGeodesicRegression(geomstats.tests.TestCase):
         intercept_hat, coef_hat = gr.intercept_, gr.coef_
         self.assertAllClose(intercept_hat.shape, self.shape_sphere)
         self.assertAllClose(coef_hat.shape, self.shape_sphere)
-        self.assertAllClose(training_score, 1.0, atol=100 * gs.atol)
+        self.assertAllClose(training_score, 1.0, atol=500 * gs.atol)
         self.assertAllClose(
             intercept_hat, self.intercept_sphere_true, atol=1e-3
         )

--- a/tests/tests_geomstats/test_geodesic_regression.py
+++ b/tests/tests_geomstats/test_geodesic_regression.py
@@ -350,7 +350,7 @@ class TestGeodesicRegression(geomstats.tests.TestCase):
         self.assertAllClose(coef_hat.shape, self.shape_sphere)
         self.assertAllClose(training_score, 1.0, atol=500 * gs.atol)
         self.assertAllClose(
-            intercept_hat, self.intercept_sphere_true, atol=1e-3
+            intercept_hat, self.intercept_sphere_true, atol=5e-3
         )
 
         tangent_vec_of_transport = self.sphere.metric.log(
@@ -460,7 +460,7 @@ class TestGeodesicRegression(geomstats.tests.TestCase):
 
         self.assertAllClose(intercept_hat.shape, self.shape_se2)
         self.assertAllClose(coef_hat.shape, self.shape_se2)
-        self.assertTrue(gs.isclose(training_score, 1.0))
+        self.assertAllClose(training_score, 1.0, atol=1e-4)
         self.assertAllClose(intercept_hat, self.intercept_se2_true, atol=1e-4)
 
         tangent_vec_of_transport = self.se2.metric.log(

--- a/tests/tests_geomstats/test_geodesic_regression.py
+++ b/tests/tests_geomstats/test_geodesic_regression.py
@@ -443,6 +443,7 @@ class TestGeodesicRegression(geomstats.tests.TestCase):
 
     @geomstats.tests.autograd_and_tf_only
     def test_fit_riemannian_se2(self):
+        init = (self.y_se2[0], gs.zeros_like(self.y_se2[0]))
         gr = GeodesicRegression(
             self.se2,
             metric=self.metric_se2,
@@ -451,7 +452,7 @@ class TestGeodesicRegression(geomstats.tests.TestCase):
             verbose=True,
             max_iter=50,
             learning_rate=0.1,
-            initialization='data'
+            initialization=init
         )
 
         gr.fit(self.X_se2, self.y_se2, compute_training_score=True)

--- a/tests/tests_geomstats/test_geodesic_regression.py
+++ b/tests/tests_geomstats/test_geodesic_regression.py
@@ -337,6 +337,7 @@ class TestGeodesicRegression(geomstats.tests.TestCase):
             verbose=True,
             max_iter=50,
             learning_rate=0.1,
+            initialization='random'
         )
 
         gr.fit(self.X_sphere, self.y_sphere, compute_training_score=True)
@@ -374,6 +375,7 @@ class TestGeodesicRegression(geomstats.tests.TestCase):
             verbose=True,
             max_iter=50,
             learning_rate=0.1,
+            initialization='warm_start',
         )
 
         gr.fit(self.X_se2, self.y_se2, compute_training_score=True)

--- a/tests/tests_geomstats/test_geodesic_regression.py
+++ b/tests/tests_geomstats/test_geodesic_regression.py
@@ -51,17 +51,12 @@ class TestGeodesicRegression(geomstats.tests.TestCase):
 
         self.shape_se2 = (3, 3)
         X = gs.random.rand(self.n_samples)
-        # X = gs.linspace(0.0, 1.0, self.n_samples)
         self.X_se2 = X - gs.mean(X)
 
-        self.intercept_se2_true = self.se2.identity  # self.se2.random_point()
-        vector = gs.array([[1.0, 4.0, 3.0], [-1.0, 2.0, -3], [0.0, -1.0, 1.0]])
+        self.intercept_se2_true = self.se2.random_point()
         self.coef_se2_true = self.se2.to_tangent(
-            vector, self.intercept_se2_true
-        )
-        # self.coef_se2_true = self.se2.to_tangent(
-        #     5. * gs.random.rand(*self.shape_se2),
-        #     self.intercept_se2_true)
+            5. * gs.random.rand(*self.shape_se2),
+            self.intercept_se2_true)
 
         self.y_se2 = self.metric_se2.exp(
             self.X_se2[:, None, None] * self.coef_se2_true[None],

--- a/tests/tests_geomstats/test_geodesic_regression.py
+++ b/tests/tests_geomstats/test_geodesic_regression.py
@@ -226,7 +226,6 @@ class TestGeodesicRegression(geomstats.tests.TestCase):
         )
         self.assertTrue(gs.all(~gs.isnan(loss_grad)))
 
-
     @geomstats.tests.autograd_tf_and_torch_only
     def test_loss_minimization_extrinsic_hypersphere(self):
         """Minimize loss from noiseless data."""

--- a/tests/tests_geomstats/test_geodesic_regression.py
+++ b/tests/tests_geomstats/test_geodesic_regression.py
@@ -340,7 +340,6 @@ class TestGeodesicRegression(geomstats.tests.TestCase):
             transported_coef_hat, self.coef_se2_true, atol=0.6
         )
 
-
     @geomstats.tests.autograd_tf_and_torch_only
     def test_fit_extrinsic_hypersphere(self):
         gr = GeodesicRegression(
@@ -376,6 +375,40 @@ class TestGeodesicRegression(geomstats.tests.TestCase):
 
         self.assertAllClose(
             transported_coef_hat, self.coef_sphere_true, atol=0.6
+        )
+
+    def test_fit_extrinsic_se2(self):
+        gr = GeodesicRegression(
+            self.se2,
+            metric=self.metric_se2,
+            center_X=False,
+            method='extrinsic',
+            verbose=True,
+            max_iter=50,
+            learning_rate=0.1,
+        )
+
+        gr.fit(self.X_se2, self.y_se2, compute_training_score=True)
+        intercept_hat, coef_hat = gr.intercept_, gr.coef_
+        training_score = gr.training_score_
+
+        self.assertAllClose(intercept_hat.shape, self.shape_se2)
+        self.assertAllClose(coef_hat.shape, self.shape_se2)
+        self.assertTrue(gs.isclose(training_score, 1.0))
+        self.assertAllClose(intercept_hat, self.intercept_se2_true, atol=1e-4)
+
+        tangent_vec_of_transport = self.se2.metric.log(
+            self.intercept_se2_true, base_point=intercept_hat
+        )
+
+        transported_coef_hat = self.se2.metric.parallel_transport(
+            tangent_vec_a=coef_hat,
+            tangent_vec_b=tangent_vec_of_transport,
+            base_point=intercept_hat,
+        )
+
+        self.assertAllClose(
+            transported_coef_hat, self.coef_se2_true, atol=0.6
         )
 
     @geomstats.tests.autograd_tf_and_torch_only


### PR DESCRIPTION
This PR adds unit tests for geodesic regression on SE2, with the backends tf and autograd (torch is missing the implementation of the matrix expm?).