### PR TITLE
Allow passing starting centroids to RiemannianKMeans

### DIFF
--- a/geomstats/learning/kmeans.py
+++ b/geomstats/learning/kmeans.py
@@ -26,12 +26,15 @@ class RiemannianKMeans(TransformerMixin, ClusterMixin, BaseEstimator):
         Optional, default: 8.
     metric : object of class RiemannianMetric
         The geomstats Riemannian metric associate to the space used.
-    init : str or array-like, shape=[n_clusters, n_features]
+    init : str or callable or array-like, shape=[n_clusters, n_features]
         How to initialize centroids at the beginning of the algorithm. The
         choice 'random' will select training points as initial centroids
         uniformly at random. The choice 'kmeans++' selects centroids
-        heuristically to improve the convergence rate. By providing an array the
-        starting centroids can be specified externally.
+        heuristically to improve the convergence rate. When providing an array
+        of shape ``(n_clusters, n_features)``, the centroids are chosen as the
+        rows of that array. When providing a callable, it receives as arguments
+        the argument ``X`` to :meth:`fit` and the number of centroids
+        ``n_clusters`` and is expected to return an array as above.
         Optional, default: 'random'.
     tol : float
         Convergence factor. Convergence is achieved when the difference of mean
@@ -129,21 +132,24 @@ class RiemannianKMeans(TransformerMixin, ClusterMixin, BaseEstimator):
                 ]
             else:
                 raise ValueError(f"Unknown initial centroids method '{self.init}'.")
+
+            centroids = gs.concatenate(centroids, axis=0)
         else:
-            if self.init.shape[0] != self.n_clusters:
+            if callable(self.init):
+                centroids = self.init(X, self.n_clusters)
+            else:
+                centroids = self.init
+
+            if centroids.shape[0] != self.n_clusters:
                 raise ValueError("Need as many initial centroids as clusters.")
 
-            if self.init.shape[1] != X.shape[1]:
+            if centroids.shape[1] != X.shape[1]:
                 raise ValueError(
                     "Dimensions of initial centroids and training data do not match."
                 )
 
-            centroids = [
-                gs.expand_dims(self.init[i], 0) for i in range(self.n_clusters)
-            ]
-
-        self.centroids = gs.concatenate(centroids, axis=0)
-        self.init_centroids = gs.concatenate(centroids, axis=0)
+        self.centroids = gs.copy(centroids)
+        self.init_centroids = gs.copy(centroids)
 
         dists = [
             gs.to_ndarray(self.metric.dist(self.centroids[i], X), 2, 1)

--- a/tests/tests_geomstats/test_riemannian_kmeans.py
+++ b/tests/tests_geomstats/test_riemannian_kmeans.py
@@ -66,7 +66,7 @@ class TestRiemannianKMeans(geomstats.tests.TestCase):
         )
         self.assertAllClose(expected, result)
 
-    def test_hypersphere_kmeans_initialization(self):
+    def test_hypersphere_kmeans_init_kmeanspp(self):
         gs.random.seed(55)
 
         manifold = hypersphere.Hypersphere(2)
@@ -82,4 +82,24 @@ class TestRiemannianKMeans(geomstats.tests.TestCase):
         centroids = kmeans.centroids
         result = centroids.shape
         expected = (n_clusters, 3)
+        self.assertAllClose(expected, result)
+
+    def test_hypersphere_kmeans_init_array(self):
+        gs.random.seed(55)
+
+        n_features = 3
+        n_clusters = 3
+
+        manifold = hypersphere.Hypersphere(n_features - 1)
+
+        x = manifold.random_von_mises_fisher(kappa=100, n_samples=200)
+        y = manifold.random_von_mises_fisher(kappa=10, n_samples=n_clusters)
+
+        kmeans = RiemannianKMeans(
+            manifold.metric, n_clusters, init_step_size=1.0, tol=1e-3, init=y
+        )
+        kmeans.fit(x)
+        centroids = kmeans.centroids
+        result = centroids.shape
+        expected = (n_clusters, n_features)
         self.assertAllClose(expected, result)

--- a/tests/tests_geomstats/test_riemannian_kmeans.py
+++ b/tests/tests_geomstats/test_riemannian_kmeans.py
@@ -66,40 +66,46 @@ class TestRiemannianKMeans(geomstats.tests.TestCase):
         )
         self.assertAllClose(expected, result)
 
