### PR TITLE
speedup parallel transport on SPD manifold

### DIFF
--- a/geomstats/geometry/spd_matrices.py
+++ b/geomstats/geometry/spd_matrices.py
@@ -712,9 +712,12 @@ class SPDMetricAffine(RiemannianMetric):
         """
         if end_point is None:
             end_point = self.exp(direction, base_point)
-        inverse_base_point = GeneralLinear.inverse(base_point)
-        congruence_mat = Matrices.mul(end_point, inverse_base_point)
-        congruence_mat = gs.linalg.sqrtm(congruence_mat)
+        # compute B^1/2(B^-1/2 A B^-1/2)B^-1/2 instead of sqrtm(AB^-1)
+        sqrt_bp, inv_sqrt_bp = SymmetricMatrices.powerm(base_point, [1.0 / 2, -1.0 / 2])
+        pdt = SymmetricMatrices.powerm(
+            Matrices.mul(inv_sqrt_bp, end_point, inv_sqrt_bp), 1.0 / 2
+        )
+        congruence_mat = Matrices.mul(sqrt_bp, pdt, inv_sqrt_bp)
         return Matrices.congruent(tangent_vec, congruence_mat)
 
 


### PR DESCRIPTION
Trying to use Bures-Wasserstein metric, we realize that is possible to avoid inverting a matrix in the parallel transport for Affine Invariant metric by using a rewriting of the squareroot of a product: sqrtm(AB^-1) being rewrite as B^1/2(B^-1/2 A B^-1/2)B^-1/2 instead.

Tests on random points shows a speedup of 1.3x for small dimension (5) up to 3x for larger dimension (100-150) with the different backend. The code results in the same results, up to the machine precision. 