### PR TITLE
Start fixing inheritance in Product/NFold/Landmarks/Curves Spaces

### DIFF
--- a/geomstats/geometry/product_manifold.py
+++ b/geomstats/geometry/product_manifold.py
@@ -8,8 +8,10 @@ import joblib
 import geomstats.backend as gs
 import geomstats.errors
 from geomstats.geometry.manifold import Manifold
-from geomstats.geometry.product_riemannian_metric import ProductRiemannianMetric
-from geomstats.geometry.riemannian_metric import RiemannianMetric
+from geomstats.geometry.product_riemannian_metric import (
+    NFoldMetric,
+    ProductRiemannianMetric,
+)
 
 
 class ProductManifold(Manifold):
@@ -487,128 +489,3 @@ class NFoldManifold(Manifold):
         raise NotImplementedError(
             "The base manifold does not implement a projection " "method."
         )
-
-
-class NFoldMetric(RiemannianMetric):
-    r"""Class for an n-fold product manifold :math:`M^n`.
-
-    Define a manifold as the product manifold of n copies of a given base manifold M.
-
-    Parameters
-    ----------
-    base_metric : RiemannianMetric
-        Base metric.
-    n_copies : int
-        Number of replication of the base metric.
-    """
-
-    def __init__(self, base_metric, n_copies):
-        geomstats.errors.check_integer(n_copies, "n_copies")
-        dim = n_copies * base_metric.dim
-        base_shape = base_metric.shape
-        super(NFoldMetric, self).__init__(dim=dim, shape=(n_copies, *base_shape))
-        self.base_shape = base_shape
-        self.base_metric = base_metric
-        self.n_copies = n_copies
-
-    def metric_matrix(self, base_point=None):
-        """Compute the matrix of the inner-product.
-
-        Matrix of the inner-product defined by the Riemmanian metric
-        at point base_point of the manifold.
-
-        Parameters
-        ----------
-        base_point : array-like, shape=[..., n_copies, *base_shape]
-            Point on the manifold at which to compute the inner-product matrix.
-            Optional, default: None.
-
-        Returns
-        -------
-        matrix : array-like, shape=[..., n_copies, dim, dim]
-            Matrix of the inner-product at the base point.
-        """
-        point_ = gs.reshape(base_point, (-1, *self.base_shape))
-        matrices = self.base_metric.metric_matrix(point_)
-        dim = self.base_metric.dim
-        reshaped = gs.reshape(matrices, (-1, self.n_copies, dim, dim))
-        return gs.squeeze(reshaped)
-
-    def inner_product(self, tangent_vec_a, tangent_vec_b, base_point):
-        """Compute the inner-product of two tangent vectors at a base point.
-
-        Inner product defined by the Riemannian metric at point `base_point`
-        between tangent vectors `tangent_vec_a` and `tangent_vec_b`.
-
-        Parameters
-        ----------
-        tangent_vec_a : array-like, shape=[..., n_copies, *base_shape]
-            First tangent vector at base point.
-        tangent_vec_b : array-like, shape=[..., n_copies, *base_shape]
-            Second tangent vector at base point.
-        base_point : array-like, shape=[..., n_copies, *base_shape]
-            Point on the manifold.
-            Optional, default: None.
-
-        Returns
-        -------
-        inner_prod : array-like, shape=[...,]
-            Inner-product of the two tangent vectors.
-        """
-        tangent_vec_a_, tangent_vec_b_, point_ = gs.broadcast_arrays(
-            tangent_vec_a, tangent_vec_b, base_point
-        )
-        point_ = gs.reshape(point_, (-1, *self.base_shape))
-        vector_a = gs.reshape(tangent_vec_a_, (-1, *self.base_shape))
-        vector_b = gs.reshape(tangent_vec_b_, (-1, *self.base_shape))
-        inner_each = self.base_metric.inner_product(vector_a, vector_b, point_)
-        reshaped = gs.reshape(inner_each, (-1, self.n_copies))
-        return gs.squeeze(gs.sum(reshaped, axis=-1))
-
-    def exp(self, tangent_vec, base_point, **kwargs):
-        """Compute the Riemannian exponential of a tangent vector.
-
-        Parameters
-        ----------
-        tangent_vec : array-like, shape=[..., n_copies, *base_shape]
-            Tangent vector at a base point.
-        base_point : array-like, shape=[..., n_copies, *base_shape]
-            Point on the manifold.
-            Optional, default: None.
-
-        Returns
-        -------
-        exp : array-like, shape=[..., n_copies, *base_shape]
-            Point on the manifold equal to the Riemannian exponential
-            of tangent_vec at the base point.
-        """
-        tangent_vec, point_ = gs.broadcast_arrays(tangent_vec, base_point)
-        point_ = gs.reshape(point_, (-1, *self.base_shape))
-        vector_ = gs.reshape(tangent_vec, (-1, *self.base_shape))
-        each_exp = self.base_metric.exp(vector_, point_)
-        reshaped = gs.reshape(each_exp, (-1, self.n_copies) + self.base_shape)
-        return gs.squeeze(reshaped)
-
-    def log(self, point, base_point, **kwargs):
-        """Compute the Riemannian logarithm of a point.
-
-        Parameters
-        ----------
-        point : array-like, shape=[..., n_copies, *base_shape]
-            Point on the manifold.
-        base_point : array-like, shape=[..., n_copies, *base_shape]
-            Point on the manifold.
-            Optional, default: None.
-
-        Returns
-        -------
-        log : array-like, shape=[..., n_copies, *base_shape]
-            Tangent vector at the base point equal to the Riemannian logarithm
-            of point at the base point.
-        """
-        point_, base_point_ = gs.broadcast_arrays(point, base_point)
-        base_point_ = gs.reshape(base_point_, (-1, *self.base_shape))
-        point_ = gs.reshape(point_, (-1, *self.base_shape))
-        each_log = self.base_metric.log(point_, base_point_)
-        reshaped = gs.reshape(each_log, (-1, self.n_copies) + self.base_shape)
-        return gs.squeeze(reshaped)

