### PR TITLE
add projection for vector representations of SEn

### DIFF
--- a/geomstats/geometry/special_euclidean.py
+++ b/geomstats/geometry/special_euclidean.py
@@ -375,7 +375,7 @@ class _SpecialEuclideanVectors(LieGroup):
 
         Parameters
         ----------
-        point : array-like, shape=[..., dimension]
+        point : array-like, shape=[..., dim]
             Point to check.
 
         Returns
@@ -391,23 +391,40 @@ class _SpecialEuclideanVectors(LieGroup):
         )
         return belongs
 
+    def projection(self, point):
+        """Project a point to the group.
+
+        The point is regularized, so that the norm of the rotation part lie in [0, pi).
+
+        Parameters
+        ----------
+        point: array-like, shape[..., dim]
+            Point.
+
+        Returns
+        -------
+        projected: array-like, shape[..., dim]
+            Regularized point.
+        """
+        return self.regularize(point)
+
     def regularize(self, point):
         """Regularize a point to the default representation for SE(n).
 
         Parameters
         ----------
-        point : array-like, shape=[..., 3]
+        point : array-like, shape=[..., dim]
             Point to regularize.
 
         Returns
         -------
-        point : array-like, shape=[..., 3]
+        point : array-like, shape=[..., dim]
             Regularized point.
         """
         rotations = self.rotations
         dim_rotations = rotations.dim
 
-        regularized_point = point
+        regularized_point = gs.copy(point)
         rot_vec = regularized_point[..., :dim_rotations]
         regularized_rot_vec = rotations.regularize(rot_vec)
 
@@ -421,7 +438,7 @@ class _SpecialEuclideanVectors(LieGroup):
 
         Parameters
         ----------
-        tangent_vec: array-like, shape=[..., 3]
+        tangent_vec: array-like, shape=[..., dim]
             Tangent vector at base point.
         metric : RiemannianMetric
             Metric.
@@ -429,7 +446,7 @@ class _SpecialEuclideanVectors(LieGroup):
 
         Returns
         -------
-        regularized_vec : array-like, shape=[..., 3]
+        regularized_vec : array-like, shape=[..., dim]
             Regularized vector.
         """
         return self.regularize_tangent_vec(tangent_vec, self.identity, metric)
@@ -440,7 +457,7 @@ class _SpecialEuclideanVectors(LieGroup):
 
         Parameters
         ----------
-        vec : array-like, shape=[..., dimension]
+        vec : array-like, shape=[..., dim]
             Vector.
 
         Returns
@@ -467,9 +484,9 @@ class _SpecialEuclideanVectors(LieGroup):
 
         Parameters
         ----------
-        point_a : array-like, shape=[..., dimension]
+        point_a : array-like, shape=[..., dim]
             Point of the group.
-        point_b : array-like, shape=[..., dimension]
+        point_b : array-like, shape=[..., dim]
             Point of the group.
 
         Equation
@@ -478,7 +495,7 @@ class _SpecialEuclideanVectors(LieGroup):
 
         Returns
         -------
-        composition : array-like, shape=[..., dimension]
+        composition : array-like, shape=[..., dim]
             Composition of point_a and point_b.
         """
         rotations = self.rotations
@@ -514,12 +531,12 @@ class _SpecialEuclideanVectors(LieGroup):
 
         Parameters
         ----------
-        point: array-like, shape=[..., dimension]
+        point: array-like, shape=[..., dim]
             Point.
 
         Returns
         -------
-        inverse_point : array-like, shape=[..., dimension]
+        inverse_point : array-like, shape=[..., dim]
             Inverted point.
 
         Notes
@@ -618,7 +635,7 @@ class _SpecialEuclideanVectors(LieGroup):
 
         Returns
         -------
-        random_point : array-like, shape=[..., dimension]
+        random_point : array-like, shape=[..., dim]
             Sample.
         """
         random_translation = self.translations.random_point(n_samples, bound)


### PR DESCRIPTION
closes #1400 

The projection method of _SpecialOrthogonalVectors is inconsistent though, because it expects a matrix input.