### PR TITLE
covariance descirptors

### DIFF
--- a/geomstats/datasets/covariance_descriptor.py
+++ b/geomstats/datasets/covariance_descriptor.py
@@ -1,0 +1,93 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import torchvision
+import torchvision.transforms as T
+import torchvision.transforms.functional as Tf
+
+from geomstats.geometry.spd_matrices import SPDMatrices
+
+
+class CovarianceDescriptor(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.sobel_x = (
+            1 / 4 * torch.tensor([[1.0, 0.0, -1.0], [2.0, 0.0, -2.0], [1.0, 0.0, -1.0]])
+        )
+        self.second_x = (
+            1
+            / 32
+            * torch.tensor(
+                [
+                    [1.0, 0.0, -2.0, 0.0, 1.0],
+                    [4.0, 0.0, -8.0, 0.0, 4.0],
+                    [6.0, 0.0, -12.0, 0.0, 6.0],
+                    [4.0, 0.0, -8.0, 0.0, 4.0],
+                    [1.0, 0.0, -2.0, 0.0, 1.0],
+                ]
+            )
+        )
+
+    def derivative_features(self, img):
+        if img.shape[1] == 3:
+            img = T.Grayscale()(img)
+        smoothed_img = Tf.gaussian_blur(img, kernel_size=(3, 3), sigma=(0.2, 0.2))
+        first_filters = torch.stack([self.sobel_x, self.sobel_x.T], axis=0).unsqueeze(1)
+        second_filters = torch.stack(
+            [self.second_x, self.second_x.T], axis=0
+        ).unsqueeze(1)
+        first_abs_derivatives = torch.abs(F.conv2d(smoothed_img, first_filters))
+        second_abs_derivtaives = torch.abs(F.conv2d(smoothed_img, second_filters))
+        norm_first_derivatives = torch.sqrt(
+            first_abs_derivatives[:, 0, :, :] ** 2
+            + first_abs_derivatives[:, 1, :, :] ** 2
+        ).unsqueeze(1)
+        angle = torch.atan2(
+            first_abs_derivatives[:, 0, :, :], first_abs_derivatives[:, 1, :, :]
+        ).unsqueeze(1)
+        return [
+            first_abs_derivatives[:, :, 1:-1, 1:-1],
+            second_abs_derivtaives,
+            norm_first_derivatives[:, :, 1:-1, 1:-1],
+            angle[:, :, 1:-1, 1:-1],
+        ]
+
+    def other_features(self, img):
+        h = img.shape[-1]
+        grid_x, grid_y = torch.meshgrid(
+            torch.arange(img.shape[-1]), torch.arange(img.shape[-1])
+        )
+        broadcasted_grid_x = (
+            torch.broadcast_to(
+                grid_x, (img.shape[0], 1, img.shape[-1], img.shape[-2])
+            ).float()
+            / h
+        )
+        broadcasted_grid_y = (
+            torch.broadcast_to(
+                grid_y, (img.shape[0], 1, img.shape[-1], img.shape[-2])
+            ).float()
+            / h
+        )
+        return [
+            broadcasted_grid_x[:, :, 2:-2, 2:-2],
+            broadcasted_grid_y[:, :, 2:-2, 2:-2],
+            img[:, :, 2:-2, 2:-2],
+        ]
+
+    def covar(self, features, noise=1e-6):
+
+        assert len(features.shape) == 3
+        _, D, N = features.shape
+
+        centered = features - torch.sum(features, 2, keepdim=True) / N
+        cov = torch.einsum("ijk,ilk->ijl", centered, centered) / (N)
+        return cov + noise * torch.eye(D)
+
+    def forward(self, img):
+        assert len(img.shape) == 4
+        derivative_features = self.derivative_features(img)
+        other_features = self.other_features(img)
+        features = torch.cat(other_features + derivative_features, axis=1)
+        vectorized = features.reshape(features.shape[0], features.shape[1], -1)
+        return self.covar(vectorized)


### PR DESCRIPTION

Covariance descriptors that converts images to SPD matrices currently only available in pytorch. @lpereira95 can you make this work into all three backends if possible ?. one has to fix convention of how to handle images (CHW or HWC)  and other things can be discussed. (this just research code @lpereira95, don't expect great code quality :) )

also closing  #1502 




## Checklist

- [ ] My pull request has a clear and explanatory title.
- [ ] If neccessary, my code is [vectorized](https://www.geeksforgeeks.org/vectorization-in-python/).
- [ ] I have added apropriate unit tests.
- [ ] I have made sure the code passes all unit tests. (refer to comment below)
- [ ] My PR follows [PEP8](https://peps.python.org/pep-0008/) guidelines. (refer to comment below)
- [ ] My PR follows [geomstats coding style](https://github.com/geomstats/geomstats/blob/master/docs/contributing.rst#coding-style-guidelines) and API.
- [ ] My code is properly documented and I made sure the documentation renders properly. ([Link](https://github.com/geomstats/geomstats/blob/master/docs/contributing.rst#documentation))
- [ ] I have linked to issues and PRs that are relevant to this PR.


<!-- For checking consistency of entire codebase
First, run the tests related to your changes. For example, if you changed something in geomstats/spd_matrices_space.py:
$ pytest tests/tests_geomstats/test_spd_matrices.py

and then run the tests of the whole codebase to check that your feature is not breaking any of them:
$ pytest tests/

This way, further modifications on the code base are guaranteed to be consistent with the desired behavior. Merging your PR should not break any test in any backend (numpy, tensorflow or pytorch)."

For testing in alternative backends such as `numpy`, `pytorch`, `autograd`, `tensorflow` set the environment variable using:
$ export GEOMSTATS_BACKEND=<backend_name>

Next, import the `backend` module using:
import geomstats.backend as gs
-->


<!-- For flake8 tests
Install dependencies
$ pip3 install -r dev-requirements.txt

Then run the following commands:
$ flake8 --ignore=D,W503,W504 geomstats examples tests   #shadows .flake8
$ flake8 geomstats/geometry geomstats/learning           #passed two subfolders
-->