### PR TITLE
Add utils to download remote datasets

### DIFF
--- a/geomstats/datasets/_base.py
+++ b/geomstats/datasets/_base.py
@@ -10,15 +10,17 @@ from urllib.request import urlretrieve
 DEFAULT_DATA_DIR = os.path.expanduser(os.path.join("~", ".geomstats_data"))
 
 
-def _get_data_home(data_home=DEFAULT_DATA_DIR):
+def _get_data_home(data_home=None):
+    if data_home is None:
+        data_home = DEFAULT_DATA_DIR
+
     os.makedirs(data_home, exist_ok=True)
 
     return data_home
 
 
 def _fetch_remote(url, filename, dirname=None):
-    if dirname is None:
-        dirname = _get_data_home()
+    dirname = _get_data_home(data_home=dirname)
 
     file_path = os.path.join(dirname, filename)
 

--- a/geomstats/datasets/_base.py
+++ b/geomstats/datasets/_base.py
@@ -1,0 +1,33 @@
+"""Base tools to handle datasets.
+
+Note: deeply inspired by sklearn.
+"""
+
+import logging
+import os
+from urllib.request import urlretrieve
+
+DEFAULT_DATA_DIR = os.path.expanduser(os.path.join("~", ".geomstats_data"))
+
+
+def _get_data_home(data_home=DEFAULT_DATA_DIR):
+    os.makedirs(data_home, exist_ok=True)
+
+    return data_home
+
+
+def _fetch_remote(url, filename, dirname=None):
+    if dirname is None:
+        dirname = _get_data_home()
+
+    file_path = os.path.join(dirname, filename)
+
+    if os.path.exists(file_path):
+        logging.info(
+            f"Data has already been downloaded... using cached file ('{file_path}')."
+        )
+    else:
+        logging.info(f"Downloading '{file_path}'' from {url} into '{dirname}'.")
+        urlretrieve(url, file_path)
+
+    return file_path

--- a/geomstats/datasets/utils.py
+++ b/geomstats/datasets/utils.py
@@ -189,7 +189,7 @@ def load_leaves():
     return beta_param, distrib_type
 
 
-def load_emg():
+def load_emg(file_path=EMG_PATH):
     """Load data from data/emg/emg.csv.
 
     Returns
@@ -198,7 +198,7 @@ def load_emg():
         Emg time serie for each of the 8 electrodes, with the time stamps
         and the label of the hand sign.
     """
-    data_emg = pd.read_csv(EMG_PATH)
+    data_emg = pd.read_csv(file_path)
     return data_emg
 
 


### PR DESCRIPTION
Large datasets should not be shipped with `geomstats` to avoid having a unnecessarily large source code. Besides, we can argue they should not even be part of the repo (e.g. 100mb is the limit in a push, if I'm not mistaken).

sklearn uses [figshare](https://figshare.com/account/home) to host datasets (notice it is very "academically" oriented, even requiring connection to ORCID). I think this is a very good solution.

As example, I've created a record for emg data available in `geomstats` (see [this](https://figshare.com/s/9a81e8f83a55c5e55e49)). With this, we can have code such as:

```
from geomstats.datasets._base import _fetch_remote

url = "https://figshare.com/ndownloader/files/35875382?private_link=9a81e8f83a55c5e55e49"
file_path = _fetch_remote(url, 'test.csv')

data = data_utils.load_emg(file_path=file_path)
```

(Notice `geomstats.datasets._base` is private because this should be handle by us, not by a user. Here it is just an example of what could be internal code)

The code in this PR is deeply inspired by [`sklearn.datasets`](https://github.com/scikit-learn/scikit-learn/blob/80598905e517759b4696c74ecc35c6e2eb508cff/sklearn/datasets/_base.py).

This PR appears at this point in time due to the needs of @Jules-Deschamps.

Some design choices:
* if user passes a `data_dir`, then such directory is created (if not existing).
* if the user does not pass `data_dir`, then `~/.geomstats_data` is (created and) used.
* the download is only performed if the file does not exist yet in the data_dir.