### PR TITLE
Add k_sampling_points as an attribute for spaces of curves

### DIFF
--- a/geomstats/geometry/discrete_curves.py
+++ b/geomstats/geometry/discrete_curves.py
@@ -24,7 +24,7 @@ class DiscreteCurves(Manifold):
     r"""Space of discrete curves sampled at points in ambient_manifold.
 
     Each individual curve is represented by a 2d-array of shape `[
-    n_sampling_points, ambient_dim]`. A batch of curves can be passed to
+    k_sampling_points, ambient_dim]`. A batch of curves can be passed to
     all methods either as a 3d-array if all curves have the same number of
     sampled points, or as a list of 2d-arrays, each representing a curve.
 
@@ -56,15 +56,15 @@ class DiscreteCurves(Manifold):
     """
 
     def __init__(
-        self, ambient_manifold, n_sampling_points=10, a=None, b=None, **kwargs
+        self, ambient_manifold, k_sampling_points=10, a=None, b=None, **kwargs
     ):
-        dim = ambient_manifold.dim * n_sampling_points
+        dim = ambient_manifold.dim * k_sampling_points
         kwargs.setdefault("metric", SRVMetric(ambient_manifold))
         super(DiscreteCurves, self).__init__(
             dim=dim, shape=(), default_point_type="matrix", **kwargs
         )
         self.ambient_manifold = ambient_manifold
-        self.n_sampling_points = n_sampling_points
+        self.k_sampling_points = k_sampling_points
         self.srv_metric = self._metric
 
         self.l2_curves_metric = L2CurvesMetric(ambient_manifold=ambient_manifold)
@@ -82,7 +82,7 @@ class DiscreteCurves(Manifold):
 
         Parameters
         ----------
-        point : array-like, shape=[..., n_sampling_points, ambient_dim]
+        point : array-like, shape=[..., k_sampling_points, ambient_dim]
             Point representing a discrete curve.
         atol : float
             Absolute tolerance.
@@ -100,7 +100,7 @@ class DiscreteCurves(Manifold):
 
             Parameters
             ----------
-            pt : array-like, shape=[n_sampling_points, ambient_dim]
+            pt : array-like, shape=[k_sampling_points, ambient_dim]
                 One curve represented as its sampling points.
 
             Returns
@@ -124,7 +124,7 @@ class DiscreteCurves(Manifold):
             _ : array-like, shape=[]
                 Whether curve has the correct number of sampling points.
             """
-            return gs.array(pt.shape[-2] == self.n_sampling_points)
+            return gs.array(pt.shape[-2] == self.k_sampling_points)
 
         if isinstance(point, list) or point.ndim > 2:
             return gs.stack(
@@ -141,9 +141,9 @@ class DiscreteCurves(Manifold):
 
         Parameters
         ----------
-        vector : array-like, shape=[..., n_sampling_points, ambient_dim]
+        vector : array-like, shape=[..., k_sampling_points, ambient_dim]
             Vector.
-        base_point : array-like, shape=[..., n_sampling_points, ambient_dim]
+        base_point : array-like, shape=[..., k_sampling_points, ambient_dim]
             Discrete curve.
         atol : float
             Absolute tolerance.
@@ -156,7 +156,7 @@ class DiscreteCurves(Manifold):
         """
         ambient_manifold = self.ambient_manifold
         shape = vector.shape
-        if shape[-2] != self.n_sampling_points:
+        if shape[-2] != self.k_sampling_points:
             return [False] * shape[0]
         stacked_vec = gs.reshape(vector, (-1, shape[-1]))
         stacked_point = gs.reshape(base_point, (-1, shape[-1]))
@@ -174,14 +174,14 @@ class DiscreteCurves(Manifold):
 
         Parameters
         ----------
-        vector : array-like, shape=[..., n_sampling_points, ambient_dim]
+        vector : array-like, shape=[..., k_sampling_points, ambient_dim]
             Vector.
-        base_point : array-like, shape=[..., n_sampling_points, ambient_dim]
+        base_point : array-like, shape=[..., k_sampling_points, ambient_dim]
             Discrete curve.
 
         Returns
         -------
-        tangent_vec : array-like, shape=[..., n_sampling_points, ambient_dim]
+        tangent_vec : array-like, shape=[..., k_sampling_points, ambient_dim]
             Tangent vector at base point.
         """
         ambient_manifold = self.ambient_manifold
@@ -197,12 +197,12 @@ class DiscreteCurves(Manifold):
 
         Parameters
         ----------
-        point: array-like, shape[..., n_sampling_points, ambient_dim]
+        point: array-like, shape[..., k_sampling_points, ambient_dim]
             Point.
 
         Returns
         -------
-        point: array-like, shape[..., n_sampling_points, ambient_dim]
+        point: array-like, shape[..., k_sampling_points, ambient_dim]
             Point.
         """
         ambient_manifold = self.ambient_manifold
@@ -226,17 +226,17 @@ class DiscreteCurves(Manifold):
             Bound of the interval in which to sample for non compact
             ambient manifolds.
             Optional, default: 1.
-        n_sampling_points : int
+        k_sampling_points : int
             Number of sampling points for the discrete curves.
             Optional, default : 10.
 
         Returns
         -------
