### PR TITLE
vectorization of connection.exp, addition of n_steps as argument in geodesic

### DIFF
--- a/geomstats/geometry/connection.py
+++ b/geomstats/geometry/connection.py
@@ -126,7 +126,7 @@ class Connection(ABC):
             Point on the manifold.
         """
         base_point = gs.broadcast_to(base_point, tangent_vec.shape)
-        n_base_point, n_tangent_vec = base_point.shape[0], tangent_vec.shape[0]
+        """n_base_point, n_tangent_vec = base_point.shape[0], tangent_vec.shape[0]
 
         base_point = gs.squeeze(base_point)
         tangent_vec = gs.squeeze(tangent_vec)
@@ -138,7 +138,7 @@ class Connection(ABC):
                     " of tangent vectors."
                 )
             else:
-                base_point = gs.tile(base_point, (n_tangent_vec, 1))
+                base_point = gs.tile(base_point, (n_tangent_vec, 1))"""
 
         initial_state = gs.stack([base_point, tangent_vec])
         flow = integrate(
@@ -560,7 +560,7 @@ class Connection(ABC):
         )
 
     def geodesic(
-        self, initial_point, end_point=None, initial_tangent_vec=None, **kwargs
+        self, initial_point, end_point=None, initial_tangent_vec=None, **exp_kwargs
     ):
         """Generate parameterized function for the geodesic curve.
 
@@ -634,7 +634,7 @@ class Connection(ABC):
                 tangent_vecs = gs.einsum("i,...kl->...ikl", t, initial_tangent_vec)
 
             points_at_time_t = [
-                self.exp(tv, pt, **kwargs)
+                self.exp(tv, pt, **exp_kwargs)
                 for tv, pt in zip(tangent_vecs, initial_point)
             ]
             points_at_time_t = gs.stack(points_at_time_t, axis=0)

--- a/geomstats/geometry/connection.py
+++ b/geomstats/geometry/connection.py
@@ -125,6 +125,22 @@ class Connection(ABC):
         exp : array-like, shape=[..., dim]
             Point on the manifold.
         """
+        base_point = gs.to_ndarray(base_point, to_ndim=2)
+        tangent_vec = gs.to_ndarray(tangent_vec, to_ndim=2)
+        n_base_point, n_tangent_vec = base_point.shape[0], tangent_vec.shape[0]
+
+        base_point = gs.squeeze(base_point)
+        tangent_vec = gs.squeeze(tangent_vec)
+
+        if n_base_point != n_tangent_vec:
+            if n_base_point > 1:
+                raise ValueError(
+                    "For several initial points, specify either one or the same number"
+                    " of tangent vectors."
+                )
+            else:
+                base_point = gs.tile(base_point, (n_tangent_vec, 1))
+
         initial_state = gs.stack([base_point, tangent_vec])
         flow = integrate(
             self.geodesic_equation, initial_state, n_steps=n_steps, step=step
@@ -544,7 +560,9 @@ class Connection(ABC):
             tangent_vec_a, tangent_vec_b, tangent_vec_a, tangent_vec_b, base_point
         )
 
-    def geodesic(self, initial_point, end_point=None, initial_tangent_vec=None):
+    def geodesic(
+        self, initial_point, end_point=None, initial_tangent_vec=None, **kwargs
+    ):
         """Generate parameterized function for the geodesic curve.
 
         Geodesic curve defined by either:
@@ -617,7 +635,8 @@ class Connection(ABC):
                 tangent_vecs = gs.einsum("i,...kl->...ikl", t, initial_tangent_vec)
 
             points_at_time_t = [
-                self.exp(tv, pt) for tv, pt in zip(tangent_vecs, initial_point)
+                self.exp(tv, pt, **kwargs)
+                for tv, pt in zip(tangent_vecs, initial_point)
             ]
             points_at_time_t = gs.stack(points_at_time_t, axis=0)
 

--- a/geomstats/geometry/connection.py
+++ b/geomstats/geometry/connection.py
@@ -126,19 +126,6 @@ class Connection(ABC):
             Point on the manifold.
         """
         base_point = gs.broadcast_to(base_point, tangent_vec.shape)
-        """n_base_point, n_tangent_vec = base_point.shape[0], tangent_vec.shape[0]
-
-        base_point = gs.squeeze(base_point)
-        tangent_vec = gs.squeeze(tangent_vec)
-
-        if n_base_point != n_tangent_vec:
-            if n_base_point > 1:
-                raise ValueError(
-                    "For several initial points, specify either one or the same number"
-                    " of tangent vectors."
-                )
-            else:
-                base_point = gs.tile(base_point, (n_tangent_vec, 1))"""
 
         initial_state = gs.stack([base_point, tangent_vec])
         flow = integrate(

--- a/geomstats/geometry/connection.py
+++ b/geomstats/geometry/connection.py
@@ -125,8 +125,7 @@ class Connection(ABC):
         exp : array-like, shape=[..., dim]
             Point on the manifold.
         """
