### PR TITLE
Add take to the backend

### DIFF
--- a/geomstats/_backend/__init__.py
+++ b/geomstats/_backend/__init__.py
@@ -116,6 +116,7 @@ BACKEND_ATTRIBUTES = {
         "stack",
         "std",
         "sum",
+        "take",
         "tan",
         "tanh",
         "tile",

--- a/geomstats/_backend/autograd/__init__.py
+++ b/geomstats/_backend/autograd/__init__.py
@@ -90,6 +90,7 @@ from autograd.numpy import (
     stack,
     std,
     sum,
+    take,
     tan,
     tanh,
     tile,

--- a/geomstats/_backend/numpy/__init__.py
+++ b/geomstats/_backend/numpy/__init__.py
@@ -90,6 +90,7 @@ from numpy import (
     stack,
     std,
     sum,
+    take,
     tan,
     tanh,
     tile,

--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -859,8 +859,8 @@ def amin(a, axis=-1):
     return values
 
 
-def take(input, index):
-    if not torch.is_tensor(index):
-        index = torch.as_tensor(index)
+def take(a, indices, axis=0):
+    if not torch.is_tensor(indices):
+        indices = torch.as_tensor(indices)
 
-    return torch.take(input, index)
+    return torch.squeeze(torch.index_select(a, axis, indices))

--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -54,7 +54,6 @@ from torch import (
     sinh,
     stack,
     std,
-    take,
     tan,
     tanh,
     trapz,
@@ -858,3 +857,10 @@ def sort(a, axis=-1):
 def amin(a, axis=-1):
     (values, _) = torch.min(a, dim=axis)
     return values
+
+
+def take(input, index):
+    if not torch.is_tensor(index):
+        index = torch.as_tensor(index)
+
+    return torch.take(input, index)

--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -54,6 +54,7 @@ from torch import (
     sinh,
     stack,
     std,
+    take,
     tan,
     tanh,
     trapz,

--- a/geomstats/_backend/tensorflow/__init__.py
+++ b/geomstats/_backend/tensorflow/__init__.py
@@ -65,6 +65,7 @@ from tensorflow import (
     zeros,
     zeros_like,
 )
+from tensorflow.experimental.numpy import take
 
 from ..constants import tf_atol, tf_rtol
 from . import autodiff  # NOQA

--- a/geomstats/_backend/tensorflow/__init__.py
+++ b/geomstats/_backend/tensorflow/__init__.py
@@ -944,5 +944,5 @@ def kron(a, b):
     return tf.linalg.LinearOperatorKronecker([a, b]).to_dense()
 
 
-def take(input, index):
-    return tf.gather(input, index)
+def take(a, indices, axis=0):
+    return tf.gather(a, indices, axis=axis)

--- a/geomstats/_backend/tensorflow/__init__.py
+++ b/geomstats/_backend/tensorflow/__init__.py
@@ -65,7 +65,6 @@ from tensorflow import (
     zeros,
     zeros_like,
 )
-from tensorflow.experimental.numpy import take
 
 from ..constants import tf_atol, tf_rtol
 from . import autodiff  # NOQA
@@ -943,3 +942,7 @@ def ravel_tril_indices(n, k=0, m=None):
 
 def kron(a, b):
     return tf.linalg.LinearOperatorKronecker([a, b]).to_dense()
+
+
+def take(input, index):
+    return tf.gather(input, index)

--- a/tests/tests_geomstats/test_backends.py
+++ b/tests/tests_geomstats/test_backends.py
@@ -977,3 +977,11 @@ class TestBackends(tests.conftest.TestCase):
         result = gs.unique(vec)
         expected = gs.array([-1, 0, 1])
         self.assertAllClose(result, expected)
+
+    def test_take(self):
+        vec = gs.array([0, 1])
+
+        expected = gs.array([0, 0, 1])
+        self.assertAllClose(gs.take(vec, expected), expected)
+
+        self.assertEqual(gs.take(vec, 0), 0)

--- a/tests/tests_geomstats/test_backends.py
+++ b/tests/tests_geomstats/test_backends.py
@@ -981,7 +981,23 @@ class TestBackends(tests.conftest.TestCase):
     def test_take(self):
         vec = gs.array([0, 1])
 
-        expected = gs.array([0, 0, 1])
-        self.assertAllClose(gs.take(vec, expected), expected)
+        indices = expected = gs.array([0, 0, 1])
+        self.assertAllClose(gs.take(vec, indices), expected)
 
         self.assertEqual(gs.take(vec, 0), 0)
+
+        mat = gs.array(
+            [
+                [0, 1],
+                [2, 3],
+            ]
+        )
+        self.assertAllClose(
+            gs.take(mat, indices, axis=0), gs.array([[0, 1]] * 2 + [[2, 3]])
+        )
+        self.assertAllClose(
+            gs.take(mat, indices, axis=1),
+            gs.transpose(gs.array([[0, 2]] * 2 + [[1, 3]])),
+        )
+
+        self.assertAllClose(gs.take(mat, 0, axis=1), gs.array([0, 2]))


### PR DESCRIPTION
Adds `take` to the backend.

Useful for the following case (common in classification tasks):

```
vec = gs.array([0, 1])
indices = [0, 0, 1, 0, 1]

prediction = gs.take(vec, indices)
```