### PR TITLE
Fix functions to work with tensorflow

### DIFF
--- a/geomstats/_backend/tensorflow/__init__.py
+++ b/geomstats/_backend/tensorflow/__init__.py
@@ -34,7 +34,6 @@ from tensorflow import (
     int64,
     less,
     less_equal,
-    linspace,
     logical_and,
     logical_or,
     maximum,
@@ -948,3 +947,11 @@ def kron(a, b):
 
 def take(a, indices, axis=0):
     return tf.gather(a, indices, axis=axis)
+
+
+def linspace(*args, **kwargs):
+    a = tf.linspace(*args, **kwargs)
+    if a.dtype is float64:
+        a = cast(a, dtype=float32)
+
+    return a

--- a/geomstats/geometry/functions.py
+++ b/geomstats/geometry/functions.py
@@ -42,12 +42,10 @@ class HilbertSphereMetric(RiemannianMetric):
         inner_prod : array-like, shape=[...,]
             Inner-product of the two tangent vectors.
         """
-        if tangent_vec_a.ndim == 1:
-            tangent_vec_a = tangent_vec_a.reshape(1, len(tangent_vec_a))
-        if tangent_vec_b.ndim == 1:
-            tangent_vec_b = tangent_vec_b.reshape(1, len(tangent_vec_b))
+        tangent_vec_a, tangent_vec_b = gs.broadcast_arrays(tangent_vec_a, tangent_vec_b)
+        x = gs.broadcast_to(self.x, tangent_vec_a.shape)
 
-        l2_norm = gs.trapz(tangent_vec_a * tangent_vec_b, x=self.x, axis=1)
+        l2_norm = gs.trapz(tangent_vec_a * tangent_vec_b, x=x, axis=-1)
 
         return l2_norm
 


### PR DESCRIPTION
Fix `functions` module to work with `tensorflow` (probably of your interest @kiranvad).

`tensorflow.linspace` is also updated in backend because output is `float64` (why?) when everywhere else it is `float32`.  