### PR TITLE
Make default_point_type a property

### DIFF
--- a/examples/learning_graph_embedding_and_predicting.py
+++ b/examples/learning_graph_embedding_and_predicting.py
@@ -28,7 +28,7 @@ def main():
     group_1 = mpatches.Patch(color=colors[1], label="Group 1")
     group_2 = mpatches.Patch(color=colors[2], label="Group 2")
 
-    circle = visualization.PoincareDisk(point_type="ball")
+    circle = visualization.PoincareDisk(coords_type="ball")
 
     _, ax = plt.subplots(figsize=(8, 8))
     ax.axes.xaxis.set_visible(False)
@@ -59,7 +59,7 @@ def main():
     labels = kmeans.predict(X=embeddings)
 
     colors = ["g", "c", "m"]
-    circle = visualization.PoincareDisk(point_type="ball")
+    circle = visualization.PoincareDisk(coords_type="ball")
     _, ax2 = plt.subplots(figsize=(8, 8))
     circle.set_ax(ax2)
     circle.draw(ax=ax2)
@@ -107,7 +107,7 @@ def main():
     labels = kmedoid.predict(data=embeddings)
 
     colors = ["g", "c", "m"]
-    circle = visualization.PoincareDisk(point_type="ball")
+    circle = visualization.PoincareDisk(coords_type="ball")
     _, ax2 = plt.subplots(figsize=(8, 8))
     circle.set_ax(ax2)
     circle.draw(ax=ax2)

--- a/examples/learning_graph_structured_data_h2.py
+++ b/examples/learning_graph_structured_data_h2.py
@@ -185,7 +185,7 @@ def main():
             "iteration %d loss_value %f", epoch, sum(total_loss, 0) / len(total_loss)
         )
 
-    circle = visualization.PoincareDisk(point_type="ball")
+    circle = visualization.PoincareDisk(coords_type="ball")
     plt.figure()
     ax = plt.subplot(111)
     circle.add_points(gs.array([[0, 0]]))

--- a/examples/plot_geodesics_h2.py
+++ b/examples/plot_geodesics_h2.py
@@ -10,7 +10,7 @@ import geomstats.backend as gs
 import geomstats.visualization as visualization
 from geomstats.geometry.hyperboloid import Hyperboloid
 
-H2 = Hyperboloid(dim=2, coords_type="extrinsic")
+H2 = Hyperboloid(dim=2, default_coords_type="extrinsic")
 METRIC = H2.metric
 
 

--- a/examples/plot_geodesics_poincare_polydisk.py
+++ b/examples/plot_geodesics_poincare_polydisk.py
@@ -12,7 +12,7 @@ from geomstats.geometry.poincare_polydisk import PoincarePolydisk
 
 N_DISKS = 4
 
-POINCARE_POLYDISK = PoincarePolydisk(n_disks=N_DISKS, coords_type="extrinsic")
+POINCARE_POLYDISK = PoincarePolydisk(n_disks=N_DISKS, default_coords_type="extrinsic")
 METRIC = POINCARE_POLYDISK.metric
 
 

--- a/examples/plot_kmeans_manifolds.py
+++ b/examples/plot_kmeans_manifolds.py
@@ -44,7 +44,7 @@ def kmean_poincare_ball():
         space="H2_poincare_disk",
         marker=".",
         color="black",
-        point_type=manifold.coords_type,
+        coords_type=manifold.default_coords_type,
     )
 
     for i in range(n_clusters):
@@ -54,7 +54,7 @@ def kmean_poincare_ball():
             space="H2_poincare_disk",
             marker=".",
             color=colors[i],
-            point_type=manifold.coords_type,
+            coords_type=manifold.default_coords_type,
         )
 
     ax = visualization.plot(
@@ -64,7 +64,7 @@ def kmean_poincare_ball():
         marker="*",
         color="green",
         s=100,
-        point_type=manifold.coords_type,
+        coords_type=manifold.default_coords_type,
     )
 
     ax.set_title("Kmeans on Poincaré Ball Manifold")

--- a/examples/plot_kmeans_manifolds.py
+++ b/examples/plot_kmeans_manifolds.py
@@ -44,7 +44,7 @@ def kmean_poincare_ball():
         space="H2_poincare_disk",
         marker=".",
         color="black",
-        point_type=manifold.point_type,
+        point_type=manifold.coords_type,
     )
 
     for i in range(n_clusters):
@@ -54,7 +54,7 @@ def kmean_poincare_ball():
             space="H2_poincare_disk",
             marker=".",
             color=colors[i],
-            point_type=manifold.point_type,
+            point_type=manifold.coords_type,
         )
 
     ax = visualization.plot(
@@ -64,7 +64,7 @@ def kmean_poincare_ball():
         marker="*",
         color="green",
         s=100,
-        point_type=manifold.point_type,
+        point_type=manifold.coords_type,
     )
 
     ax.set_title("Kmeans on Poincaré Ball Manifold")

--- a/examples/plot_kmedoids_manifolds.py
+++ b/examples/plot_kmedoids_manifolds.py
@@ -44,7 +44,7 @@ def kmedoids_poincare_ball():
         space="H2_poincare_disk",
         marker=".",
         color="black",
-        point_type=manifold.coords_type,
+        coords_type=manifold.default_coords_type,
     )
 
     for i in range(n_clusters):
@@ -54,7 +54,7 @@ def kmedoids_poincare_ball():
             space="H2_poincare_disk",
             marker=".",
             color=colors[i],
-            point_type=manifold.coords_type,
+            coords_type=manifold.default_coords_type,
         )
 
     ax = visualization.plot(
@@ -64,7 +64,7 @@ def kmedoids_poincare_ball():
         marker="*",
         color="green",
         s=100,
-        point_type=manifold.coords_type,
+        coords_type=manifold.default_coords_type,
     )
 
     ax.set_title("Kmedoids on Poincaré Ball Manifold")

--- a/examples/plot_kmedoids_manifolds.py
+++ b/examples/plot_kmedoids_manifolds.py
@@ -44,7 +44,7 @@ def kmedoids_poincare_ball():
         space="H2_poincare_disk",
         marker=".",
         color="black",
-        point_type=manifold.point_type,
+        point_type=manifold.coords_type,
     )
 
     for i in range(n_clusters):
@@ -54,7 +54,7 @@ def kmedoids_poincare_ball():
             space="H2_poincare_disk",
             marker=".",
             color=colors[i],
-            point_type=manifold.point_type,
+            point_type=manifold.coords_type,
         )
 
     ax = visualization.plot(
@@ -64,7 +64,7 @@ def kmedoids_poincare_ball():
         marker="*",
         color="green",
         s=100,
-        point_type=manifold.point_type,
+        point_type=manifold.coords_type,
     )
 
     ax.set_title("Kmedoids on Poincaré Ball Manifold")

--- a/examples/plot_square_h2_poincare_half_plane.py
+++ b/examples/plot_square_h2_poincare_half_plane.py
@@ -35,7 +35,7 @@ def main():
         edge_points,
         ax=ax,
         space="H2_poincare_half_plane",
-        point_type="extrinsic",
+        coords_type="extrinsic",
         marker=".",
         color="black",
     )

--- a/geomstats/geometry/_hyperbolic.py
+++ b/geomstats/geometry/_hyperbolic.py
@@ -354,7 +354,8 @@ class _Hyperbolic:
         -------
         point_to : array-like, shape=[..., dim]
                                or shape=[n_sample, dim + 1]