--- a/geomstats/geometry/product_riemannian_metric.py
+++ b/geomstats/geometry/product_riemannian_metric.py
@@ -287,3 +287,128 @@ class ProductRiemannianMetric(RiemannianMetric):
             axis=-2,
         )
         return logs
+
+
+class NFoldMetric(RiemannianMetric):
+    r"""Class for an n-fold product manifold :math:`M^n`.
+
+    Define a manifold as the product manifold of n copies of a given base manifold M.
+
+    Parameters
+    ----------
+    base_metric : RiemannianMetric
+        Base metric.
+    n_copies : int
+        Number of replication of the base metric.
+    """
+
+    def __init__(self, base_metric, n_copies):
+        geomstats.errors.check_integer(n_copies, "n_copies")
+        dim = n_copies * base_metric.dim
+        base_shape = base_metric.shape
+        super(NFoldMetric, self).__init__(dim=dim, shape=(n_copies, *base_shape))
+        self.base_shape = base_shape
+        self.base_metric = base_metric
+        self.n_copies = n_copies
+
+    def metric_matrix(self, base_point=None):
+        """Compute the matrix of the inner-product.
+
+        Matrix of the inner-product defined by the Riemmanian metric
+        at point base_point of the manifold.
+
+        Parameters
+        ----------
+        base_point : array-like, shape=[..., n_copies, *base_shape]
+            Point on the manifold at which to compute the inner-product matrix.
+            Optional, default: None.
+
+        Returns
+        -------
+        matrix : array-like, shape=[..., n_copies, dim, dim]
+            Matrix of the inner-product at the base point.
+        """
+        point_ = gs.reshape(base_point, (-1, *self.base_shape))
+        matrices = self.base_metric.metric_matrix(point_)
+        dim = self.base_metric.dim
+        reshaped = gs.reshape(matrices, (-1, self.n_copies, dim, dim))
+        return gs.squeeze(reshaped)
+
+    def inner_product(self, tangent_vec_a, tangent_vec_b, base_point):
+        """Compute the inner-product of two tangent vectors at a base point.
+
+        Inner product defined by the Riemannian metric at point `base_point`
+        between tangent vectors `tangent_vec_a` and `tangent_vec_b`.
+
+        Parameters
+        ----------
+        tangent_vec_a : array-like, shape=[..., n_copies, *base_shape]
+            First tangent vector at base point.
+        tangent_vec_b : array-like, shape=[..., n_copies, *base_shape]
+            Second tangent vector at base point.
+        base_point : array-like, shape=[..., n_copies, *base_shape]
+            Point on the manifold.
+            Optional, default: None.
+
+        Returns
+        -------
+        inner_prod : array-like, shape=[...,]
+            Inner-product of the two tangent vectors.
+        """
+        tangent_vec_a_, tangent_vec_b_, point_ = gs.broadcast_arrays(
+            tangent_vec_a, tangent_vec_b, base_point
+        )
+        point_ = gs.reshape(point_, (-1, *self.base_shape))
+        vector_a = gs.reshape(tangent_vec_a_, (-1, *self.base_shape))
+        vector_b = gs.reshape(tangent_vec_b_, (-1, *self.base_shape))
+        inner_each = self.base_metric.inner_product(vector_a, vector_b, point_)
+        reshaped = gs.reshape(inner_each, (-1, self.n_copies))
+        return gs.squeeze(gs.sum(reshaped, axis=-1))
+
+    def exp(self, tangent_vec, base_point, **kwargs):
+        """Compute the Riemannian exponential of a tangent vector.
+
+        Parameters
+        ----------
+        tangent_vec : array-like, shape=[..., n_copies, *base_shape]
+            Tangent vector at a base point.
+        base_point : array-like, shape=[..., n_copies, *base_shape]
+            Point on the manifold.
+            Optional, default: None.
+
+        Returns
+        -------
+        exp : array-like, shape=[..., n_copies, *base_shape]
+            Point on the manifold equal to the Riemannian exponential
+            of tangent_vec at the base point.
+        """
+        tangent_vec, point_ = gs.broadcast_arrays(tangent_vec, base_point)
+        point_ = gs.reshape(point_, (-1, *self.base_shape))
+        vector_ = gs.reshape(tangent_vec, (-1, *self.base_shape))
+        each_exp = self.base_metric.exp(vector_, point_)
+        reshaped = gs.reshape(each_exp, (-1, self.n_copies) + self.base_shape)
+        return gs.squeeze(reshaped)
+
+    def log(self, point, base_point, **kwargs):
+        """Compute the Riemannian logarithm of a point.
+
+        Parameters
+        ----------
+        point : array-like, shape=[..., n_copies, *base_shape]
+            Point on the manifold.
+        base_point : array-like, shape=[..., n_copies, *base_shape]
+            Point on the manifold.
+            Optional, default: None.
+
+        Returns
+        -------
+        log : array-like, shape=[..., n_copies, *base_shape]
+            Tangent vector at the base point equal to the Riemannian logarithm
+            of point at the base point.
+        """
+        point_, base_point_ = gs.broadcast_arrays(point, base_point)
+        base_point_ = gs.reshape(base_point_, (-1, *self.base_shape))
+        point_ = gs.reshape(point_, (-1, *self.base_shape))
+        each_log = self.base_metric.log(point_, base_point_)
+        reshaped = gs.reshape(each_log, (-1, self.n_copies) + self.base_shape)
+        return gs.squeeze(reshaped)

