### PR TITLE
Refactor FrechetMean

### DIFF
--- a/examples/empirical_frechet_mean_uncertainty_sn.py
+++ b/examples/empirical_frechet_mean_uncertainty_sn.py
@@ -66,6 +66,9 @@ def empirical_frechet_var_bubble(n_samples, theta, dim, n_expectation=1000):
         estimator = FrechetMean(
             sphere.metric, max_iter=32, method="adaptive", init_point=north_pole
         )
+        if n_samples == 1:
+            data = gs.expand_dims(data, 0)
+
         estimator.fit(data)
         current_mean = estimator.estimate_
         var.append(sphere.metric.squared_dist(north_pole, current_mean))

--- a/geomstats/learning/expectation_maximization.py
+++ b/geomstats/learning/expectation_maximization.py
@@ -241,8 +241,6 @@ class RiemannianEM(TransformerMixin, ClusterMixin, BaseEstimator):
 
     Attributes
     ----------
-    point_type : basestring
-        Whether to use vector or matrix representation.
     _dimension : int
         Manifold dimension.
     mixture_coefficients : array-like, shape=[n_gaussians,]
@@ -286,8 +284,6 @@ class RiemannianEM(TransformerMixin, ClusterMixin, BaseEstimator):
         self.metric = metric
         self.initialisation_method = initialisation_method
         self.tol = tol
-        self.mean_method = "batch"
-        self.point_type = metric.default_point_type
         self._dimension = None
         self.mixture_coefficients = None
         self.variances = None
@@ -300,6 +296,8 @@ class RiemannianEM(TransformerMixin, ClusterMixin, BaseEstimator):
         self.max_iter = max_iter
         self.max_iter_mean = max_iter_mean
         self.tol_mean = tol_mean
+
+        self._mean_method = "batch"
 
     def update_posterior_probabilities(self, posterior_probabilities):
         """Posterior probabilities update function.
@@ -320,8 +318,7 @@ class RiemannianEM(TransformerMixin, ClusterMixin, BaseEstimator):
             metric=self.metric,
             max_iter=self.max_iter_mean,
             epsilon=self.tol_mean,
-            point_type=self.point_type,
-            method=self.mean_method,
+            method=self._mean_method,
             init_step_size=self.init_step_size,
         )
 
@@ -470,7 +467,7 @@ class RiemannianEM(TransformerMixin, ClusterMixin, BaseEstimator):
                 n_clusters=self.n_gaussians,
                 init="random",
                 init_step_size=self.init_step_size,
-                mean_method="batch",
+                mean_method="default",
             )
 
             centroids = kmeans.fit(X=data)

--- a/geomstats/learning/frechet_mean.py
+++ b/geomstats/learning/frechet_mean.py
@@ -532,10 +532,14 @@ class FrechetMean(BaseEstimator):
 
     @property
     def method(self):
+        """Gradient descent method.
+        """
         return self._method
 
     @method.setter
     def method(self, value):
+        """Gradient descent method.
+        """
         error.check_parameter_accepted_values(
             value, "method", ["default", "adaptive", "batch"]
         )
@@ -583,7 +587,6 @@ class FrechetMean(BaseEstimator):
         metric_str = self.metric.__str__()
 
         if "HypersphereMetric" in metric_str and self.metric.dim == 1:
-            # FIXME: not working properly
             mean = Hypersphere.angle_to_extrinsic(_circle_mean(X))
 
         elif _is_linear_metric(metric_str):

--- a/geomstats/learning/frechet_mean.py
+++ b/geomstats/learning/frechet_mean.py
@@ -532,14 +532,12 @@ class FrechetMean(BaseEstimator):
 
     @property
     def method(self):
-        """Gradient descent method.
-        """
+        """Gradient descent method."""
         return self._method
 
     @method.setter
     def method(self, value):
-        """Gradient descent method.
-        """
+        """Gradient descent method."""
         error.check_parameter_accepted_values(
             value, "method", ["default", "adaptive", "batch"]
         )

--- a/geomstats/learning/mdm.py
+++ b/geomstats/learning/mdm.py
@@ -24,9 +24,6 @@ class RiemannianMinimumDistanceToMeanClassifier:
         Riemannian metric to be used.
     n_classes : int
         Number of classes.
-    point_type : str, {\'vector\', \'matrix\'}
-        Point type.
-        Optional, default: \'matrix\'.
 
     Attributes
     ----------
@@ -42,10 +39,9 @@ class RiemannianMinimumDistanceToMeanClassifier:
         Trans. Biomed. Eng., vol. 59, pp. 920-928, 2012.
     """
 
