### PR TITLE
Fix: Frechet mean of discrete curves by computing in SRV space

### DIFF
--- a/geomstats/learning/frechet_mean.py
+++ b/geomstats/learning/frechet_mean.py
@@ -598,7 +598,8 @@ class FrechetMean(BaseEstimator):
 
         if is_linear_metric:
             mean = linear_mean(points=X, weights=weights, point_type=self.point_type)
-        if is_srv_metric:
+
+        elif is_srv_metric:
             mean = srv_mean(points=X, weights=weights, metric=self.metric)
 
         elif self.method == "default":

--- a/geomstats/learning/frechet_mean.py
+++ b/geomstats/learning/frechet_mean.py
@@ -90,6 +90,46 @@ def linear_mean(points, weights=None, point_type="vector"):
     return mean
 
 
+def srv_mean(points, weights=None, metric=None):
+    """Compute the weighted mean of SRV representations of curves.
+
+    SRV: Square Root Velocity.
+
+    The computation of the mean goes as follows:
+    - Transform the curves into their SRVs,
+    - Compute the linear mean of the SRVs,
+    - Transform the srv mean in curve space.
+
+    Parameters
+    ----------
+    points : array-like, shape=[..., n_sampling_points, dim]
+        Points on the manifold of curves (i.e. curves) to be averaged.
+    weights : array-like, shape=[...,]
+        Weights associated to the points (i.e. curves).
+        Optional, default: None.
+
+    Returns
+    -------
+    mean : array-like, shape=[n_sampling_points, dim]
+        Weighted linear mean of the points (i.e. of the curves).
+    """
+    if isinstance(points, list):
+        points = gs.stack(points, axis=0)
+
+    srvs = metric.srv_transform(points)
+
+    srv_mean = linear_mean(srvs, weights=weights, point_type="matrix")
+
+    starting_point = (
+        FrechetMean(metric.ambient_metric)
+        .fit(points[:, 0, :], weights=weights)
+        .estimate_
+    )
+    starting_point = gs.expand_dims(starting_point, axis=0)
+    mean = metric.srv_transform_inverse(srv_mean, starting_point=starting_point)
+    return mean
+
+
 def _default_gradient_descent(
     points,
     metric,
@@ -547,6 +587,7 @@ class FrechetMean(BaseEstimator):
             or "MatricesMetric" in metric_str
             or "MinkowskiMetric" in metric_str
         )
+        is_srv_metric = "SRVMetric" in metric_str
 
         if "HypersphereMetric" in metric_str and self.metric.dim == 1:
             mean = Hypersphere.angle_to_extrinsic(_circle_mean(X))
@@ -557,6 +598,8 @@ class FrechetMean(BaseEstimator):
 
         if is_linear_metric:
             mean = linear_mean(points=X, weights=weights, point_type=self.point_type)
