### PR TITLE
Add strategy to vectorize tests during data generation

### DIFF
--- a/tests/data_generation.py
+++ b/tests/data_generation.py
@@ -144,10 +144,7 @@ class TestData:
             `repeat-first` and `repeat-second` only valid for two argument case.
             `repeat-first` and `repeat-second` test asymmetric cases, repeating
             only first or second input, respectively.
-
-
         """
-
         check_parameter_accepted_values(
             vectorization_type,
             "vectorization_type",
@@ -205,7 +202,8 @@ class _ManifoldTestData(TestData):
         return self.generate_tests([], random_data)
 
     def projection_belongs_test_data(self, belongs_atol=gs.atol):
-        """Generate data to check that a point projected on a manifold belongs to the manifold.
+        """Generate data to check that a point projected on a manifold belongs
+        to the manifold.
 
         Parameters
         ----------
@@ -300,7 +298,8 @@ class _OpenSetTestData(_ManifoldTestData):
 
 class _LevelSetTestData(_ManifoldTestData):
     def intrinsic_after_extrinsic_test_data(self):
-        """Generate data to check that changing coordinate system twice gives back the point.
+        """Generate data to check that changing coordinate system twice gives
+        back the point.
 
         Assumes that random_point generates points in extrinsic coordinates.
         """
@@ -316,7 +315,8 @@ class _LevelSetTestData(_ManifoldTestData):
         return self.generate_tests([], random_data)
 
     def extrinsic_after_intrinsic_test_data(self):
