### PR TITLE
Use assertTrue and add assertAllEqual

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -228,6 +228,16 @@ class TestCase:
             msg=pytorch_error_msg(a, b, rtol, atol),
         )
 
+    def assertAllEqual(self, a, b):
+        if tf_backend():
+            return tf.test.TestCase().assertAllEqual(a, b)
+
+        elif np_backend() or autograd_backend():
+            np.testing.assert_array_equal(a, b)
+
+        else:
+            self.assertTrue(gs.equal(a, b))
+
     def assertTrue(self, condition, msg=None):
         assert condition, msg
 

--- a/tests/geometry_test_cases.py
+++ b/tests/geometry_test_cases.py
@@ -70,7 +70,7 @@ class ManifoldTestCase(TestCase):
         space = self.space(*space_args)
         random_point = space.random_point(n_points)
         result = gs.all(space.belongs(random_point, atol=belongs_atol))
-        self.assertAllClose(result, True)
+        self.assertTrue(result)
 
     def test_projection_belongs(self, space_args, point, belongs_atol):
         """Check that a point projected on a manifold belongs to the manifold.
@@ -86,7 +86,7 @@ class ManifoldTestCase(TestCase):
         """
         space = self.space(*space_args)
         belongs = space.belongs(space.projection(gs.array(point)), belongs_atol)
