### PR TITLE
Add annotation in code review

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ on:
     branches: [master]
 
 jobs:
-  build:
+  lint:
 
     runs-on: ${{matrix.os}}
     strategy:
@@ -31,11 +31,15 @@ jobs:
           done
           pip install -e .
 
+      - name: linting [flake8] geomstats/
+        uses: reviewdog/action-flake8@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-check
+          filter_mode: nofilter
+          workdir: geomstats/
+      
       - name : linting [black and isort]
         run: |
           black . --check
           isort --profile black --check .
-
-      - name: linting [flake8]
-        run: |
-          flake8 geomstats/ tests/

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,14 +31,13 @@ jobs:
           done
           pip install -e .
 
-      - name: linting [flake8] geomstats/
-        uses: reviewdog/action-flake8@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          reporter: github-check
-          filter_mode: nofilter
-          workdir: geomstats/
+      - name: Setup flake8 annotations
+        uses: rbialon/flake8-annotations@v1
       
+      - name: linting [flake8]
+        run: |
+          flake8 geomstats/ tests/
+
       - name : linting [black and isort]
         run: |
           black . --check


### PR DESCRIPTION
Addresses #1198 

Change Log:
- flake8 is moved before black+isort. (So that failure of black, isort still allows annotations to be made).

- [PENDING]: The current modification only works on `/geomstats`. Need to call on `/tests` as well. 
Open to suggestions! :)