### PR TITLE
add Matrix basis and General linear algebra

### DIFF
--- a/geomstats/geometry/base.py
+++ b/geomstats/geometry/base.py
@@ -29,6 +29,7 @@ class VectorSpace(Manifold, abc.ABC):
             kwargs["dim"] = int(gs.prod(gs.array(shape)))
         super(VectorSpace, self).__init__(shape=shape, **kwargs)
         self.shape = shape
+        self.basis = None
 
     def belongs(self, point, atol=gs.atol):
         """Evaluate if the point belongs to the vector space.
@@ -136,6 +137,28 @@ class VectorSpace(Manifold, abc.ABC):
             size = (n_samples,) + self.shape
         point = bound * (gs.random.rand(*size) - 0.5) * 2
         return point
+
+    @property
+    def basis(self):
+        """Basis of the vector space."""
+        if self._basis is None:
+            self._basis = self._create_basis()
+
+        return self._basis
+
+    @basis.setter
+    def basis(self, basis):
+        if basis is not None:
+            if len(basis) < self.dim:
+                raise ValueError(
+                    "The basis should have length equal to the "
+                    "dimension of the space."
+                )
+        self._basis = basis
+
+    @abc.abstractmethod
+    def _create_basis(self):
+        """Create a canonical basis."""
 
 
 class LevelSet(Manifold, abc.ABC):

--- a/geomstats/geometry/base.py
+++ b/geomstats/geometry/base.py
@@ -50,7 +50,7 @@ class VectorSpace(Manifold, abc.ABC):
         """
         minimal_ndim = len(self.shape)
         belongs = point.shape[-minimal_ndim:] == self.shape
-        if point.ndim == minimal_ndim:
+        if point.ndim <= minimal_ndim:
             return belongs
         return gs.tile(gs.array([belongs]), [point.shape[0]])
 

--- a/geomstats/geometry/base.py
+++ b/geomstats/geometry/base.py
@@ -148,12 +148,10 @@ class VectorSpace(Manifold, abc.ABC):
 
     @basis.setter
     def basis(self, basis):
-        if basis is not None:
-            if len(basis) < self.dim:
-                raise ValueError(
-                    "The basis should have length equal to the "
-                    "dimension of the space."
-                )
+        if basis is not None and len(basis) < self.dim:
+            raise ValueError(
+                "The basis should have length equal to the " "dimension of the space."
+            )
         self._basis = basis
 
     @abc.abstractmethod

--- a/geomstats/geometry/euclidean.py
+++ b/geomstats/geometry/euclidean.py
@@ -42,6 +42,9 @@ class Euclidean(VectorSpace):
 
     identity = property(get_identity)
 