-            Point in hyperbolic space in coordinates given by to_point_type.
+            Point in hyperbolic space in coordinates given by
+            to_coordinates_system.
         """
         coords_transform = {
             "ball-extrinsic": _Hyperbolic._ball_to_extrinsic_coordinates,
@@ -389,7 +390,7 @@ class _Hyperbolic:
         Returns
         -------
         point_to : array-like, shape=[..., {dim, dim + 1}]
-            Point in hyperbolic space in coordinates given by to_point_type.
+            Point in hyperbolic space in coordinates given by to_coords_type.
         """
         return _Hyperbolic.change_coordinates_system(
             point, self.coords_type, to_coords_type
@@ -404,7 +405,7 @@ class _Hyperbolic:
         Parameters
         ----------
         point : array-like, shape=[..., {dim, dim + 1}]
-            Point in hyperbolic space in coordinates from_point_type.
+            Point in hyperbolic space in coordinates from_coords_type.
         from_coords_type : str, {'ball', 'extrinsic', 'intrinsic', ...}
             Coordinates type.
 

--- a/geomstats/geometry/_hyperbolic.py
+++ b/geomstats/geometry/_hyperbolic.py
@@ -21,20 +21,14 @@ class _Hyperbolic:
 
     Parameters
     ----------
-    dim : int
-        Dimension of the hyperbolic space.
-    coords_type : str, {'extrinsic', 'intrinsic', etc}
-        Default coordinates to represent points in hyperbolic space.
-        Optional, default: 'extrinsic'.
     scale : int
         Scale of the hyperbolic space, defined as the set of points
         in Minkowski space whose squared norm is equal to -scale.
         Optional, default: 1.
     """
 
-    def __init__(self, dim, scale=1, **kwargs):
-        super(_Hyperbolic, self).__init__(dim=dim, **kwargs)
-        self.dim = dim
+    def __init__(self, scale=1, **kwargs):
+        super(_Hyperbolic, self).__init__(**kwargs)
         self.scale = scale
 
     @staticmethod
@@ -393,7 +387,7 @@ class _Hyperbolic:
             Point in hyperbolic space in coordinates given by to_coords_type.
         """
         return _Hyperbolic.change_coordinates_system(
-            point, self.coords_type, to_coords_type
+            point, self.default_coords_type, to_coords_type
         )
 
     def from_coordinates(self, point, from_coords_type):
@@ -415,7 +409,7 @@ class _Hyperbolic:
             Point in hyperbolic space.
         """
         return _Hyperbolic.change_coordinates_system(
-            point, from_coords_type, self.coords_type
+            point, from_coords_type, self.default_coords_type
         )
 
     def random_point(self, n_samples=1, bound=1.0):
@@ -445,7 +439,7 @@ class _Hyperbolic:
         samples = bound * 2.0 * (gs.random.rand(*size) - 0.5)
 
         samples = _Hyperbolic.change_coordinates_system(
-            samples, "intrinsic", self.coords_type
+            samples, "intrinsic", self.default_coords_type
         )
 
         if n_samples == 1:
@@ -460,18 +454,19 @@ class HyperbolicMetric(RiemannianMetric):
     ----------
     dim : int
         Dimension of the hyperbolic space.
-    coords_type : str, {'extrinsic', 'intrinsic', etc}, optional
+    default_coords_type : str, {'extrinsic', 'intrinsic', etc}, optional
         Default coordinates to represent points in hyperbolic space.
     scale : int, optional
         Scale of the hyperbolic space, defined as the set of points
         in Minkowski space whose squared norm is equal to -scale.
     """
 
-    default_coords_type = "extrinsic"
-
-    def __init__(self, dim, scale=1):
+    def __init__(self, dim, scale=1, default_coords_type="extrinsic"):
         super(HyperbolicMetric, self).__init__(
-            dim=dim, signature=(dim, 0), shape=(dim + 1,)
+            dim=dim,
+            signature=(dim, 0),
+            shape=(dim + 1,),
+            default_coords_type=default_coords_type,
         )
 
         self.scale = scale

--- a/geomstats/geometry/_hyperbolic.py
+++ b/geomstats/geometry/_hyperbolic.py
@@ -23,7 +23,7 @@ class _Hyperbolic:
     ----------
     dim : int
         Dimension of the hyperbolic space.
-    point_type : str, {'extrinsic', 'intrinsic', etc}
+    coords_type : str, {'extrinsic', 'intrinsic', etc}
         Default coordinates to represent points in hyperbolic space.
         Optional, default: 'extrinsic'.
     scale : int
@@ -459,19 +459,19 @@ class HyperbolicMetric(RiemannianMetric):
     ----------
     dim : int
         Dimension of the hyperbolic space.
-    point_type : str, {'extrinsic', 'intrinsic', etc}, optional
+    coords_type : str, {'extrinsic', 'intrinsic', etc}, optional
         Default coordinates to represent points in hyperbolic space.
     scale : int, optional
         Scale of the hyperbolic space, defined as the set of points
         in Minkowski space whose squared norm is equal to -scale.
     """
 
-    default_point_type = "vector"
     default_coords_type = "extrinsic"
 
     def __init__(self, dim, scale=1):
-        super(HyperbolicMetric, self).__init__(dim=dim, signature=(dim, 0))
-        self.point_type = HyperbolicMetric.default_point_type
+        super(HyperbolicMetric, self).__init__(
+            dim=dim, signature=(dim, 0), shape=(dim + 1,)
+        )
 
         self.scale = scale
 

--- a/geomstats/geometry/base.py
+++ b/geomstats/geometry/base.py
@@ -8,8 +8,6 @@ import abc
 import geomstats.backend as gs
 from geomstats.geometry.manifold import Manifold
 
-POINT_TYPES = {1: "vector", 2: "matrix"}
-
 
 class VectorSpace(Manifold, abc.ABC):
     """Abstract class for vector spaces.
@@ -19,9 +17,6 @@ class VectorSpace(Manifold, abc.ABC):
     shape : tuple
         Shape of the elements of the vector space. The dimension is the
         product of these values by default.
-    default_point_type : str, {'vector', 'matrix'}
-        Point type.
-        Optional, default: 'vector'.
     """
 
     def __init__(self, shape, **kwargs):
@@ -187,10 +182,7 @@ class LevelSet(Manifold, abc.ABC):
     ):
         kwargs.setdefault("shape", embedding_space.shape)
         super(LevelSet, self).__init__(
-            dim=dim,
-            default_point_type=embedding_space.default_point_type,
-            default_coords_type=default_coords_type,
-            **kwargs
+            dim=dim, default_coords_type=default_coords_type, **kwargs
         )
         self.embedding_space = embedding_space
         self.embedding_metric = embedding_space.metric
@@ -335,7 +327,6 @@ class OpenSet(Manifold, abc.ABC):
     """
 
     def __init__(self, dim, ambient_space, **kwargs):
-        kwargs.setdefault("default_point_type", ambient_space.default_point_type)
         kwargs.setdefault("shape", ambient_space.shape)
         super().__init__(dim=dim, **kwargs)
         self.ambient_space = ambient_space

--- a/geomstats/geometry/discrete_curves.py
+++ b/geomstats/geometry/discrete_curves.py
@@ -65,7 +65,6 @@ class DiscreteCurves(Manifold):
         super(DiscreteCurves, self).__init__(
             dim=dim,
             shape=(k_sampling_points,) + ambient_manifold.shape,
-            default_point_type="matrix",
             **kwargs,
         )
         self.ambient_manifold = ambient_manifold
@@ -281,7 +280,7 @@ class ClosedDiscreteCurves(LevelSet):
         dim = ambient_manifold.dim * (k_sampling_points - 1)
         super(ClosedDiscreteCurves, self).__init__(
             dim=dim,
-            shape=(),
+            shape=(k_sampling_points,) + ambient_manifold.shape,
             submersion=None,
             tangent_submersion=None,
             value=None,
@@ -583,7 +582,11 @@ class L2CurvesMetric(RiemannianMetric):
     """
 
     def __init__(self, ambient_manifold, ambient_metric=None):
-        super(L2CurvesMetric, self).__init__(dim=math.inf, signature=(math.inf, 0, 0))
+        super(L2CurvesMetric, self).__init__(
+            dim=math.inf,
+            signature=(math.inf, 0, 0),
+            shape=(None,) + ambient_manifold.shape,
+        )
         if ambient_metric is None:
             if hasattr(ambient_manifold, "metric"):
                 self.ambient_metric = ambient_manifold.metric
@@ -831,7 +834,9 @@ class ElasticMetric(RiemannianMetric):
         self, a, b, ambient_manifold=R2, ambient_metric=None, translation_invariant=True
     ):
         super(ElasticMetric, self).__init__(
-            dim=math.inf, signature=(math.inf, 0, 0), default_point_type="matrix"
+            dim=math.inf,
+            signature=(math.inf, 0, 0),
+            shape=(None,) + ambient_manifold.shape,
         )
         self.ambient_metric = ambient_metric
         if ambient_metric is None:
@@ -2130,7 +2135,11 @@ class SRVQuotientMetric(QuotientMetric):
     def __init__(self, ambient_manifold, k_sampling_points=10):
         dim = ambient_manifold.dim * k_sampling_points
         bundle = SRVShapeBundle(ambient_manifold, dim)
-        super(SRVQuotientMetric, self).__init__(fiber_bundle=bundle, dim=dim)
+        super(SRVQuotientMetric, self).__init__(
+            fiber_bundle=bundle,
+            dim=dim,
+            shape=(k_sampling_points,) + ambient_manifold.shape,
+        )
 
     def geodesic(self, initial_point, end_point, threshold=1e-3):
         """Geodesic for the quotient SRV Metric.

--- a/geomstats/geometry/euclidean.py
+++ b/geomstats/geometry/euclidean.py
@@ -20,18 +20,11 @@ class Euclidean(VectorSpace):
     def __init__(self, dim):
         super(Euclidean, self).__init__(
             shape=(dim,),
-            default_point_type="vector",
             metric=EuclideanMetric(dim, shape=(dim,)),
         )
 
     def get_identity(self):
         """Get the identity of the group.
-
-        Parameters
-        ----------
-        point_type : str, {'vector', 'matrix'}
-            The point_type of the returned value.
-            Optional, default: self.default_point_type
 
         Returns
         -------

--- a/geomstats/geometry/full_rank_correlation_matrices.py
+++ b/geomstats/geometry/full_rank_correlation_matrices.py
@@ -262,6 +262,8 @@ class FullRankCorrelationAffineQuotientMetric(QuotientMetric):
     """
 
     def __init__(self, n):
+        fiber_bundle = CorrelationMatricesBundle(n=n)
         super(FullRankCorrelationAffineQuotientMetric, self).__init__(
-            fiber_bundle=CorrelationMatricesBundle(n=n)
+            fiber_bundle=fiber_bundle,
+            shape=fiber_bundle.shape,
         )

--- a/geomstats/geometry/heisenberg.py
+++ b/geomstats/geometry/heisenberg.py
@@ -35,13 +35,8 @@ class HeisenbergVectors(LieGroup, VectorSpace):
         """Create the canonical basis."""
         return gs.eye(3)
 
-    def get_identity(self, point_type="vector"):
+    def get_identity(self):
         """Get the identity of the 3D Heisenberg group.
-
-        Parameters
-        ----------
-        point_type : str, {'vector', 'matrix'}
-            Point_type of the returned value. Unused here.
 
         Returns
         -------

--- a/geomstats/geometry/hermitian.py
+++ b/geomstats/geometry/hermitian.py
@@ -22,9 +22,7 @@ class Hermitian(VectorSpace):
 
     def __init__(self, dim, **kwargs):
         kwargs.setdefault("metric", HermitianMetric(dim, shape=(dim,)))
-        super(Hermitian, self).__init__(
-            shape=(dim,), default_point_type="vector", **kwargs
-        )
+        super(Hermitian, self).__init__(shape=(dim,), **kwargs)
 
     def get_identity(self):
         """Get the identity of the group.

--- a/geomstats/geometry/hyperbolic.py
+++ b/geomstats/geometry/hyperbolic.py
@@ -4,14 +4,12 @@ Lead author: Thomas Gerald.
 """
 
 import geomstats.errors as errors
-from geomstats.geometry._hyperbolic import _Hyperbolic
 from geomstats.geometry.hyperboloid import Hyperboloid
-from geomstats.geometry.manifold import Manifold
 from geomstats.geometry.poincare_ball import PoincareBall
 from geomstats.geometry.poincare_half_space import PoincareHalfSpace
 
 
-class Hyperbolic(_Hyperbolic, Manifold):
+class Hyperbolic:
     """Class for the n-dimensional Hyperbolic space.
 
     This class is a common interface to the different models of hyperbolic
@@ -44,7 +42,7 @@ class Hyperbolic(_Hyperbolic, Manifold):
             ["extrinsic", "ball", "half-space"],
         )
         if default_coords_type == "extrinsic":
-            return Hyperboloid(*args, **kwargs)
+            return Hyperboloid(*args, default_coords_type=default_coords_type, **kwargs)
         if default_coords_type == "ball":
             return PoincareBall(*args, **kwargs)
         return PoincareHalfSpace(*args, **kwargs)

--- a/geomstats/geometry/hyperboloid.py
+++ b/geomstats/geometry/hyperboloid.py
@@ -23,14 +23,14 @@ class Hyperboloid(_Hyperbolic, LevelSet):
     n+1)-dimensional Minkowski space. For other representations of
     hyperbolic spaces see the `Hyperbolic` class.
 
-    The coords_type parameter allows to choose the
+    The default_coords_type parameter allows to choose the
     representation of the points as input.
 
     Parameters
     ----------
     dim : int
         Dimension of the hyperbolic space.