-        samples : array-like, shape=[..., n_sampling_points, {dim, [n, n]}]
+        samples : array-like, shape=[..., k_sampling_points, {dim, [n, n]}]
             Points sampled on the hypersphere.
         """
-        sample = self.ambient_manifold.random_point(n_samples * self.n_sampling_points)
-        sample = gs.reshape(sample, (n_samples, self.n_sampling_points, -1))
+        sample = self.ambient_manifold.random_point(n_samples * self.k_sampling_points)
+        sample = gs.reshape(sample, (n_samples, self.k_sampling_points, -1))
         return sample[0] if n_samples == 1 else sample
 
 
@@ -244,7 +244,7 @@ class ClosedDiscreteCurves(LevelSet):
     r"""Space of closed discrete curves sampled at points in ambient_manifold.
 
     Each individual curve is represented by a 2d-array of shape `[
-    n_sampling_points, ambient_dim]`.
+    k_sampling_points, ambient_dim]`.
 
     See [Sea2011]_ for details.
 
@@ -274,8 +274,8 @@ class ClosedDiscreteCurves(LevelSet):
         vol. 33, no. 7, pp. 1415-1428, July 2011.
     """
 
-    def __init__(self, ambient_manifold, n_sampling_points=10):
-        dim = ambient_manifold.dim * (n_sampling_points - 1)
+    def __init__(self, ambient_manifold, k_sampling_points=10):
+        dim = ambient_manifold.dim * (k_sampling_points - 1)
         super(ClosedDiscreteCurves, self).__init__(
             dim=dim,
             shape=(),
@@ -283,7 +283,7 @@ class ClosedDiscreteCurves(LevelSet):
             tangent_submersion=None,
             value=None,
             embedding_space=DiscreteCurves(
-                ambient_manifold=ambient_manifold, n_sampling_points=n_sampling_points
+                ambient_manifold=ambient_manifold, k_sampling_points=k_sampling_points
             ),
         )
         self.ambient_manifold = ambient_manifold
@@ -296,7 +296,7 @@ class ClosedDiscreteCurves(LevelSet):
 
         Parameters
         ----------
-        point : array-like, shape=[..., n_sampling_points, ambient_dim]
+        point : array-like, shape=[..., k_sampling_points, ambient_dim]
             Point representing a discrete curve.
         atol : float
             Absolute tolerance.
@@ -323,9 +323,9 @@ class ClosedDiscreteCurves(LevelSet):
 
         Parameters
         ----------
-        vector : array-like, shape=[..., n_sampling_points, ambient_dim]
+        vector : array-like, shape=[..., k_sampling_points, ambient_dim]
             Vector.
-        base_point : array-like, shape=[..., n_sampling_points, ambient_dim]
+        base_point : array-like, shape=[..., k_sampling_points, ambient_dim]
             Discrete curve.
         atol : float
             Absolute tolerance.
@@ -379,14 +379,14 @@ class ClosedDiscreteCurves(LevelSet):
 
         Parameters
         ----------
-        vector : array-like, shape=[..., n_sampling_points, ambient_dim]
+        vector : array-like, shape=[..., k_sampling_points, ambient_dim]
             Vector.
-        base_point : array-like, shape=[..., n_sampling_points, ambient_dim]
+        base_point : array-like, shape=[..., k_sampling_points, ambient_dim]
             Discrete curve.
 
         Returns
         -------
-        tangent_vec : array-like, shape=[..., n_sampling_points, ambient_dim]
+        tangent_vec : array-like, shape=[..., k_sampling_points, ambient_dim]
             Tangent vector at base point.
         """
         raise NotImplementedError("The to_tangent method is not implemented.")
@@ -405,13 +405,13 @@ class ClosedDiscreteCurves(LevelSet):
             Bound of the interval in which to sample for non compact
             ambient manifolds.
             Optional, default: 1.
-        n_sampling_points : int
+        k_sampling_points : int
             Number of sampling points for the discrete curves.
             Optional, default : 10.
 
         Returns
         -------
-        samples : array-like, shape=[..., n_sampling_points, {dim, [n, n]}]
+        samples : array-like, shape=[..., k_sampling_points, {dim, [n, n]}]
             Points sampled on the hypersphere.
         """
         sample = self.embedding_space.random_point(n_samples)
@@ -426,7 +426,7 @@ class ClosedDiscreteCurves(LevelSet):
 
         Parameters
         ----------
-        curve : array-like, shape=[..., n_sampling_points, ambient_dim]
+        curve : array-like, shape=[..., k_sampling_points, ambient_dim]
             Discrete curve.
         atol : float
             Tolerance of the projection algorithm.
@@ -437,7 +437,7 @@ class ClosedDiscreteCurves(LevelSet):
 
         Returns
         -------
-        proj : array-like, shape=[..., n_sampling_points, ambient_dim]
+        proj : array-like, shape=[..., k_sampling_points, ambient_dim]
         """
         is_euclidean = isinstance(self.ambient_manifold, Euclidean)
         is_planar = is_euclidean and self.ambient_manifold.dim == 2
@@ -469,7 +469,7 @@ class ClosedDiscreteCurves(LevelSet):
 
         Parameters
         ----------
-        srv : array-like, shape=[..., n_sampling_points, ambient_dim]
+        srv : array-like, shape=[..., k_sampling_points, ambient_dim]
             Discrete curve.
         atol : float
             Tolerance of the projection algorithm.
@@ -480,7 +480,7 @@ class ClosedDiscreteCurves(LevelSet):
 
         Returns
         -------
-        proj : array-like, shape=[..., n_sampling_points, ambient_dim]
+        proj : array-like, shape=[..., k_sampling_points, ambient_dim]
         """
         is_euclidean = isinstance(self.ambient_metric, EuclideanMetric)
         is_planar = is_euclidean and self.ambient_metric.dim == 2
@@ -604,11 +604,11 @@ class L2CurvesMetric(RiemannianMetric):
         Compute the left Riemann sum approximation of the integral of a
         function func defined on on the unit interval,
         given by sample points at regularly spaced times
-        t_k = k / n_sampling_points for k = 0, ..., n_sampling_points.
+        t_k = k / k_sampling_points for k = 0, ..., k_sampling_points.
 
         Parameters
         ----------
-        func : array-like, shape=[..., n_sampling_points]
+        func : array-like, shape=[..., k_sampling_points]
             Sample points of a function at regularly spaced times.
         missing_last_point : boolean.
             Is true when the last value at to time 1 is missing.
@@ -620,8 +620,8 @@ class L2CurvesMetric(RiemannianMetric):
             Left Riemann sum.
         """
         func = gs.to_ndarray(func, to_ndim=2)
-        n_sampling_points = func.shape[-1] + 1 if missing_last_point else func.shape[-1]
-        dt = 1 / n_sampling_points
+        k_sampling_points = func.shape[-1] + 1 if missing_last_point else func.shape[-1]
+        dt = 1 / k_sampling_points
         values_to_sum = func if missing_last_point else func[:, :-1]
         riemann_sum = dt * gs.sum(values_to_sum, axis=-1)
         return gs.squeeze(riemann_sum)
@@ -634,17 +634,17 @@ class L2CurvesMetric(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec_a : array-like, shape=[..., n_sampling_points, ambient_dim]
+        tangent_vec_a : array-like, shape=[..., k_sampling_points, ambient_dim]
             Tangent vector to discrete curve.
-        tangent_vec_b : array-like, shape=[..., n_sampling_points, ambient_dim]
+        tangent_vec_b : array-like, shape=[..., k_sampling_points, ambient_dim]
             Tangent vector to discrete curve.
-        base_curve : array-like, shape=[..., n_sampling_points, ambient_dim]
+        base_curve : array-like, shape=[..., k_sampling_points, ambient_dim]
             Point representing a discrete curve.
             Optional, default None.
 
         Returns
         -------
-        inner_prod : array-like, shape=[..., n_sampling_points]
+        inner_prod : array-like, shape=[..., k_sampling_points]
             Point-wise inner-product.
         """
 
@@ -678,14 +678,14 @@ class L2CurvesMetric(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec : array-like, shape=[..., n_sampling_points, ambient_dim]
+        tangent_vec : array-like, shape=[..., k_sampling_points, ambient_dim]
             Tangent vector to discrete curve.
-        base_curve : array-like, shape=[..., n_sampling_points, ambient_dim]
+        base_curve : array-like, shape=[..., k_sampling_points, ambient_dim]
             Point representing a discrete curve.
 
         Returns
         -------
-        norm : array-like, shape=[..., n_sampling_points]
+        norm : array-like, shape=[..., k_sampling_points]
             Point-wise norms.
         """
         sq_norm = self.pointwise_inner_products(
@@ -703,13 +703,13 @@ class L2CurvesMetric(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec_a : array-like, shape=[..., n_sampling_points, ambient_dim]
+        tangent_vec_a : array-like, shape=[..., k_sampling_points, ambient_dim]
             Tangent vector to a curve, i.e. infinitesimal vector field
             along a curve.
-        tangent_vec_b : array-like, shape=[..., n_sampling_points, ambient_dim]
+        tangent_vec_b : array-like, shape=[..., k_sampling_points, ambient_dim]
             Tangent vector to a curve, i.e. infinitesimal vector field
             along a curve.
-        base_point : array-like, shape=[..., n_sampling_points, ambient_dim]
+        base_point : array-like, shape=[..., k_sampling_points, ambient_dim]
             Discrete curve defined on the unit interval [0, 1].
         missing_last_point : boolean.
             Is true when the values of the tangent vectors at time 1 are missing.
@@ -730,18 +730,18 @@ class L2CurvesMetric(RiemannianMetric):
 
         Parameters
         ----------
-        tangent_vec : array-like, shape=[..., n_sampling_points, ambient_dim]
+        tangent_vec : array-like, shape=[..., k_sampling_points, ambient_dim]
             Tangent vector to discrete curve.
-        base_point : array-like, shape=[..., n_sampling_points, ambient_dim]
+        base_point : array-like, shape=[..., k_sampling_points, ambient_dim]
             Discrete curve.
 
         Return
         ------
-        end_curve :  array-like, shape=[..., n_sampling_points, ambient_dim]
+        end_curve :  array-like, shape=[..., k_sampling_points, ambient_dim]
             Discrete curve, result of the Riemannian exponential.
         """
-        n_sampling_points = base_point.shape[-2]
-        l2_landmarks_metric = self.l2_landmarks_metric(n_sampling_points)
+        k_sampling_points = base_point.shape[-2]
+        l2_landmarks_metric = self.l2_landmarks_metric(k_sampling_points)
         return l2_landmarks_metric.exp(tangent_vec, base_point)
 
     def log(self, point, base_point, **kwargs):
@@ -749,18 +749,18 @@ class L2CurvesMetric(RiemannianMetric):
 
         Parameters
         ----------
-        point : array-like, shape=[..., n_sampling_points, ambient_dim]
+        point : array-like, shape=[..., k_sampling_points, ambient_dim]
             Discrete curve.
-        base_point : array-like, shape=[..., n_sampling_points, ambient_dim]
+        base_point : array-like, shape=[..., k_sampling_points, ambient_dim]
             Discrete curve to use as base point.
 
         Returns
         -------
-        log : array-like, shape=[..., n_sampling_points, ambient_dim]
+        log : array-like, shape=[..., k_sampling_points, ambient_dim]
             Tangent vector to a discrete curve.
         """
-        n_sampling_points = base_point.shape[-2]
-        l2_landmarks_metric = self.l2_landmarks_metric(n_sampling_points)
+        k_sampling_points = base_point.shape[-2]
+        l2_landmarks_metric = self.l2_landmarks_metric(k_sampling_points)
         return l2_landmarks_metric.log(point, base_point)
 
     def geodesic(self, initial_point, end_point=None, initial_tangent_vec=None):
@@ -771,13 +771,13 @@ class L2CurvesMetric(RiemannianMetric):
 
         Parameters
         ----------
-        initial_point : array-like, shape=[..., n_sampling_points, ambient_dim]
+        initial_point : array-like, shape=[..., k_sampling_points, ambient_dim]
             Discrete curve.
-        end_point : array-like, shape=[..., n_sampling_points, ambient_dim]
+        end_point : array-like, shape=[..., k_sampling_points, ambient_dim]
             Discrete curve. If None, an initial tangent vector must be given.
             Optional, default : None
         initial_tangent_vec : array-like,
-            shape=[..., n_sampling_points, ambient_dim]
+            shape=[..., k_sampling_points, ambient_dim]
             Tangent vector at base curve, the initial speed of the geodesics.
             If None, an end curve must be given and a logarithm is computed.
             Optional, default : None
@@ -787,8 +787,8 @@ class L2CurvesMetric(RiemannianMetric):
         geodesic : callable
             The time parameterized geodesic curve.
         """
-        n_sampling_points = initial_point.shape[-2]
-        l2_landmarks_metric = self.l2_landmarks_metric(n_sampling_points)
+        k_sampling_points = initial_point.shape[-2]
+        l2_landmarks_metric = self.l2_landmarks_metric(k_sampling_points)
         return l2_landmarks_metric.geodesic(
             initial_point, end_point, initial_tangent_vec
         )
@@ -798,7 +798,7 @@ class ElasticMetric(RiemannianMetric):
     """Elastic metric defined using the F_transform.
 
     Each individual curve is represented by a 2d-array of shape `[
-    n_sampling_points, ambient_dim]`.
+    k_sampling_points, ambient_dim]`.
 
     See [NK2018]_ for details.
 
@@ -858,14 +858,14 @@ class ElasticMetric(RiemannianMetric):
 
         Parameters
         ----------
-        curve : array-like, shape=[..., n_sampling_points, ambient_dim]
+        curve : array-like, shape=[..., k_sampling_points, ambient_dim]
             Discrete curve, representing the derivative c' of a curve c.
 
         Returns
         -------
-        norms : array-like, shape=[..., n_sampling_points]
+        norms : array-like, shape=[..., k_sampling_points]
             Norms of the sampling points in polar coordinates.
