### PR TITLE
Use skip_all option in spider tests

### DIFF
--- a/tests/tests_geomstats/test_spider.py
+++ b/tests/tests_geomstats/test_spider.py
@@ -15,17 +15,14 @@ IS_NOT_NP = not np_backend()
 
 class TestSpider(PointSetTestCase, metaclass=Parametrizer):
     testing_data = SpiderTestData()
-    skip_test_set_to_array_output_shape = IS_NOT_NP
+    skip_all = IS_NOT_NP
 
 
 class TestSpiderPoint(PointTestCase, metaclass=Parametrizer):
     testing_data = SpiderPointTestData()
+    skip_all = IS_NOT_NP
 
 
 class TestSpiderMetric(PointSetMetricTestCase, metaclass=Parametrizer):
     testing_data = SpiderMetricTestData()
-
-    skip_test_dist_output_shape = IS_NOT_NP
-    skip_test_dist_properties = IS_NOT_NP
-    skip_test_geodesic_bounds = IS_NOT_NP
-    skip_test_geodesic_output_shape = IS_NOT_NP
+    skip_all = IS_NOT_NP


### PR DESCRIPTION
This will take advantage of the new option `skip_all` in tests.