-    coords_type : str, {'extrinsic', 'intrinsic'}
+    default_coords_type : str, {'extrinsic', 'intrinsic'}
         Default coordinates to represent points in hyperbolic space.
         Optional, default: 'extrinsic'.
     scale : int
@@ -39,20 +39,19 @@ class Hyperboloid(_Hyperbolic, LevelSet):
         Optional, default: 1.
     """
 
-    def __init__(self, dim, coords_type="extrinsic", scale=1, **kwargs):
-        # TODO: coords_type vs default_coords_type?
+    def __init__(self, dim, default_coords_type="extrinsic", scale=1, **kwargs):
         minkowski = Minkowski(dim + 1)
-        kwargs.setdefault("metric", HyperboloidMetric(dim, coords_type, scale))
+        kwargs.setdefault("metric", HyperboloidMetric(dim, default_coords_type, scale))
         super(Hyperboloid, self).__init__(
             dim=dim,
             embedding_space=minkowski,
             submersion=minkowski.metric.squared_norm,
             value=-1.0,
             tangent_submersion=minkowski.metric.inner_product,
+            default_coords_type=default_coords_type,
             scale=scale,
             **kwargs
         )
-        self.coords_type = coords_type
 
     def belongs(self, point, atol=gs.atol):
         """Test if a point belongs to the hyperbolic space.
@@ -78,7 +77,7 @@ class Hyperboloid(_Hyperbolic, LevelSet):
         point_dim = point.shape[-1]
         if point_dim is not self.dim + 1:
             belongs = False
-            if point_dim is self.dim and self.coords_type == "intrinsic":
+            if point_dim is self.dim and self.default_coords_type == "intrinsic":
                 belongs = True
             if gs.ndim(point) == 2:
                 belongs = gs.tile([belongs], (point.shape[0],))
@@ -125,7 +124,7 @@ class Hyperboloid(_Hyperbolic, LevelSet):
             Point in hyperbolic space in canonical representation
             in extrinsic coordinates.
         """
-        if self.coords_type == "intrinsic":
+        if self.default_coords_type == "intrinsic":
             point = self.intrinsic_to_extrinsic_coords(point)
 
         sq_norm = self.embedding_metric.squared_norm(point)
@@ -159,7 +158,7 @@ class Hyperboloid(_Hyperbolic, LevelSet):
             Tangent vector at the base point, equal to the projection of
             the vector in Minkowski space.
         """
-        if self.coords_type == "intrinsic":
+        if self.default_coords_type == "intrinsic":
             base_point = self.intrinsic_to_extrinsic_coords(base_point)
 
         sq_norm = self.embedding_metric.squared_norm(base_point)
@@ -244,7 +243,7 @@ class HyperboloidMetric(HyperbolicMetric):
     ----------
     dim : int
         Dimension of the hyperbolic space.
-    coords_type : str, {'extrinsic', 'intrinsic', etc}
+    default_coords_type : str, {'extrinsic', 'intrinsic', etc}
         Default coordinates to represent points in hyperbolic space.
         Optional, default: 'extrinsic'.
     scale : int
@@ -253,12 +252,11 @@ class HyperboloidMetric(HyperbolicMetric):
         Optional, default: 1.
     """
 
-    def __init__(self, dim, coords_type="extrinsic", scale=1):
-        super(HyperboloidMetric, self).__init__(dim=dim, scale=scale)
+    def __init__(self, dim, default_coords_type="extrinsic", scale=1):
+        super(HyperboloidMetric, self).__init__(
+            dim=dim, scale=scale, default_coords_type=default_coords_type
+        )
         self.embedding_metric = MinkowskiMetric(dim + 1)
-
-        self.coords_type = coords_type
-
         self.scale = scale
 
     def metric_matrix(self, base_point=None):
@@ -356,7 +354,7 @@ class HyperboloidMetric(HyperbolicMetric):
     def log(self, point, base_point):
         """Compute Riemannian logarithm of a point wrt a base point.
 
-        If coords_type is 'poincare' then base_point belongs
+        If `default_coords_type` is 'poincare' then base_point belongs
         to the Poincare ball and point is a vector in the Euclidean
         space of the same dimension as the ball.
 

--- a/geomstats/geometry/hyperboloid.py
+++ b/geomstats/geometry/hyperboloid.py
@@ -356,7 +356,7 @@ class HyperboloidMetric(HyperbolicMetric):
     def log(self, point, base_point):
         """Compute Riemannian logarithm of a point wrt a base point.
 
-        If point_type = 'poincare' then base_point belongs
+        If coords_type is 'poincare' then base_point belongs
         to the Poincare ball and point is a vector in the Euclidean
         space of the same dimension as the ball.
 

--- a/geomstats/geometry/hyperboloid.py
+++ b/geomstats/geometry/hyperboloid.py
@@ -39,10 +39,8 @@ class Hyperboloid(_Hyperbolic, LevelSet):
         Optional, default: 1.
     """
 
-    default_coords_type = "extrinsic"
-    default_point_type = "vector"
-
     def __init__(self, dim, coords_type="extrinsic", scale=1, **kwargs):
+        # TODO: coords_type vs default_coords_type?
         minkowski = Minkowski(dim + 1)
         kwargs.setdefault("metric", HyperboloidMetric(dim, coords_type, scale))
         super(Hyperboloid, self).__init__(
@@ -55,7 +53,6 @@ class Hyperboloid(_Hyperbolic, LevelSet):
             **kwargs
         )
         self.coords_type = coords_type
-        self.point_type = Hyperboloid.default_point_type
 
     def belongs(self, point, atol=gs.atol):
         """Test if a point belongs to the hyperbolic space.
@@ -247,7 +244,7 @@ class HyperboloidMetric(HyperbolicMetric):
     ----------
     dim : int
         Dimension of the hyperbolic space.
-    point_type : str, {'extrinsic', 'intrinsic', etc}
+    coords_type : str, {'extrinsic', 'intrinsic', etc}
         Default coordinates to represent points in hyperbolic space.
         Optional, default: 'extrinsic'.
     scale : int
@@ -256,15 +253,11 @@ class HyperboloidMetric(HyperbolicMetric):
         Optional, default: 1.
     """
 
-    default_point_type = "vector"
-    default_coords_type = "extrinsic"
-
     def __init__(self, dim, coords_type="extrinsic", scale=1):
         super(HyperboloidMetric, self).__init__(dim=dim, scale=scale)
         self.embedding_metric = MinkowskiMetric(dim + 1)
 
         self.coords_type = coords_type
-        self.point_type = HyperbolicMetric.default_point_type
 
         self.scale = scale
 

--- a/geomstats/geometry/hypersphere.py
+++ b/geomstats/geometry/hypersphere.py
@@ -876,7 +876,7 @@ class HypersphereMetric(RiemannianMetric):
         )
         return transported
 
-    def christoffels(self, point, point_type="spherical"):
+    def christoffels(self, point, coords_type="spherical"):
         """Compute the Christoffel symbols at a point.
 
         Only implemented in dimension 2 and for spherical coordinates.
@@ -886,7 +886,7 @@ class HypersphereMetric(RiemannianMetric):
         point : array-like, shape=[..., dim]
             Point on hypersphere where the Christoffel symbols are computed.
 
-        point_type: str, {'spherical', 'intrinsic', 'extrinsic'}
+        coords_type: str, {'spherical', 'intrinsic', 'extrinsic'}
             Coordinates in which to express the Christoffel symbols.
             Optional, default: 'spherical'.
 
@@ -896,7 +896,7 @@ class HypersphereMetric(RiemannianMetric):
                                          covariant index, 2nd covariant index]
             Christoffel symbols at point.
         """
-        if self.dim != 2 or point_type != "spherical":
+        if self.dim != 2 or coords_type != "spherical":
             raise NotImplementedError(
                 "The Christoffel symbols are only implemented"
                 " for spherical coordinates in the 2-sphere"

--- a/geomstats/geometry/invariant_metric.py
+++ b/geomstats/geometry/invariant_metric.py
@@ -1149,7 +1149,7 @@ class InvariantMetric(_InvariantMetricVector, _InvariantMetricMatrix):
     This class supports both left and right invariant metrics
     which exist on Lie groups.
 
-    If `point_type='vector'`, points are parameterized by the Riemannian
+    If `point_type == 'vector'`, points are parameterized by the Riemannian
     logarithm for the canonical left-invariant metric.
 
     Parameters

--- a/geomstats/geometry/invariant_metric.py
+++ b/geomstats/geometry/invariant_metric.py
@@ -47,7 +47,7 @@ class _InvariantMetricMatrix(RiemannianMetric):
         self, group, metric_mat_at_identity=None, left_or_right="left", **kwargs
     ):
         super(_InvariantMetricMatrix, self).__init__(
-            dim=group.dim, default_point_type="matrix", **kwargs
+            dim=group.dim, shape=group.shape, **kwargs
         )
 
         self.group = group
@@ -870,7 +870,9 @@ class _InvariantMetricVector(RiemannianMetric):
     """
 
     def __init__(self, group, left_or_right="left", **kwargs):
-        super(_InvariantMetricVector, self).__init__(dim=group.dim, **kwargs)
+        super(_InvariantMetricVector, self).__init__(
+            dim=group.dim, shape=group.shape, **kwargs
+        )
 
         self.group = group
         self.metric_mat_at_identity = gs.eye(group.dim)
@@ -1204,7 +1206,7 @@ class BiInvariantMetric(_InvariantMetricVector):
     """
 
     def __init__(self, group):
