### PR TITLE
Add clean way of getting backend name

### DIFF
--- a/geomstats/_backend/__init__.py
+++ b/geomstats/_backend/__init__.py
@@ -261,6 +261,7 @@ class BackendImporter:
             os.environ["GEOMSTATS_BACKEND"] = _BACKEND = "numpy"
 
         module = self._create_backend_module(_BACKEND)
+        module.__name__ = _BACKEND
         module.__loader__ = self
         sys.modules[fullname] = module
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,22 +12,22 @@ import geomstats.backend as gs
 
 def autograd_backend():
     """Check if autograd is set as backend."""
-    return os.environ["GEOMSTATS_BACKEND"] == "autograd"
+    return gs.__name__ == "autograd"
 
 
 def np_backend():
     """Check if numpy is set as backend."""
-    return os.environ["GEOMSTATS_BACKEND"] == "numpy"
+    return gs.__name__ == "numpy"
 
 
 def pytorch_backend():
     """Check if pytorch is set as backend."""
-    return os.environ["GEOMSTATS_BACKEND"] == "pytorch"
+    return gs.__name__ == "pytorch"
 
 
 def tf_backend():
     """Check if tensorflow is set as backend."""
-    return os.environ["GEOMSTATS_BACKEND"] == "tensorflow"
+    return gs.__name__ == "tensorflow"
 
 
 if tf_backend():


### PR DESCRIPTION
Follows @captain-pool suggestion in #1285 to give an easy way to know what's the backend being used. (Already used it in tests.) 