### PR TITLE
Fix max version of scipy

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     numpy >= 1.18.1
     pandas >= 1.1.5
     scikit-learn >= 0.22.1
-    scipy >= 1.4.1
+    scipy >= 1.4.1, < 1.9
 
 
 [options.packages.find]


### PR DESCRIPTION
geomstats does not work properly with scipy 1.9. We need to identify better the reason, meanwhile let's limit max version to have the tests running.