### PR TITLE
Fix use of "projection" in visualization example

### DIFF
--- a/examples/plot_expectation_maximization_ball.py
+++ b/examples/plot_expectation_maximization_ball.py
@@ -56,7 +56,7 @@ def plot_gaussian_mixture_distribution(
         "via Expectation Maximization on Poincaré Disc"
     )
 
-    ax = fig.gca(projection="3d")
+    ax = fig.add_subplot(projection="3d")
     ax.plot_surface(
         x_axis_samples,
         y_axis_samples,


### PR DESCRIPTION
Update example to work with last version of matplotlib.

closes #1645.