### PR TITLE
Update information geometry readme

### DIFF
--- a/geomstats/information_geometry/README.rst
+++ b/geomstats/information_geometry/README.rst
@@ -4,6 +4,6 @@ Geomstats information geometry module
 
 The module ``information geometry`` implements the Fisher information geometry on parametric families of probability densities.
 
-For some examples involving these geometries, see the `information geometry notebook <https://github.com/geomstats/geomstats/blob/master/notebooks/06_information_geometry.ipynb>`__.
+For some examples involving these geometries, see the `information geometry notebook <https://github.com/geomstats/geomstats/blob/master/notebooks/08_practical_methods__information_geometry.ipynb>`__ and an `application of information geometry to traffic optimization <https://github.com/geomstats/geomstats/blob/master/notebooks/18_real_world_applications__sao_paulo_traffic_optimization.ipynb>`__.
 
 If you are interested in contributing, contact us at alice.le-brigant@univ-paris1.fr.


### PR DESCRIPTION
In the README file of the information geometry module:
- Update broken link to information geometry notebook
- Add link to Sao Paulo traffic optimization notebook