### PR TITLE
Use `p` for the rank of Grassmannian manifolds

### DIFF
--- a/tests/data/grassmannian_data.py
+++ b/tests/data/grassmannian_data.py
@@ -25,8 +25,8 @@ class GrassmannianTestData(_LevelSetTestData):
 
     def belongs_test_data(self):
         smoke_data = [
-            dict(n=3, k=2, point=p_xy, expected=True),
-            dict(n=3, k=2, point=gs.array([p_yz, p_xz]), expected=[True, True]),
+            dict(n=3, p=2, point=p_xy, expected=True),
+            dict(n=3, p=2, point=gs.array([p_yz, p_xz]), expected=[True, True]),
         ]
         return self.generate_tests(smoke_data)
 
@@ -87,14 +87,14 @@ class GrassmannianCanonicalMetricTestData(_RiemannianMetricTestData):
         smoke_data = [
             dict(
                 n=3,
-                k=2,
+                p=2,
                 tangent_vec=Matrices.bracket(pi_2 * r_y, gs.array([p_xy, p_yz])),
                 base_point=gs.array([p_xy, p_yz]),
                 expected=gs.array([p_yz, p_xy]),
             ),
             dict(
                 n=3,
-                k=2,
+                p=2,
                 tangent_vec=Matrices.bracket(
                     pi_2 * gs.array([r_y, r_z]), gs.array([p_xy, p_yz])
                 ),

--- a/tests/tests_geomstats/test_grassmannian.py
+++ b/tests/tests_geomstats/test_grassmannian.py
@@ -18,8 +18,8 @@ class TestGrassmannian(LevelSetTestCase, metaclass=Parametrizer):
 
     testing_data = GrassmannianTestData()
 
-    def test_belongs(self, n, k, point, expected):
-        self.assertAllClose(self.space(n, k).belongs(point), gs.array(expected))
+    def test_belongs(self, n, p, point, expected):
+        self.assertAllClose(self.space(n, p).belongs(point), gs.array(expected))
 
 
 class TestGrassmannianCanonicalMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
@@ -30,8 +30,8 @@ class TestGrassmannianCanonicalMetric(RiemannianMetricTestCase, metaclass=Parame
 
     testing_data = GrassmannianCanonicalMetricTestData()
 
-    def test_exp(self, n, k, tangent_vec, base_point, expected):
+    def test_exp(self, n, p, tangent_vec, base_point, expected):
         self.assertAllClose(
-            self.metric(n, k).exp(gs.array(tangent_vec), gs.array(base_point)),
+            self.metric(n, p).exp(gs.array(tangent_vec), gs.array(base_point)),
             gs.array(expected),
         )


### PR DESCRIPTION
<!--
Thank you for opening this pull request!
-->

## Checklist

- [x] My pull request has a clear and explanatory title.
- [ ] If neccessary, my code is [vectorized](https://www.geeksforgeeks.org/vectorization-in-python/).
- [ ] I have added apropriate unit tests.
- [x] I have made sure the code passes all unit tests. (refer to comment below)
- [x] My PR follows [PEP8](https://peps.python.org/pep-0008/) guidelines. (refer to comment below)
- [x] My PR follows [geomstats coding style](https://github.com/geomstats/geomstats/blob/master/docs/contributing.rst#coding-style-guidelines) and API.
- [ ] My code is properly documented and I made sure the documentation renders properly. ([Link](https://github.com/geomstats/geomstats/blob/master/docs/contributing.rst#documentation))
- [x] I have linked to issues and PRs that are relevant to this PR. 

<!-- For checking consistency of entire codebase
First, run the tests related to your changes. For example, if you changed something in geomstats/spd_matrices_space.py:
$ pytest tests/tests_geomstats/test_spd_matrices.py

and then run the tests of the whole codebase to check that your feature is not breaking any of them:
$ pytest tests/

This way, further modifications on the code base are guaranteed to be consistent with the desired behavior. Merging your PR should not break any test in any backend (numpy, tensorflow or pytorch)."

For testing in alternative backends such as `numpy`, `pytorch`, `autograd`, `tensorflow` set the environment variable using:
$ export GEOMSTATS_BACKEND=<backend_name>

Next, import the `backend` module using:
import geomstats.backend as gs
-->


<!-- For flake8 tests
Install dependencies
$ pip3 install -r dev-requirements.txt

Then run the following commands:
$ flake8 --ignore=D,W503,W504 geomstats examples tests   #shadows .flake8
$ flake8 geomstats/geometry geomstats/learning           #passed two subfolders
-->

## Description

The goal of this PR is to use a consistent variable in `grassmannian.py`. Currently, the rank referred in the module and its document is either `p` or `k`.

## Issue

https://github.com/geomstats/geomstats/issues/1557
