### PR TITLE
Simplify super()

### DIFF
--- a/examples/plot_kmeans_manifolds.py
+++ b/examples/plot_kmeans_manifolds.py
@@ -44,7 +44,7 @@ def kmean_poincare_ball():
         space="H2_poincare_disk",
         marker=".",
         color="black",
-        point_type=manifold.point_type,
+        point_type=manifold.coords_type,
     )
 
     for i in range(n_clusters):
@@ -54,7 +54,7 @@ def kmean_poincare_ball():
             space="H2_poincare_disk",
             marker=".",
             color=colors[i],
-            point_type=manifold.point_type,
+            point_type=manifold.coords_type,
         )
 
     ax = visualization.plot(
@@ -64,7 +64,7 @@ def kmean_poincare_ball():
         marker="*",
         color="green",
         s=100,
-        point_type=manifold.point_type,
+        point_type=manifold.coords_type,
     )
 
     ax.set_title("Kmeans on Poincaré Ball Manifold")

--- a/examples/plot_kmedoids_manifolds.py
+++ b/examples/plot_kmedoids_manifolds.py
@@ -44,7 +44,7 @@ def kmedoids_poincare_ball():
         space="H2_poincare_disk",
         marker=".",
         color="black",
-        point_type=manifold.point_type,
+        point_type=manifold.coords_type,
     )
 
     for i in range(n_clusters):
@@ -54,7 +54,7 @@ def kmedoids_poincare_ball():
             space="H2_poincare_disk",
             marker=".",
             color=colors[i],
-            point_type=manifold.point_type,
+            point_type=manifold.coords_type,
         )
 
     ax = visualization.plot(
@@ -64,7 +64,7 @@ def kmedoids_poincare_ball():
         marker="*",
         color="green",
         s=100,
-        point_type=manifold.point_type,
+        point_type=manifold.coords_type,
     )
 
     ax.set_title("Kmedoids on Poincaré Ball Manifold")

--- a/geomstats/geometry/_hyperbolic.py
+++ b/geomstats/geometry/_hyperbolic.py
@@ -33,7 +33,7 @@ class _Hyperbolic:
     """
 
     def __init__(self, dim, scale=1, **kwargs):
-        super(_Hyperbolic, self).__init__(dim=dim, **kwargs)
+        super().__init__(dim=dim, **kwargs)
         self.dim = dim
         self.scale = scale
 
@@ -469,9 +469,7 @@ class HyperbolicMetric(RiemannianMetric):
     default_coords_type = "extrinsic"
 
     def __init__(self, dim, scale=1):
-        super(HyperbolicMetric, self).__init__(
-            dim=dim, signature=(dim, 0), shape=(dim + 1,)
-        )
+        super().__init__(dim=dim, signature=(dim, 0), shape=(dim + 1,))
 
         self.scale = scale
 

--- a/geomstats/geometry/_hyperbolic.py
+++ b/geomstats/geometry/_hyperbolic.py
@@ -23,7 +23,7 @@ class _Hyperbolic:
     ----------
     dim : int
         Dimension of the hyperbolic space.
-    point_type : str, {'extrinsic', 'intrinsic', etc}
+    coords_type : str, {'extrinsic', 'intrinsic', etc}
         Default coordinates to represent points in hyperbolic space.
         Optional, default: 'extrinsic'.
     scale : int
@@ -459,19 +459,19 @@ class HyperbolicMetric(RiemannianMetric):
     ----------
     dim : int
         Dimension of the hyperbolic space.
-    point_type : str, {'extrinsic', 'intrinsic', etc}, optional
+    coords_type : str, {'extrinsic', 'intrinsic', etc}, optional
         Default coordinates to represent points in hyperbolic space.
     scale : int, optional
         Scale of the hyperbolic space, defined as the set of points
         in Minkowski space whose squared norm is equal to -scale.
     """
 
-    default_point_type = "vector"
     default_coords_type = "extrinsic"
 
     def __init__(self, dim, scale=1):
-        super(HyperbolicMetric, self).__init__(dim=dim, signature=(dim, 0))
-        self.point_type = HyperbolicMetric.default_point_type
+        super(HyperbolicMetric, self).__init__(
+            dim=dim, signature=(dim, 0), shape=(dim + 1,)
+        )
 
         self.scale = scale
 

--- a/geomstats/geometry/_my_manifold.py
+++ b/geomstats/geometry/_my_manifold.py
@@ -36,7 +36,7 @@ class MyManifold(Manifold):
     """
 
     def __init__(self, dim, another_parameter, **kwargs):
-        super(MyManifold, self).__init__(dim, shape=(dim,))
+        super().__init__(dim, shape=(dim,))
         self.another_parameter = another_parameter
 
     # Implement the main methods of MyManifold, for example belongs:

--- a/geomstats/geometry/base.py
+++ b/geomstats/geometry/base.py
@@ -8,8 +8,6 @@ import abc
 import geomstats.backend as gs
 from geomstats.geometry.manifold import Manifold
 
-POINT_TYPES = {1: "vector", 2: "matrix"}
-
 
 class VectorSpace(Manifold, abc.ABC):
     """Abstract class for vector spaces.
@@ -19,9 +17,6 @@ class VectorSpace(Manifold, abc.ABC):
     shape : tuple
         Shape of the elements of the vector space. The dimension is the
         product of these values by default.
-    default_point_type : str, {'vector', 'matrix'}
-        Point type.
-        Optional, default: 'vector'.
     """
 
     def __init__(self, shape, **kwargs):
@@ -187,10 +182,7 @@ class LevelSet(Manifold, abc.ABC):
     ):
         kwargs.setdefault("shape", embedding_space.shape)
         super(LevelSet, self).__init__(
-            dim=dim,
-            default_point_type=embedding_space.default_point_type,
-            default_coords_type=default_coords_type,
-            **kwargs
+            dim=dim, default_coords_type=default_coords_type, **kwargs
         )
         self.embedding_space = embedding_space
         self.embedding_metric = embedding_space.metric
@@ -335,7 +327,6 @@ class OpenSet(Manifold, abc.ABC):
     """
 
     def __init__(self, dim, ambient_space, **kwargs):
-        kwargs.setdefault("default_point_type", ambient_space.default_point_type)
         kwargs.setdefault("shape", ambient_space.shape)
         super().__init__(dim=dim, **kwargs)
         self.ambient_space = ambient_space

--- a/geomstats/geometry/base.py
+++ b/geomstats/geometry/base.py
@@ -21,7 +21,7 @@ class VectorSpace(Manifold, abc.ABC):
 
     def __init__(self, shape, **kwargs):
         kwargs.setdefault("dim", int(gs.prod(gs.array(shape))))
-        super(VectorSpace, self).__init__(shape=shape, **kwargs)
+        super().__init__(shape=shape, **kwargs)
         self.shape = shape
         self._basis = None
 
@@ -181,9 +181,7 @@ class LevelSet(Manifold, abc.ABC):
         **kwargs
     ):
         kwargs.setdefault("shape", embedding_space.shape)
-        super(LevelSet, self).__init__(
-            dim=dim, default_coords_type=default_coords_type, **kwargs
-        )
+        super().__init__(dim=dim, default_coords_type=default_coords_type, **kwargs)
         self.embedding_space = embedding_space
         self.embedding_metric = embedding_space.metric
         self.submersion = submersion

--- a/geomstats/geometry/discrete_curves.py
+++ b/geomstats/geometry/discrete_curves.py
@@ -62,7 +62,7 @@ class DiscreteCurves(Manifold):
     ):
         dim = ambient_manifold.dim * k_sampling_points
         kwargs.setdefault("metric", SRVMetric(ambient_manifold))