-    def test_hypersphere_kmeans_init_kmeanspp(self):
-        gs.random.seed(55)
-
-        manifold = hypersphere.Hypersphere(2)
-        metric = hypersphere.HypersphereMetric(2)
-
-        x = manifold.random_von_mises_fisher(kappa=100, n_samples=200)
-
-        n_clusters = 3
-        kmeans = RiemannianKMeans(
-            metric, n_clusters, init_step_size=1.0, tol=1e-3, init="kmeans++"
-        )
-        kmeans.fit(x)
-        centroids = kmeans.centroids
-        result = centroids.shape
-        expected = (n_clusters, 3)
-        self.assertAllClose(expected, result)
-
-    def test_hypersphere_kmeans_init_array(self):
-        gs.random.seed(55)
-
-        n_features = 3
-        n_clusters = 3
+    def _test_hypersphere_kmeans_init(
+        self, init, *, n_features=4, n_clusters=3, seed=1
+    ):
+        gs.random.seed(seed)
 
         manifold = hypersphere.Hypersphere(n_features - 1)
 
         x = manifold.random_von_mises_fisher(kappa=100, n_samples=200)
-        y = manifold.random_von_mises_fisher(kappa=10, n_samples=n_clusters)
 
         kmeans = RiemannianKMeans(
-            manifold.metric, n_clusters, init_step_size=1.0, tol=1e-3, init=y
+            manifold.metric, n_clusters, init_step_size=1.0, tol=1e-3, init=init
         )
         kmeans.fit(x)
+
         centroids = kmeans.centroids
         result = centroids.shape
         expected = (n_clusters, n_features)
         self.assertAllClose(expected, result)
+
+    def test_hypersphere_kmeans_init_kmeanspp(self):
+        self._test_hypersphere_kmeans_init("kmeans++")
+
+    def test_hypersphere_kmeans_init_array(self):
+        n_features = 4
+        n_clusters = 3
+
+        manifold = hypersphere.Hypersphere(n_features - 1)
+        centroids = manifold.random_von_mises_fisher(kappa=10, n_samples=n_clusters)
+
+        self._test_hypersphere_kmeans_init(
+            centroids, n_features=n_features, n_clusters=n_clusters
+        )
+
+    def test_hypersphere_kmeans_init_callable(self):
+        # Note that _test_hypersphere_kmeans_init sets the random seed before
+        # make_centroids is called by RiemannianKMeans.fit.
+        def make_centroids(X, n_clusters):
+            n_features = X.shape[1]
+            manifold = hypersphere.Hypersphere(n_features - 1)
+            centroids = manifold.random_von_mises_fisher(kappa=10, n_samples=n_clusters)
+            return centroids
+
+        self._test_hypersphere_kmeans_init(make_centroids)


### PR DESCRIPTION
<!--
Thank you for opening this pull request!
-->

## Checklist

- [x] My pull request has a clear and explanatory title.
- [x] If neccessary, my code is [vectorized](https://www.geeksforgeeks.org/vectorization-in-python/).
- [x] I have added apropriate unit tests.
- [x] I have made sure the code passes all unit tests. (refer to comment below)
- [x] My PR follows [PEP8](https://peps.python.org/pep-0008/) guidelines. (refer to comment below)
- [x] My PR follows [geomstats coding style](https://github.com/geomstats/geomstats/blob/master/docs/contributing.rst#coding-style-guidelines) and API.
- [ ] My code is properly documented and I made sure the documentation renders properly. ([Link](https://github.com/geomstats/geomstats/blob/master/docs/contributing.rst#documentation))
- [x] I have linked to issues and PRs that are relevant to this PR.


<!-- For checking consistency of entire codebase
First, run the tests related to your changes. For example, if you changed something in geomstats/spd_matrices_space.py:
$ pytest tests/tests_geomstats/test_spd_matrices.py

and then run the tests of the whole codebase to check that your feature is not breaking any of them:
$ pytest tests/

This way, further modifications on the code base are guaranteed to be consistent with the desired behavior. Merging your PR should not break any test in any backend (numpy, tensorflow or pytorch)."

For testing in alternative backends such as `numpy`, `pytorch`, `autograd`, `tensorflow` set the environment variable using:
$ export GEOMSTATS_BACKEND=<backend_name>

Next, import the `backend` module using:
import geomstats.backend as gs 
-->


<!-- For flake8 tests
Install dependencies
$ pip3 install -r dev-requirements.txt

Then run the following commands:
$ flake8 --ignore=D,W503,W504 geomstats examples tests   #shadows .flake8
$ flake8 geomstats/geometry geomstats/learning           #passed two subfolders 
-->

## Description 

<!-- Include a description of your pull request. If relevant, feel free to use this space to talk about time and space complexity as well scalability of your code-->

Sometimes users have domain-specific knowledge on where to expect cluster centers. This MR lets them provide initial cluster centers to nudge k-means towards this guess. If the guess is good, this improves the convergence rate and produces a clustering matching the user's expectation.

**I updated the documentation but failed to compile it due to many unrelated errors.** I also had to run the relevant unit tests manually due to issues with the current version of the `werkzeug` library.

## Issue

<!-- Tell us which issue does this PR fix . Why this feature implementation/fix is important in practice ?-->

This closes #1500.

## Additional context

<!-- Add any extra information -->