-        base_point = gs.to_ndarray(base_point, to_ndim=2)
-        tangent_vec = gs.to_ndarray(tangent_vec, to_ndim=2)
+        base_point = gs.broadcast_to(base_point, tangent_vec.shape)
         n_base_point, n_tangent_vec = base_point.shape[0], tangent_vec.shape[0]
 
         base_point = gs.squeeze(base_point)

--- a/tests/data/connection_data.py
+++ b/tests/data/connection_data.py
@@ -54,6 +54,56 @@ class ConnectionTestData(TestData):
         ]
         return self.generate_tests(smoke_data)
 
+    def geodesic_with_exp_connection_test_data(self):
+        smoke_data = [
+            dict(
+                dim=2,
+                point=gs.array([1.0, gs.pi / 2]),
+                tangent_vec=gs.array([gs.pi / 3, gs.pi / 4]),
+                n_times=10,
+                n_steps=10,
+                expected=(10, 2),
+            ),
+            dict(
+                dim=2,
+                point=gs.array([1.0, gs.pi / 2]),
+                tangent_vec=gs.array([[gs.pi / 3, gs.pi / 4], [gs.pi / 2, -gs.pi / 4]]),
+                n_times=10,
+                n_steps=100,
+                expected=(2, 10, 2),
+            ),
+            dict(
+                dim=2,
+                point=gs.array([[1.0, gs.pi / 2], [gs.pi / 6, gs.pi / 3]]),
+                tangent_vec=gs.array([[gs.pi / 3, gs.pi / 4], [gs.pi / 2, gs.pi / 4]]),
+                n_times=10,
+                n_steps=100,
+                expected=(2, 10, 2),
+            ),
+        ]
+        return self.generate_tests(smoke_data)
+
+    def geodesic_with_log_connection_test_data(self):
+        smoke_data = [
+            dict(
+                dim=2,
+                point=gs.array([1.0, gs.pi / 2]),
+                end_point=gs.array([gs.pi / 3, gs.pi / 4]),
+                n_times=10,
+                n_steps=10,
+                expected=(10, 2),
+            ),
+            dict(
+                dim=2,
+                point=gs.array([[1.0, gs.pi / 2], [gs.pi / 6, gs.pi / 3]]),
+                end_point=gs.array([[gs.pi / 3, gs.pi / 4], [gs.pi / 2, gs.pi / 4]]),
+                n_times=10,
+                n_steps=100,
+                expected=(2, 10, 2),
+            ),
+        ]
+        return self.generate_tests(smoke_data)
+
     def geodesic_and_coincides_exp_test_data(self):
         smoke_data = [
             dict(

--- a/tests/data/connection_data.py
+++ b/tests/data/connection_data.py
@@ -45,11 +45,13 @@ class ConnectionTestData(TestData):
                 dim=2,
                 point=gs.array([1.0, gs.pi / 2]),
                 base_point=gs.array([gs.pi / 3, gs.pi / 4]),
+                atol=1e-6,
             ),
             dict(
                 dim=2,
                 point=gs.array([[1.0, gs.pi / 2], [gs.pi / 6, gs.pi / 3]]),
                 base_point=gs.array([[gs.pi / 3, gs.pi / 4], [gs.pi / 2, gs.pi / 4]]),
+                atol=1e-6,
             ),
         ]
         return self.generate_tests(smoke_data)
@@ -63,6 +65,7 @@ class ConnectionTestData(TestData):
                 n_times=10,
                 n_steps=10,
                 expected=(10, 2),
+                atol=1e-6,
             ),
             dict(
                 dim=2,
@@ -71,6 +74,7 @@ class ConnectionTestData(TestData):
                 n_times=10,
                 n_steps=100,
                 expected=(2, 10, 2),
+                atol=1e-6,
             ),
             dict(
                 dim=2,
@@ -79,6 +83,7 @@ class ConnectionTestData(TestData):
                 n_times=10,
                 n_steps=100,
                 expected=(2, 10, 2),
+                atol=1e-6,
             ),
         ]
         return self.generate_tests(smoke_data)
@@ -92,6 +97,7 @@ class ConnectionTestData(TestData):
                 n_times=10,
                 n_steps=10,
                 expected=(10, 2),
