### PR TITLE
Make VectorSpace basis property more consistent

### DIFF
--- a/geomstats/geometry/base.py
+++ b/geomstats/geometry/base.py
@@ -29,7 +29,7 @@ class VectorSpace(Manifold, abc.ABC):
             kwargs["dim"] = int(gs.prod(gs.array(shape)))
         super(VectorSpace, self).__init__(shape=shape, **kwargs)
         self.shape = shape
-        self.basis = None
+        self._basis = None
 
     def belongs(self, point, atol=gs.atol):
         """Evaluate if the point belongs to the vector space.
@@ -148,7 +148,7 @@ class VectorSpace(Manifold, abc.ABC):
 
     @basis.setter
     def basis(self, basis):
-        if basis is not None and len(basis) < self.dim:
+        if len(basis) < self.dim:
             raise ValueError(
                 "The basis should have length equal to the " "dimension of the space."
             )

--- a/geomstats/geometry/lie_algebra.py
+++ b/geomstats/geometry/lie_algebra.py
@@ -36,7 +36,6 @@ class MatrixLieAlgebra(VectorSpace, abc.ABC):
         geomstats.errors.check_integer(dim, "dim")
         geomstats.errors.check_integer(n, "n")
         self.dim = dim
-        self.basis = None
         self.n = n
 
     bracket = Matrices.bracket

--- a/geomstats/geometry/matrices.py
+++ b/geomstats/geometry/matrices.py
@@ -28,7 +28,6 @@ class Matrices(VectorSpace):
         geomstats.errors.check_integer(m, "m")
         self.m = m
         self.n = n
-        self.basis = None
 
     def _create_basis(self):
         """Create the canonical basis."""


### PR DESCRIPTION
It will initialize `_basis`, instead of `basis` in VectorSpace instantiation.