### PR TITLE
change then by after

### DIFF
--- a/tests/data_generation.py
+++ b/tests/data_generation.py
@@ -221,7 +221,7 @@ class _OpenSetTestData(_ManifoldTestData):
 
 
 class _LevelSetTestData(_ManifoldTestData):
-    def _extrinsic_then_intrinsic_test_data(
+    def _intrinsic_after_extrinsic_test_data(
         self, space_cls, space_args_list, n_points_list, rtol=gs.rtol, atol=gs.atol
     ):
         """Generate data to check that changing coordinate system twice gives back the point.
@@ -254,7 +254,7 @@ class _LevelSetTestData(_ManifoldTestData):
         ]
         return self.generate_tests([], random_data)
 
-    def _intrinsic_then_extrinsic_test_data(
+    def _extrinsic_after_intrinsic_test_data(
         self, space_cls, space_args_list, n_points_list, rtol=gs.rtol, atol=gs.atol
     ):
         """Generate data to check that changing coordinate system twice gives back the point.
@@ -572,7 +572,7 @@ class _VectorSpaceTestData(_ManifoldTestData):
 
 
 class _MatrixLieAlgebraTestData(_VectorSpaceTestData):
-    def _basis_representation_then_matrix_representation_test_data(
+    def _matrix_representation_after_basis_representation_test_data(
         self, space_cls, space_args_list, n_points_list, rtol=gs.rtol, atol=gs.atol
     ):
         """Generate data to check that changing coordinates twice gives back the point.
@@ -597,7 +597,7 @@ class _MatrixLieAlgebraTestData(_VectorSpaceTestData):
         ]
         return self.generate_tests([], random_data)
 
-    def _matrix_representation_then_basis_representation_test_data(
+    def _basis_representation_after_matrix_representation_test_data(
         self, space_cls, space_args_list, n_points_list, rtol=gs.rtol, atol=gs.atol
     ):
         """Generate data to check that changing coordinates twice gives back the point.

--- a/tests/data_generation.py
+++ b/tests/data_generation.py
@@ -386,7 +386,7 @@ class _LieGroupTestData(_ManifoldTestData):
             group_cls, group_args_list, n_points_list, rtol, atol
         )
 
-    def _exp_then_log_test_data(
+    def _log_after_exp_test_data(
         self,
         group_cls,
         group_args_list,
@@ -433,7 +433,7 @@ class _LieGroupTestData(_ManifoldTestData):
             smoke_data = []
         return self.generate_tests(smoke_data, random_data)
 
-    def _log_then_exp_test_data(
+    def _exp_after_log_test_data(
         self,
         group_cls,
         group_args_list,
@@ -930,7 +930,7 @@ class _ConnectionTestData(TestData):
             )
         return self.generate_tests([], random_data)
 
-    def _log_then_exp_test_data(
+    def _exp_after_log_test_data(
         self,
         connection_args_list,
         space_list,
@@ -969,7 +969,7 @@ class _ConnectionTestData(TestData):
             smoke_data = []
         return self.generate_tests(smoke_data, random_data)
 
-    def _exp_then_log_test_data(
+    def _log_after_exp_test_data(
         self,
         connection_args_list,
         space_list,

--- a/tests/geometry_test_cases.py
+++ b/tests/geometry_test_cases.py
@@ -240,7 +240,7 @@ class LieGroupTestCase(ManifoldTestCase):
         )
         self.assertAllClose(result, point, rtol=rtol, atol=atol)
 
-    def test_exp_then_log(self, group_args, tangent_vec, base_point, rtol, atol):
+    def test_log_after_exp(self, group_args, tangent_vec, base_point, rtol, atol):
         """Check that group exponential and logarithm are inverse.
 
         This is calling group exponential first, then group logarithm.
@@ -263,7 +263,7 @@ class LieGroupTestCase(ManifoldTestCase):
         log_vec = group.log(exp_point, gs.array(base_point))
         self.assertAllClose(log_vec, gs.array(tangent_vec), rtol, atol)
 
-    def test_log_then_exp(self, group_args, point, base_point, rtol, atol):
+    def test_exp_after_log(self, group_args, point, base_point, rtol, atol):
         """Check that group exponential and logarithm are inverse.
 
         This is calling group logarithm first, then group exponential.
@@ -355,7 +355,7 @@ class VectorSpaceTestCase(ManifoldTestCase):
 
 
 class MatrixLieAlgebraTestCase(VectorSpaceTestCase):
-    def test_basis_representation_then_matrix_representation(
+    def test_matrix_representation_after_basis_representation(
         self, algebra_args, matrix_rep, rtol, atol
     ):
         """Check that changing coordinate system twice gives back the point.
@@ -379,7 +379,7 @@ class MatrixLieAlgebraTestCase(VectorSpaceTestCase):
         result = algebra.matrix_representation(basis_rep)
         self.assertAllClose(result, gs.array(matrix_rep), rtol, atol)
 
-    def test_matrix_representation_then_basis_representation(
+    def test_basis_representation_after_matrix_representation(
         self,
         algebra_args,
         basis_rep,
@@ -409,7 +409,7 @@ class MatrixLieAlgebraTestCase(VectorSpaceTestCase):
 
 
 class LevelSetTestCase(ManifoldTestCase):
-    def test_extrinsic_then_intrinsic(self, space_args, point_extrinsic, rtol, atol):
+    def test_intrinsic_after_extrinsic(self, space_args, point_extrinsic, rtol, atol):
         """Check that changing coordinate system twice gives back the point.
 
         A point written in extrinsic coordinates is converted to
@@ -432,7 +432,7 @@ class LevelSetTestCase(ManifoldTestCase):
         expected = point_extrinsic
         self.assertAllClose(result, expected, rtol, atol)
 
-    def test_intrinsic_then_extrinsic(self, space_args, point_intrinsic, rtol, atol):
+    def test_extrinsic_after_intrinsic(self, space_args, point_intrinsic, rtol, atol):
         """Check that changing coordinate system twice gives back the point.
 
         A point written in intrinsic coordinates is converted to
@@ -656,7 +656,7 @@ class ConnectionTestCase(TestCase):
 
         self.assertAllClose(result, expected)
 
-    def test_log_then_exp(self, connection_args, point, base_point, rtol, atol):
+    def test_exp_after_log(self, connection_args, point, base_point, rtol, atol):
         """Check that connection logarithm and exponential are inverse.
 
         This is calling connection logarithm first, then connection exponential.
@@ -679,7 +679,7 @@ class ConnectionTestCase(TestCase):
         result = connection.exp(tangent_vec=log, base_point=gs.array(base_point))
         self.assertAllClose(result, point, rtol=rtol, atol=atol)
 
-    def test_exp_then_log(self, connection_args, tangent_vec, base_point, rtol, atol):
+    def test_log_after_exp(self, connection_args, tangent_vec, base_point, rtol, atol):
         """Check that connection exponential and logarithm are inverse.
 
         This is calling connection exponential first, then connection logarithm.

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -27,7 +27,7 @@ def left_log_then_exp_from_identity(metric, point):
     return result
 
 
-def left_exp_then_log_from_identity(metric, tangent_vec):
+def left_log_after_exp_from_identity(metric, tangent_vec):
     aux = metric.left_exp_from_identity(tangent_vec=tangent_vec)
     result = metric.left_log_from_identity(point=aux)
     return result
@@ -39,7 +39,7 @@ def log_then_exp_from_identity(metric, point):
     return result
 
 
-def exp_then_log_from_identity(metric, tangent_vec):
+def log_after_exp_from_identity(metric, tangent_vec):
     aux = metric.exp_from_identity(tangent_vec=tangent_vec)
     result = metric.log_from_identity(point=aux)
     return result
@@ -51,7 +51,7 @@ def log_then_exp(metric, point, base_point=None):
     return result
 
 
-def exp_then_log(metric, tangent_vec, base_point=None):
+def log_after_exp(metric, tangent_vec, base_point=None):
     aux = metric.exp(tangent_vec=tangent_vec, base_point=base_point)
     result = metric.log(point=aux, base_point=base_point)
     return result
@@ -63,7 +63,7 @@ def group_log_then_exp_from_identity(group, point):
     return result
 
 
-def group_exp_then_log_from_identity(group, tangent_vec):
+def group_log_after_exp_from_identity(group, tangent_vec):
     aux = group.exp_from_identity(tangent_vec=tangent_vec)
     result = group.log_from_identity(point=aux)
     return result
@@ -75,7 +75,7 @@ def group_log_then_exp(group, point, base_point):
     return result
 
 
-def group_exp_then_log(group, tangent_vec, base_point):
+def group_log_after_exp(group, tangent_vec, base_point):
     aux = group.exp(tangent_vec=tangent_vec, base_point=base_point)
     result = group.log(point=aux, base_point=base_point)
     return result

--- a/tests/tests_geomstats/test_euclidean.py
+++ b/tests/tests_geomstats/test_euclidean.py
@@ -356,8 +356,8 @@ class TestEuclideanMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
                 belongs_atol=gs.atol * 1000,
             )
 
-        def log_then_exp_test_data(self):
-            return self._log_then_exp_test_data(
+        def exp_after_log_test_data(self):
+            return self._exp_after_log_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.n_points_list,
@@ -365,8 +365,8 @@ class TestEuclideanMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
                 atol=gs.atol * 10000,
             )
 
-        def exp_then_log_test_data(self):
-            return self._exp_then_log_test_data(
+        def log_after_exp_test_data(self):
+            return self._log_after_exp_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.shape_list,

--- a/tests/tests_geomstats/test_full_rank_correlation_matrices.py
+++ b/tests/tests_geomstats/test_full_rank_correlation_matrices.py
@@ -19,8 +19,8 @@ from tests.geometry_test_cases import LevelSetTestCase
 class TestFullRankCorrelationMatrices(LevelSetTestCase, metaclass=Parametrizer):
 
     space = FullRankCorrelationMatrices
-    skip_test_extrinsic_then_intrinsic = True
-    skip_test_intrinsic_then_extrinsic = True
+    skip_test_intrinsic_after_extrinsic = True
+    skip_test_extrinsic_after_intrinsic = True
 
     class RankFullRankCorrelationMatricesTestData(_LevelSetTestData):
 

--- a/tests/tests_geomstats/test_general_linear.py
+++ b/tests/tests_geomstats/test_general_linear.py
@@ -182,8 +182,8 @@ class TestGeneralLinear(LieGroupTestCase, OpenSetTestCase, metaclass=Parametrize
                 GeneralLinear, self.space_args_list, self.shape_list
             )
 
-        def exp_then_log_test_data(self):
-            return self._exp_then_log_test_data(
+        def log_after_exp_test_data(self):
+            return self._log_after_exp_test_data(
                 GeneralLinear,
                 self.space_args_list,
                 self.shape_list,
@@ -192,8 +192,8 @@ class TestGeneralLinear(LieGroupTestCase, OpenSetTestCase, metaclass=Parametrize
                 atol=gs.atol * 100000,
             )
 
-        def log_then_exp_test_data(self):
-            return self._log_then_exp_test_data(
+        def exp_after_log_test_data(self):
+            return self._exp_after_log_test_data(
                 GeneralLinear, self.space_args_list, self.n_samples_list, atol=1e-2
             )
 

--- a/tests/tests_geomstats/test_general_linear.py
+++ b/tests/tests_geomstats/test_general_linear.py
@@ -19,8 +19,8 @@ from tests.geometry_test_cases import (
 
 class TestGeneralLinear(LieGroupTestCase, OpenSetTestCase, metaclass=Parametrizer):
     space = group = GeneralLinear
-    skip_test_exp_then_log = True
-    skip_test_log_then_exp = True
+    skip_test_log_after_exp = True
+    skip_test_exp_after_log = True
 
     class GeneralLinearTestData(_LieGroupTestData, _OpenSetTestData):
         n_list = random.sample(range(2, 5), 2)
@@ -276,13 +276,13 @@ class TestSquareMatrices(MatrixLieAlgebraTestCase, metaclass=Parametrizer):
             ]
             return self.generate_tests(smoke_data)
 
-        def basis_representation_then_matrix_representation_test_data(self):
-            return self._basis_representation_then_matrix_representation_test_data(
+        def matrix_representation_after_basis_representation_test_data(self):
+            return self._matrix_representation_after_basis_representation_test_data(
                 SquareMatrices, self.space_args_list, self.n_samples_list
             )
 
-        def matrix_representation_then_basis_representation_test_data(self):
-            return self._matrix_representation_then_basis_representation_test_data(
+        def basis_representation_after_matrix_representation_test_data(self):
+            return self._basis_representation_after_matrix_representation_test_data(
                 SquareMatrices, self.space_args_list, self.n_samples_list
             )
 

--- a/tests/tests_geomstats/test_grassmannian.py
+++ b/tests/tests_geomstats/test_grassmannian.py
@@ -178,8 +178,8 @@ class TestGrassmannianCanonicalMetric(RiemannianMetricTestCase, metaclass=Parame
                 belongs_atol=gs.atol * 10000,
             )
 
-        def log_then_exp_test_data(self):
-            return self._log_then_exp_test_data(
+        def exp_after_log_test_data(self):
+            return self._exp_after_log_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.n_points_list,
@@ -187,8 +187,8 @@ class TestGrassmannianCanonicalMetric(RiemannianMetricTestCase, metaclass=Parame
                 atol=gs.atol * 10000,
             )
 
-        def exp_then_log_test_data(self):
-            return self._exp_then_log_test_data(
+        def log_after_exp_test_data(self):
+            return self._log_after_exp_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.shape_list,

--- a/tests/tests_geomstats/test_grassmannian.py
+++ b/tests/tests_geomstats/test_grassmannian.py
@@ -21,8 +21,8 @@ pi_4 = gs.pi / 4
 
 class TestGrassmannian(LevelSetTestCase, metaclass=Parametrizer):
     space = Grassmannian
-    skip_test_extrinsic_then_intrinsic = True
-    skip_test_intrinsic_then_extrinsic = True
+    skip_test_intrinsic_after_extrinsic = True
+    skip_test_extrinsic_after_intrinsic = True
 
     class GrassmannianTestData(_LevelSetTestData):
         n_list = random.sample(range(3, 6), 2)
@@ -85,7 +85,7 @@ class TestGrassmannian(LevelSetTestCase, metaclass=Parametrizer):
 
 class TestGrassmannianCanonicalMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
     metric = connection = GrassmannianCanonicalMetric
-    skip_test_exp_then_log = True
+    skip_test_log_after_exp = True
     skip_test_exp_geodesic_ivp = True
     skip_test_log_is_tangent = not np_backend()
 

--- a/tests/tests_geomstats/test_heisenberg.py
+++ b/tests/tests_geomstats/test_heisenberg.py
@@ -79,16 +79,16 @@ class TestHeisenbergVectors(
                 self.n_vecs_list,
             )
 
-        def exp_then_log_test_data(self):
-            return self._exp_then_log_test_data(
+        def log_after_exp_test_data(self):
+            return self._log_after_exp_test_data(
                 HeisenbergVectors,
                 self.space_args_list,
                 self.shape_list,
                 self.n_tangent_vecs_list,
             )
 
-        def log_then_exp_test_data(self):
-            return self._log_then_exp_test_data(
+        def exp_after_log_test_data(self):
+            return self._exp_after_log_test_data(
                 HeisenbergVectors, self.space_args_list, self.n_points_list
             )
 

--- a/tests/tests_geomstats/test_hyperbolic.py
+++ b/tests/tests_geomstats/test_hyperbolic.py
@@ -21,7 +21,7 @@ RTOL = 1e-6
 
 class TestHyperbolic(LevelSetTestCase, metaclass=Parametrizer):
     space = Hyperboloid
-    skip_test_intrinsic_then_extrinsic = True
+    skip_test_extrinsic_after_intrinsic = True
     skip_test_projection_belongs = True
 
     class HyperbolicTestData(_LevelSetTestData):
@@ -107,13 +107,13 @@ class TestHyperbolic(LevelSetTestCase, metaclass=Parametrizer):
                 belongs_atol=gs.atol * 100000,
             )
 
-        def extrinsic_then_intrinsic_test_data(self):
-            return self._extrinsic_then_intrinsic_test_data(
+        def intrinsic_after_extrinsic_test_data(self):
+            return self._intrinsic_after_extrinsic_test_data(
                 Hyperbolic, self.space_args_list, self.n_points_list
             )
 
-        def intrinsic_then_extrinsic_test_data(self):
-            return self._intrinsic_then_extrinsic_test_data(
+        def extrinsic_after_intrinsic_test_data(self):
+            return self._extrinsic_after_intrinsic_test_data(
                 Hyperbolic, self.space_args_list, self.n_points_list
             )
 
@@ -408,7 +408,7 @@ class TestHyperboloidMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
                 self.n_tangent_vecs_list,
             )
 
-        def log_then_exp_intrinsic_ball_extrinsic_test_data(self):
+        def exp_after_log_intrinsic_ball_extrinsic_test_data(self):
             smoke_data = [
                 dict(
                     dim=2,
@@ -490,7 +490,9 @@ class TestHyperboloidMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
         expected = scale * distance_default_metric
         self.assertAllClose(result, expected)
 
-    def test_log_then_exp_intrinsic_ball_extrinsic(self, dim, x_intrinsic, y_intrinsic):
+    def test_exp_after_log_intrinsic_ball_extrinsic(
+        self, dim, x_intrinsic, y_intrinsic
+    ):
         intrinsic_manifold = Hyperboloid(dim=dim, coords_type="intrinsic")
         extrinsic_manifold = Hyperbolic(dim=dim, coords_type="extrinsic")
         ball_manifold = PoincareBall(dim)
@@ -503,7 +505,7 @@ class TestHyperboloidMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
         x_ball = extrinsic_manifold.to_coordinates(x_extr, to_coords_type="ball")
         y_ball = extrinsic_manifold.to_coordinates(y_extr, to_coords_type="ball")
 
-        x_ball_log_then_exp = ball_manifold.metric.exp(
+        x_ball_exp_after_log = ball_manifold.metric.exp(
             ball_manifold.metric.log(y_ball, x_ball), x_ball
         )
 
@@ -511,7 +513,7 @@ class TestHyperboloidMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
             extrinsic_manifold.metric.log(y_extr, x_extr), x_extr
         )
         x_extr_b = extrinsic_manifold.from_coordinates(
-            x_ball_log_then_exp, from_coords_type="ball"
+            x_ball_exp_after_log, from_coords_type="ball"
         )
         self.assertAllClose(x_extr_a, x_extr_b, atol=3e-4)
 

--- a/tests/tests_geomstats/test_hyperbolic.py
+++ b/tests/tests_geomstats/test_hyperbolic.py
@@ -299,8 +299,8 @@ class TestHyperboloidMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
                 belongs_atol=gs.atol * 1000,
             )
 
-        def log_then_exp_test_data(self):
-            return self._log_then_exp_test_data(
+        def exp_after_log_test_data(self):
+            return self._exp_after_log_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.n_points_list,
@@ -308,8 +308,8 @@ class TestHyperboloidMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
                 atol=gs.atol * 100000,
             )
 
-        def exp_then_log_test_data(self):
-            return self._exp_then_log_test_data(
+        def log_after_exp_test_data(self):
+            return self._log_after_exp_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.shape_list,

--- a/tests/tests_geomstats/test_hypersphere.py
+++ b/tests/tests_geomstats/test_hypersphere.py
@@ -255,15 +255,15 @@ class TestHypersphere(LevelSetTestCase, metaclass=Parametrizer):
                 self.space_args_list, self.shape_list, self.n_points_list
             )
 
-        def extrinsic_then_intrinsic_test_data(self):
+        def intrinsic_after_extrinsic_test_data(self):
             space_args_list = [(1,), (2,)]
-            return self._extrinsic_then_intrinsic_test_data(
+            return self._intrinsic_after_extrinsic_test_data(
                 Hypersphere, space_args_list, self.n_points_list, atol=gs.atol * 100
             )
 
-        def intrinsic_then_extrinsic_test_data(self):
+        def extrinsic_after_intrinsic_test_data(self):
             space_args_list = [(1,), (2,)]
-            return self._intrinsic_then_extrinsic_test_data(
+            return self._extrinsic_after_intrinsic_test_data(
                 Hypersphere, space_args_list, self.n_points_list, atol=gs.atol * 100
             )
 

--- a/tests/tests_geomstats/test_hypersphere.py
+++ b/tests/tests_geomstats/test_hypersphere.py
@@ -545,7 +545,7 @@ class TestHypersphereMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
                 belongs_atol=gs.atol * 1000,
             )
 
-        def log_then_exp_test_data(self):
+        def exp_after_log_test_data(self):
             # edge case: two very close points, base_point_2 and point_2,
             # form an angle < epsilon
             base_point = gs.array([1.0, 2.0, 3.0, 4.0, 6.0])
@@ -561,7 +561,7 @@ class TestHypersphereMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
                     atol=gs.atol,
                 )
             ]
-            return self._log_then_exp_test_data(
+            return self._exp_after_log_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.n_points_list,
@@ -569,7 +569,7 @@ class TestHypersphereMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
                 atol=1e-3,
             )
 
-        def exp_then_log_test_data(self):
+        def log_after_exp_test_data(self):
             base_point = gs.array([1.0, 0.0, 0.0, 0.0])
             tangent_vec = gs.array([0.0, 0.0, gs.pi / 6, 0.0])
 
@@ -582,7 +582,7 @@ class TestHypersphereMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
                     atol=gs.atol,
                 )
             ]
-            return self._exp_then_log_test_data(
+            return self._log_after_exp_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.shape_list,

--- a/tests/tests_geomstats/test_invariant_metric.py
+++ b/tests/tests_geomstats/test_invariant_metric.py
@@ -26,9 +26,9 @@ class TestInvariantMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
     skip_test_log_is_tangent = np_backend()
     skip_test_log_shape = np_backend()
     skip_test_geodesic_bvp_belongs = np_backend()
-    skip_test_log_then_exp = np_backend()
+    skip_test_exp_after_log = np_backend()
     skip_test_geodesic_bvp_belongs = True
-    skip_test_exp_then_log = True
+    skip_test_log_after_exp = True
     skip_test_dist_point_to_itself_is_zero = True
 
     class InvariantMetricTestData(_RiemannianMetricTestData):

--- a/tests/tests_geomstats/test_invariant_metric.py
+++ b/tests/tests_geomstats/test_invariant_metric.py
@@ -472,8 +472,8 @@ class TestInvariantMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
                 belongs_atol=gs.atol * 100000,
             )
 
-        def log_then_exp_test_data(self):
-            return self._log_then_exp_test_data(
+        def exp_after_log_test_data(self):
+            return self._exp_after_log_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.n_points_list,
@@ -481,8 +481,8 @@ class TestInvariantMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
                 atol=1e-1,
             )
 
-        def exp_then_log_test_data(self):
-            return self._exp_then_log_test_data(
+        def log_after_exp_test_data(self):
+            return self._log_after_exp_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.shape_list,

--- a/tests/tests_geomstats/test_landmarks.py
+++ b/tests/tests_geomstats/test_landmarks.py
@@ -178,8 +178,8 @@ class TestL2Metric(RiemannianMetricTestCase, metaclass=Parametrizer):
                 belongs_atol=gs.atol * 100,
             )
 
-        def log_then_exp_test_data(self):
-            return self._log_then_exp_test_data(
+        def exp_after_log_test_data(self):
+            return self._exp_after_log_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.n_tangent_vecs_list,
@@ -187,8 +187,8 @@ class TestL2Metric(RiemannianMetricTestCase, metaclass=Parametrizer):
                 atol=gs.atol * 1000,
             )
 
-        def exp_then_log_test_data(self):
-            return self._exp_then_log_test_data(
+        def log_after_exp_test_data(self):
+            return self._log_after_exp_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.shape_list,

--- a/tests/tests_geomstats/test_matrices.py
+++ b/tests/tests_geomstats/test_matrices.py
@@ -798,8 +798,8 @@ class TestMatricesMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
                 belongs_atol=gs.atol * 1000,
             )
 
-        def log_then_exp_test_data(self):
-            return self._log_then_exp_test_data(
+        def exp_after_log_test_data(self):
+            return self._exp_after_log_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.n_points_list,
@@ -807,8 +807,8 @@ class TestMatricesMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
                 atol=gs.atol * 10000,
             )
 
-        def exp_then_log_test_data(self):
-            return self._exp_then_log_test_data(
+        def log_after_exp_test_data(self):
+            return self._log_after_exp_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.shape_list,
@@ -905,7 +905,7 @@ class TestMatricesMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
             )
 
         def retraction_lifting_test_data(self):
-            return self._exp_then_log_test_data(
+            return self._log_after_exp_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.shape_list,

--- a/tests/tests_geomstats/test_minkowski.py
+++ b/tests/tests_geomstats/test_minkowski.py
@@ -216,8 +216,8 @@ class TestMinkowskiMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
                 belongs_atol=gs.atol * 1000,
             )
 
-        def log_then_exp_test_data(self):
-            return self._log_then_exp_test_data(
+        def exp_after_log_test_data(self):
+            return self._exp_after_log_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.n_points_list,
@@ -225,8 +225,8 @@ class TestMinkowskiMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
                 atol=gs.atol * 10000,
             )
 
-        def exp_then_log_test_data(self):
-            return self._exp_then_log_test_data(
+        def log_after_exp_test_data(self):
+            return self._log_after_exp_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.shape_list,

--- a/tests/tests_geomstats/test_poincare_ball.py
+++ b/tests/tests_geomstats/test_poincare_ball.py
@@ -203,8 +203,8 @@ class TestPoincareBallMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
                 belongs_atol=gs.atol * 10000,
             )
 
-        def log_then_exp_test_data(self):
-            return self._log_then_exp_test_data(
+        def exp_after_log_test_data(self):
+            return self._exp_after_log_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.n_points_list,
@@ -212,8 +212,8 @@ class TestPoincareBallMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
                 atol=gs.atol * 10000,
             )
 
-        def exp_then_log_test_data(self):
-            return self._exp_then_log_test_data(
+        def log_after_exp_test_data(self):
+            return self._log_after_exp_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.shape_list,

--- a/tests/tests_geomstats/test_poincare_half_space.py
+++ b/tests/tests_geomstats/test_poincare_half_space.py
@@ -280,8 +280,8 @@ class TestPoincareHalfSpaceMetric(RiemannianMetricTestCase, metaclass=Parametriz
                 belongs_atol=gs.atol * 1000,
             )
 
-        def log_then_exp_test_data(self):
-            return self._log_then_exp_test_data(
+        def exp_after_log_test_data(self):
+            return self._exp_after_log_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.n_points_list,
@@ -289,8 +289,8 @@ class TestPoincareHalfSpaceMetric(RiemannianMetricTestCase, metaclass=Parametriz
                 atol=gs.atol * 10000,
             )
 
-        def exp_then_log_test_data(self):
-            return self._exp_then_log_test_data(
+        def log_after_exp_test_data(self):
+            return self._log_after_exp_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.shape_list,
@@ -387,7 +387,7 @@ class TestPoincareHalfSpaceMetric(RiemannianMetricTestCase, metaclass=Parametriz
             )
 
         def retraction_lifting_test_data(self):
-            return self._exp_then_log_test_data(
+            return self._log_after_exp_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.shape_list,

--- a/tests/tests_geomstats/test_positive_lower_triangular_matrices.py
+++ b/tests/tests_geomstats/test_positive_lower_triangular_matrices.py
@@ -401,8 +401,8 @@ class TestCholeskyMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
                 belongs_atol=gs.atol * 1000,
             )
 
-        def log_then_exp_test_data(self):
-            return self._log_then_exp_test_data(
+        def exp_after_log_test_data(self):
+            return self._exp_after_log_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.n_points_list,
@@ -410,8 +410,8 @@ class TestCholeskyMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
                 atol=gs.atol * 10000,
             )
 
-        def exp_then_log_test_data(self):
-            return self._exp_then_log_test_data(
+        def log_after_exp_test_data(self):
+            return self._log_after_exp_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.shape_list,
@@ -508,7 +508,7 @@ class TestCholeskyMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
             )
 
         def retraction_lifting_test_data(self):
-            return self._exp_then_log_test_data(
+            return self._log_after_exp_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.shape_list,

--- a/tests/tests_geomstats/test_pre_shape.py
+++ b/tests/tests_geomstats/test_pre_shape.py
@@ -58,8 +58,8 @@ nabla_x_h = hor_dh + a_x_h
 
 class TestPreShapeSpace(LevelSetTestCase, metaclass=Parametrizer):
     space = PreShapeSpace
-    skip_test_extrinsic_then_intrinsic = True
-    skip_test_intrinsic_then_extrinsic = True
+    skip_test_intrinsic_after_extrinsic = True
+    skip_test_extrinsic_after_intrinsic = True
 
     class PreShapeSpaceTestData(_LevelSetTestData):
         k_landmarks_list = random.sample(range(3, 6), 2)
@@ -323,15 +323,15 @@ class TestPreShapeSpace(LevelSetTestCase, metaclass=Parametrizer):
                 self.space_args_list, self.shape_list, self.n_points_list
             )
 
-        def extrinsic_then_intrinsic_test_data(self):
+        def intrinsic_after_extrinsic_test_data(self):
             space_args_list = [(1,), (2,)]
-            return self._extrinsic_then_intrinsic_test_data(
+            return self._intrinsic_after_extrinsic_test_data(
                 PreShapeSpace, space_args_list, self.n_points_list
             )
 
-        def intrinsic_then_extrinsic_test_data(self):
+        def extrinsic_after_intrinsic_test_data(self):
             space_args_list = [(1,), (2,)]
-            return self._intrinsic_then_extrinsic_test_data(
+            return self._extrinsic_after_intrinsic_test_data(
                 PreShapeSpace, space_args_list, self.n_points_list
             )
 
@@ -653,8 +653,8 @@ class TestKendasllShapeMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
     skip_test_exp_geodesic_ivp = True
     skip_test_parallel_transport_ivp_is_isometry = True
     skip_test_parallel_transport_bvp_is_isometry = True
-    skip_test_log_then_exp = True
-    skip_test_exp_then_log = True
+    skip_test_exp_after_log = True
+    skip_test_log_after_exp = True
 
     class KendallShapeMetricTestData(_RiemannianMetricTestData):
         k_landmarks_list = random.sample(range(3, 6), 2)
@@ -1152,7 +1152,7 @@ class TestPreShapeMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
     space = PreShapeSpace
     skip_test_exp_geodesic_ivp = True
     skip_test_exp_shape = True
-    skip_test_exp_then_log = True
+    skip_test_log_after_exp = True
 
     class KendallShapeMetricTestData(_RiemannianMetricTestData):
         k_landmarks_list = random.sample(range(3, 6), 2)

--- a/tests/tests_geomstats/test_pre_shape.py
+++ b/tests/tests_geomstats/test_pre_shape.py
@@ -846,8 +846,8 @@ class TestKendasllShapeMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
                 belongs_atol=gs.atol * 1000,
             )
 
-        def log_then_exp_test_data(self):
-            return self._log_then_exp_test_data(
+        def exp_after_log_test_data(self):
+            return self._exp_after_log_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.n_samples_list,
@@ -855,8 +855,8 @@ class TestKendasllShapeMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
                 atol=gs.atol * 10000,
             )
 
-        def exp_then_log_test_data(self):
-            return self._exp_then_log_test_data(
+        def log_after_exp_test_data(self):
+            return self._log_after_exp_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.shape_list,
@@ -1222,8 +1222,8 @@ class TestPreShapeMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
                 belongs_atol=gs.atol * 1000,
             )
 
-        def log_then_exp_test_data(self):
-            return self._log_then_exp_test_data(
+        def exp_after_log_test_data(self):
+            return self._exp_after_log_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.n_samples_list,
@@ -1231,8 +1231,8 @@ class TestPreShapeMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
                 atol=1e-4,
             )
 
-        def exp_then_log_test_data(self):
-            return self._exp_then_log_test_data(
+        def log_after_exp_test_data(self):
+            return self._log_after_exp_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.shape_list,

--- a/tests/tests_geomstats/test_product_manifold.py
+++ b/tests/tests_geomstats/test_product_manifold.py
@@ -350,7 +350,7 @@ class TestProductRiemannianMetric(RiemannianMetricTestCase, metaclass=Parametriz
             ]
             return self.generate_tests([], random_data)
 
-        def dist_log_then_exp_norm_test_data(self):
+        def dist_exp_after_log_norm_test_data(self):
             smoke_data = [
                 dict(
                     space=smoke_manifolds_1,
@@ -395,7 +395,7 @@ class TestProductRiemannianMetric(RiemannianMetricTestCase, metaclass=Parametriz
         self.assertAllClose(result, expected)
 
     @geomstats.tests.np_and_autograd_only
-    def test_dist_log_then_exp_norm(
+    def test_dist_exp_after_log_norm(
         self, manifolds, default_point_type, n_samples, einsum_str, expected
     ):
         space = ProductManifold(

--- a/tests/tests_geomstats/test_product_manifold.py
+++ b/tests/tests_geomstats/test_product_manifold.py
@@ -236,8 +236,8 @@ class TestProductRiemannianMetric(RiemannianMetricTestCase, metaclass=Parametriz
                 belongs_atol=gs.atol * 1000,
             )
 
-        def log_then_exp_test_data(self):
-            return self._log_then_exp_test_data(
+        def exp_after_log_test_data(self):
+            return self._exp_after_log_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.n_points_list,
@@ -245,8 +245,8 @@ class TestProductRiemannianMetric(RiemannianMetricTestCase, metaclass=Parametriz
                 atol=1e-1,
             )
 
-        def exp_then_log_test_data(self):
-            return self._exp_then_log_test_data(
+        def log_after_exp_test_data(self):
+            return self._log_after_exp_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.shape_list,
@@ -575,8 +575,8 @@ class TestNFoldMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
                 belongs_atol=gs.atol * 100000,
             )
 
-        def log_then_exp_test_data(self):
-            return self._log_then_exp_test_data(
+        def exp_after_log_test_data(self):
+            return self._exp_after_log_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.n_points_list,
@@ -584,8 +584,8 @@ class TestNFoldMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
                 atol=1e-1,
             )
 
-        def exp_then_log_test_data(self):
-            return self._exp_then_log_test_data(
+        def log_after_exp_test_data(self):
+            return self._log_after_exp_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.shape_list,

--- a/tests/tests_geomstats/test_rank_k_psd_matrices.py
+++ b/tests/tests_geomstats/test_rank_k_psd_matrices.py
@@ -151,7 +151,7 @@ class TestPSDMetricBuresWasserstein(RiemannianMetricTestCase, metaclass=Parametr
     metric = connection = PSDMetricBuresWasserstein
     skip_test_parallel_transport_ivp_is_isometry = True
     skip_test_parallel_transport_bvp_is_isometry = True
-    skip_test_exp_then_log = True
+    skip_test_log_after_exp = True
 
     class TestDataPSDMetricBuresWasserstein(_RiemannianMetricTestData):
         n_list = random.sample(range(2, 7), 5)

--- a/tests/tests_geomstats/test_rank_k_psd_matrices.py
+++ b/tests/tests_geomstats/test_rank_k_psd_matrices.py
@@ -324,8 +324,8 @@ class TestPSDMetricBuresWasserstein(RiemannianMetricTestCase, metaclass=Parametr
                 belongs_atol=gs.atol * 1000,
             )
 
-        def log_then_exp_test_data(self):
-            return self._log_then_exp_test_data(
+        def exp_after_log_test_data(self):
+            return self._exp_after_log_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.n_samples_list,
@@ -333,8 +333,8 @@ class TestPSDMetricBuresWasserstein(RiemannianMetricTestCase, metaclass=Parametr
                 atol=gs.atol * 10000,
             )
 
-        def exp_then_log_test_data(self):
-            return self._exp_then_log_test_data(
+        def log_after_exp_test_data(self):
+            return self._log_after_exp_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.shape_list,

--- a/tests/tests_geomstats/test_skew_symmetric_matrices.py
+++ b/tests/tests_geomstats/test_skew_symmetric_matrices.py
@@ -58,13 +58,13 @@ class TestSkewSymmetricMatrices(MatrixLieAlgebraTestCase, metaclass=Parametrizer
 
             return self.generate_tests(smoke_data)
 
-        def basis_representation_then_matrix_representation_test_data(self):
-            return self._basis_representation_then_matrix_representation_test_data(
+        def matrix_representation_after_basis_representation_test_data(self):
+            return self._matrix_representation_after_basis_representation_test_data(
                 SkewSymmetricMatrices, self.space_args_list, self.n_points_list
             )
 
-        def matrix_representation_then_basis_representation_test_data(self):
-            return self._matrix_representation_then_basis_representation_test_data(
+        def basis_representation_after_matrix_representation_test_data(self):
+            return self._basis_representation_after_matrix_representation_test_data(
                 SkewSymmetricMatrices, self.space_args_list, self.n_points_list
             )
 

--- a/tests/tests_geomstats/test_spd_matrices.py
+++ b/tests/tests_geomstats/test_spd_matrices.py
@@ -814,7 +814,7 @@ class TestSPDMetricEuclidean(RiemannianMetricTestCase, metaclass=Parametrizer):
     skip_test_exp_geodesic_ivp = True
     skip_test_geodesic_ivp_belongs = True
     skip_test_exp_belongs = True
-    skip_test_exp_then_log = True
+    skip_test_log_after_exp = True
 
     class SPDMetricEuclideanTestData(_RiemannianMetricTestData):
         n_list = random.sample(range(2, 5), 2)
@@ -1074,7 +1074,7 @@ class TestSPDMetricEuclidean(RiemannianMetricTestCase, metaclass=Parametrizer):
         result = metric.log(gs.array(point), gs.array(base_point))
         self.assertAllClose(result, gs.array(expected))
 
-    def test_log_then_exp(self, n, power_euclidean, point, base_point):
+    def test_exp_after_log(self, n, power_euclidean, point, base_point):
         metric = SPDMetricEuclidean(n, power_euclidean)
         log = metric.log(gs.array(point), base_point=gs.array(base_point))
         result = metric.exp(tangent_vec=log, base_point=gs.array(base_point))
@@ -1099,8 +1099,8 @@ class TestSPDMetricLogEuclidean(RiemannianMetricTestCase, metaclass=Parametrizer
     skip_test_parallel_transport_ivp_is_isometry = True
     skip_test_parallel_transport_bvp_is_isometry = True
     skip_test_exp_geodesic_ivp = True
-    skip_test_log_then_exp = True
-    skip_test_exp_then_log = True
+    skip_test_exp_after_log = True
+    skip_test_log_after_exp = True
     skip_test_exp_ladder_parallel_transport = True
     skip_test_exp_belongs = True
 

--- a/tests/tests_geomstats/test_spd_matrices.py
+++ b/tests/tests_geomstats/test_spd_matrices.py
@@ -427,8 +427,8 @@ class TestSPDMetricAffine(RiemannianMetricTestCase, metaclass=Parametrizer):
                 belongs_atol=gs.atol * 1000,
             )
 
-        def log_then_exp_test_data(self):
-            return self._log_then_exp_test_data(
+        def exp_after_log_test_data(self):
+            return self._exp_after_log_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.n_points_list,
@@ -436,8 +436,8 @@ class TestSPDMetricAffine(RiemannianMetricTestCase, metaclass=Parametrizer):
                 atol=gs.atol * 10000,
             )
 
-        def exp_then_log_test_data(self):
-            return self._exp_then_log_test_data(
+        def log_after_exp_test_data(self):
+            return self._log_after_exp_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.shape_list,
@@ -682,8 +682,8 @@ class TestSPDMetricBuresWasserstein(RiemannianMetricTestCase, metaclass=Parametr
                 belongs_atol=gs.atol * 1000,
             )
 
-        def log_then_exp_test_data(self):
-            return self._log_then_exp_test_data(
+        def exp_after_log_test_data(self):
+            return self._exp_after_log_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.n_points_list,
@@ -691,8 +691,8 @@ class TestSPDMetricBuresWasserstein(RiemannianMetricTestCase, metaclass=Parametr
                 atol=gs.atol * 10,
             )
 
-        def exp_then_log_test_data(self):
-            return self._exp_then_log_test_data(
+        def log_after_exp_test_data(self):
+            return self._log_after_exp_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.shape_list,
@@ -943,8 +943,8 @@ class TestSPDMetricEuclidean(RiemannianMetricTestCase, metaclass=Parametrizer):
                 belongs_atol=gs.atol * 1000,
             )
 
-        def log_then_exp_test_data(self):
-            return self._log_then_exp_test_data(
+        def exp_after_log_test_data(self):
+            return self._exp_after_log_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.n_points_list,
@@ -952,8 +952,8 @@ class TestSPDMetricEuclidean(RiemannianMetricTestCase, metaclass=Parametrizer):
                 atol=gs.atol * 10000,
             )
 
-        def exp_then_log_test_data(self):
-            return self._exp_then_log_test_data(
+        def log_after_exp_test_data(self):
+            return self._log_after_exp_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.shape_list,
@@ -1204,8 +1204,8 @@ class TestSPDMetricLogEuclidean(RiemannianMetricTestCase, metaclass=Parametrizer
                 belongs_atol=gs.atol * 1000,
             )
 
-        def log_then_exp_test_data(self):
-            return self._log_then_exp_test_data(
+        def exp_after_log_test_data(self):
+            return self._exp_after_log_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.n_points_list,
@@ -1213,8 +1213,8 @@ class TestSPDMetricLogEuclidean(RiemannianMetricTestCase, metaclass=Parametrizer
                 atol=gs.atol * 10000,
             )
 
-        def exp_then_log_test_data(self):
-            return self._exp_then_log_test_data(
+        def log_after_exp_test_data(self):
+            return self._log_after_exp_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.shape_list,

--- a/tests/tests_geomstats/test_special_euclidean.py
+++ b/tests/tests_geomstats/test_special_euclidean.py
@@ -225,8 +225,8 @@ class TestSpecialEuclidean(LieGroupTestCase, metaclass=Parametrizer):
                 is_tangent_atol=gs.atol * 100,
             )
 
-        def exp_then_log_test_data(self):
-            return self._exp_then_log_test_data(
+        def log_after_exp_test_data(self):
+            return self._log_after_exp_test_data(
                 SpecialEuclidean,
                 self.space_args_list,
                 self.shape_list,
@@ -235,8 +235,8 @@ class TestSpecialEuclidean(LieGroupTestCase, metaclass=Parametrizer):
                 atol=gs.atol * 10000,
             )
 
-        def log_then_exp_test_data(self):
-            return self._log_then_exp_test_data(
+        def exp_after_log_test_data(self):
+            return self._exp_after_log_test_data(
                 SpecialEuclidean,
                 self.space_args_list,
                 self.n_points_list,
@@ -582,8 +582,8 @@ class TestSpecialEuclideanMatrixCanonicalLeftMetric(
                 belongs_atol=gs.atol * 100,
             )
 
-        def log_then_exp_test_data(self):
-            return self._log_then_exp_test_data(
+        def exp_after_log_test_data(self):
+            return self._exp_after_log_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.n_points_list,
@@ -591,8 +591,8 @@ class TestSpecialEuclideanMatrixCanonicalLeftMetric(
                 atol=gs.atol * 100,
             )
 
-        def exp_then_log_test_data(self):
-            return self._exp_then_log_test_data(
+        def log_after_exp_test_data(self):
+            return self._log_after_exp_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.shape_list,
@@ -792,8 +792,8 @@ class TestSpecialEuclideanMatrixCanonicalRightMetric(
                 belongs_atol=1e-3,
             )
 
-        def log_then_exp_test_data(self):
-            return self._log_then_exp_test_data(
+        def exp_after_log_test_data(self):
+            return self._exp_after_log_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.n_points_list,
@@ -801,8 +801,8 @@ class TestSpecialEuclideanMatrixCanonicalRightMetric(
                 atol=gs.atol * 100000,
             )
 
-        def exp_then_log_test_data(self):
-            return self._exp_then_log_test_data(
+        def log_after_exp_test_data(self):
+            return self._log_after_exp_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.shape_list,
@@ -1034,7 +1034,7 @@ class TestSpecialEuclidean3Vectors(TestCase, metaclass=Parametrizer):
                         )
             return self.generate_tests(smoke_data)
 
-        def log_then_exp_test_data(self):
+        def exp_after_log_test_data(self):
             smoke_data = []
             for metric in list(self.metrics.values()) + [SpecialEuclidean(3, "vector")]:
                 for base_point in self.elements.values():
@@ -1066,7 +1066,7 @@ class TestSpecialEuclidean3Vectors(TestCase, metaclass=Parametrizer):
                         )
             return self.generate_tests(smoke_data)
 
-        def exp_then_log_test_data(self):
+        def log_after_exp_test_data(self):
             smoke_data = []
             for metric in [
                 self.metrics_all["left_canonical"],

--- a/tests/tests_geomstats/test_special_euclidean.py
+++ b/tests/tests_geomstats/test_special_euclidean.py
@@ -73,8 +73,8 @@ ATOL = 1e-5
 class TestSpecialEuclidean(LieGroupTestCase, metaclass=Parametrizer):
 
     space = group = SpecialEuclidean
-    skip_test_exp_then_log = tf_backend()
-    skip_test_log_then_exp = tf_backend()
+    skip_test_log_after_exp = tf_backend()
+    skip_test_exp_after_log = tf_backend()
 
     class SpecialEuclideanTestData(_LieGroupTestData):
         n_list = random.sample(range(2, 4), 2)
@@ -422,15 +422,15 @@ class TestSpecialEuclideanMatrixLieAlgebra(
             ]
             return self.generate_tests(smoke_data)
 
-        def basis_representation_then_matrix_representation_test_data(self):
-            return self._basis_representation_then_matrix_representation_test_data(
+        def matrix_representation_after_basis_representation_test_data(self):
+            return self._matrix_representation_after_basis_representation_test_data(
                 SpecialEuclideanMatrixLieAlgebra,
                 self.space_args_list,
                 self.n_points_list,
             )
 
-        def matrix_representation_then_basis_representation_test_data(self):
-            return self._matrix_representation_then_basis_representation_test_data(
+        def basis_representation_after_matrix_representation_test_data(self):
+            return self._basis_representation_after_matrix_representation_test_data(
                 SpecialEuclideanMatrixLieAlgebra,
                 self.space_args_list,
                 self.n_points_list,
@@ -708,8 +708,8 @@ class TestSpecialEuclideanMatrixCanonicalRightMetric(
     skip_test_parallel_transport_ivp_is_isometry = True
     skip_test_parallel_transport_bvp_is_isometry = True
     skip_test_squared_dist_is_symmetric = np_backend()
-    skip_test_exp_then_log = True
-    skip_test_log_then_exp = True
+    skip_test_log_after_exp = True
+    skip_test_exp_after_log = True
     skip_test_log_is_tangent = np_backend()
     skip_test_geodesic_bvp_belongs = np_backend()
     skip_test_exp_ladder_parallel_transport = np_backend()
@@ -1019,7 +1019,7 @@ class TestSpecialEuclidean3Vectors(TestCase, metaclass=Parametrizer):
         if geomstats.tests.tf_backend():
             angles_close_to_pi = ["angle_close_pi_low"]
 
-        def log_then_exp_right_with_angles_close_to_pi_test_data(self):
+        def exp_after_log_right_with_angles_close_to_pi_test_data(self):
             smoke_data = []
             for metric in list(self.metrics.values()) + [SpecialEuclidean(3, "vector")]:
                 for base_point in self.elements.values():
@@ -1051,7 +1051,7 @@ class TestSpecialEuclidean3Vectors(TestCase, metaclass=Parametrizer):
                         )
             return self.generate_tests(smoke_data)
 
-        def exp_then_log_with_angles_close_to_pi_test_data(self):
+        def log_after_exp_with_angles_close_to_pi_test_data(self):
             smoke_data = []
             for metric in self.metrics_all.values():
                 for base_point in self.elements.values():
@@ -1211,7 +1211,7 @@ class TestSpecialEuclidean3Vectors(TestCase, metaclass=Parametrizer):
     testing_data = SpecialEuclidean3VectorsTestData()
 
     @geomstats.tests.np_and_autograd_only
-    def test_log_then_exp(self, metric, point, base_point):
+    def test_exp_after_log(self, metric, point, base_point):
         """
         Test that the Riemannian right exponential and the
         Riemannian right logarithm are inverse.
@@ -1228,7 +1228,7 @@ class TestSpecialEuclidean3Vectors(TestCase, metaclass=Parametrizer):
         self.assertAllClose(result, expected, atol=atol)
 
     @geomstats.tests.np_and_autograd_only
-    def test_log_then_exp_right_with_angles_close_to_pi(
+    def test_exp_after_log_right_with_angles_close_to_pi(
         self, metric, point, base_point
     ):
         group = SpecialEuclidean(3, "vector")
@@ -1248,7 +1248,7 @@ class TestSpecialEuclidean3Vectors(TestCase, metaclass=Parametrizer):
         )
 
     @geomstats.tests.np_and_autograd_only
-    def test_exp_then_log_with_angles_close_to_pi(
+    def test_log_after_exp_with_angles_close_to_pi(
         self, metric, tangent_vec, base_point
     ):
         """
@@ -1276,7 +1276,7 @@ class TestSpecialEuclidean3Vectors(TestCase, metaclass=Parametrizer):
         )
 
     @geomstats.tests.np_and_autograd_only
-    def test_exp_then_log(self, metric, tangent_vec, base_point):
+    def test_log_after_exp(self, metric, tangent_vec, base_point):
         """
         Test that the Riemannian left exponential and the
         Riemannian left logarithm are inverse.

--- a/tests/tests_geomstats/test_special_orthogonal.py
+++ b/tests/tests_geomstats/test_special_orthogonal.py
@@ -81,7 +81,7 @@ if tf_backend():
 
 class TestSpecialOrthogonal(LieGroupTestCase, metaclass=Parametrizer):
     space = group = SpecialOrthogonal
-    skip_test_log_then_exp = pytorch_backend()
+    skip_test_exp_after_log = pytorch_backend()
     skip_test_projection_belongs = True
 
     class SpecialOrthogonalTestData(_LieGroupTestData):
@@ -813,7 +813,7 @@ class TestSpecialOrthogonal3Vectors(TestCase, metaclass=Parametrizer):
             ]
             return self.generate_tests(smoke_data)
 
-        def group_log_then_exp_with_angles_close_to_pi_test_data(self):
+        def group_exp_after_log_with_angles_close_to_pi_test_data(self):
             smoke_data = []
             for angle_type in angles_close_to_pi:
                 for angle_type_base in elements.values():
@@ -825,8 +825,8 @@ class TestSpecialOrthogonal3Vectors(TestCase, metaclass=Parametrizer):
                     ]
             return self.generate_tests(smoke_data)
 
-        def group_exp_then_log_with_angles_close_to_pi_test_data(self):
-            return self.group_log_then_exp_with_angles_close_to_pi_test_data()
+        def group_log_after_exp_with_angles_close_to_pi_test_data(self):
+            return self.group_exp_after_log_with_angles_close_to_pi_test_data()
 
         def left_jacobian_vectorization_test_data(self):
             smoke_data = [dict(n_samples=3)]
@@ -1014,7 +1014,7 @@ class TestSpecialOrthogonal3Vectors(TestCase, metaclass=Parametrizer):
         self.assertAllClose(result, expected)
 
     @geomstats.tests.np_autograd_and_torch_only
-    def test_group_log_then_exp_with_angles_close_to_pi(self, point, base_point):
+    def test_group_exp_after_log_with_angles_close_to_pi(self, point, base_point):
         """
         This tests that the composition of
         log and exp gives identity.
@@ -1030,7 +1030,7 @@ class TestSpecialOrthogonal3Vectors(TestCase, metaclass=Parametrizer):
             or gs.allclose(result, inv_expected, atol=5e-3)
         )
 
-    def test_group_exp_then_log_with_angles_close_to_pi(self, tangent_vec, base_point):
+    def test_group_log_after_exp_with_angles_close_to_pi(self, tangent_vec, base_point):
         """
         This tests that the composition of
         log and exp gives identity.
@@ -1296,7 +1296,7 @@ class TestBiInvariantMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
                 self.n_tangent_vecs_list,
             )
 
-        def log_then_exp_intrinsic_ball_extrinsic_test_data(self):
+        def exp_after_log_intrinsic_ball_extrinsic_test_data(self):
             smoke_data = [
                 dict(
                     dim=2,

--- a/tests/tests_geomstats/test_special_orthogonal.py
+++ b/tests/tests_geomstats/test_special_orthogonal.py
@@ -435,8 +435,8 @@ class TestSpecialOrthogonal(LieGroupTestCase, metaclass=Parametrizer):
                 n_points_list,
             )
 
-        def exp_then_log_test_data(self):
-            return self._exp_then_log_test_data(
+        def log_after_exp_test_data(self):
+            return self._log_after_exp_test_data(
                 SpecialOrthogonal,
                 self.space_args_list,
                 self.shape_list,
@@ -446,8 +446,8 @@ class TestSpecialOrthogonal(LieGroupTestCase, metaclass=Parametrizer):
                 atol=gs.atol * 10000,
             )
 
-        def log_then_exp_test_data(self):
-            return self._log_then_exp_test_data(
+        def exp_after_log_test_data(self):
+            return self._exp_after_log_test_data(
                 SpecialOrthogonal,
                 self.space_args_list,
                 self.n_points_list,
@@ -1188,8 +1188,8 @@ class TestBiInvariantMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
                 belongs_atol=gs.atol * 1000,
             )
 
-        def log_then_exp_test_data(self):
-            return self._log_then_exp_test_data(
+        def exp_after_log_test_data(self):
+            return self._exp_after_log_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.n_points_list,
@@ -1197,8 +1197,8 @@ class TestBiInvariantMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
                 atol=gs.atol * 10000,
             )
 
-        def exp_then_log_test_data(self):
-            return self._exp_then_log_test_data(
+        def log_after_exp_test_data(self):
+            return self._log_after_exp_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.shape_list,

--- a/tests/tests_geomstats/test_stiefel.py
+++ b/tests/tests_geomstats/test_stiefel.py
@@ -207,8 +207,8 @@ class TestStiefelCanonicalMetric(RiemannianMetricTestCase, metaclass=Parametrize
                 belongs_atol=gs.atol * 1000,
             )
 
-        def log_then_exp_test_data(self):
-            return self._log_then_exp_test_data(
+        def exp_after_log_test_data(self):
+            return self._exp_after_log_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.n_points_list,
@@ -216,8 +216,8 @@ class TestStiefelCanonicalMetric(RiemannianMetricTestCase, metaclass=Parametrize
                 atol=gs.atol * 10000,
             )
 
-        def exp_then_log_test_data(self):
-            return self._exp_then_log_test_data(
+        def log_after_exp_test_data(self):
+            return self._log_after_exp_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.shape_list,
@@ -296,7 +296,7 @@ class TestStiefelCanonicalMetric(RiemannianMetricTestCase, metaclass=Parametrize
             )
 
         def retraction_lifting_test_data(self):
-            return self._exp_then_log_test_data(
+            return self._log_after_exp_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.shape_list,
@@ -306,7 +306,7 @@ class TestStiefelCanonicalMetric(RiemannianMetricTestCase, metaclass=Parametrize
             )
 
         def lifting_retraction_test_data(self):
-            return self._log_then_exp_test_data(
+            return self._exp_after_log_test_data(
                 self.metric_args_list,
                 self.space_list,
                 self.n_points_list,

--- a/tests/tests_geomstats/test_stiefel.py
+++ b/tests/tests_geomstats/test_stiefel.py
@@ -30,8 +30,8 @@ point_b = gs.array(
 
 class TestStiefel(LevelSetTestCase, metaclass=Parametrizer):
     space = Stiefel
-    skip_test_extrinsic_then_intrinsic = True
-    skip_test_intrinsic_then_extrinsic = True
+    skip_test_intrinsic_after_extrinsic = True
+    skip_test_extrinsic_after_intrinsic = True
     skip_test_to_tangent_is_tangent = True
 
     class StiefelTestData(_LevelSetTestData):
@@ -105,8 +105,8 @@ class TestStiefelCanonicalMetric(RiemannianMetricTestCase, metaclass=Parametrize
     skip_test_parallel_transport_ivp_is_isometry = True
     skip_test_parallel_transport_bvp_is_isometry = True
     skip_test_exp_geodesic_ivp = True
-    skip_test_log_then_exp = True
-    skip_test_exp_then_log = True
+    skip_test_exp_after_log = True
+    skip_test_log_after_exp = True
     skip_test_log_is_tangent = True
     skip_test_geodesic_bvp_belongs = True
     skip_test_squared_dist_is_symmetric = True


### PR DESCRIPTION
The composition is clearer when expressed as f after g than by g then f because the former respects the order of writing with \circ