-        self.assertAllClose(gs.all(belongs), gs.array(True))
+        self.assertTrue(gs.all(belongs))
 
     def test_to_tangent_is_tangent(
         self, space_args, vector, base_point, is_tangent_atol
@@ -109,7 +109,7 @@ class ManifoldTestCase(TestCase):
         result = gs.all(
             space.is_tangent(tangent, gs.array(base_point), is_tangent_atol)
         )
-        self.assertAllClose(result, gs.array(True))
+        self.assertTrue(result)
 
     def test_random_tangent_vec_is_tangent(
         self, space_args, n_samples, base_point, is_tangent_atol
@@ -130,7 +130,7 @@ class ManifoldTestCase(TestCase):
         space = self.space(*space_args)
         tangent_vec = space.random_tangent_vec(base_point, n_samples)
         result = space.is_tangent(tangent_vec, base_point, is_tangent_atol)
-        self.assertAllClose(gs.all(result), gs.array(True))
+        self.assertTrue(gs.all(result))
 
 
 class OpenSetTestCase(ManifoldTestCase):
@@ -156,7 +156,7 @@ class OpenSetTestCase(ManifoldTestCase):
         space = self.space(*space_args)
         tangent_vec = space.to_tangent(gs.array(vector), gs.array(base_point))
         result = gs.all(space.ambient_space.is_tangent(tangent_vec, is_tangent_atol))
-        self.assertAllClose(result, gs.array(True))
+        self.assertTrue(result)
 
 
 class LieGroupTestCase(ManifoldTestCase):
@@ -305,7 +305,7 @@ class LieGroupTestCase(ManifoldTestCase):
         group = self.group(*group_args)
         tangent_vec = group.to_tangent(vector, group.identity)
         result = gs.all(group.lie_algebra.belongs(tangent_vec, belongs_atol))
-        self.assertAllClose(result, gs.array(True))
+        self.assertTrue(result)
 
 
 class VectorSpaceTestCase(ManifoldTestCase):
@@ -321,7 +321,7 @@ class VectorSpaceTestCase(ManifoldTestCase):
         """
         space = self.space(*space_args)
         result = gs.all(space.belongs(space.basis, belongs_atol))
-        self.assertAllClose(result, gs.array(True))
+        self.assertTrue(result)
 
     def test_basis_cardinality(self, space_args):
         """Check that the number of basis elements is the dimension.
@@ -351,7 +351,7 @@ class VectorSpaceTestCase(ManifoldTestCase):
         points = space.random_point(n_points)
         base_point = space.random_point()
         result = space.is_tangent(points, base_point, is_tangent_atol)
-        self.assertAllClose(gs.all(result), gs.array(True))
+        self.assertTrue(gs.all(result))
 
     def test_to_tangent_is_projection(self, space_args, vector, base_point, rtol, atol):
         """Check that to_tangent is same as projection.
@@ -606,7 +606,7 @@ class ConnectionTestCase(TestCase):
         connection = self.connection(*connection_args)
         exp = connection.exp(gs.array(tangent_vec), gs.array(base_point))
         result = gs.all(space.belongs(exp, belongs_atol))
-        self.assertAllClose(result, gs.array(True))
+        self.assertTrue(result)
 
     def test_log_is_tangent(
         self, connection_args, space, point, base_point, is_tangent_atol
@@ -629,7 +629,7 @@ class ConnectionTestCase(TestCase):
         connection = self.connection(*connection_args)
         log = connection.log(gs.array(point), gs.array(base_point))
         result = gs.all(space.is_tangent(log, gs.array(base_point), is_tangent_atol))
-        self.assertAllClose(result, gs.array(True))
+        self.assertTrue(result)
 
     def test_geodesic_ivp_belongs(
         self,
@@ -884,7 +884,7 @@ class RiemannianMetricTestCase(ConnectionTestCase):
         metric = self.metric(*metric_args)
         sd_a_b = metric.dist(gs.array(point_a), gs.array(point_b))
         result = gs.all(sd_a_b > -1 * is_positive_atol)
-        self.assertAllClose(result, gs.array(True))
+        self.assertTrue(result)
 
     def test_squared_dist_is_symmetric(self, metric_args, point_a, point_b, rtol, atol):
         """Check that the squared geodesic distance is symmetric.
@@ -927,7 +927,7 @@ class RiemannianMetricTestCase(ConnectionTestCase):
 
         sd_a_b = metric.dist(gs.array(point_a), gs.array(point_b))
         result = gs.all(sd_a_b > -1 * is_positive_atol)
-        self.assertAllClose(result, gs.array(True))
+        self.assertTrue(result)
 
     def test_inner_product_is_symmetric(
         self, metric_args, tangent_vec_a, tangent_vec_b, base_point, rtol, atol
@@ -1121,7 +1121,7 @@ class RiemannianMetricTestCase(ConnectionTestCase):
         dist_bc = metric.dist(point_b, point_c)
         dist_ac = metric.dist(point_a, point_c)
         result = gs.all((dist_ab + dist_bc - dist_ac) >= atol)
-        self.assertAllClose(result, gs.array(True))
+        self.assertTrue(result)
 
 
 class ProductRiemannianMetricTestCase(RiemannianMetricTestCase):
@@ -1210,7 +1210,7 @@ class QuotientMetricTestCase(RiemannianMetricTestCase):
         quotient_distance = metric.dist(point_a, point_b)
         bundle_distance = bundle.ambient_metric(point_a, point_b)
         result = gs.all(bundle_distance - quotient_distance > atol)
-        self.assertAllClose(result, gs.array(True))
+        self.assertTrue(result)
 
     def test_log_is_horizontal(
         self, metric_args, bundle, point, base_point, is_horizontal_atol
@@ -1236,7 +1236,7 @@ class QuotientMetricTestCase(RiemannianMetricTestCase):
         metric = self.metric(*metric_args)
         log = metric.log(point, base_point)
         result = gs.all(bundle.is_horizontal(log, base_point, is_horizontal_atol))
-        self.assertAllClose(result, gs.array(True))
+        self.assertTrue(result)
 
 
 class PullbackMetricTestCase(RiemannianMetricTestCase):
@@ -1382,7 +1382,7 @@ class InvariantMetricTestCase(RiemannianMetricTestCase):
         metric = self.metric(*metric_args)
         exp = metric.exp(lie_algebra_point, group.identity)
         result = gs.all(group.belongs(exp, belongs_atol))
-        self.assertAllClose(result, gs.array(True))
+        self.assertTrue(result)
 
     def test_log_at_identity_belongs_to_lie_algebra(
         self, metric_args, group, point, belongs_atol
@@ -1405,7 +1405,7 @@ class InvariantMetricTestCase(RiemannianMetricTestCase):
         metric = self.metric(*metric_args)
         log = metric.log(point, group.identity)
         result = gs.all(group.lie_algebra.belongs(log, belongs_atol))
-        self.assertAllClose(result, gs.array(True))
+        self.assertTrue(result)
 
     def test_exp_after_log_at_identity(self, metric_args, group, point, rtol, atol):
         """Check that exp and log at identity are inverse.

--- a/tests/tests_geomstats/test_backends.py
+++ b/tests/tests_geomstats/test_backends.py
@@ -964,13 +964,9 @@ class TestBackends(tests.conftest.TestCase):
         not_pd_1_result = gs.linalg.is_single_matrix_pd(not_pd_1)
         not_pd_2_result = gs.linalg.is_single_matrix_pd(not_pd_2)
 
-        pd_expected = gs.array(True)
-        not_pd_1_expected = gs.array(False)
-        not_pd_2_expected = gs.array(False)
-
-        self.assertAllClose(pd_expected, pd_result)
-        self.assertAllClose(not_pd_1_expected, not_pd_1_result)
-        self.assertAllClose(not_pd_2_expected, not_pd_2_result)
+        self.assertTrue(pd_result)
+        self.assertFalse(not_pd_1_result)
+        self.assertFalse(not_pd_2_result)
 
     def test_unique(self):
         vec = gs.array([-1, 0, 1, 1, 0, -1])

--- a/tests/tests_geomstats/test_frechet_mean.py
+++ b/tests/tests_geomstats/test_frechet_mean.py
@@ -384,11 +384,9 @@ class TestFrechetMean(geomstats.tests.TestCase):
 
         mean = FrechetMean(metric=self.minkowski.metric)
         mean.fit(points, weights=weights)
-        result = mean.estimate_
-        result = self.minkowski.belongs(result)
-        expected = gs.array(True)
+        result = self.minkowski.belongs(mean.estimate_)
 
-        self.assertAllClose(result, expected)
+        self.assertTrue(result)
 
     def test_variance_minkowski(self):
         points = gs.array(

--- a/tests/tests_geomstats/test_full_rank_correlation_matrices.py
+++ b/tests/tests_geomstats/test_full_rank_correlation_matrices.py
@@ -34,7 +34,7 @@ class TestCorrelationMatricesBundle(TestCase, metaclass=Parametrizer):
         bundle = self.space(n)
         base = self.base(n)
         result = base.belongs(bundle.riemannian_submersion(gs.array(point)))
-        self.assertAllClose(gs.all(result), gs.array(True))
+        self.assertTrue(gs.all(result))
 
     def test_lift_riemannian_submersion_composition(self, n, point):
         bundle = self.space(n)
@@ -47,7 +47,7 @@ class TestCorrelationMatricesBundle(TestCase, metaclass=Parametrizer):
             gs.array(vec), gs.array(point)
         )
         result = gs.all(bundle.is_tangent(gs.array(tangent_vec), gs.array(point)))
-        self.assertAllClose(result, gs.array(True))
+        self.assertTrue(result)
 
     def test_vertical_projection_tangent_submersion(self, n, vec, mat):
         bundle = self.space(n)
@@ -67,19 +67,19 @@ class TestCorrelationMatricesBundle(TestCase, metaclass=Parametrizer):
         is_horizontal = gs.all(
             base.is_tangent(product_1 + product_2, mat, atol=gs.atol * 10)
         )
-        self.assertAllClose(is_horizontal, gs.array(True))
+        self.assertTrue(is_horizontal)
 
     def test_horizontal_lift_is_horizontal(self, n, tangent_vec, mat):
         bundle = self.space(n)
         lift = bundle.horizontal_lift(gs.array(tangent_vec), gs.array(mat))
         result = gs.all(bundle.is_horizontal(lift, gs.array(mat)))
-        self.assertAllClose(result, gs.array(True))
+        self.assertTrue(result)
 
     def test_vertical_projection_is_vertical(self, n, tangent_vec, mat):
         bundle = self.space(n)
         proj = bundle.vertical_projection(gs.array(tangent_vec), gs.array(mat))
         result = gs.all(bundle.is_vertical(proj, gs.array(mat)))
-        self.assertAllClose(result, gs.array(True))
+        self.assertTrue(result)
 
     @autograd_tf_and_torch_only
     def test_log_after_align_is_horizontal(self, n, point_a, point_b):
@@ -87,7 +87,7 @@ class TestCorrelationMatricesBundle(TestCase, metaclass=Parametrizer):
         aligned = bundle.align(point_a, point_b, tol=1e-10)
         log = bundle.ambient_metric.log(aligned, point_b)
         result = bundle.is_horizontal(log, point_b, atol=1e-2)
-        self.assertAllClose(result, gs.array(True))
+        self.assertTrue(result)
 
     def test_horizontal_lift_and_tangent_riemannian_submersion(
         self, n, tangent_vec, mat

--- a/tests/tests_geomstats/test_graphspace.py
+++ b/tests/tests_geomstats/test_graphspace.py
@@ -14,8 +14,7 @@ class TestGraphSpace(TestCase, metaclass=Parametrizer):
     def test_random_point_belongs(self, n, n_points):
         space = self.space(n)
         point = space.random_point(n_points)
-        result = gs.all(space.belongs(point))
-        self.assertAllClose(result, True)
+        self.assertTrue(gs.all(space.belongs(point)))
 
     def test_belongs(self, n, mat, expected):
         space = self.space(n)

--- a/tests/tests_geomstats/test_heisenberg.py
+++ b/tests/tests_geomstats/test_heisenberg.py
@@ -23,7 +23,7 @@ class TestHeisenbergVectors(
         )
 
     def test_random_point_belongs(self, n_samples, bound):
-        self.assertAllClose(gs.all(self.space().random_point(n_samples, bound)), True)
+        gs.assertTrue(gs.all(self.space().random_point(n_samples, bound)))
 
     def test_is_tangent(self, vector, expected):
         group = self.space()

--- a/tests/tests_geomstats/test_hypersphere.py
+++ b/tests/tests_geomstats/test_hypersphere.py
@@ -50,7 +50,7 @@ class TestHypersphere(LevelSetTestCase, metaclass=Parametrizer):
     def test_random_von_mises_fisher_belongs(self, dim, n_samples):
         space = self.space(dim)
         result = space.belongs(space.random_von_mises_fisher(n_samples=n_samples))
-        self.assertAllClose(gs.all(result), gs.array(True))
+        self.assertTrue(gs.all(result))
 
     def test_random_von_mises_fisher_mean(self, dim, kappa, n_samples, expected):
         space = self.space(dim)

--- a/tests/tests_geomstats/test_pre_shape.py
+++ b/tests/tests_geomstats/test_pre_shape.py
@@ -41,7 +41,7 @@ class TestPreShapeSpace(LevelSetTestCase, metaclass=Parametrizer):
         space = self.space(k_landmarks, m_ambient)
         centered_point = space.center(point)
         result = gs.all(space.is_centered(centered_point))
-        self.assertAllClose(result, gs.array(True))
+        self.assertTrue(result)
 
     def test_vertical_projection(self, k_landmarks, m_ambient, tangent_vec, point):
         space = self.space(k_landmarks, m_ambient)
@@ -69,14 +69,14 @@ class TestPreShapeSpace(LevelSetTestCase, metaclass=Parametrizer):
         space = self.space(k_landmarks, m_ambient)
         horizontal = space.horizontal_projection(tangent_vec, point)
         result = gs.all(space.is_tangent(horizontal, point))
-        self.assertAllClose(result, gs.array(True))
+        self.assertTrue(result)
 
     def test_alignment_is_symmetric(self, k_landmarks, m_ambient, point, base_point):
         space = self.space(k_landmarks, m_ambient)
         aligned = space.align(point, base_point)
         alignment = gs.matmul(Matrices.transpose(aligned), base_point)
         result = gs.all(Matrices.is_symmetric(alignment))
-        self.assertAllClose(result, gs.array(True))
+        self.assertTrue(result)
 
     @geomstats.tests.np_and_autograd_only
     def test_integrability_tensor(

--- a/tests/tests_geomstats/test_pre_shape.py
+++ b/tests/tests_geomstats/test_pre_shape.py
@@ -35,7 +35,7 @@ class TestPreShapeSpace(LevelSetTestCase, metaclass=Parametrizer):
     def test_is_centered(self, k_landmarks, m_ambient, point, expected):
         space = self.space(k_landmarks, m_ambient)
         result = space.is_centered(point)
-        self.assertAllClose(result, expected)
+        self.assertAllEqual(result, expected)
 
     def test_to_center_is_center(self, k_landmarks, m_ambient, point):
         space = self.space(k_landmarks, m_ambient)

--- a/tests/tests_geomstats/test_product_manifold.py
+++ b/tests/tests_geomstats/test_product_manifold.py
@@ -95,7 +95,7 @@ class TestNFoldManifold(ManifoldTestCase, metaclass=Parametrizer):
 
     def test_belongs(self, base, power, point, expected):
         space = self.space(base, power)
-        self.assertAllClose(space.belongs(point), expected)
+        self.assertAllEqual(space.belongs(point), expected)
 
     def test_shape(self, base, power, expected):
         space = self.space(base, power)

--- a/tests/tests_geomstats/test_spd_matrices.py
+++ b/tests/tests_geomstats/test_spd_matrices.py
@@ -46,19 +46,14 @@ class TestSPDMatrices(OpenSetTestCase, metaclass=Parametrizer):
         result = SPDMatrices.cholesky_factor(gs.array(spd_mat))
 
         self.assertAllClose(result, gs.array(cf))
-        self.assertAllClose(
-            gs.all(PositiveLowerTriangularMatrices(n).belongs(result)),
-            gs.array(True),
-        )
+        self.assertTrue(gs.all(PositiveLowerTriangularMatrices(n).belongs(result)))
 
     def test_differential_cholesky_factor(self, n, tangent_vec, base_point, expected):
         result = SPDMatrices.differential_cholesky_factor(
             gs.array(tangent_vec), gs.array(base_point)
         )
         self.assertAllClose(result, gs.array(expected))
-        self.assertAllClose(
-            gs.all(LowerTriangularMatrices(n).belongs(result)), gs.array(True)
-        )
+        self.assertTrue(gs.all(LowerTriangularMatrices(n).belongs(result)))
 
     def test_differential_power(self, power, tangent_vec, base_point, expected):
         result = SPDMatrices.differential_power(

--- a/tests/tests_geomstats/test_special_euclidean.py
+++ b/tests/tests_geomstats/test_special_euclidean.py
@@ -41,7 +41,7 @@ class TestSpecialEuclidean(LieGroupTestCase, metaclass=Parametrizer):
 
     def test_random_point_belongs(self, n, n_samples):
         group = self.cls(n)
-        self.assertAllClose(gs.all(group(n).random_point(n_samples)), gs.array(True))
+        self.assertTrue(gs.all(group(n).random_point(n_samples)))
 
     def test_identity(self, n, expected):
         self.assertAllClose(SpecialEuclidean(n).identity, gs.array(expected))

--- a/tests/tests_geomstats/test_special_orthogonal.py
+++ b/tests/tests_geomstats/test_special_orthogonal.py
@@ -194,7 +194,7 @@ class TestSpecialOrthogonal3Vectors(TestCase, metaclass=Parametrizer):
         expected1 = group.regularize(point)
         expected2 = -1 * expected1
         expected = gs.allclose(result, expected1) or gs.allclose(result, expected2)
-        self.assertAllClose(expected, gs.array(True))
+        self.assertTrue(expected)
 
     def test_quaternion_and_matrix_with_angles_close_to_pi(self, point):
         group = self.space(3, point_type="vector")
@@ -204,7 +204,7 @@ class TestSpecialOrthogonal3Vectors(TestCase, metaclass=Parametrizer):
         expected1 = mat
         expected2 = gs.linalg.inv(mat)
         expected = gs.allclose(result, expected1) or gs.allclose(result, expected2)
-        self.assertAllClose(expected, gs.array(True))
+        self.assertTrue(expected)
 
     def test_rotation_vector_and_rotation_matrix_with_angles_close_to_pi(self, point):
         group = self.space(3, point_type="vector")
@@ -213,7 +213,7 @@ class TestSpecialOrthogonal3Vectors(TestCase, metaclass=Parametrizer):
         expected1 = group.regularize(point)
         expected2 = -1 * expected1
         expected = gs.allclose(result, expected1) or gs.allclose(result, expected2)
-        self.assertAllClose(expected, gs.array(True))
+        self.assertTrue(expected)
 
     def test_lie_bracket(self, tangent_vec_a, tangent_vec_b, base_point, expected):
         group = self.space(3, point_type="vector")


### PR DESCRIPTION
This replaces `gs.assertAllClose(., True)` by `assertTrue` for more meaningful error messages. Besides `assertAllEqual` is added for better comparison of arrays of `int` and `bool`.