-        args : array-like, shape=[..., n_sampling_points]
+        args : array-like, shape=[..., k_sampling_points]
             Arguments, i.e. angle, of the sampling points in polar coordinates.
         """
         if not (
@@ -877,14 +877,14 @@ class ElasticMetric(RiemannianMetric):
                 "ambient_manifold must be a plane, but it is:\n"
                 f"{self.ambient_manifold} of dimension {self.ambient_manifold.dim}."
             )
-        n_sampling_points = curve.shape[-2]
+        k_sampling_points = curve.shape[-2]
         inner_prod = self.ambient_metric.inner_product
 
         norms = self.ambient_metric.norm(curve)
         arg_0 = gs.arctan2(curve[..., 0, 1], curve[..., 0, 0])
         args = [arg_0]
 
-        for i in range(1, n_sampling_points):
+        for i in range(1, k_sampling_points):
             point, last_point = curve[..., i, :], curve[..., i - 1, :]
             prod = inner_prod(point, last_point)
             cosine = prod / (norms[..., i] * norms[..., i - 1])
@@ -904,14 +904,14 @@ class ElasticMetric(RiemannianMetric):
 
         Parameters
         ----------
-        norms : array-like, shape=[..., n_sampling_points]
+        norms : array-like, shape=[..., k_sampling_points]
             Norms of sampling points.
-        args : array-like, shape=[..., n_sampling_points]
+        args : array-like, shape=[..., k_sampling_points]
             Arguments of sampling points.
 
         Returns
         -------
-        curve : array-like, shape=[..., n_sampling_points, ambient_dim]
+        curve : array-like, shape=[..., k_sampling_points, ambient_dim]
             Discrete curve.
         """
         if not (
@@ -973,12 +973,12 @@ class ElasticMetric(RiemannianMetric):
 
         Parameters
         ----------
-        curve : array-like, shape=[..., n_sampling_points, ambient_dim]
+        curve : array-like, shape=[..., k_sampling_points, ambient_dim]
             Discrete curve.
 
         Returns
         -------
-        f : array-like, shape=[..., n_sampling_points - 1, ambient_dim]
+        f : array-like, shape=[..., k_sampling_points - 1, ambient_dim]
             F_transform of the curve..
         """
         if not (
@@ -990,8 +990,8 @@ class ElasticMetric(RiemannianMetric):
                 "ambient_manifold must be a plane, but it is:\n"
                 f"{self.ambient_manifold} of dimension {self.ambient_manifold.dim}."
             )
-        n_sampling_points = curve.shape[-2]
-        velocity = (n_sampling_points - 1) * (curve[..., 1:, :] - curve[..., :-1, :])
+        k_sampling_points = curve.shape[-2]
+        velocity = (k_sampling_points - 1) * (curve[..., 1:, :] - curve[..., :-1, :])
         polar_velocity = self.cartesian_to_polar(velocity)
         speeds = polar_velocity[..., :, 0]
         args = polar_velocity[..., :, 1]
@@ -1024,12 +1024,12 @@ class ElasticMetric(RiemannianMetric):
 
         Parameters
         ----------
-        f : array-like, shape=[..., n_sampling_points - 1, ambient_dim]
+        f : array-like, shape=[..., k_sampling_points - 1, ambient_dim]
             f_transform of the curve.
 
         Returns
         -------
-        curve : array-like, shape=[..., n_sampling_points, ambient_dim]
+        curve : array-like, shape=[..., k_sampling_points, ambient_dim]
             Discrete curve.
         """
         if not (
@@ -1081,9 +1081,9 @@ class ElasticMetric(RiemannianMetric):
 
         Parameters
         ----------
-        curve_1 : array-like, shape=[..., n_sampling_points, ambient_dim]
+        curve_1 : array-like, shape=[..., k_sampling_points, ambient_dim]
             Discrete curve.
-        curve_2 : array-like, shape=[..., n_sampling_points, ambient_dim]
+        curve_2 : array-like, shape=[..., k_sampling_points, ambient_dim]
             Discrete curve.
 
         Returns
@@ -1100,11 +1100,11 @@ class ElasticMetric(RiemannianMetric):
                 "ambient_manifold must be a plane, but it is:\n"
                 f"{self.ambient_manifold} of dimension {self.ambient_manifold.dim}."
             )
-        n_sampling_points = curve_1.shape[-2]
-        velocity_1 = (n_sampling_points - 1) * (
+        k_sampling_points = curve_1.shape[-2]
+        velocity_1 = (k_sampling_points - 1) * (
             curve_1[..., 1:, :] - curve_1[..., :-1, :]
         )
-        velocity_2 = (n_sampling_points - 1) * (
+        velocity_2 = (k_sampling_points - 1) * (
             curve_2[..., 1:, :] - curve_2[..., :-1, :]
         )
 
@@ -1116,14 +1116,14 @@ class ElasticMetric(RiemannianMetric):
         speed_2 = polar_velocity_2[..., :, 0]
         arg_2 = polar_velocity_2[..., :, 1]
 
-        n_sampling_points = arg_1.shape[-1]
+        k_sampling_points = arg_1.shape[-1]
 
-        for i in range(n_sampling_points):
+        for i in range(k_sampling_points):
             if arg_2[..., i] - arg_1[..., i] > 2 * gs.pi * 0.9:
-                for j in range(i, n_sampling_points):
+                for j in range(i, k_sampling_points):
                     arg_2[..., j] -= 2 * gs.pi
             elif arg_2[..., i] - arg_1[..., i] < -2 * gs.pi * 0.9:
-                for j in range(i, n_sampling_points):
+                for j in range(i, k_sampling_points):
                     arg_2[..., j] += 2 * gs.pi
 
         f_1_args = arg_1[..., :] * self.a / (2 * self.b)
@@ -1202,7 +1202,7 @@ class SRVMetric(ElasticMetric):
 
         Parameters
         ----------
-        curve : array-like, shape=[..., n_sampling_points, ambient_dim]
+        curve : array-like, shape=[..., k_sampling_points, ambient_dim]
             Discrete curve.
 
         tol : float
@@ -1211,7 +1211,7 @@ class SRVMetric(ElasticMetric):
 
         Returns
         -------
-        srv : array-like, shape=[..., n_sampling_points - 1, ambient_dim]
+        srv : array-like, shape=[..., k_sampling_points - 1, ambient_dim]
             Square-root velocity representation of a discrete curve.
         """
         if gs.any(
@@ -1224,19 +1224,19 @@ class SRVMetric(ElasticMetric):
             )
         curve_ndim = gs.ndim(curve)
         curve = gs.to_ndarray(curve, to_ndim=3)
-        n_curves, n_sampling_points, n_coords = curve.shape
-        srv_shape = (n_curves, n_sampling_points - 1, n_coords)
+        n_curves, k_sampling_points, n_coords = curve.shape
+        srv_shape = (n_curves, k_sampling_points - 1, n_coords)
 
-        curve = gs.reshape(curve, (n_curves * n_sampling_points, n_coords))
-        coef = gs.cast(gs.array(n_sampling_points - 1), gs.float32)
+        curve = gs.reshape(curve, (n_curves * k_sampling_points, n_coords))
+        coef = gs.cast(gs.array(k_sampling_points - 1), gs.float32)
         velocity = coef * self.ambient_metric.log(
             point=curve[1:, :], base_point=curve[:-1, :]
         )
         velocity_norm = self.ambient_metric.norm(velocity, curve[:-1, :])
         srv = gs.einsum("...i,...->...i", velocity, 1.0 / gs.sqrt(velocity_norm))
 
-        index = gs.arange(n_curves * n_sampling_points - 1)
-        mask = ~((index + 1) % n_sampling_points == 0)
+        index = gs.arange(n_curves * k_sampling_points - 1)
+        mask = ~((index + 1) % k_sampling_points == 0)
         srv = gs.reshape(srv[mask], srv_shape)
 
         if curve_ndim == 2:
@@ -1248,12 +1248,12 @@ class SRVMetric(ElasticMetric):
 
         Parameters
         ----------
-        curve : array-like, shape=[..., n_sampling_points, ambient_dim]
+        curve : array-like, shape=[..., k_sampling_points, ambient_dim]
             Discrete curve.
 
         Returns
         -------
-        f : array-like, shape=[..., n_sampling_points - 1, ambient_dim]
+        f : array-like, shape=[..., k_sampling_points - 1, ambient_dim]
             F_transform of the curve..
         """
         return self.srv_transform(curve)
@@ -1265,7 +1265,7 @@ class SRVMetric(ElasticMetric):
 
         Parameters
         ----------
-        curve : array-like, shape=[..., n_sampling_points - 1, ambient_dim]
+        curve : array-like, shape=[..., k_sampling_points - 1, ambient_dim]
             Discrete curve.
         starting_point : array-like, shape=[..., ambient_dim]
             Point of the ambient manifold to use as start of the retrieved
@@ -1273,7 +1273,7 @@ class SRVMetric(ElasticMetric):
 
         Returns
         -------
-        f : array-like, shape=[..., n_sampling_points, ambient_dim]
+        f : array-like, shape=[..., k_sampling_points, ambient_dim]
             F_transform inverse of the curve.
         """
         return self.srv_transform_inverse(curve, starting_point)
@@ -1297,7 +1297,7 @@ class SRVMetric(ElasticMetric):
 
         Parameters
         ----------
-        srv : array-like, shape=[..., n_sampling_points - 1, ambient_dim]
+        srv : array-like, shape=[..., k_sampling_points - 1, ambient_dim]
             Square-root velocity representation of a discrete curve.
         starting_point : array-like, shape=[..., ambient_dim]
             Point of the ambient manifold to use as start of the retrieved
@@ -1305,7 +1305,7 @@ class SRVMetric(ElasticMetric):
 
         Returns
         -------
-        curve : array-like, shape=[..., n_sampling_points, ambient_dim]
+        curve : array-like, shape=[..., k_sampling_points, ambient_dim]
             Curve retrieved from its square-root velocity.
         """
         if not isinstance(self.ambient_metric, EuclideanMetric):
@@ -1339,10 +1339,10 @@ class SRVMetric(ElasticMetric):
 
         Parameters
         ----------
-        tangent_vec : array-like, shape=[..., n_sampling_points, ambient_dim]
+        tangent_vec : array-like, shape=[..., k_sampling_points, ambient_dim]
             Tangent vector to curve, i.e. infinitesimal vector field
             along curve.
-        curve : array-like, shape=[..., n_sampling_points, ambiend_dim]
+        curve : array-like, shape=[..., k_sampling_points, ambiend_dim]
             Discrete curve.
 
         Returns
@@ -1358,11 +1358,11 @@ class SRVMetric(ElasticMetric):
                 "discrete curves embedded in a Euclidean "
                 "space."
             )
-        n_sampling_points = curve.shape[-2]
-        d_vec = (n_sampling_points - 1) * (
+        k_sampling_points = curve.shape[-2]
+        d_vec = (k_sampling_points - 1) * (
             tangent_vec[..., 1:, :] - tangent_vec[..., :-1, :]
         )
-        velocity_vec = (n_sampling_points - 1) * (
+        velocity_vec = (k_sampling_points - 1) * (
             curve[..., 1:, :] - curve[..., :-1, :]
         )
         velocity_norm = self.ambient_metric.norm(velocity_vec)
@@ -1386,9 +1386,9 @@ class SRVMetric(ElasticMetric):
 
         Parameters
         ----------
-        tangent_vec : array-like, shape=[..., n_sampling_points - 1, ambient_dim]
+        tangent_vec : array-like, shape=[..., k_sampling_points - 1, ambient_dim]
             Tangent vector to srv.
-        curve : array-like, shape=[..., n_sampling_points, ambient_dim]
+        curve : array-like, shape=[..., k_sampling_points, ambient_dim]
             Discrete curve.
 
         Returns
@@ -1406,10 +1406,10 @@ class SRVMetric(ElasticMetric):
             )
 
         curve = gs.to_ndarray(curve, to_ndim=3)
-        n_curves, n_sampling_points, ambient_dim = curve.shape
+        n_curves, k_sampling_points, ambient_dim = curve.shape
 
-        n_sampling_points = curve.shape[-2]
-        velocity_vec = (n_sampling_points - 1) * (
+        k_sampling_points = curve.shape[-2]
+        velocity_vec = (k_sampling_points - 1) * (
             curve[..., 1:, :] - curve[..., :-1, :]
         )
         velocity_norm = self.ambient_metric.norm(velocity_vec)
@@ -1424,7 +1424,7 @@ class SRVMetric(ElasticMetric):
         )
         d_vec = tangent_vec + tangent_vec_tangential
         d_vec = gs.einsum("...ij,...i->...ij", d_vec, velocity_norm ** (1 / 2))
-        increment = d_vec / (n_sampling_points - 1)
+        increment = d_vec / (k_sampling_points - 1)
         initial_value = gs.zeros((n_curves, 1, ambient_dim))
 
         n_increments, _, _ = increment.shape
@@ -1450,12 +1450,12 @@ class SRVMetric(ElasticMetric):
 
         Parameters
         ----------
-        tangent_vec_a : array-like, shape=[..., n_sampling_points, ambient_dim]
+        tangent_vec_a : array-like, shape=[..., k_sampling_points, ambient_dim]
             Tangent vector to curve, i.e. infinitesimal vector field
             along curve.
-        tangent_vec_b : array-like, shape=[..., n_sampling_points, ambient_dim]
+        tangent_vec_b : array-like, shape=[..., k_sampling_points, ambient_dim]
             Tangent vector to curve, i.e. infinitesimal vector field
-        curve : array-like, shape=[..., n_sampling_points, ambiend_dim]
+        curve : array-like, shape=[..., k_sampling_points, ambiend_dim]
             Discrete curve.
 
         Return
@@ -1485,14 +1485,14 @@ class SRVMetric(ElasticMetric):
 
         Parameters
         ----------
-        tangent_vec : array-like, shape=[..., n_sampling_points, ambient_dim]
+        tangent_vec : array-like, shape=[..., k_sampling_points, ambient_dim]
             Tangent vector to discrete curve.
-        base_point : array-like, shape=[..., n_sampling_points, ambient_dim]
+        base_point : array-like, shape=[..., k_sampling_points, ambient_dim]
             Discrete curve.
 
         Return
         ------
-        end_curve :  array-like, shape=[..., n_sampling_points, ambient_dim]
+        end_curve :  array-like, shape=[..., k_sampling_points, ambient_dim]
             Discrete curve, result of the Riemannian exponential.
         """
         if not isinstance(self.ambient_metric, EuclideanMetric):
@@ -1524,14 +1524,14 @@ class SRVMetric(ElasticMetric):
 
         Parameters
         ----------
-        point : array-like, shape=[..., n_sampling_points, ambient_dim]
+        point : array-like, shape=[..., k_sampling_points, ambient_dim]
             Discrete curve.
-        base_point : array-like, shape=[..., n_sampling_points, ambient_dim]
+        base_point : array-like, shape=[..., k_sampling_points, ambient_dim]
             Discrete curve to use as base point.
 
         Returns
         -------
-        log : array-like, shape=[..., n_sampling_points, ambient_dim]
+        log : array-like, shape=[..., k_sampling_points, ambient_dim]
             Tangent vector to a discrete curve.
         """
         if not isinstance(self.ambient_metric, EuclideanMetric):
@@ -1565,13 +1565,13 @@ class SRVMetric(ElasticMetric):
 
         Parameters
         ----------
-        initial_curve : array-like, shape=[..., n_sampling_points, ambient_dim]
+        initial_curve : array-like, shape=[..., k_sampling_points, ambient_dim]
             Discrete curve.
-        end_curve : array-like, shape=[..., n_sampling_points, ambient_dim]
+        end_curve : array-like, shape=[..., k_sampling_points, ambient_dim]
             Discrete curve. If None, an initial tangent vector must be given.
             Optional, default : None
         initial_tangent_vec : array-like,
-            shape=[..., n_sampling_points, ambient_dim]
+            shape=[..., k_sampling_points, ambient_dim]
             Tangent vector at base curve, the initial speed of the geodesics.
             If None, an end curve must be given and a logarithm is computed.
             Optional, default : None
@@ -1639,9 +1639,9 @@ class SRVMetric(ElasticMetric):
 
         Parameters
         ----------
-        point_a : array-like, shape=[..., n_sampling_points, ambient_dim]
+        point_a : array-like, shape=[..., k_sampling_points, ambient_dim]
             Discrete curve.
-        point_b : array-like, shape=[..., n_sampling_points, ambient_dim]
+        point_b : array-like, shape=[..., k_sampling_points, ambient_dim]
             Discrete curve.
 
         Returns
@@ -1673,12 +1673,12 @@ class SRVMetric(ElasticMetric):
 
         Parameters
         ----------
-        curve : array-like, shape=[..., n_sampling_points, ambient_dim]
+        curve : array-like, shape=[..., k_sampling_points, ambient_dim]
             Discrete curve.
 
         Returns
         -------
-        space_deriv : array-like, shape=[...,n_sampling_points, ambient_dim]
+        space_deriv : array-like, shape=[...,k_sampling_points, ambient_dim]
         """
         n_points = curve.shape[-2]
         if n_points < 2:
@@ -1732,19 +1732,19 @@ class QuotientSRVMetric(SRVMetric):
         Parameters
         ----------
         tangent_vec : array-like,
-            shape=[..., n_sampling_points, ambient_dim]
+            shape=[..., k_sampling_points, ambient_dim]
             Tangent vector to decompose into horizontal and vertical parts.
         curve : array-like,
-            shape=[..., n_sampling_points, ambient_dim]
+            shape=[..., k_sampling_points, ambient_dim]
             Base point of tangent_vec in the manifold of curves.
 
         Returns
         -------
         tangent_vec_hor : array-like,
-            shape=[..., n_sampling_points, ambient_dim]
+            shape=[..., k_sampling_points, ambient_dim]
             Horizontal part of tangent_vec.
         tangent_vec_ver : array-like,
-            shape=[..., n_sampling_points, ambient_dim]
+            shape=[..., k_sampling_points, ambient_dim]
             Vertical part of tangent_vec.
         vertical_norm: array-like, shape=[..., n_points]
             Pointwise norm of the vertical part of tangent_vec.
@@ -1842,9 +1842,9 @@ class QuotientSRVMetric(SRVMetric):
 
         Parameters
         ----------
-        initial_curve : array-like, shape=[n_sampling_points, ambient_dim]
+        initial_curve : array-like, shape=[k_sampling_points, ambient_dim]
             Initial discrete curve.
-        end_curve : array-like, shape=[n_sampling_points, ambient_dim]
+        end_curve : array-like, shape=[k_sampling_points, ambient_dim]
             End discrete curve.
         threshold: float
             When the difference between the new end curve and the current end
@@ -1869,15 +1869,15 @@ class QuotientSRVMetric(SRVMetric):
 
             Parameters
             ----------
-            vertical_norm: array-like, shape=[n_times, n_sampling_points]
+            vertical_norm: array-like, shape=[n_times, k_sampling_points]
                 Pointwise norm of the vertical part of the time derivative of
                 the path of curves.
-            space_deriv_norm: array-like, shape=[n_times, n_sampling_points]
+            space_deriv_norm: array-like, shape=[n_times, k_sampling_points]
                 Pointwise norm of the space derivative of the path of curves.
 
             Returns
             -------
-            repar: array-like, shape=[n_times, n_sampling_points]
+            repar: array-like, shape=[n_times, k_sampling_points]
                 Path of parametrizations, such that the path of curves
                 composed with the path of parametrizations is a horizontal
                 path.
@@ -1924,10 +1924,10 @@ class QuotientSRVMetric(SRVMetric):
 
             Parameters
             ----------
-            repar: array-like, shape=[n_times, n_sampling_points]
+            repar: array-like, shape=[n_times, k_sampling_points]
                 Path of reparametrizations.
             path_of_curves: array-like,
-                shape=[n_times, n_sampling_points, ambient_dim]
+                shape=[n_times, k_sampling_points, ambient_dim]
                 Path of curves.
             repar_inverse_end: list
                 List of the inverses of the reparametrizations applied to
@@ -1939,7 +1939,7 @@ class QuotientSRVMetric(SRVMetric):
             Returns
             -------
             reparametrized_path: array-like,
-                shape=[n_times, n_sampling_points, ambient_dim]
+                shape=[n_times, k_sampling_points, ambient_dim]
                 Path of curves composed with the inverse of the path of
                 reparametrizations.
             """
@@ -2022,9 +2022,9 @@ class QuotientSRVMetric(SRVMetric):
 
         Parameters
         ----------
-        curve_a : array-like, shape=[n_sampling_points, ambient_dim]
+        curve_a : array-like, shape=[k_sampling_points, ambient_dim]
             Initial discrete curve.
-        curve_b : array-like, shape=[n_sampling_points, ambient_dim]
+        curve_b : array-like, shape=[k_sampling_points, ambient_dim]
             End discrete curve.
         n_times: int
             Number of times used to discretize the horizontal geodesic.

--- a/geomstats/geometry/discrete_curves.py
+++ b/geomstats/geometry/discrete_curves.py
@@ -131,7 +131,7 @@ class DiscreteCurves(Manifold):
                 [each_belongs(pt) and each_has_n_sampling_points(pt) for pt in point]
             )
 
-        return each_belongs(point) * each_has_n_sampling_points(point)
+        return each_belongs(point) and each_has_n_sampling_points(point)
 
     def is_tangent(self, vector, base_point, atol=gs.atol):
         """Check whether the vector is tangent at a curve.

--- a/geomstats/learning/frechet_mean.py
+++ b/geomstats/learning/frechet_mean.py
@@ -124,7 +124,7 @@ def elastic_mean(points, weights=None, metric=None):
 
     Parameters
     ----------
-    points : array-like, shape=[n_samples, n_sampling_points, dim]
+    points : array-like, shape=[n_samples, k_sampling_points, dim]
         Points on the manifold of curves (i.e. curves) to be averaged.
     weights : array-like, shape=[...,]
         Weights associated to the points (i.e. curves).
@@ -132,7 +132,7 @@ def elastic_mean(points, weights=None, metric=None):
 
     Returns
     -------
-    mean : array-like, shape=[n_sampling_points, dim]
+    mean : array-like, shape=[k_sampling_points, dim]
         Weighted linear mean of the points (i.e. of the curves).
     """
     if isinstance(points, list):

--- a/geomstats/visualization/spd_matrices.py
+++ b/geomstats/visualization/spd_matrices.py
@@ -19,12 +19,12 @@ class Ellipses:
 
     Parameters
     ----------
-    n_sampling_points : int
+    k_sampling_points : int
         Number of points to sample on the discretized ellipses.
     """
 
-    def __init__(self, n_sampling_points=100):
-        self.n_sampling_points = n_sampling_points
+    def __init__(self, k_sampling_points=100):
+        self.k_sampling_points = k_sampling_points
 
     @staticmethod
     def set_ax(ax=None):
@@ -77,9 +77,9 @@ class Ellipses:
 
         Returns
         -------
-        x_coords : array-like, shape=[n_sampling_points,]
+        x_coords : array-like, shape=[k_sampling_points,]
             x_coords coordinates of the sampling points on the discretized ellipse.
-        Y: array-like, shape = [n_sampling_points,]
+        Y: array-like, shape = [k_sampling_points,]
             y coordinates of the sampling points on the discretized ellipse.
         """
         eigvalues, eigvectors = gs.linalg.eigh(point)
@@ -89,7 +89,7 @@ class Ellipses:
 
         rot_sin = eigvectors[1, 0]
         rot_cos = eigvectors[0, 0]
-        thetas = gs.linspace(0.0, 2 * gs.pi, self.n_sampling_points + 1)
+        thetas = gs.linspace(0.0, 2 * gs.pi, self.k_sampling_points + 1)
 
         x_coords = eigvalue1 * gs.cos(thetas) * rot_cos
         x_coords -= rot_sin * eigvalue2 * gs.sin(thetas)

--- a/notebooks/10_practical_methods__shape_analysis.ipynb
+++ b/notebooks/10_practical_methods__shape_analysis.ipynb
@@ -128,8 +128,8 @@
     }
    ],
    "source": [
-    "n_sampling_points = 20\n",
-    "sampling_points = gs.linspace(0.0, 1.0, n_sampling_points + 1)\n",
+    "k_sampling_points = 20\n",
+    "sampling_points = gs.linspace(0.0, 1.0, k_sampling_points + 1)\n",
     "curve_a = parametrized_curve_a(sampling_points)\n",
     "curve_b = parametrized_curve_b(sampling_points)\n",
     "\n",
@@ -639,8 +639,8 @@
     "    gs.stack((gs.cos(4 + 8 * x), gs.sin(4 + 8 * x), 2 + 10 * x))\n",
     ")\n",
     "\n",
-    "n_sampling_points = 100\n",
-    "sampling_points = gs.linspace(0.0, 1.0, n_sampling_points)\n",
+    "k_sampling_points = 100\n",
+    "sampling_points = gs.linspace(0.0, 1.0, k_sampling_points)\n",
     "curve_a = parametrized_curve_a(sampling_points)\n",
     "curve_b = parametrized_curve_b(sampling_points)\n",
     "\n",
@@ -686,7 +686,7 @@
     "ax.plot(curve_b[:, 0], curve_b[:, 1], curve_b[:, 2], \"-\", c=\"r\", linewidth=2)\n",
     "for i in range(1, n_times - 1):\n",
     "    ax.plot(geod[i, :, 0], geod[i, :, 1], geod[i, :, 2], \"-\", c=\"k\")\n",
-    "for j in range(n_sampling_points):\n",
+    "for j in range(k_sampling_points):\n",
     "    ax.plot(geod[:, j, 0], geod[:, j, 1], geod[:, j, 2], \"--\", c=\"k\")\n",
     "plt.title(\"SRV geodesic\")\n",
     "plt.show()"
@@ -726,7 +726,7 @@
     "ax.plot(curve_b[:, 0], curve_b[:, 1], curve_b[:, 2], \"-\", c=\"r\", linewidth=2)\n",
     "for i in range(1, n_times - 1):\n",
     "    ax.plot(hgeod[i, :, 0], hgeod[i, :, 1], hgeod[i, :, 2], \"-\", c=\"k\")\n",
-    "for j in range(n_sampling_points):\n",
+    "for j in range(k_sampling_points):\n",
     "    ax.plot(hgeod[:, j, 0], hgeod[:, j, 1], hgeod[:, j, 2], \"--\", c=\"k\")\n",
     "plt.title(\"Horizontal SRV geodesic\")\n",
     "plt.show()"

--- a/notebooks/11_real_world_applications__cell_shapes_analysis.ipynb
+++ b/notebooks/11_real_world_applications__cell_shapes_analysis.ipynb
@@ -449,7 +449,7 @@
     "    return interpolation\n",
     "\n",
     "\n",
-    "N_SAMPLING_POINTS = 200"
+    "k_sampling_points = 200"
    ]
   },
   {
@@ -481,7 +481,7 @@
    ],
    "source": [
     "cell_rand = cells[gs.random.randint(len(cells))]\n",
-    "cell_interpolation = interpolate(cell_rand, N_SAMPLING_POINTS)\n",
+    "cell_interpolation = interpolate(cell_rand, k_sampling_points)\n",
     "\n",
     "fig = plt.figure(figsize=(15, 5))\n",
     "\n",
@@ -494,7 +494,7 @@
     "fig.add_subplot(122)\n",
     "plt.plot(cell_interpolation[:, 0], cell_interpolation[:, 1])\n",
     "plt.axis(\"equal\")\n",
-    "plt.title(f\"Interpolated curve ({N_SAMPLING_POINTS} points)\")\n",
+    "plt.title(f\"Interpolated curve ({k_sampling_points} points)\")\n",
     "plt.axis(\"off\")\n",
     "\n",
     "plt.savefig(\"interpolation.svg\")"
@@ -518,7 +518,7 @@
    "outputs": [],
    "source": [
     "ds_interp = apply_func_to_ds(\n",
-    "    input_ds=ds, func=lambda x: interpolate(x, N_SAMPLING_POINTS)\n",
+    "    input_ds=ds, func=lambda x: interpolate(x, k_sampling_points)\n",
     ")"
    ]
   },