+        if is_srv_metric:
+            mean = srv_mean(points=X, weights=weights, metric=self.metric)
 
         elif self.method == "default":
             mean = _default_gradient_descent(

--- a/geomstats/learning/frechet_mean.py
+++ b/geomstats/learning/frechet_mean.py
@@ -118,7 +118,7 @@ def srv_mean(points, weights=None, metric=None):
 
     srvs = metric.srv_transform(points)
 
-    srv_mean = linear_mean(srvs, weights=weights, point_type="matrix")
+    srv_linear_mean = linear_mean(srvs, weights=weights, point_type="matrix")
 
     starting_point = (
         FrechetMean(metric.ambient_metric)
@@ -126,7 +126,7 @@ def srv_mean(points, weights=None, metric=None):
         .estimate_
     )
     starting_point = gs.expand_dims(starting_point, axis=0)
-    mean = metric.srv_transform_inverse(srv_mean, starting_point=starting_point)
+    mean = metric.srv_transform_inverse(srv_linear_mean, starting_point=starting_point)
     return mean
 
 

--- a/tests/tests_geomstats/test_frechet_mean.py
+++ b/tests/tests_geomstats/test_frechet_mean.py
@@ -31,9 +31,8 @@ class TestFrechetMean(geomstats.tests.TestCase):
 
     def test_logs_at_mean_curves_2d(self):
         n_tests = 10
-        estimator = FrechetMean(
-            metric=self.curves_2d.square_root_velocity_metric, init_step_size=1.0
-        )
+        metric = self.curves_2d.square_root_velocity_metric
+        estimator = FrechetMean(metric=metric, init_step_size=1.0)
 
         result = []
         for _ in range(n_tests):
@@ -43,13 +42,17 @@ class TestFrechetMean(geomstats.tests.TestCase):
             estimator.fit(points)
             mean = estimator.estimate_
 
-            logs = self.curves_2d.square_root_velocity_metric.log(
-                point=points, base_point=mean
-            )
-            result.append(gs.linalg.norm(logs[1, :] + logs[0, :]))
+            # Expand and tile are added because of GitHub issue 1575
+            mean = gs.expand_dims(mean, axis=0)
+            mean = gs.tile(mean, (2, 1, 1))
+
+            logs = metric.log(point=points, base_point=mean)
+            logs_srv = metric.aux_differential_srv_transform(logs, curve=mean)
+            # Note that the logs are NOT inverse, only the logs_srv are.
+            result.append(gs.linalg.norm(logs_srv[1, :] + logs_srv[0, :]))
         result = gs.stack(result)
         expected = gs.zeros(n_tests)
-        self.assertAllClose(expected, result, atol=1e-4)
+        self.assertAllClose(expected, result, atol=1e-5)
 
     def test_logs_at_mean_default_gradient_descent_sphere(self):
         n_tests = 10
@@ -114,6 +117,15 @@ class TestFrechetMean(geomstats.tests.TestCase):
 
         self.assertAllClose(gs.shape(result), (dim,))
 
+    def test_estimate_shape_curves_2d(self):
+        points = self.curves_2d.random_point(n_samples=2)
+
+        mean = FrechetMean(metric=self.curves_2d.square_root_velocity_metric)
+        mean.fit(points)
+        result = mean.estimate_
+
+        self.assertAllClose(gs.shape(result), (points.shape[1:]))
+
     def test_estimate_and_belongs_default_gradient_descent_sphere(self):
         point_a = gs.array([1.0, 0.0, 0.0, 0.0, 0.0])
         point_b = gs.array([0.0, 1.0, 0.0, 0.0, 0.0])
@@ -123,6 +135,16 @@ class TestFrechetMean(geomstats.tests.TestCase):
         mean.fit(points)
 
         result = self.sphere.belongs(mean.estimate_)
+        expected = True
+        self.assertAllClose(result, expected)
+
+    def test_estimate_and_belongs_curves_2d(self):
+        points = self.curves_2d.random_point(n_samples=2)
+
+        mean = FrechetMean(metric=self.curves_2d.square_root_velocity_metric)
+        mean.fit(points)
+
+        result = self.curves_2d.belongs(mean.estimate_)
         expected = True
         self.assertAllClose(result, expected)
 
@@ -232,6 +254,18 @@ class TestFrechetMean(geomstats.tests.TestCase):
         points = gs.array([point, point])
 
         mean = FrechetMean(metric=self.sphere.metric, method="default")
+        mean.fit(X=points)
+
+        result = mean.estimate_
+        expected = point
+
+        self.assertAllClose(expected, result)
+
+    def test_estimate_curves_2d(self):
+        point = self.curves_2d.random_point(n_samples=1)
+        points = gs.array([point, point])
+
+        mean = FrechetMean(metric=self.curves_2d.square_root_velocity_metric)
         mean.fit(X=points)
 
         result = mean.estimate_


### PR DESCRIPTION
This PR fixes issue #1578 by:
- computing the FrechetMean of discrete curves directly in SRV space,
- adds tests on the FrechetMean of discrete curves in test_frechet_mean.

Notes: 
- this only fixes #1578 by avoiding the computational problem (in the vectorization of pointwise_inner_products)
- the logs of the points at the frechet mean are not inverse, only their srv are. This is because of the computations of the starting points.

## Checklist

- [x] My pull request has a clear and explanatory title.
- [x] If neccessary, my code is [vectorized](https://www.geeksforgeeks.org/vectorization-in-python/).
- [x] I have added apropriate unit tests.
- [x] I have made sure the code passes all unit tests. (refer to comment below)
- [x] My PR follows [PEP8](https://peps.python.org/pep-0008/) guidelines. (refer to comment below)
- [x] My PR follows [geomstats coding style](https://github.com/geomstats/geomstats/blob/master/docs/contributing.rst#coding-style-guidelines) and API.
- [x] My code is properly documented and I made sure the documentation renders properly. ([Link](https://github.com/geomstats/geomstats/blob/master/docs/contributing.rst#documentation))
- [x] I have linked to issues and PRs that are relevant to this PR.


<!-- For checking consistency of entire codebase
First, run the tests related to your changes. For example, if you changed something in geomstats/spd_matrices_space.py:
$ pytest tests/tests_geomstats/test_spd_matrices.py

and then run the tests of the whole codebase to check that your feature is not breaking any of them:
$ pytest tests/

This way, further modifications on the code base are guaranteed to be consistent with the desired behavior. Merging your PR should not break any test in any backend (numpy, tensorflow or pytorch)."

For testing in alternative backends such as `numpy`, `pytorch`, `autograd`, `tensorflow` set the environment variable using:
$ export GEOMSTATS_BACKEND=<backend_name>

Next, import the `backend` module using:
import geomstats.backend as gs
-->


<!-- For flake8 tests
Install dependencies
$ pip3 install -r dev-requirements.txt

Then run the following commands:
$ flake8 --ignore=D,W503,W504 geomstats examples tests   #shadows .flake8
$ flake8 geomstats/geometry geomstats/learning           #passed two subfolders
-->