### PR TITLE
Adding option to obtain backend module

### DIFF
--- a/geomstats/_backend/__init__.py
+++ b/geomstats/_backend/__init__.py
@@ -86,7 +86,7 @@ BACKEND_ATTRIBUTES = {
         "mean",
         "meshgrid",
         "mod",
-        "module",
+        "module_name",
         "ndim",
         "one_hot",
         "ones",

--- a/geomstats/_backend/__init__.py
+++ b/geomstats/_backend/__init__.py
@@ -86,6 +86,7 @@ BACKEND_ATTRIBUTES = {
         "mean",
         "meshgrid",
         "mod",
+        "module",
         "ndim",
         "one_hot",
         "ones",

--- a/geomstats/_backend/autograd/__init__.py
+++ b/geomstats/_backend/autograd/__init__.py
@@ -2,7 +2,6 @@
 
 import math
 
-import autograd
 import autograd.numpy as np
 from autograd.numpy import (
     abs,
@@ -121,10 +120,10 @@ DTYPES = {
     ndtype("complex128"): 5,
 }
 
+module_name = "autograd"
 
 atol = np_atol
 rtol = np_rtol
-module = autograd
 
 
 def comb(n, k):

--- a/geomstats/_backend/autograd/__init__.py
+++ b/geomstats/_backend/autograd/__init__.py
@@ -2,6 +2,7 @@
 
 import math
 
+import autograd
 import autograd.numpy as np
 from autograd.numpy import (
     abs,
@@ -123,6 +124,7 @@ DTYPES = {
 
 atol = np_atol
 rtol = np_rtol
+module = autograd
 
 
 def comb(n, k):

--- a/geomstats/_backend/numpy/__init__.py
+++ b/geomstats/_backend/numpy/__init__.py
@@ -123,6 +123,7 @@ DTYPES = {
 
 atol = np_atol
 rtol = np_rtol
+module = np
 
 
 def comb(n, k):

--- a/geomstats/_backend/numpy/__init__.py
+++ b/geomstats/_backend/numpy/__init__.py
@@ -120,10 +120,10 @@ DTYPES = {
     ndtype("complex128"): 5,
 }
 
+module_name = "numpy"
 
 atol = np_atol
 rtol = np_rtol
-module = np
 
 
 def comb(n, k):

--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -71,6 +71,7 @@ DTYPES = {
 
 atol = pytorch_atol
 rtol = pytorch_rtol
+module = torch
 
 
 def _raise_not_implemented_error(*args, **kwargs):

--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -68,10 +68,10 @@ DTYPES = {
     complex128: 5,
 }
 
+module_name = "torch"
 
 atol = pytorch_atol
 rtol = pytorch_rtol
-module = torch
 
 
 def _raise_not_implemented_error(*args, **kwargs):

--- a/geomstats/_backend/tensorflow/__init__.py
+++ b/geomstats/_backend/tensorflow/__init__.py
@@ -87,6 +87,7 @@ set_diag = tf.linalg.set_diag
 std = tf.math.reduce_std
 atol = tf_atol
 rtol = tf_rtol
+module = tf
 
 
 def _raise_not_implemented_error(*args, **kwargs):

--- a/geomstats/_backend/tensorflow/__init__.py
+++ b/geomstats/_backend/tensorflow/__init__.py
@@ -70,7 +70,7 @@ from . import linalg  # NOQA
 from . import random  # NOQA
 
 DTYPES = {int32: 0, int64: 1, float32: 2, float64: 3, complex64: 4, complex128: 5}
-
+module_name = "tensorflow"
 
 arctanh = tf.math.atanh
 ceil = tf.math.ceil
@@ -87,7 +87,6 @@ set_diag = tf.linalg.set_diag
 std = tf.math.reduce_std
 atol = tf_atol
 rtol = tf_rtol
-module = tf
 
 
 def _raise_not_implemented_error(*args, **kwargs):


### PR DESCRIPTION
With this patch, an user can directly get the module object of the current backend. Should facilitate in writing more backend independent code.

An user can get the module object via `geomstats.backend.module`. The actual backend name can also be obtained as `geomstats.backend.module.__name__`.

CC: @ninamiolane 