--- a/tests/tests_geomstats/test_product_manifold.py
+++ b/tests/tests_geomstats/test_product_manifold.py
@@ -4,12 +4,11 @@ import geomstats.backend as gs
 import geomstats.tests
 from geomstats.geometry.euclidean import Euclidean
 from geomstats.geometry.minkowski import Minkowski
-from geomstats.geometry.product_manifold import (
-    NFoldManifold,
+from geomstats.geometry.product_manifold import NFoldManifold, ProductManifold
+from geomstats.geometry.product_riemannian_metric import (
     NFoldMetric,
-    ProductManifold,
+    ProductRiemannianMetric,
 )
-from geomstats.geometry.product_riemannian_metric import ProductRiemannianMetric
 from tests.conftest import Parametrizer
 from tests.data.product_manifold_data import (
     NFoldManifoldTestData,


### PR DESCRIPTION
The organization of files and associated inheritance of Python classes in the Product (Manifold/Metric), NFold (Manifold/Metric), Landmarks, Curves and their metric is a mess.

This PR starts addressing this problem by addressing a few tasks of Issue #1492 

## Checklist

- [x] My pull request has a clear and explanatory title.
- [x] If neccessary, my code is [vectorized](https://www.geeksforgeeks.org/vectorization-in-python/).
- [x] I have added apropriate unit tests.
- [ ] I have made sure the code passes all unit tests. (refer to comment below)
- [x] My PR follows [PEP8](https://peps.python.org/pep-0008/) guidelines. (refer to comment below)
- [x] My PR follows [geomstats coding style](https://github.com/geomstats/geomstats/blob/master/docs/contributing.rst#coding-style-guidelines) and API.
- [x] My code is properly documented and I made sure the documentation renders properly. ([Link](https://github.com/geomstats/geomstats/blob/master/docs/contributing.rst#documentation))
- [x] I have linked to issues and PRs that are relevant to this PR.


<!-- For checking consistency of entire codebase
First, run the tests related to your changes. For example, if you changed something in geomstats/spd_matrices_space.py:
$ pytest tests/tests_geomstats/test_spd_matrices.py

and then run the tests of the whole codebase to check that your feature is not breaking any of them:
$ pytest tests/

This way, further modifications on the code base are guaranteed to be consistent with the desired behavior. Merging your PR should not break any test in any backend (numpy, tensorflow or pytorch)."

For testing in alternative backends such as `numpy`, `pytorch`, `autograd`, `tensorflow` set the environment variable using:
$ export GEOMSTATS_BACKEND=<backend_name>

Next, import the `backend` module using:
import geomstats.backend as gs
-->


<!-- For flake8 tests
Install dependencies
$ pip3 install -r dev-requirements.txt

Then run the following commands:
$ flake8 --ignore=D,W503,W504 geomstats examples tests   #shadows .flake8
$ flake8 geomstats/geometry geomstats/learning           #passed two subfolders
-->

## Description

<!-- Include a description of your pull request. If relevant, feel free to use this space to talk about time and space complexity as well scalability of your code-->

## Issue

<!-- Tell us which issue does this PR fix . Why this feature implementation/fix is important in practice ?-->

## Additional context

<!-- Add any extra information -->