-        super(BiInvariantMetric, self).__init__(group=group, shape=group.shape)
+        super(BiInvariantMetric, self).__init__(group=group)
         condition = (
             "SpecialOrthogonal" not in group.__str__()
             and "SO" not in group.__str__()
@@ -1213,7 +1215,6 @@ class BiInvariantMetric(_InvariantMetricVector):
         # TODO (nguigs): implement it for SE(3)
         if condition:
             raise ValueError("The bi-invariant metric is only implemented for SO(n)")
-        self.default_point_type = group.default_point_type
 
     def exp(self, tangent_vec, base_point=None, **kwargs):
         """Compute Riemannian exponential of tangent vector from the identity.

--- a/geomstats/geometry/lie_group.py
+++ b/geomstats/geometry/lie_group.py
@@ -279,9 +279,6 @@ class LieGroup(Manifold, abc.ABC):
     ----------
     dim : int
         Dimension of the Lie group.
-    default_point_type : str, {'vector', 'matrix'}
-        Point type.
-        Optional, default: 'vector'.
     lie_algebra : MatrixLieAlgebra
         Lie algebra for matrix groups.
         Optional, default: None.
@@ -298,12 +295,8 @@ class LieGroup(Manifold, abc.ABC):
         product at the identity.
     """
 
-    def __init__(
-        self, dim, shape, default_point_type="vector", lie_algebra=None, **kwargs
-    ):
-        super(LieGroup, self).__init__(
-            dim=dim, shape=shape, default_point_type=default_point_type, **kwargs
-        )
+    def __init__(self, dim, shape, lie_algebra=None, **kwargs):
+        super(LieGroup, self).__init__(dim=dim, shape=shape, **kwargs)
 
         self.lie_algebra = lie_algebra
         self.left_canonical_metric = InvariantMetric(
@@ -317,14 +310,8 @@ class LieGroup(Manifold, abc.ABC):
         self.metric = self.left_canonical_metric
         self.metrics = []
 
-    def get_identity(self, point_type=None):
+    def get_identity(self):
         """Get the identity of the group.
-
-        Parameters
-        ----------
-        point_type : str, {'matrix', 'vector'}
-            Point type.
-            Optional, default: None.
 
         Returns
         -------
@@ -574,7 +561,7 @@ class LieGroup(Manifold, abc.ABC):
         """
         # TODO (ninamiolane): Build a standalone decorator that *only*
         # deals with point_type None and base_point None
-        identity = self.get_identity(point_type=self.default_point_type)
+        identity = self.get_identity()
         if base_point is None:
             base_point = identity
 
@@ -619,7 +606,7 @@ class LieGroup(Manifold, abc.ABC):
             Lie bracket.
         """
         if base_point is None:
-            base_point = self.get_identity(point_type=self.default_point_type)
+            base_point = self.get_identity()
         inverse_base_point = self.inverse(base_point)
 
         first_term = Matrices.mul(inverse_base_point, tangent_vector_b)

--- a/geomstats/geometry/lower_triangular_matrices.py
+++ b/geomstats/geometry/lower_triangular_matrices.py
@@ -20,10 +20,7 @@ class LowerTriangularMatrices(VectorSpace):
     def __init__(self, n, **kwargs):
         kwargs.setdefault("metric", MatricesMetric(n, n))
         super(LowerTriangularMatrices, self).__init__(
-            dim=int(n * (n + 1) / 2),
-            shape=(n, n),
-            default_point_type="matrix",
-            **kwargs
+            dim=int(n * (n + 1) / 2), shape=(n, n), **kwargs
         )
         self.n = n
 

--- a/geomstats/geometry/manifold.py
+++ b/geomstats/geometry/manifold.py
@@ -12,8 +12,6 @@ import geomstats.backend as gs
 import geomstats.errors
 from geomstats.geometry.riemannian_metric import RiemannianMetric
 
-POINT_TYPES = {1: "vector", 2: "matrix"}
-
 
 class Manifold(abc.ABC):
     r"""Class for manifolds.
@@ -27,40 +25,34 @@ class Manifold(abc.ABC):
         Optional, default : None.
     metric : RiemannianMetric
         Metric object to use on the manifold.
-    default_point_type : str, {\'vector\', \'matrix\'}
-        Point type.
-        Optional, default: 'vector'.
     default_coords_type : str, {\'intrinsic\', \'extrinsic\', etc}
         Coordinate type.
         Optional, default: 'intrinsic'.
     """
 
     def __init__(
-        self,
-        dim,
-        shape,
-        metric=None,
-        default_point_type=None,
-        default_coords_type="intrinsic",
-        **kwargs
+        self, dim, shape, metric=None, default_coords_type="intrinsic", **kwargs
     ):
         super(Manifold, self).__init__(**kwargs)
         geomstats.errors.check_integer(dim, "dim")
 
         if not isinstance(shape, tuple):
             raise ValueError("Expected a tuple for the shape argument.")
-        if default_point_type is None:
-            default_point_type = POINT_TYPES[len(shape)]
-
-        geomstats.errors.check_parameter_accepted_values(
-            default_point_type, "default_point_type", ["vector", "matrix"]
-        )
 
         self.dim = dim
         self.shape = shape
-        self.default_point_type = default_point_type
         self.default_coords_type = default_coords_type
         self._metric = metric
+
+    @property
+    def default_point_type(self):
+        """Point type.
+
+        `vector` or `matrix`.
+        """
+        if len(self.shape) == 1:
+            return "vector"
+        return "matrix"
 
     @abc.abstractmethod
     def belongs(self, point, atol=gs.atol):

--- a/geomstats/geometry/matrices.py
+++ b/geomstats/geometry/matrices.py
@@ -22,7 +22,6 @@ class Matrices(VectorSpace):
         geomstats.errors.check_integer(n, "n")
         geomstats.errors.check_integer(m, "m")
         kwargs.setdefault("metric", MatricesMetric(m, n))
-        kwargs.setdefault("default_point_type", "matrix")
         super(Matrices, self).__init__(shape=(m, n), **kwargs)
         self.m = m
         self.n = n

--- a/geomstats/geometry/poincare_ball.py
+++ b/geomstats/geometry/poincare_ball.py
@@ -19,6 +19,8 @@ NORMALIZATION_FACTOR_CST = gs.sqrt(gs.pi / 2)
 PI_2_3 = gs.power(gs.array([2.0 * gs.pi]), gs.array([2 / 3]))
 SQRT_2 = gs.sqrt(2.0)
 
+COORDS_TYPE = "ball"
+
 
 class PoincareBall(_Hyperbolic, OpenSet):
     """Class for the n-dimensional Poincare ball.
@@ -36,9 +38,6 @@ class PoincareBall(_Hyperbolic, OpenSet):
         Optional, default: 1.
     """
 
-    default_coords_type = "ball"
-    default_point_type = "vector"
-
     def __init__(self, dim, scale=1):
         super(PoincareBall, self).__init__(
             dim=dim,
@@ -46,8 +45,7 @@ class PoincareBall(_Hyperbolic, OpenSet):
             scale=scale,
             metric=PoincareBallMetric(dim, scale),
         )
-        self.coords_type = PoincareBall.default_coords_type
-        self.point_type = PoincareBall.default_point_type
+        self.coords_type = COORDS_TYPE
 
     def belongs(self, point, atol=gs.atol):
         """Test if a point belongs to the hyperbolic space.
@@ -115,13 +113,9 @@ class PoincareBallMetric(RiemannianMetric):
         Optional, default 1.
     """
 
-    default_point_type = "vector"
-    default_coords_type = "ball"
-
     def __init__(self, dim, scale=1):
         super(PoincareBallMetric, self).__init__(dim=dim, signature=(dim, 0))
-        self.coords_type = PoincareBall.default_coords_type
-        self.point_type = PoincareBall.default_point_type
+        self.coords_type = COORDS_TYPE
         self.scale = scale
 
     def exp(self, tangent_vec, base_point, **kwargs):

--- a/geomstats/geometry/poincare_ball.py
+++ b/geomstats/geometry/poincare_ball.py
@@ -19,7 +19,7 @@ NORMALIZATION_FACTOR_CST = gs.sqrt(gs.pi / 2)
 PI_2_3 = gs.power(gs.array([2.0 * gs.pi]), gs.array([2 / 3]))
 SQRT_2 = gs.sqrt(2.0)
 
-COORDS_TYPE = "ball"
+_COORDS_TYPE = "ball"
 
 
 class PoincareBall(_Hyperbolic, OpenSet):
@@ -44,8 +44,8 @@ class PoincareBall(_Hyperbolic, OpenSet):
             ambient_space=Euclidean(dim),
             scale=scale,
             metric=PoincareBallMetric(dim, scale),
+            default_coords_type=_COORDS_TYPE,
         )
-        self.coords_type = COORDS_TYPE
 
     def belongs(self, point, atol=gs.atol):
         """Test if a point belongs to the hyperbolic space.
@@ -114,8 +114,11 @@ class PoincareBallMetric(RiemannianMetric):
     """
 
     def __init__(self, dim, scale=1):
-        super(PoincareBallMetric, self).__init__(dim=dim, signature=(dim, 0))
-        self.coords_type = COORDS_TYPE
+        super(PoincareBallMetric, self).__init__(
+            dim=dim,
+            signature=(dim, 0),
+            default_coords_type=_COORDS_TYPE,
+        )
         self.scale = scale
 
     def exp(self, tangent_vec, base_point, **kwargs):

--- a/geomstats/geometry/poincare_half_space.py
+++ b/geomstats/geometry/poincare_half_space.py
@@ -14,6 +14,8 @@ from geomstats.geometry.euclidean import Euclidean
 from geomstats.geometry.poincare_ball import PoincareBall
 from geomstats.geometry.riemannian_metric import RiemannianMetric
 
+COORDS_TYPE = "half-space"
+
 
 class PoincareHalfSpace(_Hyperbolic, OpenSet):
     """Class for the n-dimensional Poincare half-space.
@@ -30,9 +32,6 @@ class PoincareHalfSpace(_Hyperbolic, OpenSet):
         in Minkowski space whose squared norm is equal to -scale.
     """
 
-    default_coords_type = "half-space"
-    default_point_type = "vector"
-
     def __init__(self, dim, scale=1):
         super(PoincareHalfSpace, self).__init__(
             dim=dim,
@@ -40,8 +39,7 @@ class PoincareHalfSpace(_Hyperbolic, OpenSet):
             scale=scale,
             metric=PoincareHalfSpaceMetric(dim, scale),
         )
-        self.coords_type = PoincareHalfSpace.default_coords_type
-        self.point_type = PoincareHalfSpace.default_point_type
+        self.coords_type = COORDS_TYPE
 
     def belongs(self, point, atol=gs.atol):
         """Evaluate if a point belongs to the upper half space.
@@ -102,13 +100,9 @@ class PoincareHalfSpaceMetric(RiemannianMetric):
         Optional, default: 1.
     """
 
-    default_point_type = "vector"
-    default_coords_type = "half-space"
-
     def __init__(self, dim, scale=1.0):
         super(PoincareHalfSpaceMetric, self).__init__(dim=dim, signature=(dim, 0))
-        self.coords_type = PoincareHalfSpace.default_coords_type
-        self.point_type = PoincareHalfSpace.default_point_type
+        self.coords_type = COORDS_TYPE
         self.scale = scale
         self.poincare_ball = PoincareBall(dim=dim, scale=scale)
 

--- a/geomstats/geometry/poincare_half_space.py
+++ b/geomstats/geometry/poincare_half_space.py
@@ -14,8 +14,6 @@ from geomstats.geometry.euclidean import Euclidean
 from geomstats.geometry.poincare_ball import PoincareBall
 from geomstats.geometry.riemannian_metric import RiemannianMetric
 
-COORDS_TYPE = "half-space"
-
 
 class PoincareHalfSpace(_Hyperbolic, OpenSet):
     """Class for the n-dimensional Poincare half-space.
@@ -38,8 +36,8 @@ class PoincareHalfSpace(_Hyperbolic, OpenSet):
             ambient_space=Euclidean(dim),
             scale=scale,
             metric=PoincareHalfSpaceMetric(dim, scale),
+            default_coords_type="half-space",
         )
-        self.coords_type = COORDS_TYPE
 
     def belongs(self, point, atol=gs.atol):
         """Evaluate if a point belongs to the upper half space.
@@ -101,10 +99,13 @@ class PoincareHalfSpaceMetric(RiemannianMetric):
     """
 
     def __init__(self, dim, scale=1.0):
-        super(PoincareHalfSpaceMetric, self).__init__(dim=dim, signature=(dim, 0))
-        self.coords_type = COORDS_TYPE
-        self.scale = scale
         self.poincare_ball = PoincareBall(dim=dim, scale=scale)
+        super(PoincareHalfSpaceMetric, self).__init__(
+            dim=dim,
+            signature=(dim, 0),
+            default_coords_type=self.poincare_ball.default_coords_type,
+        )
+        self.scale = scale
 
     def inner_product(self, tangent_vec_a, tangent_vec_b, base_point):
         """Compute the inner-product of two tangent vectors at a base point.

--- a/geomstats/geometry/poincare_polydisk.py
+++ b/geomstats/geometry/poincare_polydisk.py
@@ -37,13 +37,9 @@ class PoincarePolydisk(ProductManifold, OpenSet):
         Optional, default: \'extrinsic\'.
     """
 
-    default_coords_type = "extrinsic"
-    default_point_type = "matrix"
-
     def __init__(self, n_disks, coords_type="extrinsic"):
         self.n_disks = n_disks
         self.coords_type = coords_type
-        self.point_type = PoincarePolydisk.default_point_type
         disk = Hyperboloid(2, coords_type=coords_type)
         list_disks = [
             disk,
@@ -142,8 +138,6 @@ class PoincarePolydiskMetric(ProductRiemannianMetric):
         https://epubs.siam.org/doi/pdf/10.1137/15M102112X
     """
 
-    default_coords_type = "extrinsic"
-
     def __init__(self, n_disks, coords_type="extrinsic"):
         self.n_disks = n_disks
         self.coords_type = coords_type
@@ -153,5 +147,6 @@ class PoincarePolydiskMetric(ProductRiemannianMetric):
             metric_i = HyperboloidMetric(2, coords_type, scale_i)
             list_metrics.append(metric_i)
         super(PoincarePolydiskMetric, self).__init__(
-            metrics=list_metrics, default_point_type="matrix"
+            metrics=list_metrics,
+            default_point_type="matrix",
         )

--- a/geomstats/geometry/poincare_polydisk.py
+++ b/geomstats/geometry/poincare_polydisk.py
@@ -32,15 +32,14 @@ class PoincarePolydisk(ProductManifold, OpenSet):
     ----------
     n_disks : int
         Number of disks.
-    coords_type : str, {\'intrinsic\', \'extrinsic\', etc}
+    default_coords_type : str, {\'intrinsic\', \'extrinsic\', etc}
         Coordinate type.
         Optional, default: \'extrinsic\'.
     """
 
-    def __init__(self, n_disks, coords_type="extrinsic"):
+    def __init__(self, n_disks, default_coords_type="extrinsic"):
         self.n_disks = n_disks
-        self.coords_type = coords_type
-        disk = Hyperboloid(2, coords_type=coords_type)
+        disk = Hyperboloid(2, default_coords_type=default_coords_type)
         list_disks = [
             disk,
         ] * n_disks
@@ -48,8 +47,11 @@ class PoincarePolydisk(ProductManifold, OpenSet):
             manifolds=list_disks,
             default_point_type="matrix",
             ambient_space=Matrices(n_disks, 2),
+            default_coords_type=default_coords_type,
         )
-        self._metric = PoincarePolydiskMetric(n_disks=n_disks, coords_type=coords_type)
+        self._metric = PoincarePolydiskMetric(
+            n_disks=n_disks, default_coords_type=default_coords_type
+        )
 
     @staticmethod
     def intrinsic_to_extrinsic_coords(point_intrinsic):
@@ -100,7 +102,7 @@ class PoincarePolydisk(ProductManifold, OpenSet):
             Tangent vector at base point.
         """
         n_disks = self.n_disks
-        hyperbolic_space = Hyperboloid(2, self.coords_type)
+        hyperbolic_space = Hyperboloid(2, self.default_coords_type)
         tangent_vec = gs.stack(
             [
                 hyperbolic_space.to_tangent(
@@ -127,7 +129,7 @@ class PoincarePolydiskMetric(ProductRiemannianMetric):
     ----------
     n_disks : int
         Number of disks.
-    coords_type : str, {\'intrinsic\', \'extrinsic\', etc}
+    default_coords_type : str, {\'intrinsic\', \'extrinsic\', etc}
         Coordinate type.
         Optional, default: \'extrinsic\'.
 
@@ -138,13 +140,12 @@ class PoincarePolydiskMetric(ProductRiemannianMetric):
         https://epubs.siam.org/doi/pdf/10.1137/15M102112X
     """
 
-    def __init__(self, n_disks, coords_type="extrinsic"):
+    def __init__(self, n_disks, default_coords_type="extrinsic"):
         self.n_disks = n_disks
-        self.coords_type = coords_type
         list_metrics = []
         for i_disk in range(n_disks):
             scale_i = (n_disks - i_disk) ** 0.5
-            metric_i = HyperboloidMetric(2, coords_type, scale_i)
+            metric_i = HyperboloidMetric(2, default_coords_type, scale_i)
             list_metrics.append(metric_i)
         super(PoincarePolydiskMetric, self).__init__(
             metrics=list_metrics,

--- a/geomstats/geometry/positive_lower_triangular_matrices.py
+++ b/geomstats/geometry/positive_lower_triangular_matrices.py
@@ -188,9 +188,7 @@ class CholeskyMetric(RiemannianMetric):
     def __init__(self, n):
         """ """
         dim = int(n * (n + 1) / 2)
-        super(CholeskyMetric, self).__init__(
-            dim=dim, signature=(dim, 0), default_point_type="matrix"
-        )
+        super(CholeskyMetric, self).__init__(dim=dim, signature=(dim, 0), shape=(n, n))
         self.n = n
 
     @staticmethod

--- a/geomstats/geometry/pre_shape.py
+++ b/geomstats/geometry/pre_shape.py
@@ -699,7 +699,8 @@ class PreShapeMetric(RiemannianMetric):
 
     def __init__(self, k_landmarks, m_ambient):
         super(PreShapeMetric, self).__init__(
-            dim=m_ambient * (k_landmarks - 1) - 1, default_point_type="matrix"
+            dim=m_ambient * (k_landmarks - 1) - 1,
+            shape=(k_landmarks, m_ambient),
         )
 
         self.embedding_metric = MatricesMetric(k_landmarks, m_ambient)

--- a/geomstats/geometry/product_riemannian_metric.py
+++ b/geomstats/geometry/product_riemannian_metric.py
@@ -28,6 +28,12 @@ class ProductRiemannianMetric(RiemannianMetric):
     """
 
     def __init__(self, metrics, default_point_type="vector", n_jobs=1):
+
+        if default_point_type == "vector":
+            shape = (sum([m.shape[0] for m in metrics]),)
+        else:
+            shape = (len(metrics), *metrics[0].shape)
+
         self.n_metrics = len(metrics)
         dims = [metric.dim for metric in metrics]
         signatures = [metric.signature for metric in metrics]
@@ -37,7 +43,7 @@ class ProductRiemannianMetric(RiemannianMetric):
         super(ProductRiemannianMetric, self).__init__(
             dim=sum(dims),
             signature=(sig_pos, sig_neg),
-            default_point_type=default_point_type,
+            shape=shape,
         )
 
         self.metrics = metrics

--- a/geomstats/geometry/quotient_metric.py
+++ b/geomstats/geometry/quotient_metric.py
@@ -37,12 +37,7 @@ class QuotientMetric(RiemannianMetric):
                     "or the group acting on the "
                     "total space must be provided to the fiber bundle."
                 )
-        super(QuotientMetric, self).__init__(
-            dim=dim,
-            shape=shape,
-            default_point_type=fiber_bundle.default_point_type,
-            **kwargs
-        )
+        super(QuotientMetric, self).__init__(dim=dim, shape=shape, **kwargs)
 
         self.fiber_bundle = fiber_bundle
         self.group = fiber_bundle.group

--- a/geomstats/geometry/rank_k_psd_matrices.py
+++ b/geomstats/geometry/rank_k_psd_matrices.py
@@ -319,5 +319,5 @@ class PSDMetricBuresWasserstein(QuotientMetric):
     def __init__(self, n, k):
         fiber_bundle = BuresWassersteinBundle(n, k)
         super(PSDMetricBuresWasserstein, self).__init__(
-            fiber_bundle=fiber_bundle, shape=(n, k)
+            fiber_bundle=fiber_bundle, shape=(n, n)
         )

--- a/geomstats/geometry/riemannian_metric.py
+++ b/geomstats/geometry/riemannian_metric.py
@@ -32,14 +32,12 @@ class RiemannianMetric(Connection, ABC):
     signature : tuple
         Signature of the metric.
         Optional, default: None.
-    default_point_type : str, {'vector', 'matrix'}
-        Point type.
-        Optional, default: 'vector'.
     """
 
-    def __init__(self, dim, shape=None, signature=None, default_point_type=None):
+    def __init__(self, dim, shape=None, signature=None):
         super(RiemannianMetric, self).__init__(
-            dim=dim, shape=shape, default_point_type=default_point_type
+            dim=dim,
+            shape=shape,
         )
         if signature is None:
             signature = (dim, 0)

--- a/geomstats/geometry/riemannian_metric.py
+++ b/geomstats/geometry/riemannian_metric.py
@@ -34,10 +34,13 @@ class RiemannianMetric(Connection, ABC):
         Optional, default: None.
     """
 
-    def __init__(self, dim, shape=None, signature=None):
+    def __init__(
+        self, dim, shape=None, signature=None, default_coords_type="intrinsic"
+    ):
         super(RiemannianMetric, self).__init__(
             dim=dim,
             shape=shape,
+            default_coords_type=default_coords_type,
         )
         if signature is None:
             signature = (dim, 0)

--- a/geomstats/geometry/sasaki_metric.py
+++ b/geomstats/geometry/sasaki_metric.py
@@ -68,7 +68,8 @@ class SasakiMetric(RiemannianMetric):
         self.n_jobs = n_jobs
 
         super(SasakiMetric, self).__init__(
-            2 * metric.dim, shape=shape, default_point_type="matrix"
+            2 * metric.dim,
+            shape=shape,
         )
 
     def exp(self, tangent_vec, base_point, n_steps=N_STEPS, **kwargs):

--- a/geomstats/geometry/spd_matrices.py
+++ b/geomstats/geometry/spd_matrices.py
@@ -484,7 +484,9 @@ class SPDMetricAffine(RiemannianMetric):
         """
         dim = int(n * (n + 1) / 2)
         super(SPDMetricAffine, self).__init__(
-            dim=dim, signature=(dim, 0), default_point_type="matrix"
+            dim=dim,
+            shape=(n, n),
+            signature=(dim, 0),
         )
         self.n = n
         self.power_affine = power_affine
@@ -757,7 +759,9 @@ class SPDMetricBuresWasserstein(RiemannianMetric):
     def __init__(self, n):
         dim = int(n * (n + 1) / 2)
         super(SPDMetricBuresWasserstein, self).__init__(
-            dim=dim, signature=(dim, 0), default_point_type="matrix"
+            dim=dim,
+            signature=(dim, 0),
+            shape=(n, n),
         )
         self.n = n
 
@@ -991,7 +995,9 @@ class SPDMetricEuclidean(RiemannianMetric):
     def __init__(self, n, power_euclidean=1):
         dim = int(n * (n + 1) / 2)
         super(SPDMetricEuclidean, self).__init__(
-            dim=dim, signature=(dim, 0), default_point_type="matrix"
+            dim=dim,
+            signature=(dim, 0),
+            shape=(n, n),
         )
         self.n = n
         self.power_euclidean = power_euclidean
@@ -1198,7 +1204,9 @@ class SPDMetricLogEuclidean(RiemannianMetric):
     def __init__(self, n):
         dim = int(n * (n + 1) / 2)
         super(SPDMetricLogEuclidean, self).__init__(
-            dim=dim, signature=(dim, 0), default_point_type="matrix"
+            dim=dim,
+            signature=(dim, 0),
+            shape=(n, n),
         )
         self.n = n
 

--- a/geomstats/geometry/special_euclidean.py
+++ b/geomstats/geometry/special_euclidean.py
@@ -341,7 +341,6 @@ class _SpecialEuclideanVectors(LieGroup):
             self,
             dim=dim,
             shape=(dim,),
-            default_point_type="vector",
             lie_algebra=Euclidean(dim),
         )
 
@@ -350,29 +349,21 @@ class _SpecialEuclideanVectors(LieGroup):
         self.rotations = SpecialOrthogonal(n=n, point_type="vector", epsilon=epsilon)
         self.translations = Euclidean(dim=n)
 
-    def get_identity(self, point_type=None):
+    def get_identity(self):
         """Get the identity of the group.
-
-        Parameters
-        ----------
-        point_type : str, {'vector', 'matrix'}
-            The point_type of the returned value.
-            Optional, default: self.default_point_type
 
         Returns
         -------
         identity : array-like, shape={[dim], [n + 1, n + 1]}
         """
-        if point_type is None:
-            point_type = self.default_point_type
         identity = gs.zeros(self.dim)
         return identity
 
     identity = property(get_identity)
 
-    def get_point_type_shape(self, point_type=None):
+    def get_point_type_shape(self):
         """Get the shape of the instance given the default_point_style."""
-        return self.get_identity(point_type).shape
+        return self.get_identity().shape
 
     def belongs(self, point, atol=gs.atol):
         """Evaluate if a point belongs to SE(2) or SE(3).

--- a/geomstats/geometry/special_orthogonal.py
+++ b/geomstats/geometry/special_orthogonal.py
@@ -298,16 +298,14 @@ class _SpecialOrthogonalVectors(LieGroup):
         Optional, default: 0.
     """
 
-    def __init__(self, n, shape, epsilon=0.0):
+    def __init__(self, n, epsilon=0.0):
         dim = n * (n - 1) // 2
-        LieGroup.__init__(
-            self, dim=dim, shape=shape, default_point_type="vector", lie_algebra=self
-        )
+        LieGroup.__init__(self, dim=dim, shape=(dim,), lie_algebra=self)
 
         self.n = n
         self.epsilon = epsilon
 
-    def get_identity(self, point_type="vector"):
+    def get_identity(self):
         """Get the identity of the group.
 
         Parameters
@@ -537,7 +535,8 @@ class _SpecialOrthogonal2Vectors(_SpecialOrthogonalVectors):
 
     def __init__(self, epsilon=0.0):
         super(_SpecialOrthogonal2Vectors, self).__init__(
-            n=2, epsilon=epsilon, shape=(2,)
+            n=2,
+            epsilon=epsilon,
         )
 
     def regularize(self, point):
@@ -703,9 +702,7 @@ class _SpecialOrthogonal3Vectors(_SpecialOrthogonalVectors):
     """
 
     def __init__(self, epsilon=0.0):
-        super(_SpecialOrthogonal3Vectors, self).__init__(
-            n=3, shape=(3,), epsilon=epsilon
-        )
+        super(_SpecialOrthogonal3Vectors, self).__init__(n=3, epsilon=epsilon)
 
         self.bi_invariant_metric = BiInvariantMetric(group=self)
         self.metric = self.bi_invariant_metric

--- a/geomstats/geometry/stiefel.py
+++ b/geomstats/geometry/stiefel.py
@@ -188,7 +188,7 @@ class StiefelCanonicalMetric(RiemannianMetric):
     def __init__(self, n, p):
         dim = int(p * n - (p * (p + 1) / 2))
         super(StiefelCanonicalMetric, self).__init__(
-            dim=dim, default_point_type="matrix", signature=(dim, 0, 0)
+            dim=dim, signature=(dim, 0, 0), shape=(n, p)
         )
         self.embedding_metric = EuclideanMetric(n * p)
         self.n = n

--- a/geomstats/geometry/symmetric_matrices.py
+++ b/geomstats/geometry/symmetric_matrices.py
@@ -24,10 +24,7 @@ class SymmetricMatrices(VectorSpace):
     def __init__(self, n, **kwargs):
         kwargs.setdefault("metric", MatricesMetric(n, n))
         super(SymmetricMatrices, self).__init__(
-            dim=int(n * (n + 1) / 2),
-            shape=(n, n),
-            default_point_type="matrix",
-            **kwargs
+            dim=int(n * (n + 1) / 2), shape=(n, n), **kwargs
         )
         self.n = n
 

--- a/geomstats/information_geometry/gamma.py
+++ b/geomstats/information_geometry/gamma.py
@@ -575,7 +575,10 @@ class GammaMetric(RiemannianMetric):
         """
         if solver == "geomstats":
             return super(GammaMetric, self).exp(
-                tangent_vec, base_point, n_steps, step, solver
+                tangent_vec,
+                base_point,
+                n_steps,
+                step,
             )
         if solver == "lsoda":
             return self._exp_ivp(tangent_vec, base_point, n_steps)

--- a/geomstats/visualization/__init__.py
+++ b/geomstats/visualization/__init__.py
@@ -57,7 +57,7 @@ def tutorial_matplotlib():
     )
 
 
-def plot(points, ax=None, space=None, point_type=None, **point_draw_kwargs):
+def plot(points, ax=None, space=None, coords_type=None, **point_draw_kwargs):
     """Plot points in one of the implemented manifolds.
 
     The implemented manifolds are:
@@ -78,7 +78,7 @@ def plot(points, ax=None, space=None, point_type=None, **point_draw_kwargs):
     space: str, optional, {'SO3_GROUP', 'SE3_GROUP', 'S1', 'S2',
         'H2_poincare_disk', 'H2_poincare_half_plane', 'H2_klein_disk',
         'poincare_polydisk', 'S32', 'M32', 'S33', 'M33', 'SPD2'}
-    point_type: str, optional, {'extrinsic', 'ball', 'half-space', 'pre-shape'}
+    coords_type: str, optional, {'extrinsic', 'ball', 'half-space', 'pre-shape'}
     """
     if space not in IMPLEMENTED:
         raise NotImplementedError(
@@ -128,19 +128,19 @@ def plot(points, ax=None, space=None, point_type=None, **point_draw_kwargs):
         sphere.draw(ax, **point_draw_kwargs)
 
     elif space == "H2_poincare_disk":
-        if point_type is None:
-            point_type = "extrinsic"
-        poincare_disk = PoincareDisk(point_type=point_type)
+        if coords_type is None:
+            coords_type = "extrinsic"
+        poincare_disk = PoincareDisk(coords_type=coords_type)
         ax = poincare_disk.set_ax(ax=ax)
         poincare_disk.add_points(points)
         poincare_disk.draw(ax, **point_draw_kwargs)
         plt.axis("off")
 
     elif space == "poincare_polydisk":
-        if point_type is None:
-            point_type = "extrinsic"
+        if coords_type is None:
+            coords_type = "extrinsic"
         n_disks = points.shape[1]
-        poincare_poly_disk = PoincarePolyDisk(point_type=point_type, n_disks=n_disks)
+        poincare_poly_disk = PoincarePolyDisk(coords_type=coords_type, n_disks=n_disks)
         n_columns = int(gs.ceil(n_disks**0.5))
         n_rows = int(gs.ceil(n_disks / n_columns))
 
@@ -156,9 +156,9 @@ def plot(points, ax=None, space=None, point_type=None, **point_draw_kwargs):
             poincare_poly_disk.draw(ax, **point_draw_kwargs)
 
     elif space == "H2_poincare_half_plane":
-        if point_type is None:
-            point_type = "half-space"
-        poincare_half_plane = PoincareHalfPlane(point_type=point_type)
+        if coords_type is None:
+            coords_type = "half-space"
+        poincare_half_plane = PoincareHalfPlane(coords_type=coords_type)
         ax = poincare_half_plane.set_ax(ax=ax)
         poincare_half_plane.add_points(points)
         poincare_half_plane.draw(ax, **point_draw_kwargs)
@@ -183,7 +183,7 @@ def plot(points, ax=None, space=None, point_type=None, **point_draw_kwargs):
         ax = sphere.ax
 
     elif space == "M32":
-        sphere = KendallSphere(point_type="extrinsic")
+        sphere = KendallSphere(coords_type="extrinsic")
         sphere.add_points(points)
         sphere.draw()
         sphere.draw_points()
@@ -197,7 +197,7 @@ def plot(points, ax=None, space=None, point_type=None, **point_draw_kwargs):
         ax = disk.ax
 
     elif space == "M33":
-        disk = KendallDisk(point_type="extrinsic")
+        disk = KendallDisk(coords_type="extrinsic")
         disk.add_points(points)
         disk.draw()
         disk.draw_points()

--- a/geomstats/visualization/hyperbolic.py
+++ b/geomstats/visualization/hyperbolic.py
@@ -66,10 +66,10 @@ class KleinDisk:
 
 
 class PoincareDisk:
-    def __init__(self, points=None, point_type="extrinsic"):
+    def __init__(self, points=None, coords_type="extrinsic"):
         self.center = gs.array([0.0, 0.0])
         self.points = []
-        self.point_type = point_type
+        self.coords_type = coords_type
         if points is not None:
             self.add_points(points)
 
@@ -90,7 +90,7 @@ class PoincareDisk:
 
     def add_points(self, points):
 
-        if self.point_type == "extrinsic":
+        if self.coords_type == "extrinsic":
             if not gs.all(H2.belongs(points)):
                 raise ValueError("Points do not belong to the hyperbolic space.")
             points = self.convert_to_poincare_coordinates(points)
@@ -119,10 +119,10 @@ class PoincareDisk:
             else:
                 raise ValueError("Points do not have dimension 2.")
 
-    def plot(self, points, ax=None, point_type=None, **point_draw_kwargs):
-        if point_type is None:
-            point_type = "extrinsic"
-        poincare_disk = PoincareDisk(point_type=point_type)
+    def plot(self, points, ax=None, coords_type=None, **point_draw_kwargs):
+        if coords_type is None:
+            coords_type = "extrinsic"
+        poincare_disk = PoincareDisk(coords_type=coords_type)
         ax = poincare_disk.set_ax(ax=ax)
         self.points = []
         poincare_disk.add_points(points)
@@ -133,21 +133,21 @@ class PoincareDisk:
 class PoincareHalfPlane:
     """Class used to plot points in the Poincare Half Plane."""
 
-    def __init__(self, points=None, point_type="half-space"):
+    def __init__(self, points=None, coords_type="half-space"):
         self.points = []
-        self.point_type = point_type
+        self.coords_type = coords_type
         if points is not None:
             self.add_points(points)
 
     def add_points(self, points):
-        if self.point_type == "extrinsic":
+        if self.coords_type == "extrinsic":
             if not gs.all(H2.belongs(points)):
                 raise ValueError(
                     "Points do not belong to the hyperbolic space "
                     "(extrinsic coordinates)"
                 )
             points = self.convert_to_half_plane_coordinates(points)
-        elif self.point_type == "half-space":
+        elif self.coords_type == "half-space":
             if not gs.all(POINCARE_HALF_PLANE.belongs(points)):
                 raise ValueError(
                     "Points do not belong to the hyperbolic space "
@@ -183,10 +183,10 @@ class PoincareHalfPlane:
         points_y = [gs.to_numpy(point[1]) for point in self.points]
         ax.scatter(points_x, points_y, **kwargs)
 
-    def plot(self, points, ax=None, point_type=None, **point_draw_kwargs):
-        if point_type is None:
-            point_type = "half-space"
-        poincare_half_plane = PoincareHalfPlane(point_type=point_type)
+    def plot(self, points, ax=None, coords_type=None, **point_draw_kwargs):
+        if coords_type is None:
+            coords_type = "half-space"
+        poincare_half_plane = PoincareHalfPlane(coords_type=coords_type)
         ax = poincare_half_plane.set_ax(ax=ax)
         self.points = []
         poincare_half_plane.add_points(points)

--- a/geomstats/visualization/poincare_polydisk.py
+++ b/geomstats/visualization/poincare_polydisk.py
@@ -10,10 +10,10 @@ AX_SCALE = 1.2
 class PoincarePolyDisk:
     """Class used to plot points in the Poincare polydisk."""
 
-    def __init__(self, points=None, point_type="ball", n_disks=2):
+    def __init__(self, points=None, coords_type="ball", n_disks=2):
         self.center = gs.array([0.0, 0.0])
         self.points = []
-        self.point_type = point_type
+        self.coords_type = coords_type
         self.n_disks = n_disks
         if points is not None:
             self.add_points(points)
@@ -29,7 +29,7 @@ class PoincarePolyDisk:
 
     def add_points(self, points):
         """Add points to draw."""
-        if self.point_type == "extrinsic":
+        if self.coords_type == "extrinsic":
             points = self.convert_to_poincare_coordinates(points)
         if not isinstance(points, list):
             points = list(points)

--- a/geomstats/visualization/pre_shape.py
+++ b/geomstats/visualization/pre_shape.py
@@ -26,7 +26,7 @@ class KendallSphere:
     ----------
     points : list
         List of points to plot on the Kendall sphere.
-    point_type : str
+    coords_type : str
         Type of the points. Can be either 'pre-shape' (for points in Kendall
         pre-shape space) or 'extrinsic' (for points given as 3x2 matrices).
         Optional, default: 'pre-shape'.
@@ -48,9 +48,9 @@ class KendallSphere:
         https://doi.org/10.1112/blms/16.2.81
     """
 
-    def __init__(self, points=None, point_type="pre-shape"):
+    def __init__(self, points=None, coords_type="pre-shape"):
         self.points = []
-        self.point_type = point_type
+        self.coords_type = coords_type
         self.ax = None
         self.elev, self.azim = None, None
 
@@ -123,11 +123,11 @@ class KendallSphere:
 
     def add_points(self, points):
         """Add points to draw on the Kendall sphere."""
-        if self.point_type == "extrinsic":
+        if self.coords_type == "extrinsic":
             if not gs.all(M32.belongs(points)):
                 raise ValueError("Points do not belong to Matrices(3, 2).")
             points = S32.projection(points)
-        elif self.point_type == "pre-shape" and not gs.all(S32.belongs(points)):
+        elif self.coords_type == "pre-shape" and not gs.all(S32.belongs(points)):
             raise ValueError("Points do not belong to the pre-shape space.")
         points = self.convert_to_spherical_coordinates(points)
         if not isinstance(points, list):
@@ -274,7 +274,7 @@ class KendallDisk:
     ----------
     points : list
         List of points to plot on the Kendall sphere.
-    point_type : str
+    coords_type : str
         Type of the points. Can be either 'pre-shape' (for points in Kendall
         pre-shape space) or 'extrinsic' (for points given as 3x2 matrices).
         Optional, default: 'pre-shape'.
@@ -302,9 +302,9 @@ class KendallDisk:
         https://doi.org/10.1112/blms/16.2.81
     """
 
-    def __init__(self, points=None, point_type="pre-shape"):
+    def __init__(self, points=None, coords_type="pre-shape"):
         self.points = []
-        self.point_type = point_type
+        self.coords_type = coords_type
         self.ax = None
 
         self.pole = gs.array(
@@ -368,11 +368,11 @@ class KendallDisk:
 
     def add_points(self, points):
         """Add points to draw on the Kendall disk."""
-        if self.point_type == "extrinsic":
+        if self.coords_type == "extrinsic":
             if not gs.all(M33.belongs(points)):
                 raise ValueError("Points do not belong to Matrices(3, 3).")
             points = S33.projection(points)
-        elif self.point_type == "pre-shape" and not gs.all(S33.belongs(points)):
+        elif self.coords_type == "pre-shape" and not gs.all(S33.belongs(points)):
             raise ValueError("Points do not belong to the pre-shape space.")
         points = self.convert_to_planar_coordinates(points)
         if not isinstance(points, list):

--- a/notebooks/03_practical_methods__data_on_manifolds.ipynb
+++ b/notebooks/03_practical_methods__data_on_manifolds.ipynb
@@ -684,7 +684,7 @@
     }
    ],
    "source": [
-    "disk = visualization.PoincareDisk(point_type=\"ball\")\n",
+    "disk = visualization.PoincareDisk(coords_type=\"ball\")\n",
     "fig, ax = plt.subplots(figsize=(8, 8))\n",
     "disk.set_ax(ax)\n",
     "disk.draw(ax=ax)\n",

--- a/notebooks/04_practical_methods__from_vector_spaces_to_manifolds.ipynb
+++ b/notebooks/04_practical_methods__from_vector_spaces_to_manifolds.ipynb
@@ -425,7 +425,7 @@
    "source": [
     "from geomstats.geometry.hyperboloid import Hyperboloid\n",
     "\n",
-    "hyperbolic = Hyperboloid(dim=2, coords_type=\"extrinsic\")\n",
+    "hyperbolic = Hyperboloid(dim=2, default_coords_type=\"extrinsic\")\n",
     "\n",
     "initial_point = gs.array([gs.sqrt(2.0), 1.0, 0.0])\n",
     "end_point = gs.array([2.5, 2.5])\n",

--- a/notebooks/13_real_world_applications__graph_embedding_and_clustering_in_hyperbolic_space.ipynb
+++ b/notebooks/13_real_world_applications__graph_embedding_and_clustering_in_hyperbolic_space.ipynb
@@ -784,7 +784,7 @@
     "group_1 = mpatches.Patch(color=colors[1], label=\"Group 1\")\n",
     "group_2 = mpatches.Patch(color=colors[2], label=\"Group 2\")\n",
     "\n",
-    "circle = visualization.PoincareDisk(point_type=\"ball\")\n",
+    "circle = visualization.PoincareDisk(coords_type=\"ball\")\n",
     "\n",
     "fig, ax = plt.subplots(figsize=(8, 8))\n",
     "ax.axes.xaxis.set_visible(False)\n",
@@ -945,7 +945,7 @@
    ],
    "source": [
     "colors = [\"g\", \"c\", \"m\"]\n",
-    "circle = visualization.PoincareDisk(point_type=\"ball\")\n",
+    "circle = visualization.PoincareDisk(coords_type=\"ball\")\n",
     "fig2, ax2 = plt.subplots(figsize=(8, 8))\n",
     "circle.set_ax(ax2)\n",
     "circle.draw(ax=ax2)\n",

--- a/notebooks/16_real_world_applications__visualizations_in_kendall_shape_spaces.ipynb
+++ b/notebooks/16_real_world_applications__visualizations_in_kendall_shape_spaces.ipynb
@@ -770,7 +770,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "D = KendallDisk(point_type=\"extrinsic\")"
+    "D = KendallDisk(coords_type=\"extrinsic\")"
    ]
   },
   {

--- a/tests/data/hyperboloid_data.py
+++ b/tests/data/hyperboloid_data.py
@@ -27,19 +27,19 @@ class HyperboloidTestData(_LevelSetTestData):
         smoke_data = [
             dict(
                 dim=3,
-                coords_type="extrinsic",
+                default_coords_type="extrinsic",
                 vec=gs.array([1.0, 0.0, 0.0, 0.0]),
                 expected=True,
             ),
             dict(
                 dim=2,
-                coords_type="extrinsic",
+                default_coords_type="extrinsic",
                 vec=gs.array([0.5, 7, 3.0]),
                 expected=False,
             ),
             dict(
                 dim=2,
-                coords_type="intrinsic",
+                default_coords_type="intrinsic",
                 vec=gs.array([0.5, 7]),
                 expected=True,
             ),

--- a/tests/data_generation.py
+++ b/tests/data_generation.py
@@ -184,6 +184,13 @@ class TestData:
 class _ManifoldTestData(TestData):
     """Class for ManifoldTestData: data to test manifold properties."""
 
+    def manifold_shape_test_data(self):
+        smoke_data = [
+            dict(space_args=space_args) for space_args in self.space_args_list
+        ]
+
+        return self.generate_tests(smoke_data)
+
     def random_point_belongs_test_data(self):
         """Generate data to check that a random point belongs to the manifold."""
         random_data = [
@@ -538,6 +545,18 @@ class _FiberBundleTestData(TestData):
 
 
 class _ConnectionTestData(TestData):
+    def manifold_shape_test_data(self):
+        smoke_data = []
+        for connection_args, space in zip(self.metric_args_list, self.space_list):
+            smoke_data.append(
+                dict(
+                    connection_args=connection_args,
+                    expected_shape=space.random_point().shape,
+                )
+            )
+
+        return self.generate_tests(smoke_data)
+
     def exp_shape_test_data(self):
         """Generate data to check that exp returns an array of the expected shape."""
         n_samples_list = [3] * len(self.metric_args_list)

--- a/tests/geometry_test_cases.py
+++ b/tests/geometry_test_cases.py
@@ -59,6 +59,26 @@ class ManifoldTestCase(TestCase):
     def Space(self):
         return self.testing_data.Space
 
+    def test_manifold_shape(self, space_args):
+        space = self.Space(*space_args)
+        point = space.random_point()
+
+        if space.metric is None:
+            return
+
+        point_shape = (1,) if point.shape == () else point.shape
+
+        self.assertTrue(
+            space.shape == point_shape,
+            f"Shape is {space.shape}, but random point shape is {point_shape}",
+        )
+
+        msg = (
+            f"Space shape is {space.shape}, "
+            f"whereas space metric shape is {space.metric.shape}",
+        )
+        self.assertTrue(space.shape == space.metric.shape, msg)
+
     def test_random_point_belongs(self, space_args, n_points, atol):
         """Check that a random point belongs to the manifold.
 
@@ -576,6 +596,14 @@ class ConnectionTestCase(TestCase):
     @property
     def Metric(self):
         return self.testing_data.Metric
+
+    def test_manifold_shape(self, connection_args, expected_shape):
+        connection = self.Metric(*connection_args)
+
+        self.assertTrue(
+            connection.shape == expected_shape,
+            f"Shape is {connection.shape}, but random point shape is {expected_shape}",
+        )
 
     def test_exp_shape(self, connection_args, tangent_vec, base_point, expected):
         """Check that exp returns an array of the expected shape.

--- a/tests/tests_geomstats/test_geodesic_regression.py
+++ b/tests/tests_geomstats/test_geodesic_regression.py
@@ -68,7 +68,6 @@ class TestGeodesicRegression(geomstats.tests.TestCase):
         # Set up for special euclidean
         self.se2 = SpecialEuclidean(n=2)
         self.metric_se2 = self.se2.left_canonical_metric
-        self.metric_se2.default_point_type = "matrix"
 
         self.shape_se2 = (3, 3)
         X = gs.random.rand(self.n_samples)
@@ -105,7 +104,6 @@ class TestGeodesicRegression(geomstats.tests.TestCase):
         k_sampling_points = 8
         self.curves_2d = DiscreteCurves(R2, k_sampling_points=k_sampling_points)
         self.metric_curves_2d = self.curves_2d.srv_metric
-        self.metric_curves_2d.default_point_type = "matrix"
 
         self.shape_curves_2d = (k_sampling_points, 2)
         X = gs.random.rand(self.n_samples)

--- a/tests/tests_geomstats/test_hyperboloid.py
+++ b/tests/tests_geomstats/test_hyperboloid.py
@@ -1,6 +1,7 @@
 """Unit tests for the Hyperbolic space."""
 
 import geomstats.backend as gs
+from geomstats.geometry._hyperbolic import _Hyperbolic
 from geomstats.geometry.hyperbolic import Hyperbolic
 from geomstats.geometry.hyperboloid import Hyperboloid
 from geomstats.geometry.minkowski import Minkowski
@@ -16,8 +17,8 @@ class TestHyperboloid(LevelSetTestCase, metaclass=Parametrizer):
 
     testing_data = HyperboloidTestData()
 
-    def test_belongs(self, dim, coords_type, vec, expected):
-        space = self.Space(dim, coords_type=coords_type)
+    def test_belongs(self, dim, default_coords_type, vec, expected):
+        space = self.Space(dim, default_coords_type=default_coords_type)
         self.assertAllClose(space.belongs(vec), gs.array(expected))
 
     def test_regularize_raises(self, dim, point, expected):
@@ -38,7 +39,7 @@ class TestHyperboloid(LevelSetTestCase, metaclass=Parametrizer):
         self.assertAllClose(result, x_ball)
 
     def test_extrinsic_ball_extrinsic_composition(self, dim, point_intrinsic):
-        x = self.Space(dim, coords_type="intrinsic").to_coordinates(
+        x = self.Space(dim, default_coords_type="intrinsic").to_coordinates(
             point_intrinsic, to_coords_type="extrinsic"
         )
         x_b = self.Space(dim).to_coordinates(x, to_coords_type="ball")
@@ -46,11 +47,11 @@ class TestHyperboloid(LevelSetTestCase, metaclass=Parametrizer):
         self.assertAllClose(x, x2)
 
     def test_extrinsic_half_plane_extrinsic_composition(self, dim, point_intrinsic):
-        x = self.Space(dim, coords_type="intrinsic").to_coordinates(
+        x = self.Space(dim, default_coords_type="intrinsic").to_coordinates(
             point_intrinsic, to_coords_type="extrinsic"
         )
         x_up = self.Space(dim).to_coordinates(x, to_coords_type="half-space")
-        x2 = Hyperbolic.change_coordinates_system(x_up, "half-space", "extrinsic")
+        x2 = _Hyperbolic.change_coordinates_system(x_up, "half-space", "extrinsic")
         self.assertAllClose(x, x2)
 
 
@@ -112,8 +113,8 @@ class TestHyperboloidMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
     def test_exp_after_log_intrinsic_ball_extrinsic(
         self, dim, x_intrinsic, y_intrinsic
     ):
-        intrinsic_manifold = Hyperboloid(dim=dim, coords_type="intrinsic")
-        extrinsic_manifold = Hyperbolic(dim=dim, coords_type="extrinsic")
+        intrinsic_manifold = Hyperboloid(dim=dim, default_coords_type="intrinsic")
+        extrinsic_manifold = Hyperbolic(dim=dim, default_coords_type="extrinsic")
         ball_manifold = PoincareBall(dim)
         x_extr = intrinsic_manifold.to_coordinates(
             x_intrinsic, to_coords_type="extrinsic"
@@ -148,8 +149,8 @@ class TestHyperboloidMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
 
     def test_distance_ball_extrinsic_intrinsic(self, dim, x_intrinsic, y_intrinsic):
 
-        intrinsic_manifold = Hyperboloid(dim, coords_type="intrinsic")
-        extrinsic_manifold = Hyperboloid(dim, coords_type="extrinsic")
+        intrinsic_manifold = Hyperboloid(dim, default_coords_type="intrinsic")
+        extrinsic_manifold = Hyperboloid(dim, default_coords_type="extrinsic")
         x_extr = intrinsic_manifold.to_coordinates(
             x_intrinsic, to_coords_type="extrinsic"
         )

--- a/tests/tests_geomstats/test_poincare_polydisk.py
+++ b/tests/tests_geomstats/test_poincare_polydisk.py
@@ -39,8 +39,10 @@ class TestPoincarePolydiskMetric(TestCase, metaclass=Parametrizer):
         duplicate_point_a = gs.stack([point_a_extrinsic, point_a_extrinsic], axis=0)
         duplicate_point_b = gs.stack([point_b_extrinsic, point_b_extrinsic], axis=0)
 
-        single_disk = PoincarePolydisk(n_disks=n_disks, coords_type="extrinsic")
-        two_disks = PoincarePolydisk(n_disks=2 * n_disks, coords_type="extrinsic")
+        single_disk = PoincarePolydisk(n_disks=n_disks, default_coords_type="extrinsic")
+        two_disks = PoincarePolydisk(
+            n_disks=2 * n_disks, default_coords_type="extrinsic"
+        )
 
         distance_single_disk = single_disk.metric.dist(
             point_a_extrinsic[None, :], point_b_extrinsic[None, :]

--- a/tests/tests_geomstats/test_visualization.py
+++ b/tests/tests_geomstats/test_visualization.py
@@ -154,7 +154,7 @@ class TestVisualization(geomstats.tests.TestCase):
     def test_plot_points_h2_poincare_half_plane_ext(self):
         points = self.H2.random_point(self.n_samples)
         visualization.plot(
-            points, space="H2_poincare_half_plane", point_type="extrinsic"
+            points, space="H2_poincare_half_plane", coords_type="extrinsic"
         )
 
     def test_plot_points_h2_poincare_half_plane_none(self):
@@ -164,7 +164,7 @@ class TestVisualization(geomstats.tests.TestCase):
     def test_plot_points_h2_poincare_half_plane_hs(self):
         points = self.H2_half_plane.random_point(self.n_samples)
         visualization.plot(
-            points, space="H2_poincare_half_plane", point_type="half_space"
+            points, space="H2_poincare_half_plane", coords_type="half_space"
         )
 
     def test_plot_points_h2_klein_disk(self):


### PR DESCRIPTION
This PR makes `default_point_dtype` a property (computed from shape).

`shape` has been corrected for several spaces and/or metrics and a general test to validate shape against the shape of a generated random point was added.