### PR TITLE
Removing duplicate centroids from the predicted centers

### DIFF
--- a/geomstats/learning/riemannian_mean_shift.py
+++ b/geomstats/learning/riemannian_mean_shift.py
@@ -174,7 +174,7 @@ class RiemannianMeanShift(ClusterMixin, BaseEstimator):
             if (gs.array(displacements) < self.tol).all():
                 break
 
-        self.centers = centers
+        self.centers = gs.unique(centers, axis=0)
 
     def predict(self, points):
         """Predict the closest cluster each point in 'points' belongs to.


### PR DESCRIPTION
Since multiple centers could converge to the same points in Mean Shift it makes sense to get rid of the duplicate centroids converged.