-    def __init__(self, riemannian_metric, n_classes, point_type="matrix"):
+    def __init__(self, riemannian_metric, n_classes):
         self.riemannian_metric = riemannian_metric
         self.n_classes = n_classes
-        self.point_type = point_type
         self.mean_estimates_ = None
         self.classes_ = None
 
@@ -54,19 +50,14 @@ class RiemannianMinimumDistanceToMeanClassifier:
 
         Parameters
         ----------
-        X : array-like, shape=[n_samples, dim]
-                              if point_type='vector'
-                              shape=[n_samples, n, n]
-                              if point_type='matrix'
+        X : array-like, shape=[n_samples, *metric.shape]
             Training data, where n_samples is the number of samples
             and n_features is the number of features.
         y : array-like, shape=[n_samples,]
             Training labels.
         """
         self.classes_ = gs.unique(y)
-        mean_estimator = FrechetMean(
-            metric=self.riemannian_metric, point_type=self.point_type
-        )
+        mean_estimator = FrechetMean(metric=self.riemannian_metric)
         frechet_means = []
         for c in self.classes_:
             X_c = X[gs.where(y == c, True, False)]
@@ -78,10 +69,7 @@ class RiemannianMinimumDistanceToMeanClassifier:
 
         Parameters
         ----------
-        X : array-like, shape=[n_samples, dim]
-                              if point_type='vector'
-                              shape=[n_samples, n, n]
-                              if point_type='matrix'
+        X : array-like, shape=[n_samples, *metric.shape]
             Test data, where n_samples is the number of samples
             and n_features is the number of features.
 
@@ -104,10 +92,7 @@ class RiemannianMinimumDistanceToMeanClassifier:
 
         Parameters
         ----------
-        X : array-like, shape=[n_samples, dim]
-                              if point_type='vector'
-                              shape=[n_samples, n, n]
-                              if point_type='matrix'
+        X : array-like, shape=[n_samples, *metric.shape]
             Test data, where n_samples is the number of samples
             and n_features is the number of features.
 
@@ -130,10 +115,7 @@ class RiemannianMinimumDistanceToMeanClassifier:
 
         Parameters
         ----------
-        X : array-like, shape=[n_samples, dim]
-                              if point_type='vector'
-                              shape=[n_samples, n, n]
-                              if point_type='matrix'
+        X : array-like, shape=[n_samples, *metric.shape]
             Test data, where n_samples is the number of samples
             and n_features is the number of features.
         y : array-like, shape=[n_samples,]

--- a/geomstats/learning/pca.py
+++ b/geomstats/learning/pca.py
@@ -246,7 +246,7 @@ class TangentPCA(_BasePCA):
             Matrices of the SVD decomposition
         """
         if base_point is None:
-            mean = FrechetMean(metric=self.metric, point_type=self.point_type)
+            mean = FrechetMean(metric=self.metric)
             mean.fit(X)
             base_point = mean.estimate_
 

--- a/notebooks/11_real_world_applications__cell_shapes_analysis.ipynb
+++ b/notebooks/11_real_world_applications__cell_shapes_analysis.ipynb
@@ -1017,9 +1017,7 @@
    "id": "a109b03d",
    "metadata": {},
    "source": [
-    "We compute the mean cell shape by using the SRV metric defined on the space of curves' shapes. The space of curves' shape is a manifold: we use the Frechet mean, associated to the SRV metric, to get the mean cell shape.\n",
-    "\n",
-    "We need to use the `point_type=\"matrix\"` because one cell shape is represented by an array of shape n_sampling_points x 2, which is a matrix."
+    "We compute the mean cell shape by using the SRV metric defined on the space of curves' shapes. The space of curves' shape is a manifold: we use the Frechet mean, associated to the SRV metric, to get the mean cell shape."
    ]
   },
   {
@@ -1052,7 +1050,7 @@
    "source": [
     "from geomstats.learning.frechet_mean import FrechetMean\n",
     "\n",
-    "mean = FrechetMean(metric=SRV_METRIC, point_type=\"matrix\", method=\"default\")\n",
+    "mean = FrechetMean(metric=SRV_METRIC, method=\"default\")\n",
     "mean.fit(cell_shapes[:500])\n",
     "\n",
     "mean_estimate = mean.estimate_\n",
@@ -2285,7 +2283,7 @@
     "    treatment_cells = []\n",
     "    for line in LINES:\n",
     "        treatment_cells.extend(ds_align[treatment][line])\n",
-    "    mean_estimator = FrechetMean(metric=SRV_METRIC, point_type=\"matrix\")\n",
+    "    mean_estimator = FrechetMean(metric=SRV_METRIC)\n",
     "    mean_estimator.fit(treatment_cells[:30])\n",
     "    mean_treatment_cells[treatment] = mean_estimator.estimate_"
    ]
@@ -2335,7 +2333,7 @@
     "    line_cells = []\n",
     "    for treatment in TREATMENTS:\n",
     "        line_cells.extend(ds_align[treatment][line])\n",
-    "    mean_estimator = FrechetMean(metric=SRV_METRIC, point_type=\"matrix\")\n",
+    "    mean_estimator = FrechetMean(metric=SRV_METRIC)\n",
     "    mean_estimator.fit(line_cells[:225])\n",
     "    mean_line_cells[line] = mean_estimator.estimate_"
    ]
