### PR TITLE
harmonize access to metric property and setting at init

### DIFF
--- a/geomstats/geometry/base.py
+++ b/geomstats/geometry/base.py
@@ -25,8 +25,7 @@ class VectorSpace(Manifold, abc.ABC):
     """
 
     def __init__(self, shape, **kwargs):
-        if "dim" not in kwargs.keys():
-            kwargs["dim"] = int(gs.prod(gs.array(shape)))
+        kwargs.setdefault("dim", int(gs.prod(gs.array(shape))))
         super(VectorSpace, self).__init__(shape=shape, **kwargs)
         self.shape = shape
         self._basis = None
@@ -183,8 +182,7 @@ class LevelSet(Manifold, abc.ABC):
         default_coords_type="intrinsic",
         **kwargs
     ):
-        if "shape" not in kwargs:
-            kwargs["shape"] = embedding_space.shape
+        kwargs.setdefault("shape", embedding_space.shape)
         super(LevelSet, self).__init__(
             dim=dim,
             default_point_type=embedding_space.default_point_type,
@@ -334,10 +332,8 @@ class OpenSet(Manifold, abc.ABC):
     """
 
     def __init__(self, dim, ambient_space, **kwargs):
-        if "default_point_type" not in kwargs:
-            kwargs["default_point_type"] = ambient_space.default_point_type
-        if "shape" not in kwargs:
-            kwargs["shape"] = ambient_space.shape
+        kwargs.setdefault("default_point_type", ambient_space.default_point_type)
+        kwargs.setdefault("shape", ambient_space.shape)
         super().__init__(dim=dim, **kwargs)
         self.ambient_space = ambient_space
 

--- a/geomstats/geometry/discrete_curves.py
+++ b/geomstats/geometry/discrete_curves.py
@@ -47,7 +47,7 @@ class DiscreteCurves(Manifold):
     def __init__(self, ambient_manifold, **kwargs):
         kwargs.setdefault("metric", SRVMetric(ambient_manifold))
         super(DiscreteCurves, self).__init__(
-            dim=math.inf, shape=(), default_point_type="matrix"
+            dim=math.inf, shape=(), default_point_type="matrix", **kwargs
         )
         self.ambient_manifold = ambient_manifold
         self.square_root_velocity_metric = self._metric

--- a/geomstats/geometry/discrete_curves.py
+++ b/geomstats/geometry/discrete_curves.py
@@ -53,6 +53,8 @@ class DiscreteCurves(Manifold):
         self.quotient_square_root_velocity_metric = QuotientSRVMetric(
             self.ambient_manifold
         )
+        if self._metric is None:
+            self._metric = self.square_root_velocity_metric
 
     def belongs(self, point, atol=gs.atol):
         """Test whether a point belongs to the manifold.

--- a/geomstats/geometry/discrete_curves.py
+++ b/geomstats/geometry/discrete_curves.py
@@ -44,17 +44,16 @@ class DiscreteCurves(Manifold):
         Square root velocity metric.
     """
 
-    def __init__(self, ambient_manifold):
+    def __init__(self, ambient_manifold, **kwargs):
+        kwargs.setdefault("metric", SRVMetric(ambient_manifold))
         super(DiscreteCurves, self).__init__(
             dim=math.inf, shape=(), default_point_type="matrix"
         )
         self.ambient_manifold = ambient_manifold
-        self.square_root_velocity_metric = SRVMetric(self.ambient_manifold)
+        self.square_root_velocity_metric = self._metric
         self.quotient_square_root_velocity_metric = QuotientSRVMetric(
             self.ambient_manifold
         )
-        if self._metric is None:
-            self._metric = self.square_root_velocity_metric
 
     def belongs(self, point, atol=gs.atol):
         """Test whether a point belongs to the manifold.

--- a/geomstats/geometry/fiber_bundle.py
+++ b/geomstats/geometry/fiber_bundle.py
@@ -56,7 +56,6 @@ class FiberBundle(Manifold, ABC):
     ):
 
         super(FiberBundle, self).__init__(dim=dim, **kwargs)
-        self.base = base
         self.group = group
         self.ambient_metric = ambient_metric
 

--- a/geomstats/geometry/fiber_bundle.py
+++ b/geomstats/geometry/fiber_bundle.py
@@ -47,7 +47,6 @@ class FiberBundle(Manifold, ABC):
     def __init__(
         self,
         dim: int,
-        base: Manifold = None,
         group: LieGroup = None,
         ambient_metric: RiemannianMetric = None,
         group_action=None,

--- a/geomstats/geometry/full_rank_correlation_matrices.py
+++ b/geomstats/geometry/full_rank_correlation_matrices.py
@@ -21,13 +21,14 @@ class FullRankCorrelationMatrices(LevelSet):
         Integer representing the shape of the matrices: n x n.
     """
 
-    def __init__(self, n):
+    def __init__(self, n, **kwargs):
         super(FullRankCorrelationMatrices, self).__init__(
             dim=int(n * (n - 1) / 2),
             embedding_space=SPDMatrices(n=n),
             submersion=Matrices.diagonal,
             value=gs.ones(n),
             tangent_submersion=lambda v, x: Matrices.diagonal(v),
+            **kwargs
         )
         self.n = n
 
@@ -54,6 +55,13 @@ class FullRankCorrelationMatrices(LevelSet):
         """
         aux = gs.einsum("...i,...j->...ij", diagonal_vec, diagonal_vec)
         return point * aux
+
+    @property
+    def metric(self):
+        """Riemannian Metric associated to the Manifold."""
+        if self._metric is None:
+            self._metric = FullRankCorrelationAffineQuotientMetric(self.n)
+        return self._metric
 
     @classmethod
     def from_covariance(cls, point):

--- a/geomstats/geometry/full_rank_correlation_matrices.py
+++ b/geomstats/geometry/full_rank_correlation_matrices.py
@@ -22,6 +22,7 @@ class FullRankCorrelationMatrices(LevelSet):
     """
 
     def __init__(self, n, **kwargs):