@@ -527,7 +527,7 @@
    "id": "1d610e19",
    "metadata": {},
    "source": [
-    "For each key treatment-control, we check that the number of sampling points is the one expected, i.e. `N_SAMPLING_POINTS`:"
+    "For each key treatment-control, we check that the number of sampling points is the one expected, i.e. `k_sampling_points`:"
    ]
   },
   {
@@ -682,7 +682,7 @@
     "\n",
     "M_AMBIENT = 2\n",
     "\n",
-    "PRESHAPE_SPACE = PreShapeSpace(m_ambient=M_AMBIENT, k_landmarks=N_SAMPLING_POINTS)\n",
+    "PRESHAPE_SPACE = PreShapeSpace(m_ambient=M_AMBIENT, k_landmarks=k_sampling_points)\n",
     "PRESHAPE_METRIC = PRESHAPE_SPACE.embedding_metric\n",
     "\n",
     "\n",
@@ -1089,7 +1089,7 @@
     "print(gs.sum(gs.isnan(mean_estimate)))\n",
     "mean_estimate_clean = mean_estimate[~gs.isnan(gs.sum(mean_estimate, axis=1)), :]\n",
     "print(mean_estimate_clean.shape)\n",
-    "mean_estimate_clean = interpolate(mean_estimate_clean, N_SAMPLING_POINTS)\n",
+    "mean_estimate_clean = interpolate(mean_estimate_clean, k_sampling_points)\n",
     "print(gs.sum(gs.isnan(mean_estimate_clean)))\n",
     "print(mean_estimate_clean.shape)"
    ]

