### PR TITLE
Fix shape of HypersphereMetric and KendallShapeMetric

### DIFF
--- a/geomstats/geometry/hypersphere.py
+++ b/geomstats/geometry/hypersphere.py
@@ -43,6 +43,7 @@ class _Hypersphere(LevelSet):
     """
 
     def __init__(self, dim, default_coords_type="extrinsic"):
+
         super(_Hypersphere, self).__init__(
             dim=dim,
             embedding_space=Euclidean(dim + 1),
@@ -657,7 +658,7 @@ class HypersphereMetric(RiemannianMetric):
     """
 
     def __init__(self, dim):
-        super(HypersphereMetric, self).__init__(dim=dim, signature=(dim, 0))
+        super(HypersphereMetric, self).__init__(dim=dim, shape=(dim + 1,), signature=(dim, 0))
         self.embedding_metric = EuclideanMetric(dim + 1)
         self._space = _Hypersphere(dim=dim)
 

--- a/geomstats/geometry/pre_shape.py
+++ b/geomstats/geometry/pre_shape.py
@@ -943,7 +943,7 @@ class KendallShapeMetric(QuotientMetric):
     def __init__(self, k_landmarks, m_ambient):
         bundle = PreShapeSpace(k_landmarks, m_ambient)
         super(KendallShapeMetric, self).__init__(
-            fiber_bundle=bundle, dim=bundle.dim - int(m_ambient * (m_ambient - 1) / 2)
+            fiber_bundle=bundle, dim=bundle.dim - int(m_ambient * (m_ambient - 1) / 2), shape=(k_landmarks, m_ambient)
         )
 
     def directional_curvature_derivative(

--- a/geomstats/geometry/quotient_metric.py
+++ b/geomstats/geometry/quotient_metric.py
@@ -23,7 +23,7 @@ class QuotientMetric(RiemannianMetric):
         Bundle structure to define the quotient.
     """
 
-    def __init__(self, fiber_bundle: FiberBundle, dim: int = None, **kwargs):
+    def __init__(self, fiber_bundle: FiberBundle, dim: int = None, shape=None, **kwargs):
         if dim is None:
             if fiber_bundle.group is not None:
                 dim = fiber_bundle.dim - fiber_bundle.group.dim
@@ -36,7 +36,7 @@ class QuotientMetric(RiemannianMetric):
                     "total space must be provided to the fiber bundle."
                 )
         super(QuotientMetric, self).__init__(
-            dim=dim, default_point_type=fiber_bundle.default_point_type, **kwargs
+            dim=dim, shape=shape, default_point_type=fiber_bundle.default_point_type, **kwargs
         )
 
         self.fiber_bundle = fiber_bundle


### PR DESCRIPTION
<!--
Thank you for opening this pull request!
-->

## Checklist
- [x] I have made sure the code passes all unit tests. (refer to comment below)
- [x] I have linked to issues and PRs that are relevant to this PR.


<!-- For checking consistency of entire codebase
First, run the tests related to your changes. For example, if you changed something in geomstats/spd_matrices_space.py:
$ pytest tests/tests_geomstats/test_spd_matrices.py

and then run the tests of the whole codebase to check that your feature is not breaking any of them:
$ pytest tests/

This way, further modifications on the code base are guaranteed to be consistent with the desired behavior. Merging your PR should not break any test in any backend (numpy, tensorflow or pytorch)."

For testing in alternative backends such as `numpy`, `pytorch`, `autograd`, `tensorflow` set the environment variable using:
$ export GEOMSTATS_BACKEND=<backend_name>

Next, import the `backend` module using:
import geomstats.backend as gs
-->


<!-- For flake8 tests
Install dependencies
$ pip3 install -r dev-requirements.txt

Then run the following commands:
$ flake8 --ignore=D,W503,W504 geomstats examples tests   #shadows .flake8
$ flake8 geomstats/geometry geomstats/learning           #passed two subfolders
-->

## Description

The constructors of HypersphereMetric and KendallShapeMetric do not (not correctly) handle the shape parameter. In fact, it gets lost on the way down to RiemannianMetric. 
It can be solved with some slight modifications in the constructors of HypersphereMetric, KendallShapeMetric and QuotientMetric.

<!-- Include a description of your pull request. If relevant, feel free to use this space to talk about time and space complexity as well scalability of your code-->

## Issue
This closes #1559 (Shape not set correctly for HypersphereMetric and KendallShapeMetric).
<!-- Tell us which issue does this PR fix . Why this feature implementation/fix is important in practice ?-->

