### PR TITLE
Fix pre-commit python version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version :
-  python : python3.7
+  python : python3
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.1.0


### PR DESCRIPTION
Fix version of python in pre-commit yml so that the precommit can run with any python 3.x version.