@@ -2384,7 +2382,7 @@
     "for treatment in TREATMENTS:\n",
     "    mean_cells[treatment] = {}\n",
     "    for line in LINES:\n",
-    "        mean_estimator = FrechetMean(metric=SRV_METRIC, point_type=\"matrix\")\n",
+    "        mean_estimator = FrechetMean(metric=SRV_METRIC)\n",
     "        mean_estimator.fit(ds_align[treatment][line][:20])\n",
     "        mean_cells[treatment][line] = mean_estimator.estimate_"
    ]

--- a/notebooks/12_real_world_applications__emg_sign_classification_in_spd_manifold.ipynb
+++ b/notebooks/12_real_world_applications__emg_sign_classification_in_spd_manifold.ipynb
@@ -483,7 +483,7 @@
    "outputs": [],
    "source": [
     "metric_affine = SPDMetricAffine(N_ELECTRODES)\n",
-    "mean_affine = FrechetMean(metric=metric_affine, point_type=\"matrix\")"
+    "mean_affine = FrechetMean(metric=metric_affine)"
    ]
   },
   {

--- a/notebooks/13_real_world_applications__graph_embedding_and_clustering_in_hyperbolic_space.ipynb
+++ b/notebooks/13_real_world_applications__graph_embedding_and_clustering_in_hyperbolic_space.ipynb
@@ -877,7 +877,7 @@
     "    metric=hyperbolic_manifold.metric,\n",
     "    n_clusters=n_clusters,\n",
     "    init=\"random\",\n",
-    "    mean_method=\"batch\",\n",
+    "    mean_method=\"default\",\n",
     ")"
    ]
   },

--- a/tests/tests_geomstats/test_expectation_maximization.py
+++ b/tests/tests_geomstats/test_expectation_maximization.py
@@ -27,7 +27,6 @@ class TestEM(geomstats.tests.TestCase):
         self.space = PoincareBall(dim=self.dim)
         self.metric = self.space.metric
         self.initialisation_method = "random"