-        """Generate data to check that changing coordinate system twice gives back the point.
+        """Generate data to check that changing coordinate system twice gives
+        back the point.
 
         Assumes that the first elements in space_args is the dimension of the space.
         """

--- a/tests/data_generation.py
+++ b/tests/data_generation.py
@@ -19,6 +19,9 @@ def _expand_point(point):
 
 
 def _repeat_point(point, n_reps=2):
+    if not gs.is_array(point):
+        return [point] * n_reps
+
     return gs.repeat(_expand_point(point), n_reps, axis=0)
 
 
@@ -79,7 +82,6 @@ class TestData:
         self, datum, comb_indices, arg_names, expected_name, check_expand=True, n_reps=2
     ):
 
-        # TODO: improving handling of expected
         if expected_name is not None:
             has_expected = True
             expected = datum.get(expected_name)

--- a/tests/data_generation.py
+++ b/tests/data_generation.py
@@ -66,8 +66,8 @@ class TestData:
 
     def _filter_combs(self, combs, vec_type, threshold):
         MAP_VEC_TYPE = {
-            "asym-left": 1,
-            "asym-right": 0,
+            "repeat-first": 1,
+            "repeat-second": 0,
         }
         index = MAP_VEC_TYPE[vec_type]
         other_index = (index + 1) % 2
@@ -78,7 +78,7 @@ class TestData:
 
         return combs
 
-    def _generate_datum_vec_tests(
+    def _generate_datum_vectorization_tests(
         self, datum, comb_indices, arg_names, expected_name, check_expand=True, n_reps=2
     ):
 
@@ -116,35 +116,61 @@ class TestData:
 
         return new_data
 
-    def generate_vec_tests(
+    def generate_vectorization_tests(
         self,
         data,
         arg_names,
         expected_name=None,
         check_expand=True,
         n_reps=2,
-        vec_type="sym",
+        vectorization_type="sym",
     ):
+        """Create new data with vectorized version of inputs.
+
+        Parameters
+        ----------
+        data : list of dict
+            Data. Each to vectorize.
+        arg_names: list
+            Name of inputs to vectorize.
+        expected_name: str
+            Output name in case it needs to be repeated.
+        check_expand: bool
+            If `True`, expanded version of each input will be tested.
+        n_reps: int
+            Number of times the input points should be repeated.
+        vectorization_type: str
+            Possible values are `sym`, `repeat-first`, `repeat-second`.
+            `repeat-first` and `repeat-second` only valid for two argument case.
+            `repeat-first` and `repeat-second` test asymmetric cases, repeating
+            only first or second input, respectively.
+
+
+        """
 
         check_parameter_accepted_values(
-            vec_type, "vec_type", ["sym", "asym-left", "asym-right"]
+            vectorization_type,
+            "vectorization_type",
+            ["sym", "repeat-first", "repeat-second"],
         )
 
         n_args = len(arg_names)
-        if n_args != 2 and vec_type != "sym":
-            raise NotImplementedError(f"`{vec_type} only implemented for 2 arguments.")
+        if n_args != 2 and vectorization_type != "sym":
+            raise NotImplementedError(
+                f"`{vectorization_type} only implemented for 2 arguments."
+            )
 
         n_indices = 2 + int(check_expand)
         comb_indices = list(itertools.product(*[range(n_indices)] * len(arg_names)))
-        if n_args == 2 and vec_type != "sym":
+        if n_args == 2 and vectorization_type != "sym":
             comb_indices = self._filter_combs(
-                comb_indices, vec_type, threshold=1 + int(check_expand)
+                comb_indices, vectorization_type, threshold=1 + int(check_expand)
             )
 
         new_data = []
         for datum in data:
             new_data.extend(
-                self._generate_datum_vec_tests(
+                self._generate_datum_vectorization_tests(
                     datum,
                     comb_indices,
                     arg_names,


### PR DESCRIPTION
**Main idea**: in most cases, vectorization testing can be handled at data generation level. That is, the same test that asserts a particular case can be used to assert any of the possible combinations of (vectorized) inputs. Thus, data generation should handle the creation of all possible combinations.

**Assumption**: repeating a given input `n_reps` times and compare the repeated output against the non-repeated expected output repeated `n_reps` is a strong way of testing the vectorization correctness of a method.

**Examples**

1) Assume a function takes a point e.g. `point = gs.ones(3)` and outputs itself. The possible input combinations are:
* `point = gs.ones(3)` -> `out = gs.ones(3)`
* `point = gs.ones(1, 3)` -> `out = gs.ones(3)` (due to the way geomstats handles single points)
* `point = gs.ones(n_reps, 3)` -> `out = gs.ones(n_reps, 3)`

How to set this case with the new strategy?
```python
from tests.data_generation import TestData

point = gs.ones(3)
expected = gs.ones(3)

data = [dict(point=point, expected_point=expected)

test_data = TestData()

new_data = test_data.generate_vec_tests(data, arg_names=['point'], expected_name='expected_point')
```
`new_data` will contain all the mentioned combinations.

2) Assume a more complex case:
* `point_a = gs.ones(3)`, `point_b = gs.ones(3)`, `out = gs.ones(3)`
* `point_a = gs.ones(3)`, `point_b = gs.ones(1, 3)`, `out = gs.ones(3)`
* `point_a = gs.ones(1, 3)`, `point_b = gs.ones(3)`, `out = gs.ones(3)`
* `point_a = gs.ones(1, 3)`, `point_b = gs.ones(1, 3)`, `out = gs.ones(3)`
* `point_a = gs.ones(3)`, `point_b = gs.ones(n_reps, 3)`, `out = gs.ones(n_reps, 3)`
* `point_a = gs.ones(1, 3)`, `point_b = gs.ones(n_reps, 3)`, `out = gs.ones(n_reps, 3)`
* `point_a = gs.ones(n_reps, 3)`, `point_b = gs.ones(3)`, `out = gs.ones(n_reps, 3)`
* `point_a = gs.ones(n_reps, 3)`, `point_b = gs.ones(1, 3)`, `out = gs.ones(n_reps, 3)`
* `point_a = gs.ones(n_reps, 3)`, `point_b = gs.ones(n_reps, 3)`, `out = gs.ones(n_reps, 3)`

How to set this case with the new strategy?
```python
from tests.data_generation import TestData

point_a = gs.ones(3)
point_b = gs.ones(3)
expected = gs.ones(3)

data = [dict(point_a=point_a, point_b=point_b, expected_point=expected)

test_data = TestData()

new_data = test_data.generate_vec_tests(data, arg_names=['point_a', 'point_b'], expected_name='expected_point')
```
`new_data` will contain all the mentioned combinations.


**Additional cases**

1. the expanded case (`gs.ones(3)` -> `gs.ones(1, 3)`) can be ignored by setting `check_expand=False`
2. asymmetric cases can also be tested for `n_input=2`. Set `vec_type='asym_left'` (first input is repeated, but not second)  or `vec_type='asym_right'` (second input is repeated, but not first)

**More information**

Sometimes some vectorization tests can be set without an expected output (e.g. for output shape testing, the shape of the input is enough to infer the shape of the output). For this case, just keep `expected_name=None`.