--- a/tests/data/discrete_curves_data.py
+++ b/tests/data/discrete_curves_data.py
@@ -32,8 +32,8 @@ curve_fun_c = s2.metric.geodesic(
 )
 
 
-n_sampling_points = 10
-sampling_times = gs.linspace(0.0, 1.0, n_sampling_points)
+k_sampling_points = 10
+sampling_times = gs.linspace(0.0, 1.0, k_sampling_points)
 curve_a = curve_fun_a(sampling_times)
 curve_b = curve_fun_b(sampling_times)
 curve_c = curve_fun_c(sampling_times)
@@ -82,7 +82,7 @@ class L2CurvesMetricTestData(_RiemannianMetricTestData):
                 curve_a=curve_a,
                 curve_b=curve_b,
                 times=times,
-                n_sampling_points=n_sampling_points,
+                k_sampling_points=k_sampling_points,
             )
         ]
         return self.generate_tests(smoke_data)
@@ -117,7 +117,7 @@ class SRVMetricTestData(_RiemannianMetricTestData):
         smoke_data = [
             dict(
                 dim=3,
-                n_sampling_points=2000,
+                k_sampling_points=2000,
                 n_curves=2000,
                 curve_fun_a=curve_fun_a,
             )
@@ -125,14 +125,14 @@ class SRVMetricTestData(_RiemannianMetricTestData):
         return self.generate_tests(smoke_data)
 
     def aux_differential_srv_transform_inverse_test_data(self):
-        smoke_data = [dict(dim=3, n_sampling_points=n_sampling_points, curve_a=curve_a)]
+        smoke_data = [dict(dim=3, k_sampling_points=k_sampling_points, curve_a=curve_a)]
         return self.generate_tests(smoke_data)
 
     def aux_differential_srv_transform_vectorization_test_data(self):
         smoke_data = [
             dict(
                 dim=3,
-                n_sampling_points=n_sampling_points,
+                k_sampling_points=k_sampling_points,
                 curve_a=curve_a,
                 curve_b=curve_b,
             )
@@ -140,7 +140,7 @@ class SRVMetricTestData(_RiemannianMetricTestData):
         return self.generate_tests(smoke_data)
 
     def srv_inner_product_elastic_test_data(self):
-        smoke_data = [dict(dim=3, n_sampling_points=n_sampling_points, curve_a=curve_a)]
+        smoke_data = [dict(dim=3, k_sampling_points=k_sampling_points, curve_a=curve_a)]
         return self.generate_tests(smoke_data)
 
     def srv_inner_product_and_dist_test_data(self):
@@ -151,7 +151,7 @@ class SRVMetricTestData(_RiemannianMetricTestData):
         smoke_data = [
             dict(
                 dim=3,
-                n_sampling_points=n_sampling_points,
+                k_sampling_points=k_sampling_points,
                 curve_a=curve_a,
                 curve_b=curve_b,
             )
@@ -175,7 +175,7 @@ class SRVMetricTestData(_RiemannianMetricTestData):
                 dim=3,
                 n_points=3,
                 n_discretized_curves=n_discretized_curves,
-                n_sampling_points=n_sampling_points,
+                k_sampling_points=k_sampling_points,
             )
         ]
         return self.generate_tests(smoke_data)
@@ -198,7 +198,7 @@ class SRVMetricTestData(_RiemannianMetricTestData):
                 curve_b=curve_b,
                 curve_c=curve_c,
                 n_discretized_curves=n_discretized_curves,
-                n_sampling_points=n_sampling_points,
+                k_sampling_points=k_sampling_points,
             )
         ]
         return self.generate_tests(smoke_data)