+                atol=1e-6,
             ),
             dict(
                 dim=2,
@@ -100,6 +106,7 @@ class ConnectionTestData(TestData):
                 n_times=10,
                 n_steps=100,
                 expected=(2, 10, 2),
+                atol=1e-6,
             ),
         ]
         return self.generate_tests(smoke_data)

--- a/tests/tests_geomstats/test_connection.py
+++ b/tests/tests_geomstats/test_connection.py
@@ -118,6 +118,37 @@ class TestConnection(TestCase, metaclass=Parametrizer):
 
         self.assertAllClose(result, expected, atol=1e-6)
 
+    def test_geodesic_with_exp_connection(
+        self, dim, point, tangent_vec, n_times, n_steps, expected
+    ):
+        sphere = Hypersphere(dim)
+        connection = Connection(dim)
+        connection.christoffels = sphere.metric.christoffels
+        geo = connection.geodesic(
+            initial_point=point, initial_tangent_vec=tangent_vec, n_steps=n_steps
+        )
+        times = gs.linspace(0, 1, n_times)
+        geo = geo(times)
+        result = geo.shape
+
+        self.assertAllClose(result, expected, atol=1e-6)
+
+    @geomstats.tests.autograd_tf_and_torch_only
+    def test_geodesic_with_log_connection(
+        self, dim, point, end_point, n_times, n_steps, expected
+    ):
+        sphere = Hypersphere(dim)
+        connection = Connection(dim)
+        connection.christoffels = sphere.metric.christoffels
+        geo = connection.geodesic(
+            initial_point=point, end_point=end_point, n_steps=n_steps
+        )
+        times = gs.linspace(0, 1, n_times)
+        geo = geo(times)
+        result = geo.shape
+
+        self.assertAllClose(result, expected, atol=1e-6)
+
     def test_geodesic_and_coincides_exp(self, space, n_geodesic_points, vector):
         initial_point = space.random_uniform(2)
         initial_tangent_vec = space.to_tangent(vector=vector, base_point=initial_point)

--- a/tests/tests_geomstats/test_connection.py
+++ b/tests/tests_geomstats/test_connection.py
@@ -104,7 +104,7 @@ class TestConnection(TestCase, metaclass=Parametrizer):
         self.assertAllClose(result, expected)
 
     @geomstats.tests.autograd_tf_and_torch_only
-    def test_log_connection_metric(self, dim, point, base_point):
+    def test_log_connection_metric(self, dim, point, base_point, atol):
         sphere = Hypersphere(dim)
         connection = Connection(dim)
         connection.christoffels = sphere.metric.christoffels
@@ -116,10 +116,10 @@ class TestConnection(TestCase, metaclass=Parametrizer):
         q_ext = sphere.spherical_to_extrinsic(point)
         expected = sphere.metric.log(base_point=p_ext, point=q_ext)
 
-        self.assertAllClose(result, expected, atol=1e-6)
+        self.assertAllClose(result, expected, atol)
 
     def test_geodesic_with_exp_connection(
-        self, dim, point, tangent_vec, n_times, n_steps, expected
+        self, dim, point, tangent_vec, n_times, n_steps, expected, atol
     ):
         sphere = Hypersphere(dim)
         connection = Connection(dim)
@@ -131,11 +131,11 @@ class TestConnection(TestCase, metaclass=Parametrizer):
         geo = geo(times)
         result = geo.shape
 
-        self.assertAllClose(result, expected, atol=1e-6)
+        self.assertAllClose(result, expected, atol)
 
     @geomstats.tests.autograd_tf_and_torch_only
     def test_geodesic_with_log_connection(
-        self, dim, point, end_point, n_times, n_steps, expected
+        self, dim, point, end_point, n_times, n_steps, expected, atol
     ):
         sphere = Hypersphere(dim)
         connection = Connection(dim)
@@ -147,7 +147,7 @@ class TestConnection(TestCase, metaclass=Parametrizer):
         geo = geo(times)
         result = geo.shape
 
-        self.assertAllClose(result, expected, atol=1e-6)
+        self.assertAllClose(result, expected, atol)
 
     def test_geodesic_and_coincides_exp(self, space, n_geodesic_points, vector):
         initial_point = space.random_uniform(2)


### PR DESCRIPTION
We modify exp of connection to make it vectorized: it did not work with the use case (one base_point, n tangent_vectors) before. It failed to raise errors before because the exps returned in the test files were not that of connection but those of the test geometries.
Moreover, we add n_steps as a potential argument in geodesic, as it was =N_STEPS=(10?) before.