### PR TITLE
add amplitude param to test exp_log_composition

### DIFF
--- a/tests/data_generation.py
+++ b/tests/data_generation.py
@@ -685,6 +685,7 @@ class ConnectionTestData(TestData):
         shape_list,
         n_samples_list,
         smoke_data=None,
+        amplitude=1.0,
         rtol=gs.rtol,
         atol=gs.atol,
     ):
@@ -700,6 +701,9 @@ class ConnectionTestData(TestData):
             List of shapes for random data to generate.
         n_samples_list : list
             List of number of random data to generate.
+        amplitude : float
+            Factor to scale the amplitude of a tangent vector to stay in the
+            injectivity domain of the exponential map.
         """
         random_data = []
         for connection_args, space, shape, n_samples in zip(
@@ -707,7 +711,7 @@ class ConnectionTestData(TestData):
         ):
             base_point = space.random_point()
             tangent_vec = space.to_tangent(
-                gs.random.normal(size=(n_samples,) + shape), base_point
+                gs.random.normal(size=(n_samples,) + shape) / amplitude, base_point
             )
             random_data.append(
                 dict(

--- a/tests/tests_geomstats/test_hypersphere.py
+++ b/tests/tests_geomstats/test_hypersphere.py
@@ -397,7 +397,6 @@ class TestHypersphere(TestCase, metaclass=LevelSetParametrizer):
 class TestHypersphereMetric(TestCase, metaclass=RiemannianMetricParametrizer):
     metric = connection = HypersphereMetric
     skip_test_exp_geodesic_ivp = True
-    skip_test_exp_log_composition = True
 
     class TestDataHypersphereMetric(RiemannianMetricTestData):
         dim_list = random.sample(range(2, 7), 5)
@@ -574,10 +573,8 @@ class TestHypersphereMetric(TestCase, metaclass=RiemannianMetricParametrizer):
             )
 
         def exp_log_composition_data(self):
-            base_point = gs.array([10.0, -2.0, -0.5, 34.0, 3.0])
-            base_point = base_point / gs.linalg.norm(base_point)
-            vector = 1e-4 * gs.array([0.06, -51.0, 6.0, 5.0, 3.0])
-            tangent_vec = self.space.to_tangent(vector=vector, base_point=base_point)
+            base_point = gs.array([1.0, 0.0, 0.0, 0.0])
+            tangent_vec = gs.array([0.0, 0.0, gs.pi / 6, 0.0])
 
             smoke_data = [
                 dict(
@@ -594,8 +591,9 @@ class TestHypersphereMetric(TestCase, metaclass=RiemannianMetricParametrizer):
                 self.shape_list,
                 self.n_samples_list,
                 smoke_data,
-                rtol=gs.rtol * 100,
-                atol=1e-3,
+                amplitude=gs.pi / 2.0,
+                rtol=gs.rtol,
+                atol=gs.atol,
             )
 
         def exp_ladder_parallel_transport_data(self):


### PR DESCRIPTION
An amplitude parameter is added in the log_exp composition test to stay within the injectivity radius of exp. This will allow to test exp_log_composition