+    def _create_basis(self):
+        return gs.eye(self.dim)
+
     def exp(self, tangent_vec, base_point=None):
         """Compute the group exponential, which is simply the addition.
 

--- a/geomstats/geometry/euclidean.py
+++ b/geomstats/geometry/euclidean.py
@@ -43,6 +43,7 @@ class Euclidean(VectorSpace):
     identity = property(get_identity)
 
     def _create_basis(self):
+        """Create the canonical basis."""
         return gs.eye(self.dim)
 
     def exp(self, tangent_vec, base_point=None):

--- a/geomstats/geometry/general_linear.py
+++ b/geomstats/geometry/general_linear.py
@@ -3,6 +3,7 @@
 import geomstats.algebra_utils as utils
 import geomstats.backend as gs
 from geomstats.geometry.base import OpenSet
+from geomstats.geometry.lie_algebra import MatrixLieAlgebra
 from geomstats.geometry.lie_group import MatrixLieGroup
 from geomstats.geometry.matrices import Matrices
 
@@ -27,7 +28,10 @@ class GeneralLinear(MatrixLieGroup, OpenSet):
         if "dim" not in kwargs.keys():
             kwargs["dim"] = n**2
         super(GeneralLinear, self).__init__(
-            ambient_space=Matrices(n, n), n=n, lie_algebra=Matrices(n, n), **kwargs
+            ambient_space=Matrices(n, n),
+            n=n,
+            lie_algebra=GeneralLinearLieAlgebra(n),
+            **kwargs
         )
         self.positive_det = positive_det
 
@@ -161,3 +165,54 @@ class GeneralLinear(MatrixLieGroup, OpenSet):
             return cls.exp(vecs, base_point)
 
         return path
+
+
+class GeneralLinearLieAlgebra(MatrixLieAlgebra):
+    """Lie algebra of the general linear group.
+
+    This is the space of matrices.
+
+    Parameters
+    ----------
+    n : int
+        Integer representing the shape of the matrices: n x n.
+    """
+
+    def __init__(self, n):
+        super(GeneralLinearLieAlgebra, self).__init__(n=n, dim=n**2)
+        self.mat_space = Matrices(n, n)
+        self.basis = self.mat_space.basis
+
+    def basis_representation(self, matrix_representation):
+        """Compute the coefficient in the usual matrix basis.
+
+        This simply flattens the input.
+
+        Parameters
+        ----------
+        matrix_representation : array-like, shape=[..., n, n]
+            Matrix.
+
+        Returns
+        -------
+        basis_representation : array-like, shape=[..., dim]
+            Representation in the basis.
+        """
+        return self.mat_space.flatten(matrix_representation)
+
+    def matrix_representation(self, basis_representation):
+        """Compute the matrix representation for the given basis coefficients.
+
+        This simply reshapes the input into a square matrix.
+
+        Parameters
+        ----------
+        basis_representation : array-like, shape=[..., dim]
+            Coefficients in the basis.
+
+        Returns
+        -------
+        matrix_representation : array-like, shape=[..., n, n]
+            Matrix.
+        """
+        return self.mat_space.reshape(basis_representation)

--- a/geomstats/geometry/general_linear.py
+++ b/geomstats/geometry/general_linear.py
@@ -181,7 +181,9 @@ class GeneralLinearLieAlgebra(MatrixLieAlgebra):
     def __init__(self, n):
         super(GeneralLinearLieAlgebra, self).__init__(n=n, dim=n**2)
         self.mat_space = Matrices(n, n)
-        self.basis = self.mat_space.basis
+
+    def _create_basis(self):
+        return self.mat_space.basis
 
     def basis_representation(self, matrix_representation):
         """Compute the coefficient in the usual matrix basis.

--- a/geomstats/geometry/general_linear.py
+++ b/geomstats/geometry/general_linear.py
@@ -28,10 +28,7 @@ class GeneralLinear(MatrixLieGroup, OpenSet):
         if "dim" not in kwargs.keys():
             kwargs["dim"] = n**2
         super(GeneralLinear, self).__init__(
-            ambient_space=Matrices(n, n),
-            n=n,
-            lie_algebra=GeneralLinearLieAlgebra(n),
-            **kwargs
+            ambient_space=Matrices(n, n), n=n, lie_algebra=SquareMatrices(n), **kwargs
         )
         self.positive_det = positive_det
 
@@ -167,7 +164,7 @@ class GeneralLinear(MatrixLieGroup, OpenSet):
         return path
 
 
-class GeneralLinearLieAlgebra(MatrixLieAlgebra):
+class SquareMatrices(MatrixLieAlgebra):
     """Lie algebra of the general linear group.
 
     This is the space of matrices.
@@ -179,7 +176,7 @@ class GeneralLinearLieAlgebra(MatrixLieAlgebra):
     """
 
     def __init__(self, n):
-        super(GeneralLinearLieAlgebra, self).__init__(n=n, dim=n**2)
+        super(SquareMatrices, self).__init__(n=n, dim=n**2)
         self.mat_space = Matrices(n, n)
 
     def _create_basis(self):

--- a/geomstats/geometry/general_linear.py
+++ b/geomstats/geometry/general_linear.py
@@ -183,6 +183,7 @@ class GeneralLinearLieAlgebra(MatrixLieAlgebra):
         self.mat_space = Matrices(n, n)
 
     def _create_basis(self):
+        """Create the canonical basis of the space of matrices."""
         return self.mat_space.basis
 
     def basis_representation(self, matrix_representation):

--- a/geomstats/geometry/general_linear.py
+++ b/geomstats/geometry/general_linear.py
@@ -26,7 +26,9 @@ class GeneralLinear(MatrixLieGroup, OpenSet):
     def __init__(self, n, positive_det=False, **kwargs):
         if "dim" not in kwargs.keys():
             kwargs["dim"] = n**2
-        super(GeneralLinear, self).__init__(ambient_space=Matrices(n, n), n=n, **kwargs)
+        super(GeneralLinear, self).__init__(
+            ambient_space=Matrices(n, n), n=n, lie_algebra=Matrices(n, n), **kwargs
+        )
         self.positive_det = positive_det
 
     def projection(self, point):

