### PR TITLE
Revert #1621

### DIFF
--- a/geomstats/geometry/connection.py
+++ b/geomstats/geometry/connection.py
@@ -188,21 +188,11 @@ class Connection(ABC):
 
         tangent_vec = gs.flatten(gs.random.rand(*max_shape))
 
-        try:
-            inject_radius = self.injectivity_radius(base_point)
-            inject_constraint = {
-                "type": "ineq",
-                "fun": lambda v: inject_radius - gs.linalg.norm(v),
-            }
-        except NotImplementedError:
-            inject_constraint = None
-
         res = minimize(
             objective_with_grad,
             tangent_vec,
             method="L-BFGS-B",
             jac=True,
-            constraints=inject_constraint,
             options={"disp": verbose, "maxiter": max_iter},
             tol=tol,
         )


### PR DESCRIPTION
This PR reverts #1621: as can be seen [here](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html), constraints are implemented only for "COBYLA, SLSQP and trust-constr". Therefore, the addition is being ignored by `minimize`. (This is one of the reasons I don't like scipy optimization API @ninamiolane.)

This is something to take into consideration in #1552.

Probably of your interest @franciscoeacosta.

