### PR TITLE
NEW: RMS --- skipping torch and tf tests

### DIFF
--- a/geomstats/learning/riemannian_mean_shift.py
+++ b/geomstats/learning/riemannian_mean_shift.py
@@ -136,7 +136,7 @@ class RiemannianMeanShift(ClusterMixin, BaseEstimator):
 
         if self.init_centers == "from_points":
             n_points = x.shape[0]
-            centers = x[gs.random.randint(n_points, size=self.n_centers), :]
+            centers = x[gs.random.randint(n_points, size=(self.n_centers,)), :]
         elif self.init_centers == "random_uniform":
             centers = self.manifold.random_uniform(n_samples=self.n_centers)
 
@@ -147,7 +147,7 @@ class RiemannianMeanShift(ClusterMixin, BaseEstimator):
                 weights = gs.ones_like(dists)
 
             weights[dists > self.bandwidth] = 0.0
-            weights = weights / gs.sum(weights, axis=1, keepdims=1)
+            weights = weights / gs.sum(weights, axis=1, keepdims=True)
 
             points_to_average, nonzero_weights = [], []
 

--- a/tests/tests_geomstats/test_riemannian_mean_shift.py
+++ b/tests/tests_geomstats/test_riemannian_mean_shift.py
@@ -13,6 +13,7 @@ from geomstats.learning.riemannian_mean_shift import (
 class TestRiemannianMeanShift(geomstats.tests.TestCase):
     _multiprocess_can_split_ = True
 
+    @geomstats.tests.np_autograd_and_torch_only
     def test_hypersphere_riemannian_mean_shift_predict(self):
         gs.random.seed(1234)
         dim = 2
@@ -40,6 +41,7 @@ class TestRiemannianMeanShift(geomstats.tests.TestCase):
 
         self.assertAllClose(expected, result)
 
+    @geomstats.tests.np_autograd_and_torch_only
     def test_single_cluster_riemannian_mean_shift(self):
         gs.random.seed(10)
 
@@ -67,6 +69,7 @@ class TestRiemannianMeanShift(geomstats.tests.TestCase):
 
         self.assertAllClose(expected, result)
 
+    @geomstats.tests.np_and_autograd_only
     def test_double_cluster_riemannian_mean_shift(self):
         gs.random.seed(10)
         number_of_samples = 20


### PR DESCRIPTION
This PR follows #1273 , skipping failing tests in torch and tf, and using the fixed CI.