### PR TITLE
added backend function gs.quantile

### DIFF
--- a/geomstats/_backend/__init__.py
+++ b/geomstats/_backend/__init__.py
@@ -105,6 +105,7 @@ BACKEND_ATTRIBUTES = {
         "polygamma",
         "power",
         "prod",
+        "quantile",
         "ravel_tril_indices",
         "real",
         "repeat",

--- a/geomstats/_backend/autograd/__init__.py
+++ b/geomstats/_backend/autograd/__init__.py
@@ -71,6 +71,7 @@ from autograd.numpy import (
     pad,
     power,
     prod,
+    quantile,
     real,
     repeat,
     reshape,

--- a/geomstats/_backend/numpy/__init__.py
+++ b/geomstats/_backend/numpy/__init__.py
@@ -71,6 +71,7 @@ from numpy import (
     pad,
     power,
     prod,
+    quantile,
     real,
     repeat,
     reshape,

--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -39,7 +39,7 @@ from torch import (
 from torch import max as amax
 from torch import mean, meshgrid, moveaxis, ones, ones_like, polygamma
 from torch import pow as power
-from torch import real
+from torch import quantile, real
 from torch import repeat_interleave as repeat
 from torch import (
     reshape,

--- a/geomstats/_backend/tensorflow/__init__.py
+++ b/geomstats/_backend/tensorflow/__init__.py
@@ -105,6 +105,16 @@ def from_numpy(x):
     return _tf.convert_to_tensor(x)
 
 
+def quantile(x, q, axis=None, out=None):
+    # Note: numpy, pytorch, and autograd convention is q in [0,1] while tfp expects
+    # [0,100]. These other libraries also default to (the equivalent of)
+    # interpolation=linear
+    result = _tfp.stats.percentile(x, q * 100, axis=axis, interpolation="linear")
+    if out is not None:
+        out[:] = result
+    return result
+
+
 def one_hot(labels, num_classes):
     return _tf.one_hot(labels, num_classes, dtype=_tf.uint8)
 

--- a/tests/tests_geomstats/test_backends.py
+++ b/tests/tests_geomstats/test_backends.py
@@ -699,6 +699,16 @@ class TestBackends(tests.conftest.TestCase):
         expected = gs.cumprod(vec)[-1]
         self.assertAllClose(result, expected)
 
+    def test_quantile(self):
+        vec = gs.random.rand(10, 10)
+        q = gs.random.rand(1)
+        expected = _np.quantile(vec, q=q)
+        result = gs.quantile(vec, q=q)
+        expected1 = _np.quantile(vec, q=q, axis=1)
+        result1 = gs.quantile(vec, q=q, axis=1)
+        self.assertAllClose(result, expected)
+        self.assertAllClose(result1, expected1)
+
     def test_is_single_matrix_pd(self):
         pd = gs.eye(3)
         not_pd_1 = -1 * gs.eye(3)


### PR DESCRIPTION
<!--
Thank you for opening this pull request!
-->

## Checklist

- [x] My pull request has a clear and explanatory title.
- [x] If neccessary, my code is [vectorized](https://www.geeksforgeeks.org/vectorization-in-python/).
- [x] I have added apropriate unit tests.
- [x] I have made sure the code passes all unit tests. (refer to comment below)
- [x] My PR follows [PEP8](https://peps.python.org/pep-0008/) guidelines. (refer to comment below)
- [x] My PR follows [geomstats coding style](https://github.com/geomstats/geomstats/blob/master/docs/contributing.rst#coding-style-guidelines) and API.
- [x] My code is properly documented and I made sure the documentation renders properly. ([Link](https://github.com/geomstats/geomstats/blob/master/docs/contributing.rst#documentation))
- [x] I have linked to issues and PRs that are relevant to this PR.


<!-- For checking consistency of entire codebase
First, run the tests related to your changes. For example, if you changed something in geomstats/spd_matrices_space.py:
$ pytest tests/tests_geomstats/test_spd_matrices.py

and then run the tests of the whole codebase to check that your feature is not breaking any of them:
$ pytest tests/

This way, further modifications on the code base are guaranteed to be consistent with the desired behavior. Merging your PR should not break any test in any backend (numpy, tensorflow or pytorch)."

For testing in alternative backends such as `numpy`, `pytorch`, `autograd`, `tensorflow` set the environment variable using:
$ export GEOMSTATS_BACKEND=<backend_name>

Next, import the `backend` module using:
import geomstats.backend as gs
-->


<!-- For flake8 tests
Install dependencies
$ pip3 install -r dev-requirements.txt

Then run the following commands:
$ flake8 --ignore=D,W503,W504 geomstats examples tests   #shadows .flake8
$ flake8 geomstats/geometry geomstats/learning           #passed two subfolders
-->

## Description

Simply adding `gs.quantile`, mirroring `np.quantile`, `torch.quantile`, and `tfp.stats.percentile`.

## Additional context

I am using this in a project of mine because I am constructing SPD matrices using a kernel, and automatically setting the length scale of the kernel according to the median distance between points.