### PR TITLE
Update backend name for more meaningful error messages

### DIFF
--- a/geomstats/_backend/__init__.py
+++ b/geomstats/_backend/__init__.py
@@ -261,7 +261,7 @@ class BackendImporter:
             os.environ["GEOMSTATS_BACKEND"] = _BACKEND = "numpy"
 
         module = self._create_backend_module(_BACKEND)
-        module.__name__ = _BACKEND
+        module.__name__ = f"geomstats.{_BACKEND}"
         module.__loader__ = self
         sys.modules[fullname] = module
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,22 +12,22 @@ import geomstats.backend as gs
 
 def autograd_backend():
     """Check if autograd is set as backend."""
-    return gs.__name__ == "autograd"
+    return gs.__name__.endswith("autograd")
 
 
 def np_backend():
     """Check if numpy is set as backend."""
-    return gs.__name__ == "numpy"
+    return gs.__name__.endswith("numpy")
 
 
 def pytorch_backend():
     """Check if pytorch is set as backend."""
-    return gs.__name__ == "pytorch"
+    return gs.__name__.endswith("pytorch")
 
 
 def tf_backend():
     """Check if tensorflow is set as backend."""
-    return gs.__name__ == "tensorflow"
+    return gs.__name__.endswith("tensorflow")
 
 
 if tf_backend():


### PR DESCRIPTION
Update `gs.backend` name to `geomstats.{_BACKEND}` for more meaningful error messages.

e.g.

`gs.min` raises `module 'geomstats.numpy' has no attribute 'min'` instead of `module 'numpy' has no attribute 'min'`.