### PR TITLE
Make `array_from_sparse` more general

### DIFF
--- a/geomstats/_backend/__init__.py
+++ b/geomstats/_backend/__init__.py
@@ -71,7 +71,6 @@ BACKEND_ATTRIBUTES = {
         "flip",
         "floor",
         "from_numpy",
-        "get_mask_i_float",
         "get_slice",
         "greater",
         "hsplit",

--- a/geomstats/_backend/autograd/__init__.py
+++ b/geomstats/_backend/autograd/__init__.py
@@ -152,28 +152,6 @@ def one_hot(labels, num_classes):
     return _np.eye(num_classes, dtype=_np.dtype("uint8"))[labels]
 
 
-def get_mask_i_float(i, n):
-    """Create a 1D array of zeros with one element at one, with floating type.
-
-    Parameters
-    ----------
-    i : int
-        Index of the non-zero element.
-    n: n
-        Length of the created array.
-
-    Returns
-    -------
-    mask_i_float : array-like, shape=[n,]
-        1D array of zeros except at index i, where it is one
-    """
-    range_n = arange(n)
-    i_float = cast(array([i]), int32)[0]
-    mask_i = equal(range_n, i_float)
-    mask_i_float = cast(mask_i, float32)
-    return mask_i_float
-
-
 def _is_boolean(x):
     if isinstance(x, bool):
         return True

--- a/geomstats/_backend/autograd/__init__.py
+++ b/geomstats/_backend/autograd/__init__.py
@@ -379,7 +379,10 @@ def array_from_sparse(indices, data, target_shape):
     a : array, shape=target_shape
         Array of zeros with specified values assigned to specified indices.
     """
-    return array(_coo_matrix((data, list(zip(*indices))), target_shape).todense())
+    data = array(data)
+    out = zeros(target_shape, dtype=data.dtype)
+    out.put(_np.ravel_multi_index(_np.array(indices).T, target_shape), data)
+    return out
 
 
 def tril_to_vec(x, k=0):

--- a/geomstats/_backend/numpy/__init__.py
+++ b/geomstats/_backend/numpy/__init__.py
@@ -152,28 +152,6 @@ def one_hot(labels, num_classes):
     return _np.eye(num_classes, dtype=_np.dtype("uint8"))[labels]
 
 
-def get_mask_i_float(i, n):
-    """Create a 1D array of zeros with one element at one, with floating type.
-
-    Parameters
-    ----------
-    i : int
-        Index of the non-zero element.
-    n: n
-        Length of the created array.
-
-    Returns
-    -------
-    mask_i_float : array-like, shape=[n,]
-        1D array of zeros except at index i, where it is one
-    """
-    range_n = arange(n)
-    i_float = cast(array([i]), int32)[0]
-    mask_i = equal(range_n, i_float)
-    mask_i_float = cast(mask_i, float32)
-    return mask_i_float
-
-
 def _is_boolean(x):
     if isinstance(x, bool):
         return True

--- a/geomstats/_backend/numpy/__init__.py
+++ b/geomstats/_backend/numpy/__init__.py
@@ -379,7 +379,10 @@ def array_from_sparse(indices, data, target_shape):
     a : array, shape=target_shape
         Array of zeros with specified values assigned to specified indices.
     """
-    return array(_coo_matrix((data, list(zip(*indices))), target_shape).todense())
+    data = array(data)
+    out = zeros(target_shape, dtype=data.dtype)
+    out.put(_np.ravel_multi_index(_np.array(indices).T, target_shape), data)
+    return out
 
 
 def vec_to_diag(vec):

--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -485,28 +485,6 @@ def where(condition, x=None, y=None):
     return _torch.where(condition, x, y)
 
 
-def get_mask_i_float(i, n):
-    """Create a 1D array of zeros with one element at one, with floating type.
-
-    Parameters
-    ----------
-    i : int
-        Index of the non-zero element.
-    n: n
-        Length of the created array.
-
-    Returns
-    -------
-    mask_i_float : array-like, shape=[n,]
-        1D array of zeros except at index i, where it is one
-    """
-    range_n = arange(cast(array(n), int32))
-    i_float = cast(array(i), int32)
-    mask_i = equal(range_n, i_float)
-    mask_i_float = cast(mask_i, float32)
-    return mask_i_float
-
-
 def _is_boolean(x):
     if isinstance(x, bool):
         return True

--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -662,7 +662,7 @@ def array_from_sparse(indices, data, target_shape):
     """
     return _torch.sparse.FloatTensor(
         _torch.LongTensor(indices).t(),
-        _torch.FloatTensor(cast(data, float32)),
+        array(data),
         _torch.Size(target_shape),
     ).to_dense()
 

--- a/geomstats/_backend/tensorflow/__init__.py
+++ b/geomstats/_backend/tensorflow/__init__.py
@@ -191,28 +191,6 @@ def _is_boolean(x):
     return False
 
 
-def get_mask_i_float(i, n):
-    """Create a 1D array of zeros with one element at one, with floating type.
-
-    Parameters
-    ----------
-    i : int
-        Index of the non-zero element.
-    n: n
-        Length of the created array.
-
-    Returns
-    -------
-    mask_i_float : array-like, shape=[n,]
-        1D array of zeros except at index i, where it is one
-    """
-    range_n = arange(n)
-    i_float = cast(array([i]), int32)[0]
-    mask_i = equal(range_n, i_float)
-    mask_i_float = cast(mask_i, float32)
-    return mask_i_float
-
-
 def _mask_from_indices(indices, mask_shape, dtype=float32):
     """Create a binary mask.
 

--- a/geomstats/geometry/skew_symmetric_matrices.py
+++ b/geomstats/geometry/skew_symmetric_matrices.py
@@ -40,13 +40,14 @@ class SkewSymmetricMatrices(MatrixLieAlgebra):
                     [[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
                 ]
             )
-        basis = []
+        indices, data = [], []
+        k = -1
         for row in gs.arange(n - 1):
             for col in gs.arange(row + 1, n):
-                basis.append(
-                    gs.array_from_sparse([(row, col), (col, row)], [1.0, -1.0], (n, n))
-                )
-        return gs.stack(basis)
+                k += 1
+                indices.extend([(k, row, col), (k, col, row)])
+                data.extend([[1.0, -1.0]])
+        return gs.array_from_sparse(indices, data, (k + 1, n, n))
 
     def belongs(self, mat, atol=gs.atol):
         """Evaluate if mat is a skew-symmetric matrix.

--- a/geomstats/geometry/skew_symmetric_matrices.py
+++ b/geomstats/geometry/skew_symmetric_matrices.py
@@ -42,11 +42,12 @@ class SkewSymmetricMatrices(MatrixLieAlgebra):
             )
         indices, data = [], []
         k = -1
-        for row in gs.arange(n - 1):
-            for col in gs.arange(row + 1, n):
+        for row in range(n - 1):
+            for col in range(row + 1, n):
                 k += 1
                 indices.extend([(k, row, col), (k, col, row)])
-                data.extend([[1.0, -1.0]])
+                data.extend([1.0, -1.0])
+
         return gs.array_from_sparse(indices, data, (k + 1, n, n))
 
     def belongs(self, mat, atol=gs.atol):

--- a/geomstats/geometry/special_euclidean.py
+++ b/geomstats/geometry/special_euclidean.py
@@ -1354,11 +1354,11 @@ class SpecialEuclideanMatrixLieAlgebra(MatrixLieAlgebra):
             (self.skew.dim, n + 1, n + 1),
             0.0,
         )
-        basis = list(basis)
 
-        for row in gs.arange(n):
-            basis.append(gs.array_from_sparse([(row, n)], [1.0], (n + 1, n + 1)))
-        return gs.stack(basis)
+        indices = [(row, row, n) for row in gs.arange(n)]
+        add_basis = gs.array_from_sparse(indices, [1.0] * n, (n, n + 1, n + 1))
+
+        return gs.vstack([basis, add_basis])
 
     def belongs(self, mat, atol=ATOL):
         """Evaluate if the rotation part of mat is a skew-symmetric matrix.

--- a/geomstats/geometry/special_euclidean.py
+++ b/geomstats/geometry/special_euclidean.py
@@ -1355,7 +1355,7 @@ class SpecialEuclideanMatrixLieAlgebra(MatrixLieAlgebra):
             0.0,
         )
 