-        self.mean_method = "batch"
 
         cluster_1 = gs.random.uniform(
             low=0.2, high=0.6, size=(self.n_samples, self.dim)
@@ -99,9 +98,7 @@ class TestEM(geomstats.tests.TestCase):
         """Test for weighted mean."""
         data = gs.array([[0.1, 0.2], [0.25, 0.35]])
         weights = gs.array([3.0, 1.0])
-        mean_o = FrechetMean(
-            metric=self.metric, point_type="vector", init_step_size=1.0
-        )
+        mean_o = FrechetMean(metric=self.metric, init_step_size=1.0)
         mean_o.fit(data, weights=weights)
         result = mean_o.estimate_
         expected = self.metric.exp(

--- a/tests/tests_geomstats/test_frechet_mean.py
+++ b/tests/tests_geomstats/test_frechet_mean.py
@@ -544,10 +544,9 @@ class TestFrechetMean(geomstats.tests.TestCase):
         estimator.fit(points)
         mean = estimator.estimate_
 
-        mean_gd = estimator._minimize(
-            points=points, weights=None, metric=space.metric)
+        mean_gd = estimator._minimize(points=points, weights=None, metric=space.metric)
 
-        sum_sd_mean = gs.sum(space.metric.dist(points, mean)**2)
-        sum_sd_mean_gd = gs.sum(space.metric.dist(points, mean_gd)**2)
+        sum_sd_mean = gs.sum(space.metric.dist(points, mean) ** 2)
+        sum_sd_mean_gd = gs.sum(space.metric.dist(points, mean_gd) ** 2)
 
         self.assertTrue(sum_sd_mean < sum_sd_mean_gd + gs.atol)

--- a/tests/tests_geomstats/test_frechet_mean.py
+++ b/tests/tests_geomstats/test_frechet_mean.py
@@ -310,7 +310,7 @@ class TestFrechetMean(geomstats.tests.TestCase):
     def test_estimate_spd(self):
         point = SPDMatrices(3).random_point()
         points = gs.array([point, point])
-        mean = FrechetMean(metric=SPDMetricAffine(3), point_type="matrix")
+        mean = FrechetMean(metric=SPDMetricAffine(3))
         mean.fit(X=points)
         result = mean.estimate_
         expected = point
@@ -385,7 +385,7 @@ class TestFrechetMean(geomstats.tests.TestCase):
         self.assertAllClose(result, expected)
 
         points = gs.array([[1.0, 2.0], [2.0, 3.0], [3.0, 4.0], [4.0, 5.0]])
-        weights = [1.0, 2.0, 1.0, 2.0]
+        weights = gs.array([1.0, 2.0, 1.0, 2.0])
 
         mean = FrechetMean(metric=self.euclidean.metric)
         mean.fit(points, weights=weights)
@@ -412,7 +412,7 @@ class TestFrechetMean(geomstats.tests.TestCase):
         point = gs.array([[1.0, 4.0], [2.0, 3.0]])
 
         metric = MatricesMetric(m, n)
-        mean = FrechetMean(metric=metric, point_type="matrix")
+        mean = FrechetMean(metric=metric)
         points = [point, point, point]
         mean.fit(points)
 
@@ -425,7 +425,7 @@ class TestFrechetMean(geomstats.tests.TestCase):
         point = gs.array([[1.0, 4.0], [2.0, 3.0]])
 
         metric = MatricesMetric(m, n)
-        mean = FrechetMean(metric=metric, point_type="matrix")
+        mean = FrechetMean(metric=metric)
         points = [point, point, point]
         mean.fit(points)
 
@@ -483,20 +483,20 @@ class TestFrechetMean(geomstats.tests.TestCase):
         self.assertAllClose(result, expected)
 
     def test_one_point(self):
-        point = gs.array([0.0, 0.0, 0.0, 0.0, 1.0])
+        point = gs.array([[0.0, 0.0, 0.0, 0.0, 1.0]])
 
         mean = FrechetMean(metric=self.sphere.metric, method="default")
         mean.fit(X=point)
 
         result = mean.estimate_
-        expected = point
+        expected = point[0]
         self.assertAllClose(expected, result)
 
         mean = FrechetMean(metric=self.sphere.metric, method="default")
         mean.fit(X=point)
 
         result = mean.estimate_
-        expected = point
+        expected = point[0]
         self.assertAllClose(expected, result)
 
     def test_batched(self):

--- a/tests/tests_geomstats/test_frechet_mean.py
+++ b/tests/tests_geomstats/test_frechet_mean.py
@@ -540,14 +540,14 @@ class TestFrechetMean(geomstats.tests.TestCase):
     def test_circle_mean(self):
         space = Hypersphere(1)
         points = space.random_uniform(10)
-        mean_circle = FrechetMean(space.metric)
-        mean_circle.fit(points)
-        estimate_circle = mean_circle.estimate_
+        estimator = FrechetMean(space.metric)
+        estimator.fit(points)
+        mean = estimator.estimate_
 
-        # set a wrong dimension so that the extrinsic coordinates are used
-        metric = space.metric
-        metric.dim = 2
-        mean_extrinsic = FrechetMean(metric)
-        mean_extrinsic.fit(points)
-        estimate_extrinsic = mean_extrinsic.estimate_
-        self.assertAllClose(estimate_circle, estimate_extrinsic)
+        mean_gd = estimator._minimize(
+            points=points, weights=None, metric=space.metric)
+
+        sum_sd_mean = gs.sum(space.metric.dist(points, mean)**2)
+        sum_sd_mean_gd = gs.sum(space.metric.dist(points, mean_gd)**2)
+
+        self.assertTrue(sum_sd_mean < sum_sd_mean_gd + gs.atol)

--- a/tests/tests_geomstats/test_frechet_mean.py
+++ b/tests/tests_geomstats/test_frechet_mean.py
@@ -549,4 +549,5 @@ class TestFrechetMean(geomstats.tests.TestCase):
         sum_sd_mean = gs.sum(space.metric.dist(points, mean) ** 2)
         sum_sd_mean_gd = gs.sum(space.metric.dist(points, mean_gd) ** 2)
 
-        self.assertTrue(sum_sd_mean < sum_sd_mean_gd + gs.atol)
+        msg = f"circular mean: {mean}, {sum_sd_mean}\ngd: {mean_gd}, {sum_sd_mean_gd}"
+        self.assertTrue(sum_sd_mean < sum_sd_mean_gd + gs.atol, msg)

--- a/tests/tests_geomstats/test_frechet_mean.py
+++ b/tests/tests_geomstats/test_frechet_mean.py
@@ -550,4 +550,4 @@ class TestFrechetMean(geomstats.tests.TestCase):
         sum_sd_mean_gd = gs.sum(space.metric.dist(points, mean_gd) ** 2)
 
         msg = f"circular mean: {mean}, {sum_sd_mean}\ngd: {mean_gd}, {sum_sd_mean_gd}"
-        self.assertTrue(sum_sd_mean < sum_sd_mean_gd + gs.atol, msg)
+        self.assertTrue(sum_sd_mean < sum_sd_mean_gd + 1e-4, msg)

--- a/tests/tests_geomstats/test_mdm.py
+++ b/tests/tests_geomstats/test_mdm.py
@@ -24,7 +24,8 @@ class TestRiemannianMinimumDistanceToMeanClassifier(geomstats.tests.TestCase):
 
         for metric in METRICS:
             MDMEstimator = RiemannianMinimumDistanceToMeanClassifier(
-                metric(n=2), n_classes=2, point_type="matrix"
+                metric(n=2),
+                n_classes=2,
             )
             MDMEstimator.fit(X_train, y_train)
             bary_a_fit = MDMEstimator.mean_estimates_[0]
@@ -54,7 +55,8 @@ class TestRiemannianMinimumDistanceToMeanClassifier(geomstats.tests.TestCase):
 
         for metric in METRICS:
             MDMEstimator = RiemannianMinimumDistanceToMeanClassifier(
-                metric(n=2), n_classes=2, point_type="matrix"
+                metric(n=2),
+                n_classes=2,
             )
             MDMEstimator.fit(X_train, y_train)
             y_test = MDMEstimator.predict(X_test)
@@ -72,7 +74,8 @@ class TestRiemannianMinimumDistanceToMeanClassifier(geomstats.tests.TestCase):
 
         for metric in METRICS:
             MDMEstimator = RiemannianMinimumDistanceToMeanClassifier(
-                metric(n=2), n_classes=2, point_type="matrix"
+                metric(n=2),
+                n_classes=2,
             )
             MDMEstimator.fit(X_train, y_train)
             proba_test = MDMEstimator.predict_proba(X_test)
@@ -97,7 +100,8 @@ class TestRiemannianMinimumDistanceToMeanClassifier(geomstats.tests.TestCase):
 
         for metric in METRICS:
             MDMEstimator = RiemannianMinimumDistanceToMeanClassifier(
-                metric(n=2), n_classes=2, point_type="matrix"
+                metric(n=2),
+                n_classes=2,
             )
             MDMEstimator.fit(X_train, y_train)
 

--- a/tests/tests_geomstats/test_riemannian_kmeans.py
+++ b/tests/tests_geomstats/test_riemannian_kmeans.py
@@ -42,7 +42,7 @@ class TestRiemannianKMeans(geomstats.tests.TestCase):
         kmeans.fit(data)
         result = kmeans.centroids
 
-        mean = FrechetMean(metric=metric, max_iter=100, point_type="matrix")
+        mean = FrechetMean(metric=metric, max_iter=100)
         mean.fit(data)
         expected = mean.estimate_
         self.assertAllClose(result, expected)


### PR DESCRIPTION
This PR removes `point_type` argument from `FrechetMean` and updates dependent algorithms to not use it either if related with FrechetMean call.

**Why?** Only reason for `point_type` is a scalar multiplication. This can be done with einsum without really knowing if it is a vector or a matrix.  More interestingly, FrechetMean can be now applied even for ndim > 2 (may be relevant for e.g. Sasaki metric (#1568)).

A strong assumption now, that was already being used in another learning algorithms, but not in `FrechetMean`, is that the first dimension of `X` represents `n_samples`. This follows `sklearn` behavior. Therefore, if a single point is passed to `fit`, it will not work.

I've also taken advantage of this PR to clean a bit the code in `FrechetMean`.


**Points that deserve further attention/should be discussed**

1) For the code branch `if "HypersphereMetric" in metric_str and self.metric.dim == 1:` a mean was being computed with `_circle_mean`, but later being recomputed with one of the methods. When correcting the flow, i.e. computing `mean` only once, the tests in circular mean do not pass (see test workflow). What's wrong?

2) `_batch_gradient_descent` used to verify the dimensions of `X` and use `default_gradient_descent` if not batch. I removed this behavior because I think it is misleading (e.g. some code was setting `batch` as default method and in practice using `default_gradient_descent`). I think users should know batch requires a transformation of the input and take care of it themselves.



