### PR TITLE
Add ability of using kwargs in test functions

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,16 +97,17 @@ def pytorch_error_msg(a, b, rtol, atol):
 
 
 def copy_func(f, name=None):
-    """
-    Return a function with same code, globals, defaults, closure, and
-    name (or provide a new name)
+    """Return a function with same code, globals, defaults, closure, and
+    name (or provide a new name).
+
+    Additionally, keyword arguments are transformed into positional arguments for
+    compatibility with pytest.
     """
     fn = types.FunctionType(
         f.__code__, f.__globals__, name or f.__name__, f.__defaults__, f.__closure__
     )
     fn.__dict__.update(f.__dict__)
 
-    # transform keyword arguments in positional arguments (due to pytest)
     sign = inspect.signature(fn)
     defaults, new_params = {}, []
     for param in sign.parameters.values():

--- a/tests/tests_geomstats/test_backends2.py
+++ b/tests/tests_geomstats/test_backends2.py
@@ -171,10 +171,10 @@ class TestBackends(TestCase, metaclass=Parametrizer):
         else:
             self.assertFalse(out)
 
-    def test_func_out_allclose(self, func_name, args, expected, **kwargs):
+    def test_func_out_allclose(self, func_name, args, expected):
         gs_fnc = get_backend_fnc(func_name)
 
-        out = gs_fnc(*args, **kwargs)
+        out = gs_fnc(*args)
         self.assertAllClose(out, expected)
 
     def test_func_out_equal(self, func_name, args, expected):


### PR DESCRIPTION
This change will allow to do something like:

```python
def test_func(self, a, b, c=3):
  pass
```

This is achieved by changing the function signature to e.g. `(self, a, b, c)` and passing the default as data value if not encountered in the datum.

This feature is handy sometimes to reduce verbose in data creation.