-        indices = [(row, row, n) for row in gs.arange(n)]
+        indices = [(row, row, n) for row in range(n)]
         add_basis = gs.array_from_sparse(indices, [1.0] * n, (n, n + 1, n + 1))
 
         return gs.vstack([basis, add_basis])

--- a/geomstats/geometry/special_orthogonal.py
+++ b/geomstats/geometry/special_orthogonal.py
@@ -1040,7 +1040,7 @@ class _SpecialOrthogonal3Vectors(_SpecialOrthogonalVectors):
                 ]
             )
 
-            mask_i = gs.get_mask_i_float(i, n_quaternions)
+            mask_i = gs.array_from_sparse([(i,)], [1.0], n_quaternions)
             rot_mat_i = gs.transpose(gs.hstack([column_1, column_2, column_3]))
             rot_mat_i = gs.to_ndarray(rot_mat_i, to_ndim=3)
             rot_mat += gs.einsum("...,...ij->...ij", mask_i, rot_mat_i)

--- a/geomstats/geometry/special_orthogonal.py
+++ b/geomstats/geometry/special_orthogonal.py
@@ -1040,7 +1040,7 @@ class _SpecialOrthogonal3Vectors(_SpecialOrthogonalVectors):
                 ]
             )
 
-            mask_i = gs.array_from_sparse([(i,)], [1.0], n_quaternions)
+            mask_i = gs.array_from_sparse([(i,)], [1.0], (n_quaternions,))
             rot_mat_i = gs.transpose(gs.hstack([column_1, column_2, column_3]))
             rot_mat_i = gs.to_ndarray(rot_mat_i, to_ndim=3)
             rot_mat += gs.einsum("...,...ij->...ij", mask_i, rot_mat_i)

