### PR TITLE
Fix test skipping

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -230,7 +230,7 @@ class Parametrizer(type):
                     test_data,
                 )(test_func)
             else:
-                attrs[attr_name] = pytest.mark.skip("skipped")(attr_value)
+                attrs[attr_name] = pytest.mark.skip("skipped")(test_func)
 
         return super(Parametrizer, cls).__new__(cls, name, bases, attrs)
 


### PR DESCRIPTION
fixes and closes #1623 (thanks for spotting it out @ninamiolane).

Skip was being applied to the original function instead of the copied one.
 