--- a/geomstats/geometry/heisenberg.py
+++ b/geomstats/geometry/heisenberg.py
@@ -32,6 +32,7 @@ class HeisenbergVectors(LieGroup, VectorSpace):
         )
 
     def _create_basis(self):
+        """Create the canonical basis."""
         return gs.eye(3)
 
     def get_identity(self, point_type="vector"):

--- a/geomstats/geometry/heisenberg.py
+++ b/geomstats/geometry/heisenberg.py
@@ -31,6 +31,9 @@ class HeisenbergVectors(LieGroup, VectorSpace):
             dim=3, shape=(3,), lie_algebra=Euclidean(3)
         )
 
+    def _create_basis(self):
+        return gs.eye(3)
+
     def get_identity(self, point_type="vector"):
         """Get the identity of the 3D Heisenberg group.
 

--- a/geomstats/geometry/lie_algebra.py
+++ b/geomstats/geometry/lie_algebra.py
@@ -109,7 +109,7 @@ class MatrixLieAlgebra(VectorSpace, abc.ABC):
     def matrix_representation(self, basis_representation):
         """Compute the matrix representation for the given basis coefficients.
 
-        Sums the basis elements according to the coefficents given in
+        Sums the basis elements according to the coefficients given in
         basis_representation.
 
         Parameters

--- a/geomstats/geometry/lower_triangular_matrices.py
+++ b/geomstats/geometry/lower_triangular_matrices.py
@@ -26,7 +26,7 @@ class LowerTriangularMatrices(VectorSpace):
         )
         self.n = n
 
-    def get_basis(self):
+    def _create_basis(self):
         """Compute the basis of the vector space of lower triangular.
 
         Returns
@@ -37,8 +37,6 @@ class LowerTriangularMatrices(VectorSpace):
         tril_idxs = gs.ravel_tril_indices(self.n)
         vector_bases = gs.one_hot(tril_idxs, self.n * self.n)
         return gs.reshape(vector_bases, [-1, self.n, self.n])
-
-    basis = property(get_basis)
 
     def belongs(self, point, atol=gs.atol):
         """Evaluate if a matrix is lower triangular.

--- a/geomstats/geometry/matrices.py
+++ b/geomstats/geometry/matrices.py
@@ -31,6 +31,7 @@ class Matrices(VectorSpace):
         self.basis = None
 
     def _create_basis(self):
+        """Create the canonical basis."""
         m, n = self.m, self.n
         return gs.reshape(gs.eye(n * m), (n * m, m, n))
 

--- a/geomstats/geometry/matrices.py
+++ b/geomstats/geometry/matrices.py
@@ -28,7 +28,7 @@ class Matrices(VectorSpace):
         geomstats.errors.check_integer(m, "m")
         self.m = m
         self.n = n
-        self.basis = gs.eye(n * m).reshape(n * m, m, n)
+        self.basis = gs.reshape(gs.eye(n * m), (n * m, m, n))
 
     def belongs(self, point, atol=gs.atol):
         """Check if point belongs to the Matrices space.

--- a/geomstats/geometry/matrices.py
+++ b/geomstats/geometry/matrices.py
@@ -28,6 +28,7 @@ class Matrices(VectorSpace):
         geomstats.errors.check_integer(m, "m")
         self.m = m
         self.n = n
+        self.basis = gs.eye(n * m).reshape(n * m, m, n)
 
     def belongs(self, point, atol=gs.atol):
         """Check if point belongs to the Matrices space.

--- a/geomstats/geometry/matrices.py
+++ b/geomstats/geometry/matrices.py
@@ -28,7 +28,11 @@ class Matrices(VectorSpace):
         geomstats.errors.check_integer(m, "m")
         self.m = m
         self.n = n
