### PR TITLE
fixing the typo in docs

### DIFF
--- a/docs/api-reference.rst
+++ b/docs/api-reference.rst
@@ -15,7 +15,7 @@ scikit-learn's base classes and mixins.
 
 In both modules, the operations are vectorized for batch computation and provide
 support for different execution backends---namely NumPy, PyTorch, and TensorFlow.
-The module `backend` implements the operations needed to use Geomstats seemlessly with any backend.
+The module `backend` implements the operations needed to use Geomstats seamlessly with any backend.
 
 .. toctree::
    :maxdepth: 3


### PR DESCRIPTION
In the [file](https://github.com/geomstats/geomstats/blob/master/docs/api-reference.rst)
seamlessly was mispelled

## Checklist

- [x] My pull request has a clear and explanatory title.
- [x] If neccessary, my code is [vectorized](https://www.geeksforgeeks.org/vectorization-in-python/).
- [x] I have added apropriate unit tests.
- [x] I have made sure the code passes all unit tests. (refer to comment below)
- [x] My PR follows [PEP8](https://peps.python.org/pep-0008/) guidelines. (refer to comment below)
- [x] My PR follows [geomstats coding style](https://github.com/geomstats/geomstats/blob/master/docs/contributing.rst#coding-style-guidelines) and API.
- [x] My code is properly documented and I made sure the documentation renders properly. ([Link](https://github.com/geomstats/geomstats/blob/master/docs/contributing.rst#documentation))
- [X] I have linked to issues and PRs that are relevant to this PR.



