### PR TITLE
Add cache flag for dependency caching in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
           cache-name: cache-pip-modules
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-{{ python-version }}-${{ hashFiles('setup.cfg') }}
+          key: ${{ runner.os }}-pip-{{ matrix.python-version }}-${{ hashFiles('setup.cfg') }}
 
       - name: Build using Python ${{matrix.python-version}} and Backend ${{matrix.geomstats-backend}}
         if: steps.cache-pip.outputs.cache-hit != 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,13 +52,11 @@ jobs:
           key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('setup.cfg') }}
 
       - name: install dependencies [pip]
-        if: steps.cache-pip.outputs.cache-hit != 'true'
         run:  |
           pip install --upgrade pip setuptools wheel
           pip install -e .[ci,dev,doc,opt]
 
       - name: Add annotations [pytest]
-        if: steps.cache-pip.outputs.cache-hit != 'true'
         run: pip install pytest-github-actions-annotate-failures
 
       - name: unit testing [pytest]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
           cache-name: cache-pip-modules
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-{{ matrix.python-version }}-${{ hashFiles('setup.cfg') }}
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('setup.cfg') }}
 
       - name: Build using Python ${{matrix.python-version}} and Backend ${{matrix.geomstats-backend}}
         if: steps.cache-pip.outputs.cache-hit != 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
+      - name: Build using Python ${{matrix.python-version}} and Backend ${{matrix.geomstats-backend}}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{matrix.python-version}}
+
       - name: Cache dependencies
         id: cache-pip
         uses: actions/cache@v3
@@ -45,17 +51,11 @@ jobs:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('setup.cfg') }}
 
-      - name: Build using Python ${{matrix.python-version}} and Backend ${{matrix.geomstats-backend}}
-        if: steps.cache-pip.outputs.cache-hit != 'true'
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{matrix.python-version}}
-
       - name: install dependencies [pip]
         if: steps.cache-pip.outputs.cache-hit != 'true'
         run:  |
           pip install --upgrade pip setuptools wheel
-          pip install .[ci,dev,doc,opt]
+          pip install -e .[ci,dev,doc,opt]
 
       - name: Add annotations [pytest]
         if: steps.cache-pip.outputs.cache-hit != 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{matrix.python-version}}
+          cache: 'pip'
 
       - name: install dependencies [pip]
         run:  |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ on:
 
 jobs:
   build:
+    - uses: actions/checkout@v2
 
     runs-on: ${{matrix.os}}
     strategy:
@@ -35,20 +36,29 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Cache dependencies
+        id: cache-pip
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-pip-modules
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-{{ python-version }}-${{ hashFiles('setup.cfg') }}
+
       - name: Build using Python ${{matrix.python-version}} and Backend ${{matrix.geomstats-backend}}
+        if: steps.cache-pip.outputs.cache-hit != 'true'
         uses: actions/setup-python@v2
         with:
           python-version: ${{matrix.python-version}}
-          cache: 'pip'
-          cache-dependency-path: 'setup.cfg'
 
       - name: install dependencies [pip]
+        if: steps.cache-pip.outputs.cache-hit != 'true'
         run:  |
           pip install --upgrade pip setuptools wheel
-          pip install -e .[ci,dev,doc,opt]
+          pip install .[ci,dev,doc,opt]
 
       - name: Add annotations [pytest]
+        if: steps.cache-pip.outputs.cache-hit != 'true'
         run: pip install pytest-github-actions-annotate-failures
 
       - name: unit testing [pytest]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,7 @@ jobs:
         with:
           python-version: ${{matrix.python-version}}
           cache: 'pip'
+          cache-dependency-path: 'setup.cfg'
 
       - name: install dependencies [pip]
         run:  |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,6 @@ on:
 
 jobs:
   build:
-    - uses: actions/checkout@v2
 
     runs-on: ${{matrix.os}}
     strategy:
@@ -36,6 +35,7 @@ jobs:
       fail-fast: false
 
     steps:
+      - uses: actions/checkout@v2
       - name: Cache dependencies
         id: cache-pip
         uses: actions/cache@v3


### PR DESCRIPTION
Avoid installing dependencies all the time (since they rarely change) in the CI (it will run faster). (Follows [GitHub Actions: setup-python now supports dependency caching](https://github.blog/changelog/2021-11-23-github-actions-setup-python-now-supports-dependency-caching/)).