@@ -281,7 +281,7 @@ class ElasticMetricTestData(TestData):
 class QuotientSRVMetricTestData(TestData):
     def horizontal_geodesic_test_data(self):
         smoke_data = [
-            dict(n_sampling_points=n_sampling_points, curve_a=curve_a, n_times=20)
+            dict(k_sampling_points=k_sampling_points, curve_a=curve_a, n_times=20)
         ]
         return self.generate_tests(smoke_data)
 
@@ -291,7 +291,7 @@ class QuotientSRVMetricTestData(TestData):
                 sampling_times=sampling_times,
                 curve_fun_a=curve_fun_a,
                 curve_a=curve_a,
-                n_sampling_points=n_sampling_points,
+                k_sampling_points=k_sampling_points,
             )
         ]
         return self.generate_tests(smoke_data)

--- a/tests/data/landmarks_data.py
+++ b/tests/data/landmarks_data.py
@@ -85,8 +85,8 @@ class TestDataL2LandmarksMetric(_RiemannianMetricTestData):
         initial_point=initial_point, initial_tangent_vec=initial_tangent_vec_c
     )
 
-    n_sampling_points = 10
-    sampling_times = gs.linspace(0.0, 1.0, n_sampling_points)
+    k_sampling_points = 10
+    sampling_times = gs.linspace(0.0, 1.0, k_sampling_points)
     landmark_set_a = landmarks_a(sampling_times)
     landmark_set_b = landmarks_b(sampling_times)
     landmark_set_c = landmarks_c(sampling_times)
@@ -94,7 +94,7 @@ class TestDataL2LandmarksMetric(_RiemannianMetricTestData):
     n_landmark_sets = 5
     times = gs.linspace(0.0, 1.0, n_landmark_sets)
     space_landmarks_in_sphere_2d = Landmarks(
-        ambient_manifold=s2, k_landmarks=n_sampling_points
+        ambient_manifold=s2, k_landmarks=k_sampling_points
     )
     l2_metric_s2 = space_landmarks_in_sphere_2d.metric
 
@@ -145,7 +145,7 @@ class TestDataL2LandmarksMetric(_RiemannianMetricTestData):
             dict(
                 l2_metric_s2=self.l2_metric_s2,
                 times=self.times,
-                n_sampling_points=self.n_sampling_points,
+                k_sampling_points=self.k_sampling_points,
                 landmarks_a=self.landmark_set_a,
                 landmarks_b=self.landmark_set_b,
             )