-        self.basis = gs.reshape(gs.eye(n * m), (n * m, m, n))
+        self.basis = None
+
+    def _create_basis(self):
+        m, n = self.m, self.n
+        return gs.reshape(gs.eye(n * m), (n * m, m, n))
 
     def belongs(self, point, atol=gs.atol):
         """Check if point belongs to the Matrices space.

--- a/geomstats/geometry/skew_symmetric_matrices.py
+++ b/geomstats/geometry/skew_symmetric_matrices.py
@@ -27,27 +27,25 @@ class SkewSymmetricMatrices(MatrixLieAlgebra):
         super(SkewSymmetricMatrices, self).__init__(dim, n)
         self.ambient_space = Matrices(n, n)
 
+    def _create_basis(self):
+        n = self.n
         if n == 2:
-            self.basis = gs.array([[[0.0, -1.0], [1.0, 0.0]]])
-        elif n == 3:
-            self.basis = gs.array(
+            return gs.array([[[0.0, -1.0], [1.0, 0.0]]])
+        if n == 3:
+            return gs.array(
                 [
                     [[0.0, 0.0, 0.0], [0.0, 0.0, -1.0], [0.0, 1.0, 0.0]],
                     [[0.0, 0.0, 1.0], [0.0, 0.0, 0.0], [-1.0, 0.0, 0.0]],
                     [[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
                 ]
             )
-        else:
-            self.basis = gs.zeros((dim, n, n))
-            basis = []
-            for row in gs.arange(n - 1):
-                for col in gs.arange(row + 1, n):
-                    basis.append(
-                        gs.array_from_sparse(
-                            [(row, col), (col, row)], [1.0, -1.0], (n, n)
-                        )
-                    )
-            self.basis = gs.stack(basis)
+        basis = []
+        for row in gs.arange(n - 1):
+            for col in gs.arange(row + 1, n):
+                basis.append(
+                    gs.array_from_sparse([(row, col), (col, row)], [1.0, -1.0], (n, n))
+                )
+        return gs.stack(basis)
 
     def belongs(self, mat, atol=gs.atol):
         """Evaluate if mat is a skew-symmetric matrix.

--- a/geomstats/geometry/skew_symmetric_matrices.py
+++ b/geomstats/geometry/skew_symmetric_matrices.py
@@ -28,6 +28,7 @@ class SkewSymmetricMatrices(MatrixLieAlgebra):
         self.ambient_space = Matrices(n, n)
 
     def _create_basis(self):
+        """Create the canonical basis."""
         n = self.n
         if n == 2:
             return gs.array([[[0.0, -1.0], [1.0, 0.0]]])

--- a/geomstats/geometry/special_euclidean.py
+++ b/geomstats/geometry/special_euclidean.py
@@ -1287,6 +1287,9 @@ class SpecialEuclideanMatrixLieAlgebra(MatrixLieAlgebra):
         super(SpecialEuclideanMatrixLieAlgebra, self).__init__(dim, n)
 
         self.skew = SkewSymmetricMatrices(n)
