### PR TITLE
Fix empty list array creation for torch

### DIFF
--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -236,7 +236,7 @@ def array(val, dtype=None):
     elif isinstance(val, _np.ndarray):
         return from_numpy(val, dtype=dtype)
 
-    elif isinstance(val, (list, tuple)):
+    elif isinstance(val, (list, tuple)) and len(val):
         tensors = [array(tensor, dtype=dtype) for tensor in val]
         return stack(tensors)
 

--- a/tests/tests_geomstats/test_backends.py
+++ b/tests/tests_geomstats/test_backends.py
@@ -24,6 +24,11 @@ class TestBackends(tests.conftest.TestCase):
         self.n_samples = 2
 
     def test_array(self):
+
+        gs_mat = gs.array([])
+        np_mat = _np.array([])
+        self.assertAllCloseToNp(gs_mat, np_mat)
+
         gs_mat = gs.array(1.5)
         np_mat = _np.array(1.5)
         self.assertAllCloseToNp(gs_mat, np_mat)


### PR DESCRIPTION
Fix `gs.array([])` for `torch`.

Closes ##1347.