-        super(DiscreteCurves, self).__init__(
+        super().__init__(
             dim=dim,
             shape=(k_sampling_points,) + ambient_manifold.shape,
             **kwargs,
@@ -278,7 +278,7 @@ class ClosedDiscreteCurves(LevelSet):
 
     def __init__(self, ambient_manifold, k_sampling_points=10):
         dim = ambient_manifold.dim * (k_sampling_points - 1)
-        super(ClosedDiscreteCurves, self).__init__(
+        super().__init__(
             dim=dim,
             shape=(k_sampling_points,) + ambient_manifold.shape,
             submersion=None,
@@ -582,7 +582,7 @@ class L2CurvesMetric(RiemannianMetric):
     """
 
     def __init__(self, ambient_manifold, ambient_metric=None):
-        super(L2CurvesMetric, self).__init__(
+        super().__init__(
             dim=math.inf,
             signature=(math.inf, 0, 0),
             shape=(None,) + ambient_manifold.shape,
@@ -833,7 +833,7 @@ class ElasticMetric(RiemannianMetric):
     def __init__(
         self, a, b, ambient_manifold=R2, ambient_metric=None, translation_invariant=True
     ):
-        super(ElasticMetric, self).__init__(
+        super().__init__(
             dim=math.inf,
             signature=(math.inf, 0, 0),
             shape=(None,) + ambient_manifold.shape,
@@ -1229,7 +1229,7 @@ class SRVMetric(ElasticMetric):
     def __init__(
         self, ambient_manifold, ambient_metric=None, translation_invariant=True
     ):
-        super(SRVMetric, self).__init__(
+        super().__init__(
             a=1,
             b=0.5,
             ambient_manifold=ambient_manifold,
@@ -1780,7 +1780,7 @@ class SRVShapeBundle(DiscreteCurves, FiberBundle):
     """
 
     def __init__(self, ambient_manifold, k_sampling_points=10):
-        super(SRVShapeBundle, self).__init__(
+        super().__init__(
             ambient_manifold=ambient_manifold,
             k_sampling_points=k_sampling_points,
         )
@@ -2135,7 +2135,7 @@ class SRVQuotientMetric(QuotientMetric):
     def __init__(self, ambient_manifold, k_sampling_points=10):
         dim = ambient_manifold.dim * k_sampling_points
         bundle = SRVShapeBundle(ambient_manifold, dim)
-        super(SRVQuotientMetric, self).__init__(
+        super().__init__(
             fiber_bundle=bundle,
             dim=dim,
             shape=(k_sampling_points,) + ambient_manifold.shape,

--- a/geomstats/geometry/discrete_curves.py
+++ b/geomstats/geometry/discrete_curves.py
@@ -65,7 +65,6 @@ class DiscreteCurves(Manifold):
         super(DiscreteCurves, self).__init__(
             dim=dim,
             shape=(k_sampling_points,) + ambient_manifold.shape,
-            default_point_type="matrix",
             **kwargs,
         )
         self.ambient_manifold = ambient_manifold
@@ -281,7 +280,7 @@ class ClosedDiscreteCurves(LevelSet):
         dim = ambient_manifold.dim * (k_sampling_points - 1)
         super(ClosedDiscreteCurves, self).__init__(
             dim=dim,
-            shape=(),
+            shape=(k_sampling_points,) + ambient_manifold.shape,
             submersion=None,
             tangent_submersion=None,
             value=None,
@@ -583,7 +582,11 @@ class L2CurvesMetric(RiemannianMetric):
     """
 
     def __init__(self, ambient_manifold, ambient_metric=None):
-        super(L2CurvesMetric, self).__init__(dim=math.inf, signature=(math.inf, 0, 0))
+        super(L2CurvesMetric, self).__init__(
+            dim=math.inf,
+            signature=(math.inf, 0, 0),
+            shape=(None,) + ambient_manifold.shape,
+        )
         if ambient_metric is None:
             if hasattr(ambient_manifold, "metric"):
                 self.ambient_metric = ambient_manifold.metric
@@ -831,7 +834,9 @@ class ElasticMetric(RiemannianMetric):
         self, a, b, ambient_manifold=R2, ambient_metric=None, translation_invariant=True
     ):
         super(ElasticMetric, self).__init__(
-            dim=math.inf, signature=(math.inf, 0, 0), default_point_type="matrix"
+            dim=math.inf,
+            signature=(math.inf, 0, 0),
+            shape=(None,) + ambient_manifold.shape,
         )
         self.ambient_metric = ambient_metric
         if ambient_metric is None:
@@ -2130,7 +2135,11 @@ class SRVQuotientMetric(QuotientMetric):
     def __init__(self, ambient_manifold, k_sampling_points=10):
         dim = ambient_manifold.dim * k_sampling_points
         bundle = SRVShapeBundle(ambient_manifold, dim)
-        super(SRVQuotientMetric, self).__init__(fiber_bundle=bundle, dim=dim)
+        super(SRVQuotientMetric, self).__init__(
+            fiber_bundle=bundle,
+            dim=dim,
+            shape=(k_sampling_points,) + ambient_manifold.shape,
+        )
 
     def geodesic(self, initial_point, end_point, threshold=1e-3):
         """Geodesic for the quotient SRV Metric.

--- a/geomstats/geometry/euclidean.py
+++ b/geomstats/geometry/euclidean.py
@@ -18,7 +18,7 @@ class Euclidean(VectorSpace):
     """
 
     def __init__(self, dim):
-        super(Euclidean, self).__init__(
+        super().__init__(
             shape=(dim,),
             metric=EuclideanMetric(dim, shape=(dim,)),
         )
@@ -75,7 +75,7 @@ class EuclideanMetric(RiemannianMetric):
     """
 
     def __init__(self, dim, shape=None):
-        super(EuclideanMetric, self).__init__(
+        super().__init__(
             dim=dim,
             shape=shape,
             signature=(dim, 0),

--- a/geomstats/geometry/euclidean.py
+++ b/geomstats/geometry/euclidean.py
@@ -20,18 +20,11 @@ class Euclidean(VectorSpace):
     def __init__(self, dim):
         super(Euclidean, self).__init__(
             shape=(dim,),
-            default_point_type="vector",
             metric=EuclideanMetric(dim, shape=(dim,)),
         )
 
     def get_identity(self):
         """Get the identity of the group.
-
-        Parameters
-        ----------
-        point_type : str, {'vector', 'matrix'}
-            The point_type of the returned value.
-            Optional, default: self.default_point_type
 
         Returns
         -------

--- a/geomstats/geometry/fiber_bundle.py
+++ b/geomstats/geometry/fiber_bundle.py
@@ -55,7 +55,7 @@ class FiberBundle(Manifold, ABC):
         **kwargs
     ):
 
-        super(FiberBundle, self).__init__(dim=dim, **kwargs)
+        super().__init__(dim=dim, **kwargs)
         self.group = group
         self.total_space_metric = total_space_metric
 

--- a/geomstats/geometry/full_rank_correlation_matrices.py
+++ b/geomstats/geometry/full_rank_correlation_matrices.py
@@ -23,7 +23,7 @@ class FullRankCorrelationMatrices(LevelSet):
 
     def __init__(self, n, **kwargs):
         kwargs.setdefault("metric", FullRankCorrelationAffineQuotientMetric(n))
-        super(FullRankCorrelationMatrices, self).__init__(
+        super().__init__(
             dim=int(n * (n - 1) / 2),
             embedding_space=SPDMatrices(n=n),
             submersion=Matrices.diagonal,
@@ -154,7 +154,7 @@ class CorrelationMatricesBundle(SPDMatrices, FiberBundle):
     """
 
     def __init__(self, n):
-        super(CorrelationMatricesBundle, self).__init__(
+        super().__init__(
             n=n,
             total_space_metric=SPDMetricAffine(n),
             group_dim=n,
@@ -263,7 +263,7 @@ class FullRankCorrelationAffineQuotientMetric(QuotientMetric):
 
     def __init__(self, n):
         fiber_bundle = CorrelationMatricesBundle(n=n)
-        super(FullRankCorrelationAffineQuotientMetric, self).__init__(
+        super().__init__(
             fiber_bundle=fiber_bundle,
             shape=fiber_bundle.shape,
         )

--- a/geomstats/geometry/full_rank_correlation_matrices.py
+++ b/geomstats/geometry/full_rank_correlation_matrices.py
@@ -262,6 +262,8 @@ class FullRankCorrelationAffineQuotientMetric(QuotientMetric):
     """
 
     def __init__(self, n):
+        fiber_bundle = CorrelationMatricesBundle(n=n)
         super(FullRankCorrelationAffineQuotientMetric, self).__init__(
-            fiber_bundle=CorrelationMatricesBundle(n=n)
+            fiber_bundle=fiber_bundle,
+            shape=fiber_bundle.shape,
         )

--- a/geomstats/geometry/full_rank_matrices.py
+++ b/geomstats/geometry/full_rank_matrices.py
@@ -22,7 +22,7 @@ class FullRankMatrices(OpenSet):
     def __init__(self, n, k, **kwargs):
         kwargs.setdefault("dim", n * k)
         kwargs.setdefault("metric", MatricesMetric(n, k))
-        super(FullRankMatrices, self).__init__(ambient_space=Matrices(n, k), **kwargs)
+        super().__init__(ambient_space=Matrices(n, k), **kwargs)
         self.rank = min(n, k)
         self.n = n
         self.k = k

--- a/geomstats/geometry/general_linear.py
+++ b/geomstats/geometry/general_linear.py
@@ -29,7 +29,7 @@ class GeneralLinear(MatrixLieGroup, OpenSet):
         kwargs.setdefault("dim", n**2)
         kwargs.setdefault("metric", ambient_space.metric)
 
-        super(GeneralLinear, self).__init__(
+        super().__init__(
             ambient_space=ambient_space, n=n, lie_algebra=SquareMatrices(n), **kwargs
         )
 
@@ -179,7 +179,7 @@ class SquareMatrices(MatrixLieAlgebra):
     """
 
     def __init__(self, n):
-        super(SquareMatrices, self).__init__(n=n, dim=n**2)
+        super().__init__(n=n, dim=n**2)
         self.mat_space = Matrices(n, n)
 
     def _create_basis(self):

--- a/geomstats/geometry/grassmannian.py
+++ b/geomstats/geometry/grassmannian.py
@@ -185,7 +185,7 @@ class Grassmannian(LevelSet):
 
         kwargs.setdefault("metric", GrassmannianCanonicalMetric(n, p))
         dim = int(p * (n - p))
-        super(Grassmannian, self).__init__(
+        super().__init__(
             dim=dim,
             embedding_space=SymmetricMatrices(n),
             submersion=lambda x: submersion(x, p),
@@ -316,9 +316,7 @@ class GrassmannianCanonicalMetric(MatricesMetric, RiemannianMetric):
             raise ValueError("p <= n is required.")
 
         dim = int(p * (n - p))
-        super(GrassmannianCanonicalMetric, self).__init__(
-            m=n, n=n, dim=dim, signature=(dim, 0, 0)
-        )
+        super().__init__(m=n, n=n, dim=dim, signature=(dim, 0, 0))
 
         self.n = n
         self.p = p

--- a/geomstats/geometry/heisenberg.py
+++ b/geomstats/geometry/heisenberg.py
@@ -35,13 +35,8 @@ class HeisenbergVectors(LieGroup, VectorSpace):
         """Create the canonical basis."""
         return gs.eye(3)
 
-    def get_identity(self, point_type="vector"):
+    def get_identity(self):
         """Get the identity of the 3D Heisenberg group.
-
-        Parameters
-        ----------
-        point_type : str, {'vector', 'matrix'}
-            Point_type of the returned value. Unused here.
 
         Returns
         -------

--- a/geomstats/geometry/heisenberg.py
+++ b/geomstats/geometry/heisenberg.py
@@ -27,9 +27,7 @@ class HeisenbergVectors(LieGroup, VectorSpace):
     """
 
     def __init__(self, **kwargs):
-        super(HeisenbergVectors, self).__init__(
-            dim=3, shape=(3,), lie_algebra=Euclidean(3), **kwargs
-        )
+        super().__init__(dim=3, shape=(3,), lie_algebra=Euclidean(3), **kwargs)
 
     def _create_basis(self):
         """Create the canonical basis."""

--- a/geomstats/geometry/hermitian.py
+++ b/geomstats/geometry/hermitian.py
@@ -22,9 +22,7 @@ class Hermitian(VectorSpace):
 
     def __init__(self, dim, **kwargs):
         kwargs.setdefault("metric", HermitianMetric(dim, shape=(dim,)))
-        super(Hermitian, self).__init__(
-            shape=(dim,), default_point_type="vector", **kwargs
-        )
+        super(Hermitian, self).__init__(shape=(dim,), **kwargs)
 
     def get_identity(self):
         """Get the identity of the group.

--- a/geomstats/geometry/hermitian.py
+++ b/geomstats/geometry/hermitian.py
@@ -22,7 +22,7 @@ class Hermitian(VectorSpace):
 
     def __init__(self, dim, **kwargs):
         kwargs.setdefault("metric", HermitianMetric(dim, shape=(dim,)))
-        super(Hermitian, self).__init__(shape=(dim,), **kwargs)
+        super().__init__(shape=(dim,), **kwargs)
 
     def get_identity(self):
         """Get the identity of the group.
@@ -76,7 +76,7 @@ class HermitianMetric(RiemannianMetric):
     """
 
     def __init__(self, dim, shape=None):
-        super(HermitianMetric, self).__init__(
+        super().__init__(
             dim=dim,
             shape=shape,
             signature=(dim, 0),

--- a/geomstats/geometry/hyperboloid.py
+++ b/geomstats/geometry/hyperboloid.py
@@ -43,7 +43,7 @@ class Hyperboloid(_Hyperbolic, LevelSet):
         # TODO: coords_type vs default_coords_type?
         minkowski = Minkowski(dim + 1)
         kwargs.setdefault("metric", HyperboloidMetric(dim, coords_type, scale))
-        super(Hyperboloid, self).__init__(
+        super().__init__(
             dim=dim,
             embedding_space=minkowski,
             submersion=minkowski.metric.squared_norm,
@@ -84,7 +84,7 @@ class Hyperboloid(_Hyperbolic, LevelSet):
                 belongs = gs.tile([belongs], (point.shape[0],))
             return belongs
 
-        return super(Hyperboloid, self).belongs(point, atol)
+        return super().belongs(point, atol)
 
     def projection(self, point):
         """Project a point in space on the hyperboloid.
@@ -254,7 +254,7 @@ class HyperboloidMetric(HyperbolicMetric):
     """
 
     def __init__(self, dim, coords_type="extrinsic", scale=1):
-        super(HyperboloidMetric, self).__init__(dim=dim, scale=scale)
+        super().__init__(dim=dim, scale=scale)
         self.embedding_metric = MinkowskiMetric(dim + 1)
 
         self.coords_type = coords_type

--- a/geomstats/geometry/hyperboloid.py
+++ b/geomstats/geometry/hyperboloid.py
@@ -39,10 +39,8 @@ class Hyperboloid(_Hyperbolic, LevelSet):
         Optional, default: 1.
     """
 
-    default_coords_type = "extrinsic"
-    default_point_type = "vector"
-
     def __init__(self, dim, coords_type="extrinsic", scale=1, **kwargs):
+        # TODO: coords_type vs default_coords_type?
         minkowski = Minkowski(dim + 1)
         kwargs.setdefault("metric", HyperboloidMetric(dim, coords_type, scale))
         super(Hyperboloid, self).__init__(
@@ -55,7 +53,6 @@ class Hyperboloid(_Hyperbolic, LevelSet):
             **kwargs
         )
         self.coords_type = coords_type
-        self.point_type = Hyperboloid.default_point_type
 
     def belongs(self, point, atol=gs.atol):
         """Test if a point belongs to the hyperbolic space.
@@ -247,7 +244,7 @@ class HyperboloidMetric(HyperbolicMetric):
     ----------
     dim : int
         Dimension of the hyperbolic space.
-    point_type : str, {'extrinsic', 'intrinsic', etc}
+    coords_type : str, {'extrinsic', 'intrinsic', etc}
         Default coordinates to represent points in hyperbolic space.
         Optional, default: 'extrinsic'.
     scale : int
@@ -256,15 +253,11 @@ class HyperboloidMetric(HyperbolicMetric):
         Optional, default: 1.
     """
 
-    default_point_type = "vector"
-    default_coords_type = "extrinsic"
-
     def __init__(self, dim, coords_type="extrinsic", scale=1):
         super(HyperboloidMetric, self).__init__(dim=dim, scale=scale)
         self.embedding_metric = MinkowskiMetric(dim + 1)
 
         self.coords_type = coords_type
-        self.point_type = HyperbolicMetric.default_point_type
 
         self.scale = scale
 

--- a/geomstats/geometry/hypersphere.py
+++ b/geomstats/geometry/hypersphere.py
@@ -44,7 +44,7 @@ class _Hypersphere(LevelSet):
 
     def __init__(self, dim, default_coords_type="extrinsic"):
 
-        super(_Hypersphere, self).__init__(
+        super().__init__(
             dim=dim,
             embedding_space=Euclidean(dim + 1),
             submersion=lambda x: gs.sum(x**2, axis=-1),
@@ -658,9 +658,7 @@ class HypersphereMetric(RiemannianMetric):
     """
 
     def __init__(self, dim):
-        super(HypersphereMetric, self).__init__(
-            dim=dim, shape=(dim + 1,), signature=(dim, 0)
-        )
+        super().__init__(dim=dim, shape=(dim + 1,), signature=(dim, 0))
         self.embedding_metric = EuclideanMetric(dim + 1)
         self._space = _Hypersphere(dim=dim)
 
@@ -1136,5 +1134,5 @@ class Hypersphere(_Hypersphere):
     """
 
     def __init__(self, dim, default_coords_type="extrinsic"):
-        super(Hypersphere, self).__init__(dim, default_coords_type)
+        super().__init__(dim, default_coords_type)
         self._metric = HypersphereMetric(dim)

--- a/geomstats/geometry/invariant_metric.py
+++ b/geomstats/geometry/invariant_metric.py
@@ -46,9 +46,7 @@ class _InvariantMetricMatrix(RiemannianMetric):
     def __init__(
         self, group, metric_mat_at_identity=None, left_or_right="left", **kwargs
     ):
-        super(_InvariantMetricMatrix, self).__init__(
-            dim=group.dim, shape=group.shape, **kwargs
-        )
+        super().__init__(dim=group.dim, shape=group.shape, **kwargs)
 
         self.group = group
         self.lie_algebra = group.lie_algebra
@@ -694,7 +692,7 @@ class _InvariantMetricMatrix(RiemannianMetric):
                 f" antipodal matrices: {point} and {base_point}."
             )
         return self.group.to_tangent(
-            super(_InvariantMetricMatrix, self).log(
+            super().log(
                 point,
                 base_point,
                 n_steps=n_steps,
@@ -870,9 +868,7 @@ class _InvariantMetricVector(RiemannianMetric):
     """
 
     def __init__(self, group, left_or_right="left", **kwargs):
-        super(_InvariantMetricVector, self).__init__(
-            dim=group.dim, shape=group.shape, **kwargs
-        )
+        super().__init__(dim=group.dim, shape=group.shape, **kwargs)
 
         self.group = group
         self.metric_mat_at_identity = gs.eye(group.dim)
@@ -1206,7 +1202,7 @@ class BiInvariantMetric(_InvariantMetricVector):
     """
 
     def __init__(self, group):
-        super(BiInvariantMetric, self).__init__(group=group)
+        super().__init__(group=group)
         condition = (
             "SpecialOrthogonal" not in group.__str__()
             and "SO" not in group.__str__()
@@ -1288,9 +1284,7 @@ class BiInvariantMetric(_InvariantMetricVector):
             Inner-product of the two tangent vectors.
         """
         if self.default_point_type == "vector":
-            return super(BiInvariantMetric, self).inner_product_at_identity(
-                tangent_vec_a, tangent_vec_b
-            )
+            return super().inner_product_at_identity(tangent_vec_a, tangent_vec_b)
         return Matrices.frobenius_product(tangent_vec_a, tangent_vec_b) / 2
 
     def inner_product(self, tangent_vec_a, tangent_vec_b, base_point=None):
@@ -1314,9 +1308,7 @@ class BiInvariantMetric(_InvariantMetricVector):
         if base_point is None or self.default_point_type == "matrix":
             return self.inner_product_at_identity(tangent_vec_a, tangent_vec_b)
 
-        return super(BiInvariantMetric, self).inner_product(
-            tangent_vec_a, tangent_vec_b, base_point
-        )
+        return super().inner_product(tangent_vec_a, tangent_vec_b, base_point)
 
     def parallel_transport(
         self, tangent_vec, base_point, direction=None, end_point=None

--- a/geomstats/geometry/invariant_metric.py
+++ b/geomstats/geometry/invariant_metric.py
@@ -47,7 +47,7 @@ class _InvariantMetricMatrix(RiemannianMetric):
         self, group, metric_mat_at_identity=None, left_or_right="left", **kwargs
     ):
         super(_InvariantMetricMatrix, self).__init__(
-            dim=group.dim, default_point_type="matrix", **kwargs
+            dim=group.dim, shape=group.shape, **kwargs
         )
 
         self.group = group
@@ -870,7 +870,9 @@ class _InvariantMetricVector(RiemannianMetric):
     """
 
     def __init__(self, group, left_or_right="left", **kwargs):
-        super(_InvariantMetricVector, self).__init__(dim=group.dim, **kwargs)
+        super(_InvariantMetricVector, self).__init__(
+            dim=group.dim, shape=group.shape, **kwargs
+        )
 
         self.group = group
         self.metric_mat_at_identity = gs.eye(group.dim)
@@ -1204,7 +1206,7 @@ class BiInvariantMetric(_InvariantMetricVector):
     """
 
     def __init__(self, group):
-        super(BiInvariantMetric, self).__init__(group=group, shape=group.shape)
+        super(BiInvariantMetric, self).__init__(group=group)
         condition = (
             "SpecialOrthogonal" not in group.__str__()
             and "SO" not in group.__str__()
@@ -1213,7 +1215,6 @@ class BiInvariantMetric(_InvariantMetricVector):
         # TODO (nguigs): implement it for SE(3)
         if condition:
             raise ValueError("The bi-invariant metric is only implemented for SO(n)")
-        self.default_point_type = group.default_point_type
 
     def exp(self, tangent_vec, base_point=None, **kwargs):
         """Compute Riemannian exponential of tangent vector from the identity.

--- a/geomstats/geometry/landmarks.py
+++ b/geomstats/geometry/landmarks.py
@@ -26,9 +26,7 @@ class Landmarks(NFoldManifold):
         kwargs.setdefault(
             "metric", L2LandmarksMetric(ambient_manifold.metric, k_landmarks)
         )
-        super(Landmarks, self).__init__(
-            base_manifold=ambient_manifold, n_copies=k_landmarks, **kwargs
-        )
+        super().__init__(base_manifold=ambient_manifold, n_copies=k_landmarks, **kwargs)
         self.ambient_manifold = ambient_manifold
         self.k_landmarks = k_landmarks
 
@@ -49,8 +47,6 @@ class L2LandmarksMetric(NFoldMetric):
     """
 
     def __init__(self, ambient_metric, k_landmarks, **kwargs):
-        super(L2LandmarksMetric, self).__init__(
-            base_metric=ambient_metric, n_copies=k_landmarks, **kwargs
-        )
+        super().__init__(base_metric=ambient_metric, n_copies=k_landmarks, **kwargs)
         self.ambient_metric = ambient_metric
         self.k_landmarks = k_landmarks

--- a/geomstats/geometry/lie_algebra.py
+++ b/geomstats/geometry/lie_algebra.py
@@ -32,7 +32,7 @@ class MatrixLieAlgebra(VectorSpace, abc.ABC):
     """
 
     def __init__(self, dim, n, **kwargs):
-        super(MatrixLieAlgebra, self).__init__(shape=(n, n), **kwargs)
+        super().__init__(shape=(n, n), **kwargs)
         geomstats.errors.check_integer(dim, "dim")
         geomstats.errors.check_integer(n, "n")
         self.dim = dim

--- a/geomstats/geometry/lie_group.py
+++ b/geomstats/geometry/lie_group.py
@@ -279,9 +279,6 @@ class LieGroup(Manifold, abc.ABC):
     ----------
     dim : int
         Dimension of the Lie group.
-    default_point_type : str, {'vector', 'matrix'}
-        Point type.
-        Optional, default: 'vector'.
     lie_algebra : MatrixLieAlgebra
         Lie algebra for matrix groups.
         Optional, default: None.
@@ -298,12 +295,8 @@ class LieGroup(Manifold, abc.ABC):
         product at the identity.
     """
 
-    def __init__(
-        self, dim, shape, default_point_type="vector", lie_algebra=None, **kwargs
-    ):
-        super(LieGroup, self).__init__(
-            dim=dim, shape=shape, default_point_type=default_point_type, **kwargs
-        )
+    def __init__(self, dim, shape, lie_algebra=None, **kwargs):
+        super(LieGroup, self).__init__(dim=dim, shape=shape, **kwargs)
 
         self.lie_algebra = lie_algebra
         self.left_canonical_metric = InvariantMetric(
@@ -317,14 +310,8 @@ class LieGroup(Manifold, abc.ABC):
         self.metric = self.left_canonical_metric
         self.metrics = []
 
-    def get_identity(self, point_type=None):
+    def get_identity(self):
         """Get the identity of the group.
-
-        Parameters
-        ----------
-        point_type : str, {'matrix', 'vector'}
-            Point type.
-            Optional, default: None.
 
         Returns
         -------
@@ -574,7 +561,7 @@ class LieGroup(Manifold, abc.ABC):
         """
         # TODO (ninamiolane): Build a standalone decorator that *only*
         # deals with point_type None and base_point None
-        identity = self.get_identity(point_type=self.default_point_type)
+        identity = self.get_identity()
         if base_point is None:
             base_point = identity
 
@@ -619,7 +606,7 @@ class LieGroup(Manifold, abc.ABC):
             Lie bracket.
         """
         if base_point is None:
-            base_point = self.get_identity(point_type=self.default_point_type)
+            base_point = self.get_identity()
         inverse_base_point = self.inverse(base_point)
 
         first_term = Matrices.mul(inverse_base_point, tangent_vector_b)

--- a/geomstats/geometry/lie_group.py
+++ b/geomstats/geometry/lie_group.py
@@ -18,7 +18,7 @@ class MatrixLieGroup(Manifold, abc.ABC):
     """Class for matrix Lie groups."""
 
     def __init__(self, dim, n, lie_algebra=None, **kwargs):
-        super(MatrixLieGroup, self).__init__(dim=dim, shape=(n, n), **kwargs)
+        super().__init__(dim=dim, shape=(n, n), **kwargs)
         self.lie_algebra = lie_algebra
         self.n = n
         self.left_canonical_metric = InvariantMetric(
@@ -296,7 +296,7 @@ class LieGroup(Manifold, abc.ABC):
     """
 
     def __init__(self, dim, shape, lie_algebra=None, **kwargs):
-        super(LieGroup, self).__init__(dim=dim, shape=shape, **kwargs)
+        super().__init__(dim=dim, shape=shape, **kwargs)
 
         self.lie_algebra = lie_algebra
         self.left_canonical_metric = InvariantMetric(

--- a/geomstats/geometry/lower_triangular_matrices.py
+++ b/geomstats/geometry/lower_triangular_matrices.py
@@ -20,10 +20,7 @@ class LowerTriangularMatrices(VectorSpace):
     def __init__(self, n, **kwargs):
         kwargs.setdefault("metric", MatricesMetric(n, n))
         super(LowerTriangularMatrices, self).__init__(
-            dim=int(n * (n + 1) / 2),
-            shape=(n, n),
-            default_point_type="matrix",
-            **kwargs
+            dim=int(n * (n + 1) / 2), shape=(n, n), **kwargs
         )
         self.n = n
 

--- a/geomstats/geometry/lower_triangular_matrices.py
+++ b/geomstats/geometry/lower_triangular_matrices.py
@@ -19,9 +19,7 @@ class LowerTriangularMatrices(VectorSpace):
 
     def __init__(self, n, **kwargs):
         kwargs.setdefault("metric", MatricesMetric(n, n))
-        super(LowerTriangularMatrices, self).__init__(
-            dim=int(n * (n + 1) / 2), shape=(n, n), **kwargs
-        )
+        super().__init__(dim=int(n * (n + 1) / 2), shape=(n, n), **kwargs)
         self.n = n
 
     def _create_basis(self):
@@ -55,7 +53,7 @@ class LowerTriangularMatrices(VectorSpace):
         belongs : array-like, shape=[...,]
             Boolean evaluating if point belongs to the space.
         """
-        belongs = super(LowerTriangularMatrices, self).belongs(point)
+        belongs = super().belongs(point)
         if gs.any(belongs):
             is_lower_triangular = Matrices.is_lower_triangular(point, atol)
             return gs.logical_and(belongs, is_lower_triangular)
@@ -109,5 +107,5 @@ class LowerTriangularMatrices(VectorSpace):
         point : array-like, shape=[..., n, n]
            Sample.
         """
-        sample = super(LowerTriangularMatrices, self).random_point(n_samples, bound)
+        sample = super().random_point(n_samples, bound)
         return Matrices.to_lower_triangular(sample)

--- a/geomstats/geometry/manifold.py
+++ b/geomstats/geometry/manifold.py
@@ -12,8 +12,6 @@ import geomstats.backend as gs
 import geomstats.errors
 from geomstats.geometry.riemannian_metric import RiemannianMetric
 
-POINT_TYPES = {1: "vector", 2: "matrix"}
-
 
 class Manifold(abc.ABC):
     r"""Class for manifolds.
@@ -27,40 +25,34 @@ class Manifold(abc.ABC):
         Optional, default : None.
     metric : RiemannianMetric
         Metric object to use on the manifold.
-    default_point_type : str, {\'vector\', \'matrix\'}
-        Point type.
-        Optional, default: 'vector'.
     default_coords_type : str, {\'intrinsic\', \'extrinsic\', etc}
         Coordinate type.
         Optional, default: 'intrinsic'.
     """
 
     def __init__(
-        self,
-        dim,
-        shape,
-        metric=None,
-        default_point_type=None,
-        default_coords_type="intrinsic",
-        **kwargs
+        self, dim, shape, metric=None, default_coords_type="intrinsic", **kwargs
     ):
         super(Manifold, self).__init__(**kwargs)
         geomstats.errors.check_integer(dim, "dim")
 
         if not isinstance(shape, tuple):
             raise ValueError("Expected a tuple for the shape argument.")
-        if default_point_type is None:
-            default_point_type = POINT_TYPES[len(shape)]
-
-        geomstats.errors.check_parameter_accepted_values(
-            default_point_type, "default_point_type", ["vector", "matrix"]
-        )
 
         self.dim = dim
         self.shape = shape
-        self.default_point_type = default_point_type
         self.default_coords_type = default_coords_type
         self._metric = metric
+
+    @property
+    def default_point_type(self):
+        """Point type.
+
+        `vector` or `matrix`.
+        """
+        if len(self.shape) == 1:
+            return "vector"
+        return "matrix"
 
     @abc.abstractmethod
     def belongs(self, point, atol=gs.atol):

--- a/geomstats/geometry/manifold.py
+++ b/geomstats/geometry/manifold.py
@@ -33,7 +33,7 @@ class Manifold(abc.ABC):
     def __init__(
         self, dim, shape, metric=None, default_coords_type="intrinsic", **kwargs
     ):
-        super(Manifold, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         geomstats.errors.check_integer(dim, "dim")
 
         if not isinstance(shape, tuple):

--- a/geomstats/geometry/matrices.py
+++ b/geomstats/geometry/matrices.py
@@ -22,7 +22,6 @@ class Matrices(VectorSpace):
         geomstats.errors.check_integer(n, "n")
         geomstats.errors.check_integer(m, "m")
         kwargs.setdefault("metric", MatricesMetric(m, n))
-        kwargs.setdefault("default_point_type", "matrix")
         super(Matrices, self).__init__(shape=(m, n), **kwargs)
         self.m = m
         self.n = n

--- a/geomstats/geometry/matrices.py
+++ b/geomstats/geometry/matrices.py
@@ -22,7 +22,7 @@ class Matrices(VectorSpace):
         geomstats.errors.check_integer(n, "n")
         geomstats.errors.check_integer(m, "m")
         kwargs.setdefault("metric", MatricesMetric(m, n))
-        super(Matrices, self).__init__(shape=(m, n), **kwargs)
+        super().__init__(shape=(m, n), **kwargs)
         self.m = m
         self.n = n
 
@@ -714,7 +714,7 @@ class MatricesMetric(EuclideanMetric):
 
     def __init__(self, m, n, **kwargs):
         dimension = m * n
-        super(MatricesMetric, self).__init__(dim=dimension, shape=(m, n))
+        super().__init__(dim=dimension, shape=(m, n))
 
     def inner_product(self, tangent_vec_a, tangent_vec_b, base_point=None):
         """Compute Frobenius inner-product of two tangent vectors.

--- a/geomstats/geometry/minkowski.py
+++ b/geomstats/geometry/minkowski.py
@@ -46,7 +46,7 @@ class MinkowskiMetric(RiemannianMetric):
     """
 
     def __init__(self, dim):
-        super(MinkowskiMetric, self).__init__(dim=dim, signature=(dim - 1, 1))
+        super().__init__(dim=dim, signature=(dim - 1, 1))
 
     def metric_matrix(self, base_point=None):
         """Compute the inner product matrix, independent of the base point.

--- a/geomstats/geometry/poincare_ball.py
+++ b/geomstats/geometry/poincare_ball.py
@@ -19,6 +19,8 @@ NORMALIZATION_FACTOR_CST = gs.sqrt(gs.pi / 2)
 PI_2_3 = gs.power(gs.array([2.0 * gs.pi]), gs.array([2 / 3]))
 SQRT_2 = gs.sqrt(2.0)
 
+COORDS_TYPE = "ball"
+
 
 class PoincareBall(_Hyperbolic, OpenSet):
     """Class for the n-dimensional Poincare ball.
@@ -36,9 +38,6 @@ class PoincareBall(_Hyperbolic, OpenSet):
         Optional, default: 1.
     """
 
-    default_coords_type = "ball"
-    default_point_type = "vector"
-
     def __init__(self, dim, scale=1):
         super(PoincareBall, self).__init__(
             dim=dim,
@@ -46,8 +45,7 @@ class PoincareBall(_Hyperbolic, OpenSet):
             scale=scale,
             metric=PoincareBallMetric(dim, scale),
         )
-        self.coords_type = PoincareBall.default_coords_type
-        self.point_type = PoincareBall.default_point_type
+        self.coords_type = COORDS_TYPE
 
     def belongs(self, point, atol=gs.atol):
         """Test if a point belongs to the hyperbolic space.
@@ -115,13 +113,9 @@ class PoincareBallMetric(RiemannianMetric):
         Optional, default 1.
     """
 
-    default_point_type = "vector"
-    default_coords_type = "ball"
-
     def __init__(self, dim, scale=1):
         super(PoincareBallMetric, self).__init__(dim=dim, signature=(dim, 0))
-        self.coords_type = PoincareBall.default_coords_type
-        self.point_type = PoincareBall.default_point_type
+        self.coords_type = COORDS_TYPE
         self.scale = scale
 
     def exp(self, tangent_vec, base_point, **kwargs):

--- a/geomstats/geometry/poincare_ball.py
+++ b/geomstats/geometry/poincare_ball.py
@@ -39,7 +39,7 @@ class PoincareBall(_Hyperbolic, OpenSet):
     """
 
     def __init__(self, dim, scale=1):
-        super(PoincareBall, self).__init__(
+        super().__init__(
             dim=dim,
             ambient_space=Euclidean(dim),
             scale=scale,
@@ -114,7 +114,7 @@ class PoincareBallMetric(RiemannianMetric):
     """
 
     def __init__(self, dim, scale=1):
-        super(PoincareBallMetric, self).__init__(dim=dim, signature=(dim, 0))
+        super().__init__(dim=dim, signature=(dim, 0))
         self.coords_type = COORDS_TYPE
         self.scale = scale
 

--- a/geomstats/geometry/poincare_half_space.py
+++ b/geomstats/geometry/poincare_half_space.py
@@ -33,7 +33,7 @@ class PoincareHalfSpace(_Hyperbolic, OpenSet):
     """
 
     def __init__(self, dim, scale=1):
-        super(PoincareHalfSpace, self).__init__(
+        super().__init__(
             dim=dim,
             ambient_space=Euclidean(dim),
             scale=scale,
@@ -101,7 +101,7 @@ class PoincareHalfSpaceMetric(RiemannianMetric):
     """
 
     def __init__(self, dim, scale=1.0):
-        super(PoincareHalfSpaceMetric, self).__init__(dim=dim, signature=(dim, 0))
+        super().__init__(dim=dim, signature=(dim, 0))
         self.coords_type = COORDS_TYPE
         self.scale = scale
         self.poincare_ball = PoincareBall(dim=dim, scale=scale)

--- a/geomstats/geometry/poincare_half_space.py
+++ b/geomstats/geometry/poincare_half_space.py
@@ -14,6 +14,8 @@ from geomstats.geometry.euclidean import Euclidean
 from geomstats.geometry.poincare_ball import PoincareBall
 from geomstats.geometry.riemannian_metric import RiemannianMetric
 
+COORDS_TYPE = "half-space"
+
 
 class PoincareHalfSpace(_Hyperbolic, OpenSet):
     """Class for the n-dimensional Poincare half-space.
@@ -30,9 +32,6 @@ class PoincareHalfSpace(_Hyperbolic, OpenSet):
         in Minkowski space whose squared norm is equal to -scale.
     """
 
-    default_coords_type = "half-space"
-    default_point_type = "vector"
-
     def __init__(self, dim, scale=1):
         super(PoincareHalfSpace, self).__init__(
             dim=dim,
@@ -40,8 +39,7 @@ class PoincareHalfSpace(_Hyperbolic, OpenSet):
             scale=scale,
             metric=PoincareHalfSpaceMetric(dim, scale),
         )
-        self.coords_type = PoincareHalfSpace.default_coords_type
-        self.point_type = PoincareHalfSpace.default_point_type
+        self.coords_type = COORDS_TYPE
 
     def belongs(self, point, atol=gs.atol):
         """Evaluate if a point belongs to the upper half space.
@@ -102,13 +100,9 @@ class PoincareHalfSpaceMetric(RiemannianMetric):
         Optional, default: 1.
     """
 
-    default_point_type = "vector"
-    default_coords_type = "half-space"
-
     def __init__(self, dim, scale=1.0):
         super(PoincareHalfSpaceMetric, self).__init__(dim=dim, signature=(dim, 0))
-        self.coords_type = PoincareHalfSpace.default_coords_type
-        self.point_type = PoincareHalfSpace.default_point_type
+        self.coords_type = COORDS_TYPE
         self.scale = scale
         self.poincare_ball = PoincareBall(dim=dim, scale=scale)
 

--- a/geomstats/geometry/poincare_polydisk.py
+++ b/geomstats/geometry/poincare_polydisk.py
@@ -37,13 +37,9 @@ class PoincarePolydisk(ProductManifold, OpenSet):
         Optional, default: \'extrinsic\'.
     """
 
-    default_coords_type = "extrinsic"
-    default_point_type = "matrix"
-
     def __init__(self, n_disks, coords_type="extrinsic"):
         self.n_disks = n_disks
         self.coords_type = coords_type
-        self.point_type = PoincarePolydisk.default_point_type
         disk = Hyperboloid(2, coords_type=coords_type)
         list_disks = [
             disk,
@@ -142,8 +138,6 @@ class PoincarePolydiskMetric(ProductRiemannianMetric):
         https://epubs.siam.org/doi/pdf/10.1137/15M102112X
     """
 
-    default_coords_type = "extrinsic"
-
     def __init__(self, n_disks, coords_type="extrinsic"):
         self.n_disks = n_disks
         self.coords_type = coords_type
@@ -153,5 +147,6 @@ class PoincarePolydiskMetric(ProductRiemannianMetric):
             metric_i = HyperboloidMetric(2, coords_type, scale_i)
             list_metrics.append(metric_i)
         super(PoincarePolydiskMetric, self).__init__(
-            metrics=list_metrics, default_point_type="matrix"
+            metrics=list_metrics,
+            default_point_type="matrix",
         )

--- a/geomstats/geometry/poincare_polydisk.py
+++ b/geomstats/geometry/poincare_polydisk.py
@@ -44,7 +44,7 @@ class PoincarePolydisk(ProductManifold, OpenSet):
         list_disks = [
             disk,
         ] * n_disks
-        super(PoincarePolydisk, self).__init__(
+        super().__init__(
             manifolds=list_disks,
             default_point_type="matrix",
             ambient_space=Matrices(n_disks, 2),
@@ -146,7 +146,7 @@ class PoincarePolydiskMetric(ProductRiemannianMetric):
             scale_i = (n_disks - i_disk) ** 0.5
             metric_i = HyperboloidMetric(2, coords_type, scale_i)
             list_metrics.append(metric_i)
-        super(PoincarePolydiskMetric, self).__init__(
+        super().__init__(
             metrics=list_metrics,
             default_point_type="matrix",
         )

--- a/geomstats/geometry/positive_lower_triangular_matrices.py
+++ b/geomstats/geometry/positive_lower_triangular_matrices.py
@@ -188,9 +188,7 @@ class CholeskyMetric(RiemannianMetric):
     def __init__(self, n):
         """ """
         dim = int(n * (n + 1) / 2)
-        super(CholeskyMetric, self).__init__(
-            dim=dim, signature=(dim, 0), default_point_type="matrix"
-        )
+        super(CholeskyMetric, self).__init__(dim=dim, signature=(dim, 0), shape=(n, n))
         self.n = n
 
     @staticmethod

--- a/geomstats/geometry/positive_lower_triangular_matrices.py
+++ b/geomstats/geometry/positive_lower_triangular_matrices.py
@@ -30,7 +30,7 @@ class PositiveLowerTriangularMatrices(OpenSet):
 
     def __init__(self, n, **kwargs):
         kwargs.setdefault("metric", CholeskyMetric(n))
-        super(PositiveLowerTriangularMatrices, self).__init__(
+        super().__init__(
             dim=int(n * (n + 1) / 2), ambient_space=LowerTriangularMatrices(n), **kwargs
         )
         self.n = n
@@ -52,9 +52,7 @@ class PositiveLowerTriangularMatrices(OpenSet):
         point : array-like, shape=[..., n, n]
            Sample.
         """
-        sample = super(PositiveLowerTriangularMatrices, self).random_point(
-            n_samples, bound
-        )
+        sample = super().random_point(n_samples, bound)
         return self.projection(sample)
 
     def belongs(self, mat, atol=gs.atol):
@@ -188,7 +186,7 @@ class CholeskyMetric(RiemannianMetric):
     def __init__(self, n):
         """ """
         dim = int(n * (n + 1) / 2)
-        super(CholeskyMetric, self).__init__(dim=dim, signature=(dim, 0), shape=(n, n))
+        super().__init__(dim=dim, signature=(dim, 0), shape=(n, n))
         self.n = n
 
     @staticmethod

--- a/geomstats/geometry/pre_shape.py
+++ b/geomstats/geometry/pre_shape.py
@@ -699,7 +699,8 @@ class PreShapeMetric(RiemannianMetric):
 
     def __init__(self, k_landmarks, m_ambient):
         super(PreShapeMetric, self).__init__(
-            dim=m_ambient * (k_landmarks - 1) - 1, default_point_type="matrix"
+            dim=m_ambient * (k_landmarks - 1) - 1,
+            shape=(k_landmarks, m_ambient),
         )
 
         self.embedding_metric = MatricesMetric(k_landmarks, m_ambient)

--- a/geomstats/geometry/pre_shape.py
+++ b/geomstats/geometry/pre_shape.py
@@ -43,7 +43,7 @@ class PreShapeSpace(LevelSet, FiberBundle):
     def __init__(self, k_landmarks, m_ambient):
         embedding_manifold = Matrices(k_landmarks, m_ambient)
         embedding_metric = embedding_manifold.metric
-        super(PreShapeSpace, self).__init__(
+        super().__init__(
             dim=m_ambient * (k_landmarks - 1) - 1,
             embedding_space=embedding_manifold,
             submersion=embedding_metric.squared_norm,
@@ -698,7 +698,7 @@ class PreShapeMetric(RiemannianMetric):
     """
 
     def __init__(self, k_landmarks, m_ambient):
-        super(PreShapeMetric, self).__init__(
+        super().__init__(
             dim=m_ambient * (k_landmarks - 1) - 1,
             shape=(k_landmarks, m_ambient),
         )
@@ -943,7 +943,7 @@ class KendallShapeMetric(QuotientMetric):
 
     def __init__(self, k_landmarks, m_ambient):
         bundle = PreShapeSpace(k_landmarks, m_ambient)
-        super(KendallShapeMetric, self).__init__(
+        super().__init__(
             fiber_bundle=bundle,
             dim=bundle.dim - int(m_ambient * (m_ambient - 1) / 2),
             shape=(k_landmarks, m_ambient),

--- a/geomstats/geometry/product_manifold.py
+++ b/geomstats/geometry/product_manifold.py
@@ -64,7 +64,7 @@ class ProductManifold(Manifold):
         else:
             shape = (len(manifolds), *manifolds[0].shape)
 
-        super(ProductManifold, self).__init__(
+        super().__init__(
             dim=dim,
             shape=shape,
             **kwargs,
@@ -334,7 +334,7 @@ class NFoldManifold(Manifold):
         dim = n_copies * base_manifold.dim
         shape = (n_copies,) + base_manifold.shape
 
-        super(NFoldManifold, self).__init__(
+        super().__init__(
             dim=dim,
             shape=shape,
             default_coords_type=default_coords_type,

--- a/geomstats/geometry/product_riemannian_metric.py
+++ b/geomstats/geometry/product_riemannian_metric.py
@@ -28,6 +28,12 @@ class ProductRiemannianMetric(RiemannianMetric):
     """
 
     def __init__(self, metrics, default_point_type="vector", n_jobs=1):
+
+        if default_point_type == "vector":
+            shape = (sum([m.shape[0] for m in metrics]),)
+        else:
+            shape = (len(metrics), *metrics[0].shape)
+
         self.n_metrics = len(metrics)
         dims = [metric.dim for metric in metrics]
         signatures = [metric.signature for metric in metrics]
@@ -37,7 +43,7 @@ class ProductRiemannianMetric(RiemannianMetric):
         super(ProductRiemannianMetric, self).__init__(
             dim=sum(dims),
             signature=(sig_pos, sig_neg),
-            default_point_type=default_point_type,
+            shape=shape,
         )
 
         self.metrics = metrics

--- a/geomstats/geometry/product_riemannian_metric.py
+++ b/geomstats/geometry/product_riemannian_metric.py
@@ -40,7 +40,7 @@ class ProductRiemannianMetric(RiemannianMetric):
 
         sig_pos = sum(sig[0] for sig in signatures)
         sig_neg = sum(sig[1] for sig in signatures)
-        super(ProductRiemannianMetric, self).__init__(
+        super().__init__(
             dim=sum(dims),
             signature=(sig_pos, sig_neg),
             shape=shape,
@@ -313,7 +313,7 @@ class NFoldMetric(RiemannianMetric):
         geomstats.errors.check_integer(n_copies, "n_copies")
         dim = n_copies * base_metric.dim
         base_shape = base_metric.shape
-        super(NFoldMetric, self).__init__(dim=dim, shape=(n_copies, *base_shape))
+        super().__init__(dim=dim, shape=(n_copies, *base_shape))
         self.base_shape = base_shape
         self.base_metric = base_metric
         self.n_copies = n_copies

--- a/geomstats/geometry/pullback_metric.py
+++ b/geomstats/geometry/pullback_metric.py
@@ -49,7 +49,7 @@ class PullbackMetric(RiemannianMetric):
         jacobian_immersion=None,
         tangent_immersion=None,
     ):
-        super(PullbackMetric, self).__init__(dim=dim)
+        super().__init__(dim=dim)
         self.embedding_metric = EuclideanMetric(embedding_dim)
         self.immersion = immersion
         if jacobian_immersion is None:
@@ -122,7 +122,7 @@ class PullbackDiffeoMetric(RiemannianMetric, abc.ABC):
     """
 
     def __init__(self, dim, shape=None):
-        super(PullbackDiffeoMetric, self).__init__(dim=dim, shape=shape)
+        super().__init__(dim=dim, shape=shape)
 
         self._embedding_metric = None
         self._raw_jacobian_diffeomorphism = None

--- a/geomstats/geometry/quotient_metric.py
+++ b/geomstats/geometry/quotient_metric.py
@@ -37,12 +37,7 @@ class QuotientMetric(RiemannianMetric):
                     "or the group acting on the "
                     "total space must be provided to the fiber bundle."
                 )
-        super(QuotientMetric, self).__init__(
-            dim=dim,
-            shape=shape,
-            default_point_type=fiber_bundle.default_point_type,
-            **kwargs
-        )
+        super(QuotientMetric, self).__init__(dim=dim, shape=shape, **kwargs)
 
         self.fiber_bundle = fiber_bundle
         self.group = fiber_bundle.group

--- a/geomstats/geometry/quotient_metric.py
+++ b/geomstats/geometry/quotient_metric.py
@@ -37,7 +37,7 @@ class QuotientMetric(RiemannianMetric):
                     "or the group acting on the "
                     "total space must be provided to the fiber bundle."
                 )
-        super(QuotientMetric, self).__init__(dim=dim, shape=shape, **kwargs)
+        super().__init__(dim=dim, shape=shape, **kwargs)
 
         self.fiber_bundle = fiber_bundle
         self.group = fiber_bundle.group

--- a/geomstats/geometry/rank_k_psd_matrices.py
+++ b/geomstats/geometry/rank_k_psd_matrices.py
@@ -319,5 +319,5 @@ class PSDMetricBuresWasserstein(QuotientMetric):
     def __init__(self, n, k):
         fiber_bundle = BuresWassersteinBundle(n, k)
         super(PSDMetricBuresWasserstein, self).__init__(
-            fiber_bundle=fiber_bundle, shape=(n, k)
+            fiber_bundle=fiber_bundle, shape=(n, n)
         )

--- a/geomstats/geometry/rank_k_psd_matrices.py
+++ b/geomstats/geometry/rank_k_psd_matrices.py
@@ -30,7 +30,7 @@ class RankKPSDMatrices(Manifold):
 
     def __init__(self, n, k, **kwargs):
         kwargs.setdefault("metric", PSDMetricBuresWasserstein(n, k))
-        super(RankKPSDMatrices, self).__init__(
+        super().__init__(
             **kwargs,
             dim=int(k * n - k * (k + 1) / 2),
             shape=(n, n),
@@ -217,7 +217,7 @@ class BuresWassersteinBundle(FullRankMatrices, FiberBundle):
     """Class for the quotient structure on PSD matrices."""
 
     def __init__(self, n, k):
-        super(BuresWassersteinBundle, self).__init__(
+        super().__init__(
             n=n,
             k=k,
             group=SpecialOrthogonal(k),
@@ -318,6 +318,4 @@ class PSDMetricBuresWasserstein(QuotientMetric):
 
     def __init__(self, n, k):
         fiber_bundle = BuresWassersteinBundle(n, k)
-        super(PSDMetricBuresWasserstein, self).__init__(
-            fiber_bundle=fiber_bundle, shape=(n, n)
-        )
+        super().__init__(fiber_bundle=fiber_bundle, shape=(n, n))

--- a/geomstats/geometry/riemannian_metric.py
+++ b/geomstats/geometry/riemannian_metric.py
@@ -32,14 +32,12 @@ class RiemannianMetric(Connection, ABC):
     signature : tuple
         Signature of the metric.
         Optional, default: None.
-    default_point_type : str, {'vector', 'matrix'}
-        Point type.
-        Optional, default: 'vector'.
     """
 
-    def __init__(self, dim, shape=None, signature=None, default_point_type=None):
+    def __init__(self, dim, shape=None, signature=None):
         super(RiemannianMetric, self).__init__(
-            dim=dim, shape=shape, default_point_type=default_point_type
+            dim=dim,
+            shape=shape,
         )
         if signature is None:
             signature = (dim, 0)

--- a/geomstats/geometry/riemannian_metric.py
+++ b/geomstats/geometry/riemannian_metric.py
@@ -35,7 +35,7 @@ class RiemannianMetric(Connection, ABC):
     """
 
     def __init__(self, dim, shape=None, signature=None):
-        super(RiemannianMetric, self).__init__(
+        super().__init__(
             dim=dim,
             shape=shape,
         )

--- a/geomstats/geometry/sasaki_metric.py
+++ b/geomstats/geometry/sasaki_metric.py
@@ -67,7 +67,7 @@ class SasakiMetric(RiemannianMetric):
 
         self.n_jobs = n_jobs
 
-        super(SasakiMetric, self).__init__(
+        super().__init__(
             2 * metric.dim,
             shape=shape,
         )

--- a/geomstats/geometry/sasaki_metric.py
+++ b/geomstats/geometry/sasaki_metric.py
@@ -68,7 +68,8 @@ class SasakiMetric(RiemannianMetric):
         self.n_jobs = n_jobs
 
         super(SasakiMetric, self).__init__(
-            2 * metric.dim, shape=shape, default_point_type="matrix"
+            2 * metric.dim,
+            shape=shape,
         )
 
     def exp(self, tangent_vec, base_point, n_steps=N_STEPS, **kwargs):

--- a/geomstats/geometry/skew_symmetric_matrices.py
+++ b/geomstats/geometry/skew_symmetric_matrices.py
@@ -24,7 +24,7 @@ class SkewSymmetricMatrices(MatrixLieAlgebra):
 
     def __init__(self, n):
         dim = int(n * (n - 1) / 2)
-        super(SkewSymmetricMatrices, self).__init__(dim, n)
+        super().__init__(dim, n)
         self.ambient_space = Matrices(n, n)
 
     def _create_basis(self):
@@ -88,9 +88,7 @@ class SkewSymmetricMatrices(MatrixLieAlgebra):
         point : array-like, shape=[..., n, n]
             Sample.
         """
-        return self.projection(
-            super(SkewSymmetricMatrices, self).random_point(n_samples, bound)
-        )
+        return self.projection(super().random_point(n_samples, bound))
 
     @classmethod
     def projection(cls, mat):

--- a/geomstats/geometry/spd_matrices.py
+++ b/geomstats/geometry/spd_matrices.py
@@ -29,7 +29,7 @@ class SPDMatrices(OpenSet):
 
     def __init__(self, n, **kwargs):
         kwargs.setdefault("metric", SPDMetricAffine(n))
-        super(SPDMatrices, self).__init__(
+        super().__init__(
             dim=int(n * (n + 1) / 2), ambient_space=SymmetricMatrices(n), **kwargs
         )
         self.n = n
@@ -483,7 +483,7 @@ class SPDMetricAffine(RiemannianMetric):
             2019. https://arxiv.org/abs/1906.01349
         """
         dim = int(n * (n + 1) / 2)
-        super(SPDMetricAffine, self).__init__(
+        super().__init__(
             dim=dim,
             shape=(n, n),
             signature=(dim, 0),
@@ -758,7 +758,7 @@ class SPDMetricBuresWasserstein(RiemannianMetric):
 
     def __init__(self, n):
         dim = int(n * (n + 1) / 2)
-        super(SPDMetricBuresWasserstein, self).__init__(
+        super().__init__(
             dim=dim,
             signature=(dim, 0),
             shape=(n, n),
@@ -994,7 +994,7 @@ class SPDMetricEuclidean(RiemannianMetric):
 
     def __init__(self, n, power_euclidean=1):
         dim = int(n * (n + 1) / 2)
-        super(SPDMetricEuclidean, self).__init__(
+        super().__init__(
             dim=dim,
             signature=(dim, 0),
             shape=(n, n),
@@ -1203,7 +1203,7 @@ class SPDMetricLogEuclidean(RiemannianMetric):
 
     def __init__(self, n):
         dim = int(n * (n + 1) / 2)
-        super(SPDMetricLogEuclidean, self).__init__(
+        super().__init__(
             dim=dim,
             signature=(dim, 0),
             shape=(n, n),

--- a/geomstats/geometry/spd_matrices.py
+++ b/geomstats/geometry/spd_matrices.py
@@ -484,7 +484,9 @@ class SPDMetricAffine(RiemannianMetric):
         """
         dim = int(n * (n + 1) / 2)
         super(SPDMetricAffine, self).__init__(
-            dim=dim, signature=(dim, 0), default_point_type="matrix"
+            dim=dim,
+            shape=(n, n),
+            signature=(dim, 0),
         )
         self.n = n
         self.power_affine = power_affine
@@ -757,7 +759,9 @@ class SPDMetricBuresWasserstein(RiemannianMetric):
     def __init__(self, n):
         dim = int(n * (n + 1) / 2)
         super(SPDMetricBuresWasserstein, self).__init__(
-            dim=dim, signature=(dim, 0), default_point_type="matrix"
+            dim=dim,
+            signature=(dim, 0),
+            shape=(n, n),
         )
         self.n = n
 
@@ -991,7 +995,9 @@ class SPDMetricEuclidean(RiemannianMetric):
     def __init__(self, n, power_euclidean=1):
         dim = int(n * (n + 1) / 2)
         super(SPDMetricEuclidean, self).__init__(
-            dim=dim, signature=(dim, 0), default_point_type="matrix"
+            dim=dim,
+            signature=(dim, 0),
+            shape=(n, n),
         )
         self.n = n
         self.power_euclidean = power_euclidean
@@ -1198,7 +1204,9 @@ class SPDMetricLogEuclidean(RiemannianMetric):
     def __init__(self, n):
         dim = int(n * (n + 1) / 2)
         super(SPDMetricLogEuclidean, self).__init__(
-            dim=dim, signature=(dim, 0), default_point_type="matrix"
+            dim=dim,
+            signature=(dim, 0),
+            shape=(n, n),
         )
         self.n = n
 

--- a/geomstats/geometry/special_euclidean.py
+++ b/geomstats/geometry/special_euclidean.py
@@ -656,7 +656,7 @@ class _SpecialEuclidean2Vectors(_SpecialEuclideanVectors):
     """
 
     def __init__(self, epsilon=0.0):
-        super(_SpecialEuclidean2Vectors, self).__init__(n=2, epsilon=epsilon)
+        super().__init__(n=2, epsilon=epsilon)
 
     def regularize_tangent_vec(self, tangent_vec, base_point, metric=None):
         """Regularize a tangent vector at a base point.
@@ -767,7 +767,7 @@ class _SpecialEuclidean3Vectors(_SpecialEuclideanVectors):
     """
 
     def __init__(self, epsilon=0.0):
-        super(_SpecialEuclidean3Vectors, self).__init__(n=3, epsilon=epsilon)
+        super().__init__(n=3, epsilon=epsilon)
 
     def regularize_tangent_vec(self, tangent_vec, base_point, metric=None):
         """Regularize a tangent vector at a base point.
@@ -1045,7 +1045,7 @@ class SpecialEuclideanMatrixCannonicalLeftMetric(_InvariantMetricMatrix):
                 "group must be an instance of the "
                 "SpecialEclidean class with `point_type=matrix`."
             )
-        super(SpecialEuclideanMatrixCannonicalLeftMetric, self).__init__(group=group)
+        super().__init__(group=group)
         self.n = group.n
 
     def inner_product(self, tangent_vec_a, tangent_vec_b, base_point=None):
@@ -1331,7 +1331,7 @@ class SpecialEuclideanMatrixLieAlgebra(MatrixLieAlgebra):
 
     def __init__(self, n):
         dim = int(n * (n + 1) / 2)
-        super(SpecialEuclideanMatrixLieAlgebra, self).__init__(dim, n + 1)
+        super().__init__(dim, n + 1)
 
         self.skew = SkewSymmetricMatrices(n)
         self.n = n
@@ -1398,9 +1398,7 @@ class SpecialEuclideanMatrixLieAlgebra(MatrixLieAlgebra):
         point : array-like, shape=[..., n + 1, n + 1]
            Sample.
         """
-        point = super(SpecialEuclideanMatrixLieAlgebra, self).random_point(
-            n_samples, bound
-        )
+        point = super().random_point(n_samples, bound)
         return self.projection(point)
 
     def projection(self, mat):

--- a/geomstats/geometry/special_euclidean.py
+++ b/geomstats/geometry/special_euclidean.py
@@ -341,7 +341,6 @@ class _SpecialEuclideanVectors(LieGroup):
             self,
             dim=dim,
             shape=(dim,),
-            default_point_type="vector",
             lie_algebra=Euclidean(dim),
         )
 
@@ -350,29 +349,21 @@ class _SpecialEuclideanVectors(LieGroup):
         self.rotations = SpecialOrthogonal(n=n, point_type="vector", epsilon=epsilon)
         self.translations = Euclidean(dim=n)
 
-    def get_identity(self, point_type=None):
+    def get_identity(self):
         """Get the identity of the group.
-
-        Parameters
-        ----------
-        point_type : str, {'vector', 'matrix'}
-            The point_type of the returned value.
-            Optional, default: self.default_point_type
 
         Returns
         -------
         identity : array-like, shape={[dim], [n + 1, n + 1]}
         """
-        if point_type is None:
-            point_type = self.default_point_type
         identity = gs.zeros(self.dim)
         return identity
 
     identity = property(get_identity)
 
-    def get_point_type_shape(self, point_type=None):
+    def get_point_type_shape(self):
         """Get the shape of the instance given the default_point_style."""
-        return self.get_identity(point_type).shape
+        return self.get_identity().shape
 
     def belongs(self, point, atol=gs.atol):
         """Evaluate if a point belongs to SE(2) or SE(3).

--- a/geomstats/geometry/special_orthogonal.py
+++ b/geomstats/geometry/special_orthogonal.py
@@ -40,7 +40,7 @@ class _SpecialOrthogonalMatrices(MatrixLieGroup, LevelSet):
     def __init__(self, n, **kwargs):
         matrices = Matrices(n, n)
         gln = GeneralLinear(n, positive_det=True)
-        super(_SpecialOrthogonalMatrices, self).__init__(
+        super().__init__(
             dim=int((n * (n - 1)) / 2),
             n=n,
             value=gs.eye(n),
@@ -534,7 +534,7 @@ class _SpecialOrthogonal2Vectors(_SpecialOrthogonalVectors):
     """
 
     def __init__(self, epsilon=0.0):
-        super(_SpecialOrthogonal2Vectors, self).__init__(
+        super().__init__(
             n=2,
             epsilon=epsilon,
         )
@@ -702,7 +702,7 @@ class _SpecialOrthogonal3Vectors(_SpecialOrthogonalVectors):
     """
 
     def __init__(self, epsilon=0.0):
-        super(_SpecialOrthogonal3Vectors, self).__init__(n=3, epsilon=epsilon)
+        super().__init__(n=3, epsilon=epsilon)
 
         self.bi_invariant_metric = BiInvariantMetric(group=self)
         self.metric = self.bi_invariant_metric

--- a/geomstats/geometry/special_orthogonal.py
+++ b/geomstats/geometry/special_orthogonal.py
@@ -298,16 +298,14 @@ class _SpecialOrthogonalVectors(LieGroup):
         Optional, default: 0.
     """
 
-    def __init__(self, n, shape, epsilon=0.0):
+    def __init__(self, n, epsilon=0.0):
         dim = n * (n - 1) // 2
-        LieGroup.__init__(
-            self, dim=dim, shape=shape, default_point_type="vector", lie_algebra=self
-        )
+        LieGroup.__init__(self, dim=dim, shape=(dim,), lie_algebra=self)
 
         self.n = n
         self.epsilon = epsilon
 
-    def get_identity(self, point_type="vector"):
+    def get_identity(self):
         """Get the identity of the group.
 
         Parameters
@@ -537,7 +535,8 @@ class _SpecialOrthogonal2Vectors(_SpecialOrthogonalVectors):
 
     def __init__(self, epsilon=0.0):
         super(_SpecialOrthogonal2Vectors, self).__init__(
-            n=2, epsilon=epsilon, shape=(2,)
+            n=2,
+            epsilon=epsilon,
         )
 
     def regularize(self, point):
@@ -703,9 +702,7 @@ class _SpecialOrthogonal3Vectors(_SpecialOrthogonalVectors):
     """
 
     def __init__(self, epsilon=0.0):
-        super(_SpecialOrthogonal3Vectors, self).__init__(
-            n=3, shape=(3,), epsilon=epsilon
-        )
+        super(_SpecialOrthogonal3Vectors, self).__init__(n=3, epsilon=epsilon)
 
         self.bi_invariant_metric = BiInvariantMetric(group=self)
         self.metric = self.bi_invariant_metric

--- a/geomstats/geometry/stiefel.py
+++ b/geomstats/geometry/stiefel.py
@@ -42,7 +42,7 @@ class Stiefel(LevelSet):
         matrices = Matrices(n, p)
         canonical_metric = StiefelCanonicalMetric(n, p)
         kwargs.setdefault("metric", canonical_metric)
-        super(Stiefel, self).__init__(
+        super().__init__(
             dim=dim,
             embedding_space=matrices,
             submersion=lambda x: matrices.mul(matrices.transpose(x), x),
@@ -187,9 +187,7 @@ class StiefelCanonicalMetric(RiemannianMetric):
 
     def __init__(self, n, p):
         dim = int(p * n - (p * (p + 1) / 2))
-        super(StiefelCanonicalMetric, self).__init__(
-            dim=dim, signature=(dim, 0, 0), shape=(n, p)
-        )
+        super().__init__(dim=dim, signature=(dim, 0, 0), shape=(n, p))
         self.embedding_metric = EuclideanMetric(n * p)
         self.n = n
         self.p = p

--- a/geomstats/geometry/stiefel.py
+++ b/geomstats/geometry/stiefel.py
@@ -188,7 +188,7 @@ class StiefelCanonicalMetric(RiemannianMetric):
     def __init__(self, n, p):
         dim = int(p * n - (p * (p + 1) / 2))
         super(StiefelCanonicalMetric, self).__init__(
-            dim=dim, default_point_type="matrix", signature=(dim, 0, 0)
+            dim=dim, signature=(dim, 0, 0), shape=(n, p)
         )
         self.embedding_metric = EuclideanMetric(n * p)
         self.n = n

--- a/geomstats/geometry/stratified/point_set.py
+++ b/geomstats/geometry/stratified/point_set.py
@@ -172,7 +172,7 @@ class PointSetMetric(ABC):
     """
 
     def __init__(self, space: PointSet, **kwargs):
-        super(PointSetMetric, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.space = space
 
     @abstractmethod

--- a/geomstats/geometry/stratified/spider.py
+++ b/geomstats/geometry/stratified/spider.py
@@ -30,7 +30,7 @@ class SpiderPoint(Point):
     """
 
     def __init__(self, stratum, stratum_coord):
-        super(SpiderPoint, self).__init__()
+        super().__init__()
         if stratum == 0 and stratum_coord != 0:
             raise ValueError("If the stratum is zero, x must be zero.")
         self.stratum = stratum
@@ -76,7 +76,7 @@ class Spider(PointSet):
     """
 
     def __init__(self, n_rays):
-        super(Spider, self).__init__()
+        super().__init__()
         self.n_rays = n_rays
 
     def random_point(self, n_samples=1):
@@ -184,7 +184,7 @@ class SpiderMetric(PointSetMetric):
     """Geometry on the Spider, induced by the rays Geometry."""
 
     def __init__(self, space, ray_metric=EuclideanMetric(1)):
-        super(SpiderMetric, self).__init__(space=space)
+        super().__init__(space=space)
         self.ray_metric = ray_metric
 
     @property

--- a/geomstats/geometry/symmetric_matrices.py
+++ b/geomstats/geometry/symmetric_matrices.py
@@ -24,10 +24,7 @@ class SymmetricMatrices(VectorSpace):
     def __init__(self, n, **kwargs):
         kwargs.setdefault("metric", MatricesMetric(n, n))
         super(SymmetricMatrices, self).__init__(
-            dim=int(n * (n + 1) / 2),
-            shape=(n, n),
-            default_point_type="matrix",
-            **kwargs
+            dim=int(n * (n + 1) / 2), shape=(n, n), **kwargs
         )
         self.n = n
 

--- a/geomstats/geometry/symmetric_matrices.py
+++ b/geomstats/geometry/symmetric_matrices.py
@@ -23,9 +23,7 @@ class SymmetricMatrices(VectorSpace):
 
     def __init__(self, n, **kwargs):
         kwargs.setdefault("metric", MatricesMetric(n, n))
-        super(SymmetricMatrices, self).__init__(
-            dim=int(n * (n + 1) / 2), shape=(n, n), **kwargs
-        )
+        super().__init__(dim=int(n * (n + 1) / 2), shape=(n, n), **kwargs)
         self.n = n
 
     def _create_basis(self):
@@ -59,7 +57,7 @@ class SymmetricMatrices(VectorSpace):
         belongs : array-like, shape=[...,]
             Boolean evaluating if point belongs to the space.
         """
-        belongs = super(SymmetricMatrices, self).belongs(point)
+        belongs = super().belongs(point)
         if gs.any(belongs):
             is_symmetric = Matrices.is_symmetric(point, atol)
             return gs.logical_and(belongs, is_symmetric)
@@ -97,7 +95,7 @@ class SymmetricMatrices(VectorSpace):
         point : array-like, shape=[..., n, n]
            Sample.
         """
-        sample = super(SymmetricMatrices, self).random_point(n_samples, bound)
+        sample = super().random_point(n_samples, bound)
         return Matrices.to_symmetric(sample)
 
     @staticmethod

--- a/geomstats/information_geometry/beta.py
+++ b/geomstats/information_geometry/beta.py
@@ -30,7 +30,7 @@ class BetaDistributions(DirichletDistributions):
     """
 
     def __init__(self):
-        super(BetaDistributions, self).__init__(dim=2)
+        super().__init__(dim=2)
         self.metric = BetaMetric()
 
     def sample(self, point, n_samples=1):
@@ -140,7 +140,7 @@ class BetaMetric(DirichletMetric):
     """Class for the Fisher information metric on beta distributions."""
 
     def __init__(self):
-        super(BetaMetric, self).__init__(dim=2)
+        super().__init__(dim=2)
 
     @staticmethod
     def metric_det(param_a, param_b):

--- a/geomstats/information_geometry/binomial.py
+++ b/geomstats/information_geometry/binomial.py
@@ -20,7 +20,7 @@ class BinomialDistributions(OpenSet):
     """
 
     def __init__(self, n_draws):
-        super(BinomialDistributions, self).__init__(
+        super().__init__(
             dim=1,
             ambient_space=Euclidean(dim=1),
             metric=BinomialFisherRaoMetric(n_draws),
@@ -167,7 +167,7 @@ class BinomialFisherRaoMetric(RiemannianMetric):
     """
 
     def __init__(self, n_draws):
-        super(BinomialFisherRaoMetric, self).__init__(dim=1)
+        super().__init__(dim=1)
         self.n_draws = n_draws
 
     def squared_dist(self, point_a, point_b, **kwargs):

--- a/geomstats/information_geometry/categorical.py
+++ b/geomstats/information_geometry/categorical.py
@@ -26,7 +26,7 @@ class CategoricalDistributions(MultinomialDistributions):
     """
 
     def __init__(self, dim):
-        super(CategoricalDistributions, self).__init__(
+        super().__init__(
             dim=dim,
             n_draws=1,
         )
@@ -47,4 +47,4 @@ class CategoricalMetric(MultinomialMetric):
     """
 
     def __init__(self, dim):
-        super(CategoricalMetric, self).__init__(dim=dim, n_draws=1)
+        super().__init__(dim=dim, n_draws=1)

--- a/geomstats/information_geometry/dirichlet.py
+++ b/geomstats/information_geometry/dirichlet.py
@@ -33,7 +33,7 @@ class DirichletDistributions(OpenSet):
     """
 
     def __init__(self, dim):
-        super(DirichletDistributions, self).__init__(
+        super().__init__(
             dim=dim, ambient_space=Euclidean(dim=dim), metric=DirichletMetric(dim=dim)
         )
 
@@ -190,7 +190,7 @@ class DirichletMetric(RiemannianMetric):
     """Class for the Fisher information metric on Dirichlet distributions."""
 
     def __init__(self, dim):
-        super(DirichletMetric, self).__init__(dim=dim)
+        super().__init__(dim=dim)
 
     def metric_matrix(self, base_point=None):
         """Compute the inner-product matrix.

--- a/geomstats/information_geometry/exponential.py
+++ b/geomstats/information_geometry/exponential.py
@@ -20,7 +20,7 @@ class ExponentialDistributions(OpenSet):
     """
 
     def __init__(self):
-        super(ExponentialDistributions, self).__init__(
+        super().__init__(
             dim=1, ambient_space=Euclidean(dim=1), metric=ExponentialFisherRaoMetric()
         )
 
@@ -156,7 +156,7 @@ class ExponentialFisherRaoMetric(RiemannianMetric):
     """
 
     def __init__(self):
-        super(ExponentialFisherRaoMetric, self).__init__(dim=1)
+        super().__init__(dim=1)
 
     def squared_dist(self, point_a, point_b, **kwargs):
         """Compute squared distance associated with the exponential Fisher Rao metric.

--- a/geomstats/information_geometry/gamma.py
+++ b/geomstats/information_geometry/gamma.py
@@ -45,9 +45,7 @@ class GammaDistributions(OpenSet):
     """
 
     def __init__(self):
-        super(GammaDistributions, self).__init__(
-            dim=2, ambient_space=Euclidean(2), metric=GammaMetric()
-        )
+        super().__init__(dim=2, ambient_space=Euclidean(2), metric=GammaMetric())
 
     def belongs(self, point, atol=gs.atol):
         """Evaluate if a point belongs to the manifold of Gamma distributions.
@@ -339,7 +337,7 @@ class GammaMetric(RiemannianMetric):
     """
 
     def __init__(self):
-        super(GammaMetric, self).__init__(dim=2)
+        super().__init__(dim=2)
 
     def metric_matrix(self, base_point=None):
         """Compute the inner-product matrix.
@@ -574,7 +572,7 @@ class GammaMetric(RiemannianMetric):
             initial velocity tangent_vec and stopping at time 1.
         """
         if solver == "geomstats":
-            return super(GammaMetric, self).exp(
+            return super().exp(
                 tangent_vec,
                 base_point,
                 n_steps,
@@ -629,7 +627,7 @@ class GammaMetric(RiemannianMetric):
         """
         try:
             if method == "geodesic_shooting":
-                return super(GammaMetric, self).log(
+                return super().log(
                     point, base_point, n_steps, step, max_iter, verbose, tol
                 )
             if method == "ode_bvp":
@@ -686,7 +684,7 @@ class GammaMetric(RiemannianMetric):
             initial conditions.
         """
         if solver == "geomstats":
-            return super(GammaMetric, self).geodesic(
+            return super().geodesic(
                 initial_point, end_point, initial_tangent_vec, n_steps=n_steps
             )
         if solver == "vp":

--- a/geomstats/information_geometry/gamma.py
+++ b/geomstats/information_geometry/gamma.py
@@ -575,7 +575,10 @@ class GammaMetric(RiemannianMetric):
         """
         if solver == "geomstats":
             return super(GammaMetric, self).exp(
-                tangent_vec, base_point, n_steps, step, solver
+                tangent_vec,
+                base_point,
+                n_steps,
+                step,
             )
         if solver == "lsoda":
             return self._exp_ivp(tangent_vec, base_point, n_steps)

--- a/geomstats/information_geometry/multinomial.py
+++ b/geomstats/information_geometry/multinomial.py
@@ -32,7 +32,7 @@ class MultinomialDistributions(LevelSet):
     """
 
     def __init__(self, dim, n_draws):
-        super(MultinomialDistributions, self).__init__(
+        super().__init__(
             dim=dim,
             embedding_space=Euclidean(dim + 1),
             submersion=lambda x: gs.sum(x, axis=-1),
@@ -153,7 +153,7 @@ class MultinomialMetric(RiemannianMetric):
     """
 
     def __init__(self, dim, n_draws):
-        super(MultinomialMetric, self).__init__(dim=dim)
+        super().__init__(dim=dim)
         self.n_draws = n_draws
         self.sphere_metric = HypersphereMetric(dim)
 

--- a/geomstats/information_geometry/normal.py
+++ b/geomstats/information_geometry/normal.py
@@ -20,7 +20,7 @@ class NormalDistributions(PoincareHalfSpace):
     """
 
     def __init__(self):
-        super(NormalDistributions, self).__init__(dim=2)
+        super().__init__(dim=2)
         self.metric = FisherRaoMetric()
 
     @staticmethod
@@ -122,4 +122,4 @@ class FisherRaoMetric(PoincareHalfSpaceMetric):
     """
 
     def __init__(self):
-        super(FisherRaoMetric, self).__init__(dim=2)
+        super().__init__(dim=2)

--- a/geomstats/learning/kernel_density_estimation_classifier.py
+++ b/geomstats/learning/kernel_density_estimation_classifier.py
@@ -177,7 +177,7 @@ class KernelDensityEstimationClassifier(RadiusNeighborsClassifier):
         if len(data_shape) == 1:
             n_samples = data_shape[0]
             X = gs.reshape(X, (n_samples, 1))
-        super(KernelDensityEstimationClassifier, self).fit(X, y)
+        super().fit(X, y)
 
     def predict(self, X):
         """Predict the class labels for the provided data.
@@ -197,7 +197,7 @@ class KernelDensityEstimationClassifier(RadiusNeighborsClassifier):
         if len(data_shape) == 1:
             n_samples = data_shape[0]
             X = gs.reshape(X, (n_samples, 1))
-        y_pred = super(KernelDensityEstimationClassifier, self).predict(X)
+        y_pred = super().predict(X)
         return y_pred
 
     def predict_proba(self, X):
@@ -220,5 +220,5 @@ class KernelDensityEstimationClassifier(RadiusNeighborsClassifier):
         if len(data_shape) == 1:
             n_samples = data_shape[0]
             X = gs.reshape(X, (n_samples, 1))
-        probabilities = super(KernelDensityEstimationClassifier, self).predict_proba(X)
+        probabilities = super().predict_proba(X)
         return probabilities

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -232,7 +232,7 @@ class Parametrizer(type):
             else:
                 attrs[attr_name] = pytest.mark.skip("skipped")(test_func)
 
-        return super(Parametrizer, cls).__new__(cls, name, bases, attrs)
+        return super().__new__(cls, name, bases, attrs)
 
 
 class TestCase:

--- a/tests/data/pullback_diffeo_metric_data.py
+++ b/tests/data/pullback_diffeo_metric_data.py
@@ -19,7 +19,7 @@ class CircleAsSO2Metric(PullbackDiffeoMetric):
                 "This dummy class using SO(2) metric for S1 has "
                 "a meaning only when dim=1"
             )
-        super(CircleAsSO2Metric, self).__init__(dim=1, shape=(2,))
+        super().__init__(dim=1, shape=(2,))
 
     def define_embedding_metric(self):
         return SpecialOrthogonal(n=2, point_type="matrix").bi_invariant_metric
@@ -40,7 +40,7 @@ class CircleAsSO2(Hypersphere):
                 "This dummy class using SO(2) metric for S1 has "
                 "a meaning only when dim=1"
             )
-        super(CircleAsSO2, self).__init__(1, "extrinsic")
+        super().__init__(1, "extrinsic")
         self._metric = CircleAsSO2Metric(1)
 
 

--- a/tests/data/quotient_metric_data.py
+++ b/tests/data/quotient_metric_data.py
@@ -10,7 +10,7 @@ from tests.data_generation import TestData
 
 class BuresWassersteinBundle(GeneralLinear, FiberBundle):
     def __init__(self, n):
-        super(BuresWassersteinBundle, self).__init__(
+        super().__init__(
             n=n,
             group=SpecialOrthogonal(n),
             total_space_metric=MatricesMetric(n, n),

--- a/tests/data/sub_riemannian_metric_data.py
+++ b/tests/data/sub_riemannian_metric_data.py
@@ -5,7 +5,7 @@ from tests.data_generation import TestData
 
 class ExampleMetric(SubRiemannianMetric):
     def __init__(self, dim, dist_dim, default_point_type="vector"):
-        super(ExampleMetric, self).__init__(
+        super().__init__(
             dim=dim, dist_dim=dist_dim, default_point_type=default_point_type
         )
 

--- a/tests/data_generation.py
+++ b/tests/data_generation.py
@@ -184,6 +184,13 @@ class TestData:
 class _ManifoldTestData(TestData):
     """Class for ManifoldTestData: data to test manifold properties."""
 
+    def manifold_shape_test_data(self):
+        smoke_data = [
+            dict(space_args=space_args) for space_args in self.space_args_list
+        ]
+
+        return self.generate_tests(smoke_data)
+
     def random_point_belongs_test_data(self):
         """Generate data to check that a random point belongs to the manifold."""
         random_data = [
@@ -538,6 +545,18 @@ class _FiberBundleTestData(TestData):
 
 
 class _ConnectionTestData(TestData):
+    def manifold_shape_test_data(self):
+        smoke_data = []
+        for connection_args, space in zip(self.metric_args_list, self.space_list):
+            smoke_data.append(
+                dict(
+                    connection_args=connection_args,
+                    expected_shape=space.random_point().shape,
+                )
+            )
+
+        return self.generate_tests(smoke_data)
+
     def exp_shape_test_data(self):
         """Generate data to check that exp returns an array of the expected shape."""
         n_samples_list = [3] * len(self.metric_args_list)

--- a/tests/geometry_test_cases.py
+++ b/tests/geometry_test_cases.py
@@ -59,6 +59,26 @@ class ManifoldTestCase(TestCase):
     def Space(self):
         return self.testing_data.Space
 
+    def test_manifold_shape(self, space_args):
+        space = self.Space(*space_args)
+        point = space.random_point()
+
+        if space.metric is None:
+            return
+
+        point_shape = (1,) if point.shape == () else point.shape
+
+        self.assertTrue(
+            space.shape == point_shape,
+            f"Shape is {space.shape}, but random point shape is {point_shape}",
+        )
+
+        msg = (
+            f"Space shape is {space.shape}, "
+            f"whereas space metric shape is {space.metric.shape}",
+        )
+        self.assertTrue(space.shape == space.metric.shape, msg)
+
     def test_random_point_belongs(self, space_args, n_points, atol):
         """Check that a random point belongs to the manifold.
 
@@ -576,6 +596,14 @@ class ConnectionTestCase(TestCase):
     @property
     def Metric(self):
         return self.testing_data.Metric
+
+    def test_manifold_shape(self, connection_args, expected_shape):
+        connection = self.Metric(*connection_args)
+
+        self.assertTrue(
+            connection.shape == expected_shape,
+            f"Shape is {connection.shape}, but random point shape is {expected_shape}",
+        )
 
     def test_exp_shape(self, connection_args, tangent_vec, base_point, expected):
         """Check that exp returns an array of the expected shape.

--- a/tests/tests_geomstats/test_geodesic_regression.py
+++ b/tests/tests_geomstats/test_geodesic_regression.py
@@ -68,7 +68,6 @@ class TestGeodesicRegression(geomstats.tests.TestCase):
         # Set up for special euclidean
         self.se2 = SpecialEuclidean(n=2)
         self.metric_se2 = self.se2.left_canonical_metric
-        self.metric_se2.default_point_type = "matrix"
 
         self.shape_se2 = (3, 3)
         X = gs.random.rand(self.n_samples)
@@ -105,7 +104,6 @@ class TestGeodesicRegression(geomstats.tests.TestCase):
         k_sampling_points = 8
         self.curves_2d = DiscreteCurves(R2, k_sampling_points=k_sampling_points)
         self.metric_curves_2d = self.curves_2d.srv_metric
-        self.metric_curves_2d.default_point_type = "matrix"
 
         self.shape_curves_2d = (k_sampling_points, 2)
         X = gs.random.rand(self.n_samples)


### PR DESCRIPTION
Simplify uses of `super()` by making it more python3 friendly (basically remove class name and self).

Can only be merged after #1644 as it builds on top of it (to avoid merge conflicts).