### PR TITLE
Add skip_all flag to tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -175,10 +175,15 @@ class Parametrizer(type):
             for test_fn in test_fn_list:
                 attrs[test_fn] = copy_func(getattr(base, test_fn))
 
+        skip_all = attrs.get("skip_all", False)
+
         for attr_name, attr_value in attrs.copy().items():
             if isinstance(attr_value, types.FunctionType):
 
-                if ("skip_" + attr_name, True) not in locals()["attrs"].items():
+                if (
+                    not skip_all
+                    and ("skip_" + attr_name, True) not in locals()["attrs"].items()
+                ):
                     args_str = ", ".join(inspect.getfullargspec(attr_value)[0][1:])
                     data_fn_str = attr_name[5:] + "_test_data"
                     if "testing_data" not in locals()["attrs"]:


### PR DESCRIPTION
This pull request adds option `skip_all` for tests. If `skip_all=True`, then all the tests are skipped.

**Why is this required?** We are starting to allow some parts of the library to be handled only by a subset of the available backends (e.g. stratified spaces). Therefore, we need a robust way to skip tests for the unsupported backends. Currently, such goal can be reached using a decorator (e.g. `np_only`). The main issue with the decorator is that it acts too late, i.e. data is generated anyway and then pytest is informed the test should be skipped. This, besides adding useless computational time,  is problematic when the data generation uses methods that are not available in all the backends.

With this approach, one can do e.g. `skip_all = not np_backend()`.

Am I missing something @SaitejaUtpala?

@ninamiolane, I think this may be somehow related with the problems you were having with @YannCabanes during the hackathon.

P.S. let me know if you see a different way of performing this task @SaitejaUtpala. Maybe if we can access the decorators in advance we can handle this better. Do you see how it can be done? 