### PR TITLE
Add KMeans++ initialization

### DIFF
--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -831,5 +831,5 @@ def sort(a, axis=-1):
 
 
 def amin(a, axis=-1):
-    (values, indices) = torch.min(a, dim=axis)
+    (values, _) = torch.min(a, dim=axis)
     return values

--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -32,9 +32,7 @@ from torch import (
 from torch import fmod as mod
 from torch import greater, hstack, imag, int32, int64, isnan, less, log, logical_or
 from torch import max as amax
-from torch import mean, meshgrid
-from torch import min as amin
-from torch import nonzero, ones, ones_like, outer, polygamma
+from torch import mean, meshgrid, nonzero, ones, ones_like, outer, polygamma
 from torch import pow as power
 from torch import real
 from torch import repeat_interleave as repeat
@@ -830,3 +828,8 @@ def ravel_tril_indices(n, k=0, m=None):
 def sort(a, axis=-1):
     sorted_a, _ = torch.sort(a, dim=axis)
     return sorted_a
+
+
+def amin(a, axis=None):
+    (values, indices) = torch.min(a, dim=axis)
+    return values

--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -830,6 +830,6 @@ def sort(a, axis=-1):
     return sorted_a
 
 
-def amin(a, axis=None):
+def amin(a, axis=-1):
     (values, indices) = torch.min(a, dim=axis)
     return values

--- a/tests/tests_geomstats/test_riemannian_kmeans.py
+++ b/tests/tests_geomstats/test_riemannian_kmeans.py
@@ -66,7 +66,7 @@ class TestRiemannianKMeans(geomstats.tests.TestCase):
         )
         self.assertAllClose(expected, result)
 
-    def test_initialization(self):
+    def test_hypersphere_kmeans_initialization(self):
         gs.random.seed(55)
 
         manifold = hypersphere.Hypersphere(2)

--- a/tests/tests_geomstats/test_riemannian_kmeans.py
+++ b/tests/tests_geomstats/test_riemannian_kmeans.py
@@ -65,3 +65,21 @@ class TestRiemannianKMeans(geomstats.tests.TestCase):
             [int(metric.closest_neighbor_index(x_i, centroids)) for x_i in x]
         )
         self.assertAllClose(expected, result)
+
+    def test_initialization(self):
+        gs.random.seed(55)
+
+        manifold = hypersphere.Hypersphere(2)
+        metric = hypersphere.HypersphereMetric(2)
+
+        x = manifold.random_von_mises_fisher(kappa=100, n_samples=200)
+
+        n_clusters = 3
+        kmeans = RiemannianKMeans(
+            metric, n_clusters, init_step_size=1.0, tol=1e-3, init="kmeans++"
+        )
+        kmeans.fit(x)
+        centroids = kmeans.centroids
+        result = centroids.shape
+        expected = (n_clusters, 3)
+        self.assertAllClose(expected, result)


### PR DESCRIPTION
Improve KMeans by:
- adding KMeans++ initialization (choose one centroid randomly, then choose the others by maximizing the distance to the centroids already chosen)
- adding prints in the verbose mode, in particular the evolution of the convergence criterion
-  returning the variance of the clustering, to be able to compare different solutions obtained by running kmeans several times and picking best one.
- returning the clustering labels at the `.fit` method so that one does not need to run the `.predict` method if the set of points is the same.