+
+    def _create_basis(self):
+        n = self.n
         basis = homogeneous_representation(
             self.skew.basis,
             gs.zeros((self.skew.dim, n)),
@@ -1297,7 +1300,7 @@ class SpecialEuclideanMatrixLieAlgebra(MatrixLieAlgebra):
 
         for row in gs.arange(n):
             basis.append(gs.array_from_sparse([(row, n)], [1.0], (n + 1, n + 1)))
-        self.basis = gs.stack(basis)
+        return gs.stack(basis)
 
     def belongs(self, mat, atol=ATOL):
         """Evaluate if the rotation part of mat is a skew-symmetric matrix.

--- a/geomstats/geometry/special_euclidean.py
+++ b/geomstats/geometry/special_euclidean.py
@@ -1289,6 +1289,7 @@ class SpecialEuclideanMatrixLieAlgebra(MatrixLieAlgebra):
         self.skew = SkewSymmetricMatrices(n)
 
     def _create_basis(self):
+        """Create the canonical basis."""
         n = self.n
         basis = homogeneous_representation(
             self.skew.basis,

--- a/geomstats/geometry/symmetric_matrices.py
+++ b/geomstats/geometry/symmetric_matrices.py
@@ -30,7 +30,7 @@ class SymmetricMatrices(VectorSpace):
         )
         self.n = n
 
-    def get_basis(self):
+    def _create_basis(self):
         """Compute the basis of the vector space of symmetric matrices."""
         basis = []
         for row in gs.arange(self.n):
@@ -44,8 +44,6 @@ class SymmetricMatrices(VectorSpace):
                 basis.append(gs.array_from_sparse(indices, values, (self.n,) * 2))
         basis = gs.stack(basis)
         return basis
-
-    basis = property(get_basis)
 
     def belongs(self, point, atol=gs.atol):
         """Evaluate if a matrix is symmetric.

--- a/tests/tests_geomstats/test_general_linear.py
+++ b/tests/tests_geomstats/test_general_linear.py
@@ -3,7 +3,7 @@
 import random
 
 import geomstats.backend as gs
-from geomstats.geometry.general_linear import GeneralLinear, GeneralLinearLieAlgebra
+from geomstats.geometry.general_linear import GeneralLinear, SquareMatrices
 from tests.conftest import TestCase
 from tests.data_generation import LieGroupTestData, MatrixLieAlgebraTestData
 from tests.parametrizers import LieGroupParametrizer, MatrixLieAlgebraParametrizer
@@ -217,10 +217,10 @@ class TestGeneralLinear(TestCase, metaclass=LieGroupParametrizer):
         self.assertAllClose(result, gs.array(expected))
 
 
-class TestGeneralLinearLieAlgebra(TestCase, metaclass=MatrixLieAlgebraParametrizer):
-    space = algebra = GeneralLinearLieAlgebra
+class TestSquareMatrices(TestCase, metaclass=MatrixLieAlgebraParametrizer):
+    space = algebra = SquareMatrices
 
-    class TestDataGeneralLinearLieAlgebra(MatrixLieAlgebraTestData):
+    class TestDataSquareMatrices(MatrixLieAlgebraTestData):
         n_list = random.sample(range(2, 5), 2)
         space_args_list = [(n,) for n in n_list]
         shape_list = [(n, n) for n in n_list]
@@ -238,12 +238,12 @@ class TestGeneralLinearLieAlgebra(TestCase, metaclass=MatrixLieAlgebraParametriz
 
         def basis_representation_matrix_representation_composition_data(self):
             return self._basis_representation_matrix_representation_composition_data(
-                GeneralLinearLieAlgebra, self.space_args_list, self.n_samples_list
+                SquareMatrices, self.space_args_list, self.n_samples_list
             )
 
         def matrix_representation_basis_representation_composition_data(self):
             return self._matrix_representation_basis_representation_composition_data(
-                GeneralLinearLieAlgebra, self.space_args_list, self.n_samples_list
+                SquareMatrices, self.space_args_list, self.n_samples_list
             )
 
         def basis_belongs_data(self):
@@ -269,13 +269,13 @@ class TestGeneralLinearLieAlgebra(TestCase, metaclass=MatrixLieAlgebraParametriz
 
         def to_tangent_is_tangent_data(self):
             return self._to_tangent_is_tangent_data(
-                GeneralLinearLieAlgebra,
+                SquareMatrices,
                 self.space_args_list,
                 self.shape_list,
                 self.n_vecs_list,
             )
 
-    testing_data = TestDataGeneralLinearLieAlgebra()
+    testing_data = TestDataSquareMatrices()
 
     def test_belongs(self, n, mat, expected):
         space = self.space(n)

--- a/tests/tests_geomstats/test_general_linear.py
+++ b/tests/tests_geomstats/test_general_linear.py
@@ -3,15 +3,14 @@
 import random
 
 import geomstats.backend as gs
-from geomstats.geometry.general_linear import GeneralLinear
+from geomstats.geometry.general_linear import GeneralLinear, GeneralLinearLieAlgebra
 from tests.conftest import TestCase
-from tests.data_generation import LieGroupTestData
-from tests.parametrizers import LieGroupParametrizer
+from tests.data_generation import LieGroupTestData, MatrixLieAlgebraTestData
+from tests.parametrizers import LieGroupParametrizer, MatrixLieAlgebraParametrizer
 
 
 class TestGeneralLinear(TestCase, metaclass=LieGroupParametrizer):
     space = group = GeneralLinear
-    skip_test_to_tangent_is_tangent = True
     skip_test_exp_log_composition = True
     skip_test_log_exp_composition = True
 
@@ -216,3 +215,68 @@ class TestGeneralLinear(TestCase, metaclass=LieGroupParametrizer):
         group = self.space(n)
         result = group.orbit(gs.array(point), gs.array(base_point))(time)
         self.assertAllClose(result, gs.array(expected))
+
+
+class TestGeneralLinearLieAlgebra(TestCase, metaclass=MatrixLieAlgebraParametrizer):
+    space = algebra = GeneralLinearLieAlgebra
+
+    class TestDataGeneralLinearLieAlgebra(MatrixLieAlgebraTestData):
+        n_list = random.sample(range(2, 5), 2)
+        space_args_list = [(n,) for n in n_list]
+        shape_list = [(n, n) for n in n_list]
+        n_samples_list = random.sample(range(2, 5), 2)
+        n_points_list = random.sample(range(2, 5), 2)
+        n_vecs_list = random.sample(range(2, 5), 2)
+
+        def belongs_data(self):
+            smoke_data = [
+                dict(n=3, mat=gs.eye(3), expected=True),
+                dict(n=3, mat=gs.ones((3, 3)), expected=True),
+                dict(n=3, mat=gs.ones(3), expected=False),
+            ]
+            return self.generate_tests(smoke_data)
+
+        def basis_representation_matrix_representation_composition_data(self):
+            return self._basis_representation_matrix_representation_composition_data(
+                GeneralLinearLieAlgebra, self.space_args_list, self.n_samples_list
+            )
+
+        def matrix_representation_basis_representation_composition_data(self):
+            return self._matrix_representation_basis_representation_composition_data(
+                GeneralLinearLieAlgebra, self.space_args_list, self.n_samples_list
+            )
+
+        def basis_belongs_data(self):
+            return self._basis_belongs_data(self.space_args_list)
+
+        def basis_cardinality_data(self):
+            return self._basis_cardinality_data(self.space_args_list)
+
+        def random_point_belongs_data(self):
+            smoke_space_args_list = [(2,), (3,)]
+            smoke_n_points_list = [1, 2]
+            return self._random_point_belongs_data(
+                smoke_space_args_list,
+                smoke_n_points_list,
+                self.space_args_list,
+                self.n_points_list,
+            )
+
+        def projection_belongs_data(self):
+            return self._projection_belongs_data(
+                self.space_args_list, self.shape_list, self.n_samples_list
+            )
+
+        def to_tangent_is_tangent_data(self):
+            return self._to_tangent_is_tangent_data(
+                GeneralLinearLieAlgebra,
+                self.space_args_list,
+                self.shape_list,
+                self.n_vecs_list,
+            )
+
+    testing_data = TestDataGeneralLinearLieAlgebra()
+
+    def test_belongs(self, n, mat, expected):
+        space = self.space(n)
+        self.assertAllClose(space.belongs(gs.array(mat)), gs.array(expected))

--- a/tests/tests_geomstats/test_lower_triangular_matrices.py
+++ b/tests/tests_geomstats/test_lower_triangular_matrices.py
@@ -12,7 +12,6 @@ class TestLowerTriangularMatrices(TestCase, metaclass=VectorSpaceParametrizer):
     """Test of LowerTriangularMatrices methods."""
 
     space = LowerTriangularMatrices
-    skip_test_basis_belongs = True
 
     class TestDataLowerTriangularMatrices(VectorSpaceTestData):
         n_list = random.sample(range(2, 5), 2)
@@ -152,7 +151,7 @@ class TestLowerTriangularMatrices(TestCase, metaclass=VectorSpaceParametrizer):
         self.assertAllClose(self.space(n).to_vector(gs.array(mat)), gs.array(expected))
 
     def test_get_basis(self, n, expected):
-        self.assertAllClose(self.space(n).get_basis(), gs.array(expected))
+        self.assertAllClose(self.space(n).basis, gs.array(expected))
 
     def test_projection(self, n, point, expected):
         self.assertAllClose(

--- a/tests/tests_geomstats/test_lower_triangular_matrices.py
+++ b/tests/tests_geomstats/test_lower_triangular_matrices.py
@@ -12,6 +12,7 @@ class TestLowerTriangularMatrices(TestCase, metaclass=VectorSpaceParametrizer):
     """Test of LowerTriangularMatrices methods."""
 
     space = LowerTriangularMatrices
+    skip_test_basis_belongs = True
 
     class TestDataLowerTriangularMatrices(VectorSpaceTestData):
         n_list = random.sample(range(2, 5), 2)

--- a/tests/tests_geomstats/test_matrices.py
+++ b/tests/tests_geomstats/test_matrices.py
@@ -450,7 +450,7 @@ class TestMatrices(TestCase, metaclass=VectorSpaceParametrizer):
                 "strictly_lower_triangular",
                 "strictly_upper_triangular",
             ]
-            list_n = random.sample(range(1, 200), 50)
+            list_n = random.sample(range(1, 100), 50)
             n_samples = 50
             random_data = []
             for matrix_type in matrix_types:

--- a/tests/tests_geomstats/test_matrices.py
+++ b/tests/tests_geomstats/test_matrices.py
@@ -28,8 +28,6 @@ MAT8_33 = [[0.0, 3.0, 4.0], [0.0, 0.0, 6.0], [0.0, 0.0, 0.0]]
 
 class TestMatrices(TestCase, metaclass=VectorSpaceParametrizer):
     space = Matrices
-    skip_test_basis_belongs = True
-    skip_test_basis_cardinality = True
 
     class TestDataMatrices(VectorSpaceTestData):
         m_list = random.sample(range(3, 5), 2)
@@ -496,7 +494,30 @@ class TestMatrices(TestCase, metaclass=VectorSpaceParametrizer):
             )
 
         def basis_data(self):
-            smoke_data = [dict(n=2, m=2), dict(n=2, m=3)]
+            smoke_data = [
+                dict(
+                    n=2,
+                    m=2,
+                    expected=gs.array(
+                        [
+                            gs.array_from_sparse([(i, j)], [1], (2, 2))
+                            for i in range(2)
+                            for j in range(2)
+                        ]
+                    ),
+                ),
+                dict(
+                    n=2,
+                    m=3,
+                    expected=gs.array(
+                        [
+                            gs.array_from_sparse([(i, j)], [1], (2, 3))
+                            for i in range(2)
+                            for j in range(3)
+                        ]
+                    ),
+                ),
+            ]
             return self.generate_tests(smoke_data)
 
     testing_data = TestDataMatrices()
@@ -634,14 +655,7 @@ class TestMatrices(TestCase, metaclass=VectorSpaceParametrizer):
         is_function = getattr(cls_mn, "is_" + matrix_type)
         self.assertAllClose(gs.all(is_function(to_function(gs.array(mat)))), True)
 
-    def test_basis(self, m, n):
-        expected = gs.array(
-            [
-                gs.array_from_sparse([(i, j)], [1], (m, n))
-                for i in range(m)
-                for j in range(n)
-            ]
-        )
+    def test_basis(self, m, n, expected):
         result = Matrices(m, n).basis
         self.assertAllClose(result, expected)
 

--- a/tests/tests_geomstats/test_matrices.py
+++ b/tests/tests_geomstats/test_matrices.py
@@ -495,6 +495,10 @@ class TestMatrices(TestCase, metaclass=VectorSpaceParametrizer):
                 is_tangent_atol,
             )
 
+        def basis_data(self):
+            smoke_data = [dict(n=2, m=2), dict(n=2, m=3)]
+            return self.generate_tests(smoke_data)
+
     testing_data = TestDataMatrices()
 
     def test_belongs(self, m, n, mat, expected):
@@ -629,6 +633,17 @@ class TestMatrices(TestCase, metaclass=VectorSpaceParametrizer):
         to_function = getattr(cls_mn, "to_" + matrix_type)
         is_function = getattr(cls_mn, "is_" + matrix_type)
         self.assertAllClose(gs.all(is_function(to_function(gs.array(mat)))), True)
+
+    def test_basis(self, m, n):
+        expected = gs.array(
+            [
+                gs.array_from_sparse([(i, j)], [1], (m, n))
+                for i in range(m)
+                for j in range(n)
+            ]
+        )
+        result = Matrices(m, n).basis
+        self.assertAllClose(result, expected)
 
 
 class TestMatricesMetric(TestCase, metaclass=RiemannianMetricParametrizer):

--- a/tests/tests_geomstats/test_symmetric_matrices.py
+++ b/tests/tests_geomstats/test_symmetric_matrices.py
@@ -166,7 +166,7 @@ class TestSymmetricMatrices(TestCase, metaclass=VectorSpaceParametrizer):
         self.assertAllClose(result, gs.array(expected))
 
     def test_basis(self, n, basis):
-        self.assertAllClose(SymmetricMatrices(n).get_basis(), gs.array(basis))
+        self.assertAllClose(SymmetricMatrices(n).basis, gs.array(basis))
 
     def test_expm(self, mat, expected):
         result = SymmetricMatrices.expm(gs.array(mat))


### PR DESCRIPTION
The `basis` is turned into a property of all vector spaces. It is only created and stored if needed, to avoid memory overload.

closes #1336 