+        kwargs.setdefault("metric", FullRankCorrelationAffineQuotientMetric(n))
         super(FullRankCorrelationMatrices, self).__init__(
             dim=int(n * (n - 1) / 2),
             embedding_space=SPDMatrices(n=n),
@@ -156,7 +157,6 @@ class CorrelationMatricesBundle(SPDMatrices, FiberBundle):
     def __init__(self, n):
         super(CorrelationMatricesBundle, self).__init__(
             n=n,
-            base=FullRankCorrelationMatrices(n),
             ambient_metric=SPDMetricAffine(n),
             group_dim=n,
             group_action=FullRankCorrelationMatrices.diag_action,

--- a/geomstats/geometry/full_rank_matrices.py
+++ b/geomstats/geometry/full_rank_matrices.py
@@ -9,7 +9,7 @@ from geomstats.geometry.matrices import Matrices, MatricesMetric
 
 
 class FullRankMatrices(OpenSet):
-    r"""Class for `math:`R_*^{m\times n}` matrices of dimension m x n and full rank.
+    r"""Class for `math:`R_*^{n\times k}` matrices of dimension n x k and full rank.
 
     Parameters
     ----------

--- a/geomstats/geometry/full_rank_matrices.py
+++ b/geomstats/geometry/full_rank_matrices.py
@@ -22,12 +22,12 @@ class FullRankMatrices(OpenSet):
     def __init__(self, n, k, **kwargs):
         if "dim" not in kwargs.keys():
             kwargs["dim"] = n * k
-        super(FullRankMatrices, self).__init__(
-            ambient_space=Matrices(n, k), metric=MatricesMetric(n, k), **kwargs
-        )
+        super(FullRankMatrices, self).__init__(ambient_space=Matrices(n, k), **kwargs)
         self.rank = min(n, k)
         self.n = n
         self.k = k
+        if self._metric is None:
+            self._metric = MatricesMetric(n, k)
 
     def belongs(self, point, atol=gs.atol):
         r"""Check if the matrix belongs to `math:`R_*^{n \times k}`.

--- a/geomstats/geometry/full_rank_matrices.py
+++ b/geomstats/geometry/full_rank_matrices.py
@@ -20,14 +20,12 @@ class FullRankMatrices(OpenSet):
     """
 
     def __init__(self, n, k, **kwargs):
-        if "dim" not in kwargs.keys():
-            kwargs["dim"] = n * k
+        kwargs.setdefault("dim", n * k)
+        kwargs.setdefault("metric", MatricesMetric(n, k))
         super(FullRankMatrices, self).__init__(ambient_space=Matrices(n, k), **kwargs)
         self.rank = min(n, k)
         self.n = n
         self.k = k
-        if self._metric is None:
-            self._metric = MatricesMetric(n, k)
 
     def belongs(self, point, atol=gs.atol):
         r"""Check if the matrix belongs to `math:`R_*^{n \times k}`.

--- a/geomstats/geometry/general_linear.py
+++ b/geomstats/geometry/general_linear.py
@@ -5,7 +5,7 @@ import geomstats.backend as gs
 from geomstats.geometry.base import OpenSet
 from geomstats.geometry.lie_algebra import MatrixLieAlgebra
 from geomstats.geometry.lie_group import MatrixLieGroup
-from geomstats.geometry.matrices import Matrices
+from geomstats.geometry.matrices import Matrices, MatricesMetric
 
 
 class GeneralLinear(MatrixLieGroup, OpenSet):
@@ -30,6 +30,9 @@ class GeneralLinear(MatrixLieGroup, OpenSet):
         super(GeneralLinear, self).__init__(
             ambient_space=Matrices(n, n), n=n, lie_algebra=SquareMatrices(n), **kwargs
         )
+        if self._metric is None:
+            self._metric = MatricesMetric(n, n)
+
         self.positive_det = positive_det
 
     def projection(self, point):

--- a/geomstats/geometry/general_linear.py
+++ b/geomstats/geometry/general_linear.py
@@ -5,7 +5,7 @@ import geomstats.backend as gs
 from geomstats.geometry.base import OpenSet
 from geomstats.geometry.lie_algebra import MatrixLieAlgebra
 from geomstats.geometry.lie_group import MatrixLieGroup
-from geomstats.geometry.matrices import Matrices, MatricesMetric
+from geomstats.geometry.matrices import Matrices
 
 
 class GeneralLinear(MatrixLieGroup, OpenSet):
@@ -25,13 +25,13 @@ class GeneralLinear(MatrixLieGroup, OpenSet):
     """
 
     def __init__(self, n, positive_det=False, **kwargs):
-        if "dim" not in kwargs.keys():
-            kwargs["dim"] = n**2
+        ambient_space = Matrices(n, n)
+        kwargs.setdefault("dim", n**2)
+        kwargs.setdefault("metric", ambient_space.metric)
+
         super(GeneralLinear, self).__init__(
-            ambient_space=Matrices(n, n), n=n, lie_algebra=SquareMatrices(n), **kwargs
+            ambient_space=ambient_space, n=n, lie_algebra=SquareMatrices(n), **kwargs
         )
-        if self._metric is None:
-            self._metric = MatricesMetric(n, n)
 
         self.positive_det = positive_det
 

--- a/geomstats/geometry/grassmannian.py
+++ b/geomstats/geometry/grassmannian.py
@@ -170,7 +170,7 @@ class Grassmannian(LevelSet):
         Dimension of the subspaces.
     """
 
-    def __init__(self, n, k):
+    def __init__(self, n, k, **kwargs):
         geomstats.errors.check_integer(k, "k")
         geomstats.errors.check_integer(n, "n")
         if k > n:
@@ -181,6 +181,7 @@ class Grassmannian(LevelSet):
         self.n = n
         self.k = k
 
+        kwargs.setdefault("metric", GrassmannianCanonicalMetric(n, k))
         dim = int(k * (n - k))
         super(Grassmannian, self).__init__(
             dim=dim,
@@ -190,9 +191,8 @@ class Grassmannian(LevelSet):
             tangent_submersion=lambda v, x: 2
             * Matrices.to_symmetric(Matrices.mul(x, v))
             - v,
+            **kwargs
         )
-        if self.metric is None:
-            self.metric = GrassmannianCanonicalMetric(n, k)
 
     def random_uniform(self, n_samples=1):
         """Sample random points from a uniform distribution.

--- a/geomstats/geometry/grassmannian.py
+++ b/geomstats/geometry/grassmannian.py
@@ -190,8 +190,9 @@ class Grassmannian(LevelSet):
             tangent_submersion=lambda v, x: 2
             * Matrices.to_symmetric(Matrices.mul(x, v))
             - v,
-            metric=GrassmannianCanonicalMetric(n, k),
         )
+        if self.metric is None:
+            self.metric = GrassmannianCanonicalMetric(n, k)
 
     def random_uniform(self, n_samples=1):
         """Sample random points from a uniform distribution.

--- a/geomstats/geometry/heisenberg.py
+++ b/geomstats/geometry/heisenberg.py
@@ -28,7 +28,7 @@ class HeisenbergVectors(LieGroup, VectorSpace):
 
     def __init__(self, **kwargs):
         super(HeisenbergVectors, self).__init__(
-            dim=3, shape=(3,), lie_algebra=Euclidean(3)
+            dim=3, shape=(3,), lie_algebra=Euclidean(3), **kwargs
         )
 
     def _create_basis(self):

--- a/geomstats/geometry/hermitian.py
+++ b/geomstats/geometry/hermitian.py
@@ -20,11 +20,10 @@ class Hermitian(VectorSpace):
         Dimension of the Hermitian space.
     """
 
-    def __init__(self, dim):
+    def __init__(self, dim, **kwargs):
+        kwargs.setdefault("metric", HermitianMetric(dim, shape=(dim,)))
         super(Hermitian, self).__init__(
-            shape=(dim,),
-            default_point_type="vector",
-            metric=HermitianMetric(dim, shape=(dim,)),
+            shape=(dim,), default_point_type="vector", **kwargs
         )
 
     def get_identity(self):

--- a/geomstats/geometry/hyperboloid.py
+++ b/geomstats/geometry/hyperboloid.py
@@ -44,6 +44,7 @@ class Hyperboloid(_Hyperbolic, LevelSet):
 
     def __init__(self, dim, coords_type="extrinsic", scale=1, **kwargs):
         minkowski = Minkowski(dim + 1)
+        kwargs.setdefault("metric", HyperboloidMetric(dim, coords_type, scale))
         super(Hyperboloid, self).__init__(
             dim=dim,
             embedding_space=minkowski,
@@ -55,8 +56,6 @@ class Hyperboloid(_Hyperbolic, LevelSet):
         )
         self.coords_type = coords_type
         self.point_type = Hyperboloid.default_point_type
-        if self._metric is None:
-            self._metric = HyperboloidMetric(dim, coords_type, scale)
 
     def belongs(self, point, atol=gs.atol):
         """Test if a point belongs to the hyperbolic space.

--- a/geomstats/geometry/hyperboloid.py
+++ b/geomstats/geometry/hyperboloid.py
@@ -42,7 +42,7 @@ class Hyperboloid(_Hyperbolic, LevelSet):
     default_coords_type = "extrinsic"
     default_point_type = "vector"
 
-    def __init__(self, dim, coords_type="extrinsic", scale=1):
+    def __init__(self, dim, coords_type="extrinsic", scale=1, **kwargs):
         minkowski = Minkowski(dim + 1)
         super(Hyperboloid, self).__init__(
             dim=dim,
@@ -51,10 +51,12 @@ class Hyperboloid(_Hyperbolic, LevelSet):
             value=-1.0,
             tangent_submersion=minkowski.metric.inner_product,
             scale=scale,
+            **kwargs
         )
         self.coords_type = coords_type
         self.point_type = Hyperboloid.default_point_type
-        self.metric = HyperboloidMetric(self.dim, self.coords_type, self.scale)
+        if self._metric is None:
+            self._metric = HyperboloidMetric(dim, coords_type, scale)
 
     def belongs(self, point, atol=gs.atol):
         """Test if a point belongs to the hyperbolic space.

--- a/geomstats/geometry/hypersphere.py
+++ b/geomstats/geometry/hypersphere.py
@@ -1132,4 +1132,4 @@ class Hypersphere(_Hypersphere):
 
     def __init__(self, dim, default_coords_type="extrinsic"):
         super(Hypersphere, self).__init__(dim, default_coords_type)
-        self.metric = HypersphereMetric(dim)
+        self._metric = HypersphereMetric(dim)

--- a/geomstats/geometry/invariant_metric.py
+++ b/geomstats/geometry/invariant_metric.py
@@ -1287,7 +1287,7 @@ class BiInvariantMetric(_InvariantMetricVector):
             return super(BiInvariantMetric, self).inner_product_at_identity(
                 tangent_vec_a, tangent_vec_b
             )
-        return Matrices.frobenius_product(tangent_vec_a, tangent_vec_b)
+        return Matrices.frobenius_product(tangent_vec_a, tangent_vec_b) / 2
 
     def inner_product(self, tangent_vec_a, tangent_vec_b, base_point=None):
         """Compute inner product of two vectors in tangent space at base point.

--- a/geomstats/geometry/landmarks.py
+++ b/geomstats/geometry/landmarks.py
@@ -23,13 +23,12 @@ class Landmarks(ProductManifold):
         Number of landmarks.
     """
 
-    def __init__(self, ambient_manifold, k_landmarks):
+    def __init__(self, ambient_manifold, k_landmarks, **kwargs):
+        kwargs.setdefault("metric", L2Metric(ambient_manifold, k_landmarks))
         super(Landmarks, self).__init__(
             manifolds=[ambient_manifold] * k_landmarks, default_point_type="matrix"
         )
         self.ambient_manifold = ambient_manifold
-        if self._metric is None:
-            self._metric = L2Metric(ambient_manifold, k_landmarks)
         self.k_landmarks = k_landmarks
 
 

--- a/geomstats/geometry/landmarks.py
+++ b/geomstats/geometry/landmarks.py
@@ -26,7 +26,9 @@ class Landmarks(ProductManifold):
     def __init__(self, ambient_manifold, k_landmarks, **kwargs):
         kwargs.setdefault("metric", L2Metric(ambient_manifold, k_landmarks))
         super(Landmarks, self).__init__(
-            manifolds=[ambient_manifold] * k_landmarks, default_point_type="matrix"
+            manifolds=[ambient_manifold] * k_landmarks,
+            default_point_type="matrix",
+            **kwargs
         )
         self.ambient_manifold = ambient_manifold
         self.k_landmarks = k_landmarks

--- a/geomstats/geometry/landmarks.py
+++ b/geomstats/geometry/landmarks.py
@@ -28,7 +28,8 @@ class Landmarks(ProductManifold):
             manifolds=[ambient_manifold] * k_landmarks, default_point_type="matrix"
         )
         self.ambient_manifold = ambient_manifold
-        self.metric = L2Metric(ambient_manifold, k_landmarks)
+        if self._metric is None:
+            self._metric = L2Metric(ambient_manifold, k_landmarks)
         self.k_landmarks = k_landmarks
 
 

--- a/geomstats/geometry/lower_triangular_matrices.py
+++ b/geomstats/geometry/lower_triangular_matrices.py
@@ -21,10 +21,12 @@ class LowerTriangularMatrices(VectorSpace):
         super(LowerTriangularMatrices, self).__init__(
             dim=int(n * (n + 1) / 2),
             shape=(n, n),
-            metric=MatricesMetric(n, n),
             default_point_type="matrix",
+            **kwargs
         )
         self.n = n
+        if self._metric is None:
+            self._metric = MatricesMetric(n, n)
 
     def _create_basis(self):
         """Compute the basis of the vector space of lower triangular.

--- a/geomstats/geometry/lower_triangular_matrices.py
+++ b/geomstats/geometry/lower_triangular_matrices.py
@@ -18,6 +18,7 @@ class LowerTriangularMatrices(VectorSpace):
     """
 
     def __init__(self, n, **kwargs):
+        kwargs.setdefault("metric", MatricesMetric(n, n))
         super(LowerTriangularMatrices, self).__init__(
             dim=int(n * (n + 1) / 2),
             shape=(n, n),
@@ -25,8 +26,6 @@ class LowerTriangularMatrices(VectorSpace):
             **kwargs
         )
         self.n = n
-        if self._metric is None:
-            self._metric = MatricesMetric(n, n)
 
     def _create_basis(self):
         """Compute the basis of the vector space of lower triangular.

--- a/geomstats/geometry/manifold.py
+++ b/geomstats/geometry/manifold.py
@@ -60,7 +60,7 @@ class Manifold(abc.ABC):
         self.shape = shape
         self.default_point_type = default_point_type
         self.default_coords_type = default_coords_type
-        self.metric = metric
+        self._metric = metric
 
     @abc.abstractmethod
     def belongs(self, point, atol=gs.atol):
@@ -161,6 +161,7 @@ class Manifold(abc.ABC):
 
     @metric.setter
     def metric(self, metric):
+        print(" hi")
         if metric is not None:
             if not isinstance(metric, RiemannianMetric):
                 raise ValueError("The argument must be a RiemannianMetric object")

--- a/geomstats/geometry/manifold.py
+++ b/geomstats/geometry/manifold.py
@@ -161,7 +161,6 @@ class Manifold(abc.ABC):
 
     @metric.setter
     def metric(self, metric):
-        print(" hi")
         if metric is not None:
             if not isinstance(metric, RiemannianMetric):
                 raise ValueError("The argument must be a RiemannianMetric object")

--- a/geomstats/geometry/matrices.py
+++ b/geomstats/geometry/matrices.py
@@ -21,11 +21,11 @@ class Matrices(VectorSpace):
     def __init__(self, m, n, **kwargs):
         if "default_point_type" not in kwargs.keys():
             kwargs["default_point_type"] = "matrix"
-        super(Matrices, self).__init__(
-            shape=(m, n), metric=MatricesMetric(m, n), **kwargs
-        )
+        super(Matrices, self).__init__(shape=(m, n), **kwargs)
         geomstats.errors.check_integer(n, "n")
         geomstats.errors.check_integer(m, "m")
+        if self.metric is None:
+            self.metric = MatricesMetric(m, n)
         self.m = m
         self.n = n
 

--- a/geomstats/geometry/matrices.py
+++ b/geomstats/geometry/matrices.py
@@ -19,13 +19,11 @@ class Matrices(VectorSpace):
     """
 
     def __init__(self, m, n, **kwargs):
-        if "default_point_type" not in kwargs.keys():
-            kwargs["default_point_type"] = "matrix"
-        super(Matrices, self).__init__(shape=(m, n), **kwargs)
         geomstats.errors.check_integer(n, "n")
         geomstats.errors.check_integer(m, "m")
-        if self.metric is None:
-            self.metric = MatricesMetric(m, n)
+        kwargs.setdefault("metric", MatricesMetric(m, n))
+        kwargs.setdefault("default_point_type", "matrix")
+        super(Matrices, self).__init__(shape=(m, n), **kwargs)
         self.m = m
         self.n = n
 

--- a/geomstats/geometry/minkowski.py
+++ b/geomstats/geometry/minkowski.py
@@ -30,7 +30,7 @@ class Minkowski(Euclidean):
         `MinkowskiMetric`.
         """
         space = Euclidean(dim)
-        space.metric = MinkowskiMetric(dim)
+        space._metric = MinkowskiMetric(dim)
         return space
 
 

--- a/geomstats/geometry/poincare_polydisk.py
+++ b/geomstats/geometry/poincare_polydisk.py
@@ -53,7 +53,7 @@ class PoincarePolydisk(ProductManifold, OpenSet):
             default_point_type="matrix",
             ambient_space=Matrices(n_disks, 2),
         )
-        self.metric = PoincarePolydiskMetric(n_disks=n_disks, coords_type=coords_type)
+        self._metric = PoincarePolydiskMetric(n_disks=n_disks, coords_type=coords_type)
 
     @staticmethod
     def intrinsic_to_extrinsic_coords(point_intrinsic):

--- a/geomstats/geometry/positive_lower_triangular_matrices.py
+++ b/geomstats/geometry/positive_lower_triangular_matrices.py
@@ -29,12 +29,11 @@ class PositiveLowerTriangularMatrices(OpenSet):
     """
 
     def __init__(self, n, **kwargs):
+        kwargs.setdefault("metric", CholeskyMetric(n))
         super(PositiveLowerTriangularMatrices, self).__init__(
             dim=int(n * (n + 1) / 2), ambient_space=LowerTriangularMatrices(n), **kwargs
         )
         self.n = n
-        if self._metric is None:
-            self._metric = CholeskyMetric(n)
 
     def random_point(self, n_samples=1, bound=1.0):
         """Sample from the manifold.

--- a/geomstats/geometry/positive_lower_triangular_matrices.py
+++ b/geomstats/geometry/positive_lower_triangular_matrices.py
@@ -30,12 +30,11 @@ class PositiveLowerTriangularMatrices(OpenSet):
 
     def __init__(self, n, **kwargs):
         super(PositiveLowerTriangularMatrices, self).__init__(
-            dim=int(n * (n + 1) / 2),
-            metric=(CholeskyMetric(n)),
-            ambient_space=LowerTriangularMatrices(n),
-            **kwargs
+            dim=int(n * (n + 1) / 2), ambient_space=LowerTriangularMatrices(n), **kwargs
         )
         self.n = n
+        if self._metric is None:
+            self._metric = CholeskyMetric(n)
 
     def random_point(self, n_samples=1, bound=1.0):
         """Sample from the manifold.

--- a/geomstats/geometry/product_manifold.py
+++ b/geomstats/geometry/product_manifold.py
@@ -52,8 +52,11 @@ class ProductManifold(Manifold):
         self.dims = [manifold.dim for manifold in manifolds]
         if metrics is None:
             metrics = [manifold.metric for manifold in manifolds]
-        metric = ProductRiemannianMetric(
-            metrics, default_point_type=default_point_type, n_jobs=n_jobs
+        kwargs.setdefault(
+            "metric",
+            ProductRiemannianMetric(
+                metrics, default_point_type=default_point_type, n_jobs=n_jobs
+            ),
         )
         dim = sum(self.dims)
 
@@ -65,7 +68,6 @@ class ProductManifold(Manifold):
         super(ProductManifold, self).__init__(
             dim=dim,
             shape=shape,
-            metric=metric,
             default_point_type=default_point_type,
             **kwargs,
         )

--- a/geomstats/geometry/quotient_metric.py
+++ b/geomstats/geometry/quotient_metric.py
@@ -25,15 +25,15 @@ class QuotientMetric(RiemannianMetric):
 
     def __init__(self, fiber_bundle: FiberBundle, dim: int = None, **kwargs):
         if dim is None:
-            if fiber_bundle.base is not None:
-                dim = fiber_bundle.base.dim
-            elif fiber_bundle.group is not None:
+            if fiber_bundle.group is not None:
                 dim = fiber_bundle.dim - fiber_bundle.group.dim
+            elif fiber_bundle.group_dim is not None:
+                dim = fiber_bundle.dim - fiber_bundle.group_dim
             else:
                 raise ValueError(
-                    "Either the base manifold, "
-                    "its dimension, or the group acting on the "
-                    "total space must be provided."
+                    "Either the dimension of the base manifold, "
+                    "or the group acting on the "
+                    "total space must be provided to the fiber bundle."
                 )
         super(QuotientMetric, self).__init__(
             dim=dim, default_point_type=fiber_bundle.default_point_type, **kwargs

--- a/geomstats/geometry/rank_k_psd_matrices.py
+++ b/geomstats/geometry/rank_k_psd_matrices.py
@@ -29,6 +29,7 @@ class RankKPSDMatrices(Manifold):
     """
 
     def __init__(self, n, k, **kwargs):
+        kwargs.setdefault("metric", PSDMetricBuresWasserstein(n, k))
         super(RankKPSDMatrices, self).__init__(
             **kwargs,
             dim=int(k * n - k * (k + 1) / 2),
@@ -37,10 +38,6 @@ class RankKPSDMatrices(Manifold):
         self.n = n
         self.rank = k
         self.sym = SymmetricMatrices(self.n)
-        if self._metric is None:
-            _metric = PSDMetricBuresWasserstein(n, k)
-            _metric.fiber_bundle.base = self
-            self._metric = _metric
 
     def belongs(self, mat, atol=gs.atol):
         r"""Check if the matrix belongs to the space.

--- a/geomstats/geometry/rank_k_psd_matrices.py
+++ b/geomstats/geometry/rank_k_psd_matrices.py
@@ -38,6 +38,13 @@ class RankKPSDMatrices(Manifold):
         self.rank = k
         self.sym = SymmetricMatrices(self.n)
 
+    @property
+    def metric(self):
+        """Riemannian Metric associated to the Manifold."""
+        if self._metric is None:
+            self._metric = PSDMetricBuresWasserstein(self.n, self.rank)
+        return self._metric
+
     def belongs(self, mat, atol=gs.atol):
         r"""Check if the matrix belongs to the space.
 

--- a/geomstats/geometry/spd_matrices.py
+++ b/geomstats/geometry/spd_matrices.py
@@ -29,12 +29,11 @@ class SPDMatrices(OpenSet):
 
     def __init__(self, n, **kwargs):
         super(SPDMatrices, self).__init__(
-            dim=int(n * (n + 1) / 2),
-            metric=SPDMetricAffine(n),
-            ambient_space=SymmetricMatrices(n),
-            **kwargs
+            dim=int(n * (n + 1) / 2), ambient_space=SymmetricMatrices(n), **kwargs
         )
         self.n = n
+        if self._metric is None:
+            self._metric = SPDMetricAffine(n)
 
     def belongs(self, mat, atol=gs.atol):
         """Check if a matrix is symmetric with positive eigenvalues.

--- a/geomstats/geometry/spd_matrices.py
+++ b/geomstats/geometry/spd_matrices.py
@@ -28,12 +28,11 @@ class SPDMatrices(OpenSet):
     """
 
     def __init__(self, n, **kwargs):
+        kwargs.setdefault("metric", SPDMetricAffine(n))
         super(SPDMatrices, self).__init__(
             dim=int(n * (n + 1) / 2), ambient_space=SymmetricMatrices(n), **kwargs
         )
         self.n = n
-        if self._metric is None:
-            self._metric = SPDMetricAffine(n)
 
     def belongs(self, mat, atol=gs.atol):
         """Check if a matrix is symmetric with positive eigenvalues.

--- a/geomstats/geometry/special_euclidean.py
+++ b/geomstats/geometry/special_euclidean.py
@@ -220,7 +220,7 @@ class _SpecialEuclideanMatrices(MatrixLieGroup, LevelSet):
         The Euclidean (Frobenius) inner product.
     """
 
-    def __init__(self, n):
+    def __init__(self, n, **kwargs):
         super().__init__(
             n=n + 1,
             dim=int((n * (n + 1)) / 2),
@@ -229,6 +229,7 @@ class _SpecialEuclideanMatrices(MatrixLieGroup, LevelSet):
             value=gs.eye(n + 1),
             tangent_submersion=tangent_submersion,
             lie_algebra=SpecialEuclideanMatrixLieAlgebra(n=n),
+            **kwargs
         )
         self.rotations = SpecialOrthogonal(n=n)
         self.translations = Euclidean(dim=n)
@@ -237,7 +238,8 @@ class _SpecialEuclideanMatrices(MatrixLieGroup, LevelSet):
         self.left_canonical_metric = SpecialEuclideanMatrixCannonicalLeftMetric(
             group=self
         )
-        self.metric = self.left_canonical_metric
+        if self._metric is None:
+            self._metric = self.left_canonical_metric
 
     @property
     def identity(self):

--- a/geomstats/geometry/special_orthogonal.py
+++ b/geomstats/geometry/special_orthogonal.py
@@ -37,7 +37,7 @@ class _SpecialOrthogonalMatrices(MatrixLieGroup, LevelSet):
         Integer representing the shape of the matrices: n x n.
     """
 
-    def __init__(self, n):
+    def __init__(self, n, **kwargs):
         matrices = Matrices(n, n)
         gln = GeneralLinear(n, positive_det=True)
         super(_SpecialOrthogonalMatrices, self).__init__(
@@ -49,9 +49,11 @@ class _SpecialOrthogonalMatrices(MatrixLieGroup, LevelSet):
             submersion=lambda x: matrices.mul(matrices.transpose(x), x),
             tangent_submersion=lambda v, x: 2
             * matrices.to_symmetric(matrices.mul(matrices.transpose(x), v)),
+            **kwargs,
         )
         self.bi_invariant_metric = BiInvariantMetric(group=self)
-        self.metric = self.bi_invariant_metric
+        if self._metric is None:
+            self._metric = self.bi_invariant_metric
 
     @classmethod
     def inverse(cls, point):
@@ -1723,7 +1725,7 @@ class SpecialOrthogonal(
         default: 0
     """
 
-    def __new__(cls, n, point_type="matrix", epsilon=0.0):
+    def __new__(cls, n, point_type="matrix", epsilon=0.0, **kwargs):
         """Instantiate a special orthogonal group.
 
         Select the object to instantiate depending on the point_type.
@@ -1736,4 +1738,4 @@ class SpecialOrthogonal(
             raise NotImplementedError(
                 "SO(n) is only implemented in vector representation" " when n = 3."
             )
-        return _SpecialOrthogonalMatrices(n)
+        return _SpecialOrthogonalMatrices(n, **kwargs)

--- a/geomstats/geometry/stiefel.py
+++ b/geomstats/geometry/stiefel.py
@@ -40,6 +40,8 @@ class Stiefel(LevelSet):
 
         dim = int(p * n - (p * (p + 1) / 2))
         matrices = Matrices(n, p)
+        canonical_metric = StiefelCanonicalMetric(n, p)
+        kwargs.setdefault("metric", canonical_metric)
         super(Stiefel, self).__init__(
             dim=dim,
             embedding_space=matrices,
@@ -49,10 +51,7 @@ class Stiefel(LevelSet):
             * matrices.to_symmetric(matrices.mul(matrices.transpose(x), v)),
             **kwargs
         )
-        self.canonical_metric = StiefelCanonicalMetric(n, p)
-        if self._metric is None:
-            self._metric = self.canonical_metric
-
+        self.canonical_metric = canonical_metric
         self.n = n
         self.p = p
 

--- a/geomstats/geometry/stiefel.py
+++ b/geomstats/geometry/stiefel.py
@@ -32,7 +32,7 @@ class Stiefel(LevelSet):
         Number of basis vectors in the orthonormal frame.
     """
 
-    def __init__(self, n, p):
+    def __init__(self, n, p, **kwargs):
         geomstats.errors.check_integer(n, "n")
         geomstats.errors.check_integer(p, "p")
         if p > n:
@@ -47,12 +47,14 @@ class Stiefel(LevelSet):
             value=gs.eye(p),
             tangent_submersion=lambda v, x: 2
             * matrices.to_symmetric(matrices.mul(matrices.transpose(x), v)),
-            metric=StiefelCanonicalMetric(n, p),
+            **kwargs
         )
+        self.canonical_metric = StiefelCanonicalMetric(n, p)
+        if self._metric is None:
+            self._metric = self.canonical_metric
 
         self.n = n
         self.p = p
-        self.canonical_metric = self.metric
 
     @staticmethod
     def to_grassmannian(point):

--- a/geomstats/geometry/symmetric_matrices.py
+++ b/geomstats/geometry/symmetric_matrices.py
@@ -22,14 +22,13 @@ class SymmetricMatrices(VectorSpace):
     """
 
     def __init__(self, n, **kwargs):
+        kwargs.setdefault("metric", MatricesMetric(n, n))
         super(SymmetricMatrices, self).__init__(
             dim=int(n * (n + 1) / 2),
             shape=(n, n),
             default_point_type="matrix",
             **kwargs
         )
-        if self._metric is None:
-            self._metric = MatricesMetric(n, n)
         self.n = n
 
     def _create_basis(self):

--- a/geomstats/geometry/symmetric_matrices.py
+++ b/geomstats/geometry/symmetric_matrices.py
@@ -25,9 +25,11 @@ class SymmetricMatrices(VectorSpace):
         super(SymmetricMatrices, self).__init__(
             dim=int(n * (n + 1) / 2),
             shape=(n, n),
-            metric=MatricesMetric(n, n),
             default_point_type="matrix",
+            **kwargs
         )
+        if self._metric is None:
+            self._metric = MatricesMetric(n, n)
         self.n = n
 
     def _create_basis(self):

--- a/tests/data/full_rank_correlation_matrices_data.py
+++ b/tests/data/full_rank_correlation_matrices_data.py
@@ -52,16 +52,16 @@ class CorrelationMatricesBundleTestData(TestData):
     def riemannian_submersion_belongs_to_base_test_data(self):
         random_data = []
         for n, n_samples in zip(self.n_list, self.n_samples_list):
-            bundle = CorrelationMatricesBundle(n)
-            point = bundle.base.random_point(n_samples)
+            base = FullRankCorrelationMatrices(n)
+            point = base.random_point(n_samples)
             random_data.append(dict(n=n, point=point))
         return self.generate_tests([], random_data)
 
     def lift_riemannian_submersion_composition_test_data(self):
         random_data = []
         for n, n_samples in zip(self.n_list, self.n_samples_list):
-            bundle = CorrelationMatricesBundle(n)
-            point = bundle.base.random_point(n_samples)
+            base = FullRankCorrelationMatrices(n)
+            point = base.random_point(n_samples)
             random_data.append(dict(n=n, point=point))
         return self.generate_tests([], random_data)
 
@@ -96,10 +96,10 @@ class CorrelationMatricesBundleTestData(TestData):
     def horizontal_lift_is_horizontal_test_data(self):
         random_data = []
         for n, n_samples in zip(self.n_list, self.n_samples_list):
-            bundle = CorrelationMatricesBundle(n)
-            mat = bundle.base.random_point()
-            vec = bundle.base.random_point(n_samples)
-            tangent_vec = bundle.base.to_tangent(vec, mat)
+            base = FullRankCorrelationMatrices(n)
+            mat = base.random_point()
+            vec = base.random_point(n_samples)
+            tangent_vec = base.to_tangent(vec, mat)
             random_data.append(dict(n=n, tangent_vec=tangent_vec, mat=mat))
         return self.generate_tests([], random_data)
 
@@ -107,19 +107,20 @@ class CorrelationMatricesBundleTestData(TestData):
         random_data = []
         for n, n_samples in zip(self.n_list, self.n_samples_list):
             bundle = CorrelationMatricesBundle(n)
+            base = FullRankCorrelationMatrices(n)
             mat = bundle.random_point()
             vec = bundle.random_point(n_samples)
-            tangent_vec = bundle.base.to_tangent(vec, mat)
+            tangent_vec = base.to_tangent(vec, mat)
             random_data.append(dict(n=n, tangent_vec=tangent_vec, mat=mat))
         return self.generate_tests([], random_data)
 
     def horizontal_lift_and_tangent_riemannian_submersion_test_data(self):
         random_data = []
         for n, n_samples in zip(self.n_list, self.n_samples_list):
-            bundle = CorrelationMatricesBundle(n)
-            mat = bundle.base.random_point()
-            vec = bundle.base.random_point(n_samples)
-            tangent_vec = bundle.base.to_tangent(vec, mat)
+            base = FullRankCorrelationMatrices(n)
+            mat = base.random_point()
+            vec = base.random_point(n_samples)
+            tangent_vec = base.to_tangent(vec, mat)
             random_data.append(dict(n=n, tangent_vec=tangent_vec, mat=mat))
 
         return self.generate_tests([], random_data)
@@ -142,9 +143,9 @@ class FullRankcorrelationAffineQuotientMetricTestData(TestData):
         return self.generate_tests([], random_data)
 
     def exp_belongs_test_data(self):
-
         bundle = CorrelationMatricesBundle(3)
-        base_point = bundle.base.random_point()
-        tangent_vec = bundle.base.to_tangent(bundle.random_point(), base_point)
+        base = FullRankCorrelationMatrices(3)
+        base_point = base.random_point()
+        tangent_vec = base.to_tangent(bundle.random_point(), base_point)
         smoke_data = [dict(dim=3, tangent_vec=tangent_vec, base_point=base_point)]
         return self.generate_tests(smoke_data)

--- a/tests/data/quotient_metric_data.py
+++ b/tests/data/quotient_metric_data.py
@@ -11,7 +11,6 @@ class BuresWassersteinBundle(GeneralLinear, FiberBundle):
     def __init__(self, n):
         super(BuresWassersteinBundle, self).__init__(
             n=n,
-            base=SPDMatrices(n),
             group=SpecialOrthogonal(n),
             ambient_metric=MatricesMetric(n, n),
         )
@@ -48,7 +47,7 @@ class QuotientMetricTestData(TestData):
         return self.generate_tests([], random_data)
 
     def lift_and_riemannian_submersion_test_data(self):
-        random_data = [dict(n=2, mat=BuresWassersteinBundle(2).base.random_point())]
+        random_data = [dict(n=2, mat=SPDMatrices(2).random_point())]
         return self.generate_tests([], random_data)
 
     def tangent_riemannian_submersion_test_data(self):

--- a/tests/data/rank_k_psd_matrices_data.py
+++ b/tests/data/rank_k_psd_matrices_data.py
@@ -118,13 +118,23 @@ class BuresWassersteinBundleTestData(_FiberBundleTestData):
             gs.atol,
         )
 
+    def is_tangent_after_tangent_riemannian_submersion_test_data(self):
+        return self._is_tangent_after_tangent_riemannian_submersion_test_data(
+            BuresWassersteinBundle,
+            PSDMatrices,
+            self.space_args_list,
+            self.n_vecs_list,
+            rtol=gs.rtol,
+            atol=gs.atol,
+        )
+
 
 class TestDataPSDMetricBuresWasserstein(_QuotientMetricTestData):
-    n_list = random.sample(range(2, 7), 5)
-    metric_args_list = [(n, n) for n in n_list]
+    n_list = random.sample(range(3, 8), 5)
+    metric_args_list = [(n, n - 1) for n in n_list]
     shape_list = [(n, n) for n in n_list]
-    space_list = [PSDMatrices(n, n) for n in n_list]
-    bundle_list = [BuresWassersteinBundle(n, n) for n in n_list]
+    space_list = [PSDMatrices(n, n - 1) for n in n_list]
+    bundle_list = [BuresWassersteinBundle(n, n - 1) for n in n_list]
     n_points_list = random.sample(range(1, 7), 5)
     n_samples_list = random.sample(range(1, 7), 5)
     n_points_a_list = random.sample(range(1, 7), 5)

--- a/tests/data/rank_k_psd_matrices_data.py
+++ b/tests/data/rank_k_psd_matrices_data.py
@@ -111,7 +111,7 @@ class BuresWassersteinBundleTestData(_FiberBundleTestData):
 
     def riemannian_submersion_after_lift_test_data(self):
         return self._riemannian_submersion_after_lift_test_data(
-            BuresWassersteinBundle,
+            PSDMatrices,
             self.space_args_list,
             self.n_base_points_list,
             gs.rtol,

--- a/tests/data_generation.py
+++ b/tests/data_generation.py
@@ -712,7 +712,7 @@ class _FiberBundleTestData(TestData):
 
     def _riemannian_submersion_after_lift_test_data(
         self,
-        space_cls,
+        base_cls,
         space_args_list,
         n_base_points_list,
         rtol=gs.rtol,
@@ -721,12 +721,36 @@ class _FiberBundleTestData(TestData):
         random_data = [
             dict(
                 space_args=space_args,
-                base_point=space_cls(*space_args).base.random_point(n_points),
+                base_point=base_cls(*space_args).random_point(n_points),
                 rtol=rtol,
                 atol=atol,
             )
             for space_args, n_points in zip(space_args_list, n_base_points_list)
         ]
+        return self.generate_tests([], random_data)
+
+    def _is_tangent_after_tangent_riemannian_submersion_test_data(
+        self,
+        bundle_cls,
+        base_cls,
+        space_args_list,
+        n_vecs_list,
+        rtol=gs.rtol,
+        atol=gs.atol,
+    ):
+        random_data = []
+        for space_args, n_vecs in zip(space_args_list, n_vecs_list):
+            base_point = bundle_cls(*space_args).random_point()
+            tangent_vec = bundle_cls(*space_args).random_tangent_vec(base_point, n_vecs)
+            d = dict(
+                space_args=space_args,
+                base_cls=base_cls,
+                tangent_vec=tangent_vec,
+                base_point=base_point,
+                rtol=rtol,
+                atol=atol,
+            )
+            random_data.append(d)
         return self.generate_tests([], random_data)
 
 

--- a/tests/geometry_test_cases.py
+++ b/tests/geometry_test_cases.py
@@ -482,33 +482,47 @@ class FiberBundleTestCase(TestCase):
     def test_is_horizontal_after_horizontal_projection(
         self, space_args, tangent_vec, base_point, rtol, atol
     ):
-        space = self.space(*space_args)
-        horizontal = space.horizontal_projection(tangent_vec, base_point)
-        result = space.is_horizontal(horizontal, base_point, atol)
+        bundle = self.bundle(*space_args)
+        horizontal = bundle.horizontal_projection(tangent_vec, base_point)
+        result = bundle.is_horizontal(horizontal, base_point, atol)
         self.assertTrue(gs.all(result))
 
     def test_is_vertical_after_vertical_projection(
         self, space_args, tangent_vec, base_point, rtol, atol
     ):
-        space = self.space(*space_args)
-        vertical = space.vertical_projection(tangent_vec, base_point)
-        result = space.is_vertical(vertical, base_point, atol)
+        bundle = self.bundle(*space_args)
+        vertical = bundle.vertical_projection(tangent_vec, base_point)
+        result = bundle.is_vertical(vertical, base_point, atol)
         self.assertTrue(gs.all(result))
 
     def test_is_horizontal_after_log_after_align(
         self, space_args, base_point, point, rtol, atol
     ):
-        space = self.space(*space_args)
-        aligned = space.align(point, base_point)
-        log = space.ambient_metric.log(aligned, base_point)
-        result = space.is_horizontal(log, base_point)
+        bundle = self.bundle(*space_args)
+        aligned = bundle.align(point, base_point)
+        log = bundle.ambient_metric.log(aligned, base_point)
+        result = bundle.is_horizontal(log, base_point)
         self.assertTrue(gs.all(result))
 
     def test_riemannian_submersion_after_lift(self, space_args, base_point, rtol, atol):
-        space = self.space(*space_args)
-        lift = space.lift(base_point)
-        result = space.riemannian_submersion(lift)
+        bundle = self.bundle(*space_args)
+        lift = bundle.lift(base_point)
+        result = bundle.riemannian_submersion(lift)
         self.assertAllClose(result, base_point, rtol, atol)
+
+    def test_is_tangent_after_tangent_riemannian_submersion(
+        self, space_args, base_cls, tangent_vec, base_point, rtol, atol
+    ):
+        bundle = self.bundle(*space_args)
+        projected = bundle.tangent_riemannian_submersion(tangent_vec, base_point)
+        projected_pt = bundle.riemannian_submersion(base_point)
+        result = base_cls(*space_args).is_tangent(projected, projected_pt)
+        expected = (
+            True
+            if tangent_vec.shape == bundle.shape
+            else gs.array([True] * len(tangent_vec))
+        )
+        self.assertAllClose(result, expected, rtol, atol)
 
 
 class ProductManifoldTestCase(ManifoldTestCase):

--- a/tests/tests_geomstats/test_full_rank_correlation_matrices.py
+++ b/tests/tests_geomstats/test_full_rank_correlation_matrices.py
@@ -27,11 +27,13 @@ class TestFullRankCorrelationMatrices(LevelSetTestCase, metaclass=Parametrizer):
 
 class TestCorrelationMatricesBundle(TestCase, metaclass=Parametrizer):
     space = CorrelationMatricesBundle
+    base = FullRankCorrelationMatrices
     testing_data = CorrelationMatricesBundleTestData()
 
     def test_riemannian_submersion_belongs_to_base(self, n, point):
         bundle = self.space(n)
-        result = bundle.base.belongs(bundle.riemannian_submersion(gs.array(point)))
+        base = self.base(n)
+        result = base.belongs(bundle.riemannian_submersion(gs.array(point)))
         self.assertAllClose(gs.all(result), gs.array(True))
 
     def test_lift_riemannian_submersion_composition(self, n, point):
@@ -57,12 +59,13 @@ class TestCorrelationMatricesBundle(TestCase, metaclass=Parametrizer):
 
     def test_horizontal_projection(self, n, vec, mat):
         bundle = self.space(n)
+        base = self.base(n)
         horizontal_vec = bundle.horizontal_projection(vec, mat)
         inverse = GeneralLinear.inverse(mat)
         product_1 = Matrices.mul(horizontal_vec, inverse)
         product_2 = Matrices.mul(inverse, horizontal_vec)
         is_horizontal = gs.all(
-            bundle.base.is_tangent(product_1 + product_2, mat, atol=gs.atol * 10)
+            base.is_tangent(product_1 + product_2, mat, atol=gs.atol * 10)
         )
         self.assertAllClose(is_horizontal, gs.array(True))
 

--- a/tests/tests_geomstats/test_quotient_metric.py
+++ b/tests/tests_geomstats/test_quotient_metric.py
@@ -7,7 +7,7 @@ import geomstats.tests
 from geomstats.geometry.general_linear import GeneralLinear
 from geomstats.geometry.matrices import Matrices
 from geomstats.geometry.quotient_metric import QuotientMetric
-from geomstats.geometry.spd_matrices import SPDMetricBuresWasserstein
+from geomstats.geometry.spd_matrices import SPDMatrices, SPDMetricBuresWasserstein
 from tests.conftest import Parametrizer, TestCase
 from tests.data.quotient_metric_data import (
     BuresWassersteinBundle,
@@ -18,6 +18,7 @@ from tests.data.quotient_metric_data import (
 class TestQuotientMetric(TestCase, metaclass=Parametrizer):
     metric = QuotientMetric
     bundle = BuresWassersteinBundle
+    base = SPDMatrices
     base_metric = SPDMetricBuresWasserstein
 
     testing_data = QuotientMetricTestData()
@@ -28,18 +29,17 @@ class TestQuotientMetric(TestCase, metaclass=Parametrizer):
         result = gs.all(bundle.belongs(point))
         self.assertTrue(result)
 
-    @pytest.mark.skip("giving error")
     def test_lift_and_riemannian_submersion(self, n, mat):
         bundle = self.bundle(n)
-        mat = bundle.lift(mat)
-        result = bundle.riemannian_submersion(mat)
+        lift = bundle.lift(mat)
+        result = bundle.riemannian_submersion(lift)
         self.assertAllClose(result, mat)
 
     def test_tangent_riemannian_submersion(self, n, mat, vec):
         bundle = self.bundle(n)
         point = bundle.riemannian_submersion(mat)
         tangent_vec = bundle.tangent_riemannian_submersion(vec, point)
-        result = bundle.base.is_tangent(tangent_vec, point)
+        result = self.base(n).is_tangent(tangent_vec, point)
         self.assertTrue(result)
 
     def test_horizontal_projection(self, n, mat, vec):

--- a/tests/tests_geomstats/test_rank_k_psd_matrices.py
+++ b/tests/tests_geomstats/test_rank_k_psd_matrices.py
@@ -30,7 +30,7 @@ class TestPSDMatrices(ManifoldTestCase, metaclass=Parametrizer):
 
 
 class TestBuresWassersteinBundle(FiberBundleTestCase, metaclass=Parametrizer):
-    space = BuresWassersteinBundle
+    bundle = BuresWassersteinBundle
 
     testing_data = BuresWassersteinBundleTestData()
 


### PR DESCRIPTION
closes #1453 
closes #1461 

This PR changes the remove the `metric` attribute that was coexisting with the `metric` property and the `_metric` attribute.
It also changes the way `_metric` is set to allow to pass other metric as kwarg when initializing a manifold. Some exceptions are made for the spaces that make sense for a given metric only, e.g. Poincare halfspace.

@lpereira95 this could be of interest to you