--- a/geomstats/geometry/symmetric_matrices.py
+++ b/geomstats/geometry/symmetric_matrices.py
@@ -33,18 +33,19 @@ class SymmetricMatrices(VectorSpace):
 
     def _create_basis(self):
         """Compute the basis of the vector space of symmetric matrices."""
-        basis = []
+        indices, values = [], []
+        k = -1
         for row in gs.arange(self.n):
             for col in gs.arange(row, self.n):
+                k += 1
                 if row == col:
-                    indices = [(row, row)]
-                    values = [1.0]
+                    indices.append((k, row, row))
+                    values.append(1.0)
                 else:
-                    indices = [(row, col), (col, row)]
-                    values = [1.0, 1.0]
-                basis.append(gs.array_from_sparse(indices, values, (self.n,) * 2))
-        basis = gs.stack(basis)
-        return basis
+                    indices.extend([(k, row, col), (k, col, row)])
+                    values.extend([1.0, 1.0])
+
+        return gs.array_from_sparse(indices, values, (k + 1, self.n, self.n))
 
     def belongs(self, point, atol=gs.atol):
         """Evaluate if a matrix is symmetric.

--- a/geomstats/geometry/symmetric_matrices.py
+++ b/geomstats/geometry/symmetric_matrices.py
@@ -35,8 +35,8 @@ class SymmetricMatrices(VectorSpace):
         """Compute the basis of the vector space of symmetric matrices."""
         indices, values = [], []
         k = -1
-        for row in gs.arange(self.n):
-            for col in gs.arange(row, self.n):
+        for row in range(self.n):
+            for col in range(row, self.n):
                 k += 1
                 if row == col:
                     indices.append((k, row, row))

--- a/tests/data/backends_data.py
+++ b/tests/data/backends_data.py
@@ -231,7 +231,31 @@ class BackendsTestData(TestData):
         return data
 
     def func_out_allclose_test_data(self):
+        # TODO: verify dtype
         smoke_data = [
+            dict(
+                func_name="array_from_sparse",
+                kwargs={"indices": [(0,)], "data": [1.0], "target_shape": (2,)},
+                expected=gs.array([1.0, 0.0]),
+            ),
+            dict(
+                func_name="array_from_sparse",
+                kwargs={
+                    "indices": [(0, 0), (0, 1), (1, 2)],
+                    "data": [1.0, 2.0, 3.0],
+                    "target_shape": (2, 3),
+                },
+                expected=gs.array([[1.0, 2.0, 0], [0, 0, 3.0]]),
+            ),
+            dict(
+                func_name="array_from_sparse",
+                kwargs={
+                    "indices": [(0, 1, 1), (1, 1, 1)],
+                    "data": [1.0, 2.0],
+                    "target_shape": (2, 2, 2),
+                },
+                expected=gs.array([[[0.0, 0.0], [0.0, 1.0]], [[0.0, 0.0], [0.0, 2.0]]]),
+            ),
             dict(
                 func_name="linalg.logm",
                 args=[gs.array([[2.0, 0.0, 0.0], [0.0, 3.0, 0.0], [0.0, 0.0, 4.0]])],

--- a/tests/tests_geomstats/test_backends.py
+++ b/tests/tests_geomstats/test_backends.py
@@ -57,11 +57,6 @@ class TestBackends(tests.conftest.TestCase):
         expected = gs.array(([[0, 1, 3, 6, 10], [5, 11, 18, 26, 35]]))
         self.assertAllClose(result, expected)
 
-    def test_array_from_sparse(self):
-        expected = gs.array([[0, 1, 0], [0, 0, 2]])
-        result = gs.array_from_sparse([(0, 1), (1, 2)], [1, 2], (2, 3))
-        self.assertAllClose(result, expected)
-
     def test_einsum_dtypes(self):
         np_array_1 = _np.array([[1, 4]])
         np_array_2 = _np.array([[2.0, 3.0]])

--- a/tests/tests_geomstats/test_backends2.py
+++ b/tests/tests_geomstats/test_backends2.py
@@ -171,10 +171,11 @@ class TestBackends(TestCase, metaclass=Parametrizer):
         else:
             self.assertFalse(out)
 
-    def test_func_out_allclose(self, func_name, args, expected):
+    def test_func_out_allclose(self, func_name, expected, args=(), kwargs=None):
+        kwargs = kwargs or {}
         gs_fnc = get_backend_fnc(func_name)
 
-        out = gs_fnc(*args)
+        out = gs_fnc(*args, **kwargs)
         self.assertAllClose(out, expected)
 
     def test_func_out_equal(self, func_name, args, expected):


### PR DESCRIPTION
This PR makes `array_from_sparse` more general by allowing creation of arrays with dimensions other than 2. Handling of dtype is also improved in pytorch.

Following this change:
* the computation of basis for some cases is simplified by avoiding using of `gs.stack`.
* `get_mask_i_float` is removed from backend as it is a particular case (this pruning of backend functions is valuable to ensure we keep it slim and tested properly)