### PR TITLE
matrices.py: add 'full_matrices=False' to svd call

### DIFF
--- a/geomstats/geometry/matrices.py
+++ b/geomstats/geometry/matrices.py
@@ -687,7 +687,7 @@ class Matrices(VectorSpace):
             R.point.
         """
         mat = gs.matmul(cls.transpose(point), base_point)
-        left, singular_values, right = gs.linalg.svd(mat)
+        left, singular_values, right = gs.linalg.svd(mat, full_matrices=False)
         det = gs.linalg.det(mat)
         conditioning = (
             singular_values[..., -2] + gs.sign(det) * singular_values[..., -1]


### PR DESCRIPTION
<!--
Thank you for opening this pull request!
-->
## Description

The align method in geomstats/geometry/pre_shape.py invokes align_matrices from matrices.py that employs singular value decomposition for which autodiff fails if a full set of left/right singular vectors are requested. However, providing the flag 'full_matrices=False' to svd avoids this pitfall and yields the same alignment.

## Issue

This pull request fixes the issue [autodiff fails on svd in matrices.py #1545](https://github.com/geomstats/geomstats/issues/1545).
<!-- Tell us which issue does this PR fix . Why this feature implementation/fix is important in practice ?-->

## Additional context

The issue originally appeared in the [ICLR Computational Geometry & Topology Challenge 2022](https://github.com/geomstats/challenge-iclr-2022/issues/8) when trying to perform geodesic regression in Kendall shape space.
<!-- Add any extra information -->