### PR TITLE
Correct metrics for PSD matrices

### DIFF
--- a/geomstats/geometry/rank_k_psd_matrices.py
+++ b/geomstats/geometry/rank_k_psd_matrices.py
@@ -9,10 +9,8 @@ from geomstats.geometry.manifold import Manifold
 from geomstats.geometry.matrices import Matrices
 from geomstats.geometry.spd_matrices import (
     SPDMatrices,
-    SPDMetricAffine,
     SPDMetricBuresWasserstein,
     SPDMetricEuclidean,
-    SPDMetricLogEuclidean,
 )
 from geomstats.geometry.symmetric_matrices import SymmetricMatrices
 
@@ -184,10 +182,6 @@ class RankKPSDMatrices(Manifold):
 PSDMetricBuresWasserstein = SPDMetricBuresWasserstein
 
 PSDMetricEuclidean = SPDMetricEuclidean
-
-PSDMetricLogEuclidean = SPDMetricLogEuclidean
-
-PSDMetricAffine = SPDMetricAffine
 
 
 class PSDMatrices(RankKPSDMatrices, SPDMatrices):


### PR DESCRIPTION
closes #1352 

This PR is to remove LogEclidean and AffineInvariant metrics for PSD matrices manifold defined in `rank_k_psd_matrices`.