### PR TITLE
Fix tests for composition of exp and log of BW metric on SPD

### DIFF
--- a/geomstats/geometry/spd_matrices.py
+++ b/geomstats/geometry/spd_matrices.py
@@ -830,10 +830,11 @@ class SPDMetricBuresWasserstein(RiemannianMetric):
         log : array-like, shape=[..., n, n]
             Riemannian logarithm.
         """
-        product = gs.matmul(base_point, point)
-        sqrt_product = gs.linalg.sqrtm(product)
+        # compute B^1/2(B^-1/2 A B^-1/2)B^-1/2 instead of sqrtm(AB^-1)
+        sqrt_bp, inv_sqrt_bp = SymmetricMatrices.powerm(base_point, [0.5, -0.5])
+        pdt = SymmetricMatrices.powerm(Matrices.mul(sqrt_bp, point, sqrt_bp), 0.5)
+        sqrt_product = Matrices.mul(sqrt_bp, pdt, inv_sqrt_bp)
         transp_sqrt_product = Matrices.transpose(sqrt_product)
-
         return sqrt_product + transp_sqrt_product - 2 * base_point
 
     def squared_dist(self, point_a, point_b, **kwargs):

--- a/tests/data_generation.py
+++ b/tests/data_generation.py
@@ -685,6 +685,7 @@ class ConnectionTestData(TestData):
         shape_list,
         n_samples_list,
         smoke_data=None,
+        amplitude=1.0,
         rtol=gs.rtol,
         atol=gs.atol,
     ):
@@ -700,6 +701,9 @@ class ConnectionTestData(TestData):
             List of shapes for random data to generate.
         n_samples_list : list
             List of number of random data to generate.
+        amplitude : float
+            Factor to scale the amplitude of a tangent vector to stay in the
+            injectivity domain of the exponential map.
         """
         random_data = []
         for connection_args, space, shape, n_samples in zip(
@@ -707,7 +711,7 @@ class ConnectionTestData(TestData):
         ):
             base_point = space.random_point()
             tangent_vec = space.to_tangent(
-                gs.random.normal(size=(n_samples,) + shape), base_point
+                gs.random.normal(size=(n_samples,) + shape) / amplitude, base_point
             )
             random_data.append(
                 dict(

--- a/tests/tests_geomstats/test_spd_matrices.py
+++ b/tests/tests_geomstats/test_spd_matrices.py
@@ -320,8 +320,6 @@ class TestSPDMetricAffine(
     skip_test_parallel_transport_ivp_is_isometry = True
     skip_test_parallel_transport_bvp_is_isometry = True
     skip_test_exp_geodesic_ivp = True
-    skip_test_log_exp_composition = True
-    skip_test_exp_log_composition = True
     skip_test_exp_ladder_parallel_transport = True
 
     class TestDataSPDMetricAffine(RiemannianMetricTestData):
@@ -524,8 +522,6 @@ class TestSPDMetricBuresWasserstein(TestCase, metaclass=RiemannianMetricParametr
     skip_test_parallel_transport_ivp_is_isometry = True
     skip_test_parallel_transport_bvp_is_isometry = True
     skip_test_exp_geodesic_ivp = True
-    # skip_test_log_exp_composition = True
-    skip_test_exp_log_composition = True
 
     class TestDataSPDMetricBuresWasserstein(RiemannianMetricTestData):
         n_list = random.sample(range(2, 7), 5)
@@ -659,8 +655,9 @@ class TestSPDMetricBuresWasserstein(TestCase, metaclass=RiemannianMetricParametr
                 self.space_list,
                 self.shape_list,
                 self.n_samples_list,
-                rtol=gs.rtol * 100,
-                atol=gs.atol * 10000,
+                amplitude=7.0,
+                rtol=gs.rtol,
+                atol=gs.atol,
             )
 
         def exp_ladder_parallel_transport_data(self):

--- a/tests/tests_geomstats/test_spd_matrices.py
+++ b/tests/tests_geomstats/test_spd_matrices.py
@@ -524,7 +524,7 @@ class TestSPDMetricBuresWasserstein(TestCase, metaclass=RiemannianMetricParametr
     skip_test_parallel_transport_ivp_is_isometry = True
     skip_test_parallel_transport_bvp_is_isometry = True
     skip_test_exp_geodesic_ivp = True
-    skip_test_log_exp_composition = True
+    # skip_test_log_exp_composition = True
     skip_test_exp_log_composition = True
 
     class TestDataSPDMetricBuresWasserstein(RiemannianMetricTestData):

--- a/tests/tests_geomstats/test_spd_matrices.py
+++ b/tests/tests_geomstats/test_spd_matrices.py
@@ -645,8 +645,8 @@ class TestSPDMetricBuresWasserstein(TestCase, metaclass=RiemannianMetricParametr
                 self.metric_args_list,
                 self.space_list,
                 self.n_samples_list,
-                rtol=gs.rtol * 100,
-                atol=gs.atol * 10000,
+                rtol=gs.rtol * 10,
+                atol=gs.atol * 10,
             )
 
         def exp_log_composition_data(self):
@@ -656,8 +656,8 @@ class TestSPDMetricBuresWasserstein(TestCase, metaclass=RiemannianMetricParametr
                 self.shape_list,
                 self.n_samples_list,
                 amplitude=7.0,
-                rtol=gs.rtol,
-                atol=gs.atol,
+                rtol=gs.rtol * 10,
+                atol=gs.atol * 10,
             )
 
         def exp_ladder_parallel_transport_data(self):


### PR DESCRIPTION
- The log is now implemented using only eigen decomposition of symmetric matrices instead of linalg.sqrtm
- An `amplitude` parameter is added in the log_exp composition test to stay within the injectivity radius of exp