@@ -155,7 +155,7 @@ class TestDataL2LandmarksMetric(_RiemannianMetricTestData):
     def innerproduct_is_sum_of_innerproducts_test_data(self):
         smoke_data = [
             dict(
-                metric_args=(Hypersphere(dim=2).metric, self.n_sampling_points),
+                metric_args=(Hypersphere(dim=2).metric, self.k_sampling_points),
                 tangent_vec_a=self.landmark_set_a,
                 tangent_vec_b=self.landmark_set_b,
                 base_point=self.landmark_set_c,

--- a/tests/data_generation.py
+++ b/tests/data_generation.py
@@ -69,7 +69,7 @@ class _ManifoldTestData(TestData):
         return self.generate_tests([], random_data)
 
     def projection_belongs_test_data(self, belongs_atol=gs.atol):
-        """Generate data to check that a point projected on a manifold belongs to the manifold.
+        """Generate data to check that a projected point belongs to the manifold.
 
         Parameters
         ----------
@@ -164,7 +164,8 @@ class _OpenSetTestData(_ManifoldTestData):
 
 class _LevelSetTestData(_ManifoldTestData):
     def intrinsic_after_extrinsic_test_data(self):
-        """Generate data to check that changing coordinate system twice gives back the point.
+        """Generate data to check that changing coordinate system twice
+        gives back the point.
 
         Assumes that random_point generates points in extrinsic coordinates.
         """
@@ -180,7 +181,8 @@ class _LevelSetTestData(_ManifoldTestData):
         return self.generate_tests([], random_data)
 
     def extrinsic_after_intrinsic_test_data(self):
-        """Generate data to check that changing coordinate system twice gives back the point.
+        """Generate data to check that changing coordinate system twice
+        gives back the point.
 
         Assumes that the first elements in space_args is the dimension of the space.
         """

--- a/tests/tests_geomstats/test_discrete_curves.py
+++ b/tests/tests_geomstats/test_discrete_curves.py
@@ -73,7 +73,7 @@ class TestL2CurvesMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
     testing_data = L2CurvesMetricTestData()
 
     def test_l2_metric_geodesic(
-        self, ambient_manifold, curve_a, curve_b, times, n_sampling_points
+        self, ambient_manifold, curve_a, curve_b, times, k_sampling_points
     ):
         """Test the geodesic method of L2LandmarksMetric."""
         l2_metric_s2 = self.Metric(ambient_manifold=s2)
@@ -82,7 +82,7 @@ class TestL2CurvesMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
 
         result = curves_ab
         expected = []
-        for k in range(n_sampling_points):
+        for k in range(k_sampling_points):
             geod = l2_metric_s2.ambient_metric.geodesic(
                 initial_point=curve_a[k, :], end_point=curve_b[k, :]
             )
@@ -164,7 +164,7 @@ class TestSRVMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
 
     @geomstats.tests.np_and_autograd_only
     def test_aux_differential_srv_transform(
-        self, dim, n_sampling_points, n_curves, curve_fun_a
+        self, dim, k_sampling_points, n_curves, curve_fun_a
     ):
         """Test differential of square root velocity transform.
         Check that its value at (curve, tangent_vec) coincides
@@ -173,10 +173,10 @@ class TestSRVMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
         initial derivative tangent_vec.
         """
         srv_metric_r3 = SRVMetric(r3)
-        sampling_times = gs.linspace(0.0, 1.0, n_sampling_points)
+        sampling_times = gs.linspace(0.0, 1.0, k_sampling_points)
         curve_a = curve_fun_a(sampling_times)
         tangent_vec = gs.transpose(
-            gs.tile(gs.linspace(1.0, 2.0, n_sampling_points), (dim, 1))
+            gs.tile(gs.linspace(1.0, 2.0, k_sampling_points), (dim, 1))
         )
         result = srv_metric_r3.aux_differential_srv_transform(tangent_vec, curve_a)
 
@@ -188,13 +188,13 @@ class TestSRVMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
 
     @geomstats.tests.np_and_autograd_only
     def test_aux_differential_srv_transform_inverse(
-        self, dim, n_sampling_points, curve_a
+        self, dim, k_sampling_points, curve_a
     ):
         """Test inverse of differential of square root velocity transform.
         Check that it is the inverse of aux_differential_srv_transform.
         """
         tangent_vec = gs.transpose(
-            gs.tile(gs.linspace(0.0, 1.0, n_sampling_points), (dim, 1))
+            gs.tile(gs.linspace(0.0, 1.0, k_sampling_points), (dim, 1))
         )
         srv_metric_r3 = SRVMetric(r3)
         d_srv = srv_metric_r3.aux_differential_srv_transform(tangent_vec, curve_a)
@@ -203,14 +203,14 @@ class TestSRVMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
         self.assertAllClose(result, expected, atol=1e-3, rtol=1e-3)
 
     def test_aux_differential_srv_transform_vectorization(
-        self, dim, n_sampling_points, curve_a, curve_b
+        self, dim, k_sampling_points, curve_a, curve_b
     ):
         """Test differential of square root velocity transform.
         Check vectorization.
         """
         dim = 3
         curves = gs.stack((curve_a, curve_b))
-        tangent_vecs = gs.random.rand(2, n_sampling_points, dim)
+        tangent_vecs = gs.random.rand(2, k_sampling_points, dim)
         srv_metric_r3 = SRVMetric(r3)
         result = srv_metric_r3.aux_differential_srv_transform(tangent_vecs, curves)
 
@@ -219,24 +219,24 @@ class TestSRVMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
         expected = gs.stack([res_a, res_b])
         self.assertAllClose(result, expected)
 
-    def test_srv_inner_product_elastic(self, dim, n_sampling_points, curve_a):
+    def test_srv_inner_product_elastic(self, dim, k_sampling_points, curve_a):
         """Test inner product of SRVMetric.
         Check that the pullback metric gives an elastic metric
         with parameters a=1, b=1/2.
         """
-        tangent_vec_a = gs.random.rand(n_sampling_points, dim)
-        tangent_vec_b = gs.random.rand(n_sampling_points, dim)
+        tangent_vec_a = gs.random.rand(k_sampling_points, dim)
+        tangent_vec_b = gs.random.rand(k_sampling_points, dim)
         r3 = Euclidean(dim)
         srv_metric_r3 = SRVMetric(r3)
         result = srv_metric_r3.inner_product(tangent_vec_a, tangent_vec_b, curve_a)
 
-        d_vec_a = (n_sampling_points - 1) * (
+        d_vec_a = (k_sampling_points - 1) * (
             tangent_vec_a[1:, :] - tangent_vec_a[:-1, :]
         )
-        d_vec_b = (n_sampling_points - 1) * (
+        d_vec_b = (k_sampling_points - 1) * (
             tangent_vec_b[1:, :] - tangent_vec_b[:-1, :]
         )
-        velocity_vec = (n_sampling_points - 1) * (curve_a[1:, :] - curve_a[:-1, :])
+        velocity_vec = (k_sampling_points - 1) * (curve_a[1:, :] - curve_a[:-1, :])
         velocity_norm = r3.metric.norm(velocity_vec)
         unit_velocity_vec = gs.einsum("ij,i->ij", velocity_vec, 1 / velocity_norm)
         a_param = 1
@@ -247,7 +247,7 @@ class TestSRVMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
             * gs.sum(d_vec_a * unit_velocity_vec, axis=1)
             * gs.sum(d_vec_b * unit_velocity_vec, axis=1)
         ) / velocity_norm
-        expected = gs.sum(integrand) / n_sampling_points
+        expected = gs.sum(integrand) / k_sampling_points
         self.assertAllClose(result, expected)
 
     def test_srv_inner_product_and_dist(self, dim, curve_a, curve_b):
@@ -268,14 +268,14 @@ class TestSRVMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
                 self.assertAllClose(result, expected)
 
     def test_srv_inner_product_vectorization(
-        self, dim, n_sampling_points, curve_a, curve_b
+        self, dim, k_sampling_points, curve_a, curve_b
     ):
         """Test inner product of SRVMetric.
         Check vectorization.
         """
         curves = gs.stack((curve_a, curve_b))
-        tangent_vecs_1 = gs.random.rand(2, n_sampling_points, dim)
-        tangent_vecs_2 = gs.random.rand(2, n_sampling_points, dim)
+        tangent_vecs_1 = gs.random.rand(2, k_sampling_points, dim)
+        tangent_vecs_2 = gs.random.rand(2, k_sampling_points, dim)
         srv_metric_r3 = SRVMetric(r3)
         result = srv_metric_r3.inner_product(tangent_vecs_1, tangent_vecs_2, curves)
 
@@ -325,7 +325,7 @@ class TestSRVMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
         self.assertAllClose(result, expected)
 
     def test_space_derivative(
-        self, dim, n_points, n_discretized_curves, n_sampling_points
+        self, dim, n_points, n_discretized_curves, k_sampling_points
     ):
         """Test space derivative.
         Check result on an example and vectorization.
@@ -350,7 +350,7 @@ class TestSRVMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
         )
         self.assertAllClose(result, expected)
 
-        path_of_curves = gs.random.rand(n_discretized_curves, n_sampling_points, dim)
+        path_of_curves = gs.random.rand(n_discretized_curves, k_sampling_points, dim)
         result = srv_metric_r3.space_derivative(path_of_curves)
         expected = []
         for i in range(n_discretized_curves):
@@ -359,7 +359,7 @@ class TestSRVMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
         self.assertAllClose(result, expected)
 
     def test_srv_metric_pointwise_inner_products(
-        self, times, curve_a, curve_b, curve_c, n_discretized_curves, n_sampling_points
+        self, times, curve_a, curve_b, curve_c, n_discretized_curves, k_sampling_points
     ):
         l2_metric_s2 = L2CurvesMetric(ambient_manifold=s2)
         srv_metric_r3 = SRVMetric(ambient_manifold=r3)
@@ -372,7 +372,7 @@ class TestSRVMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
         result = srv_metric_r3.l2_curves_metric.pointwise_inner_products(
             tangent_vec_a=tangent_vecs, tangent_vec_b=tangent_vecs, base_curve=curves_ab
         )
-        expected_shape = (n_discretized_curves, n_sampling_points)
+        expected_shape = (n_discretized_curves, k_sampling_points)
         self.assertAllClose(gs.shape(result), expected_shape)
 
         result = srv_metric_r3.l2_curves_metric.pointwise_inner_products(
@@ -380,7 +380,7 @@ class TestSRVMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
             tangent_vec_b=tangent_vecs[0],
             base_curve=curves_ab[0],
         )
-        expected_shape = (n_sampling_points,)
+        expected_shape = (k_sampling_points,)
         self.assertAllClose(gs.shape(result), expected_shape)
 
     def test_srv_transform_and_inverse(self, times, curve_a, curve_b):
@@ -491,7 +491,7 @@ class TestQuotientSRVMetric(TestCase, metaclass=Parametrizer):
     testing_data = QuotientSRVMetricTestData()
 
     @geomstats.tests.np_autograd_and_torch_only
-    def test_horizontal_geodesic(self, n_sampling_points, curve_a, n_times):
+    def test_horizontal_geodesic(self, k_sampling_points, curve_a, n_times):
         """Test horizontal geodesic.
         Check that the time derivative of the geodesic is
         horizontal at all time.
@@ -499,9 +499,9 @@ class TestQuotientSRVMetric(TestCase, metaclass=Parametrizer):
         curve_b = gs.transpose(
             gs.stack(
                 (
-                    gs.zeros(n_sampling_points),
-                    gs.zeros(n_sampling_points),
-                    gs.linspace(1.0, 0.5, n_sampling_points),
+                    gs.zeros(k_sampling_points),
+                    gs.zeros(k_sampling_points),
+                    gs.linspace(1.0, 0.5, k_sampling_points),
                 )
             )
         )
@@ -521,7 +521,7 @@ class TestQuotientSRVMetric(TestCase, metaclass=Parametrizer):
 
     @geomstats.tests.np_autograd_and_torch_only
     def test_quotient_dist(
-        self, sampling_times, curve_fun_a, curve_a, n_sampling_points
+        self, sampling_times, curve_fun_a, curve_a, k_sampling_points
     ):
         """Test quotient distance.
         Check that the quotient distance is the same as the distance
@@ -531,9 +531,9 @@ class TestQuotientSRVMetric(TestCase, metaclass=Parametrizer):
         curve_b = gs.transpose(
             gs.stack(
                 (
-                    gs.zeros(n_sampling_points),
-                    gs.zeros(n_sampling_points),
-                    gs.linspace(1.0, 0.5, n_sampling_points),
+                    gs.zeros(k_sampling_points),
+                    gs.zeros(k_sampling_points),
+                    gs.linspace(1.0, 0.5, k_sampling_points),
                 )
             )
         )

--- a/tests/tests_geomstats/test_frechet_mean.py
+++ b/tests/tests_geomstats/test_frechet_mean.py
@@ -28,6 +28,7 @@ class TestFrechetMean(geomstats.tests.TestCase):
         self.so3 = SpecialOrthogonal(n=3, point_type="vector")
         self.so_matrix = SpecialOrthogonal(n=3)
         self.curves_2d = DiscreteCurves(R2)
+        self.curves_2d_many_sampling_points = DiscreteCurves(R2, n_sampling_points=300)
         self.elastic_metric = ElasticMetric(a=1, b=1, ambient_manifold=R2)
 
     def test_logs_at_mean_curves_2d(self):
@@ -127,8 +128,19 @@ class TestFrechetMean(geomstats.tests.TestCase):
 
         self.assertAllClose(gs.shape(result), (points.shape[1:]))
 
-    def test_estimate_shape_elastic_metric_big(self):
-        points = self.curves_2d.random_point(n_samples=1000)
+    def test_estimate_shape_srv_metric_many_sampling_points(self):
+        points = self.curves_2d_many_sampling_points.random_point(n_samples=1000)
+
+        mean = FrechetMean(
+            metric=self.curves_2d_many_sampling_points.srv_metric, method="default"
+        )
+        mean.fit(points)
+        result = mean.estimate_
+
+        self.assertAllClose(gs.shape(result), (points.shape[1:]))
+
+    def test_estimate_shape_elastic_metric_many_sampling_points(self):
+        points = self.curves_2d_many_sampling_points.random_point(n_samples=1000)
 
         mean = FrechetMean(metric=self.elastic_metric, method="default")
         mean.fit(points)

--- a/tests/tests_geomstats/test_frechet_mean.py
+++ b/tests/tests_geomstats/test_frechet_mean.py
@@ -28,7 +28,7 @@ class TestFrechetMean(geomstats.tests.TestCase):
         self.so3 = SpecialOrthogonal(n=3, point_type="vector")
         self.so_matrix = SpecialOrthogonal(n=3)
         self.curves_2d = DiscreteCurves(R2)
-        self.curves_2d_many_sampling_points = DiscreteCurves(R2, n_sampling_points=300)
+        self.curves_2d_many_sampling_points = DiscreteCurves(R2, k_sampling_points=300)
         self.elastic_metric = ElasticMetric(a=1, b=1, ambient_manifold=R2)
 
     def test_logs_at_mean_curves_2d(self):

--- a/tests/tests_geomstats/test_frechet_mean.py
+++ b/tests/tests_geomstats/test_frechet_mean.py
@@ -127,6 +127,15 @@ class TestFrechetMean(geomstats.tests.TestCase):
 
         self.assertAllClose(gs.shape(result), (points.shape[1:]))
 
+    def test_estimate_shape_elastic_metric_big(self):
+        points = self.curves_2d.random_point(n_samples=1000)
+
+        mean = FrechetMean(metric=self.elastic_metric, method="default")
+        mean.fit(points)
+        result = mean.estimate_
+
+        self.assertAllClose(gs.shape(result), (points.shape[1:]))
+
     def test_estimate_shape_metric(self):
         points = self.curves_2d.random_point(n_samples=2)
 

--- a/tests/tests_geomstats/test_geodesic_regression.py
+++ b/tests/tests_geomstats/test_geodesic_regression.py
@@ -103,7 +103,7 @@ class TestGeodesicRegression(geomstats.tests.TestCase):
 
         # Set up for discrete curves
         n_sampling_points = 8
-        self.curves_2d = DiscreteCurves(R2)
+        self.curves_2d = DiscreteCurves(R2, n_sampling_points=n_sampling_points)
         self.metric_curves_2d = self.curves_2d.srv_metric
         self.metric_curves_2d.default_point_type = "matrix"
 
@@ -111,9 +111,7 @@ class TestGeodesicRegression(geomstats.tests.TestCase):
         X = gs.random.rand(self.n_samples)
         self.X_curves_2d = X - gs.mean(X)
 
-        self.intercept_curves_2d_true = self.curves_2d.random_point(
-            n_sampling_points=n_sampling_points
-        )
+        self.intercept_curves_2d_true = self.curves_2d.random_point()
         self.coef_curves_2d_true = self.curves_2d.to_tangent(
             5.0 * gs.random.rand(*self.shape_curves_2d), self.intercept_curves_2d_true
         )

--- a/tests/tests_geomstats/test_geodesic_regression.py
+++ b/tests/tests_geomstats/test_geodesic_regression.py
@@ -102,12 +102,12 @@ class TestGeodesicRegression(geomstats.tests.TestCase):
         )
 
         # Set up for discrete curves
-        n_sampling_points = 8
-        self.curves_2d = DiscreteCurves(R2, n_sampling_points=n_sampling_points)
+        k_sampling_points = 8
+        self.curves_2d = DiscreteCurves(R2, k_sampling_points=k_sampling_points)
         self.metric_curves_2d = self.curves_2d.srv_metric
         self.metric_curves_2d.default_point_type = "matrix"
 
-        self.shape_curves_2d = (n_sampling_points, 2)
+        self.shape_curves_2d = (k_sampling_points, 2)
         X = gs.random.rand(self.n_samples)
         self.X_curves_2d = X - gs.mean(X)
 

--- a/tests/tests_geomstats/test_landmarks.py
+++ b/tests/tests_geomstats/test_landmarks.py
@@ -73,7 +73,7 @@ class TestL2LandmarksMetric(NFoldMetricTestCase, metaclass=Parametrizer):
 
     @geomstats.tests.np_autograd_and_tf_only
     def test_l2_metric_geodesic(
-        self, l2_metric_s2, times, n_sampling_points, landmarks_a, landmarks_b
+        self, l2_metric_s2, times, k_sampling_points, landmarks_a, landmarks_b
     ):
         """Test the geodesic method of L2LandmarksMetric."""
         landmarks_ab = l2_metric_s2.geodesic(landmarks_a, landmarks_b)
@@ -81,7 +81,7 @@ class TestL2LandmarksMetric(NFoldMetricTestCase, metaclass=Parametrizer):
 
         result = landmarks_ab
         expected = []
-        for k in range(n_sampling_points):
+        for k in range(k_sampling_points):
             geod = l2_metric_s2.ambient_metric.geodesic(
                 initial_point=landmarks_a[k, :], end_point=landmarks_b[k, :]
             )

--- a/tests/tests_geomstats/test_visualization.py
+++ b/tests/tests_geomstats/test_visualization.py
@@ -187,7 +187,7 @@ class TestVisualization(geomstats.tests.TestCase):
 
     def test_compute_coordinates_spd2(self):
         point = gs.eye(2)
-        ellipsis = visualization.Ellipses(n_sampling_points=4)
+        ellipsis = visualization.Ellipses(k_sampling_points=4)
         x, y = ellipsis.compute_coordinates(point)
         self.assertAllClose(x, gs.array([1, 0, -1, 0, 1]))
         self.assertAllClose(y, gs.array([0, 1, 0, -1, 0]))


### PR DESCRIPTION
This PR:
- renames `n_sampling_points` into `k_sampling_points`
- adds `k_sampling_points` as an input parameter and attribute for the spaces of curves
- modifies the belongs functions accordingly
- modifies the dimension of the spaces accordingly
- adapts the unit-tests.

This continues to address Issue #1183 .

This allows:
- to become more consistent with spaces of landmarks, that takes `k_landmarks` as input
- to avoid existing confusions between `n_points` (number of points on a given manifold)
- to allow the spaces of (closed) discrete curves to have the right dimension (which was set to infinity before).

What remains to be done:
- potentially make the changes in the metrics defined on curves.

## Checklist

- [x] My pull request has a clear and explanatory title.
- [x] If neccessary, my code is [vectorized](https://www.geeksforgeeks.org/vectorization-in-python/).
- [x] I have added apropriate unit tests.
- [ ] I have made sure the code passes all unit tests. (refer to comment below)
- [x] My PR follows [PEP8](https://peps.python.org/pep-0008/) guidelines. (refer to comment below)
- [x] My PR follows [geomstats coding style](https://github.com/geomstats/geomstats/blob/master/docs/contributing.rst#coding-style-guidelines) and API.
- [x] My code is properly documented and I made sure the documentation renders properly. ([Link](https://github.com/geomstats/geomstats/blob/master/docs/contributing.rst#documentation))
- [x] I have linked to issues and PRs that are relevant to this PR.


<!-- For checking consistency of entire codebase
First, run the tests related to your changes. For example, if you changed something in geomstats/spd_matrices_space.py:
$ pytest tests/tests_geomstats/test_spd_matrices.py

and then run the tests of the whole codebase to check that your feature is not breaking any of them:
$ pytest tests/

This way, further modifications on the code base are guaranteed to be consistent with the desired behavior. Merging your PR should not break any test in any backend (numpy, tensorflow or pytorch)."

For testing in alternative backends such as `numpy`, `pytorch`, `autograd`, `tensorflow` set the environment variable using:
$ export GEOMSTATS_BACKEND=<backend_name>

Next, import the `backend` module using:
import geomstats.backend as gs
-->


<!-- For flake8 tests
Install dependencies
$ pip3 install -r dev-requirements.txt

Then run the following commands:
$ flake8 --ignore=D,W503,W504 geomstats examples tests   #shadows .flake8
$ flake8 geomstats/geometry geomstats/learning           #passed two subfolders
-->

## Description

<!-- Include a description of your pull request. If relevant, feel free to use this space to talk about time and space complexity as well scalability of your code-->

## Issue

<!-- Tell us which issue does this PR fix . Why this feature implementation/fix is important in practice ?-->

## Additional context

<!-- Add any extra information -->