### PR TITLE
Fix inheritance of GrassmanianCanonicallMetric, SpecialEuclidean and SpecialOrthogonal

### DIFF
--- a/geomstats/geometry/grassmannian.py
+++ b/geomstats/geometry/grassmannian.py
@@ -41,7 +41,6 @@ from geomstats.geometry.base import LevelSet
 from geomstats.geometry.euclidean import EuclideanMetric
 from geomstats.geometry.general_linear import GeneralLinear
 from geomstats.geometry.matrices import Matrices, MatricesMetric
-from geomstats.geometry.riemannian_metric import RiemannianMetric
 from geomstats.geometry.symmetric_matrices import SymmetricMatrices
 
 
@@ -296,7 +295,7 @@ class Grassmannian(LevelSet):
         return Matrices.mul(p_d, Matrices.transpose(eigvecs))
 
 
-class GrassmannianCanonicalMetric(MatricesMetric, RiemannianMetric):
+class GrassmannianCanonicalMetric(MatricesMetric):
     """Canonical metric of the Grassmann manifold.
 
     Coincides with the Frobenius metric.

--- a/geomstats/geometry/special_euclidean.py
+++ b/geomstats/geometry/special_euclidean.py
@@ -1276,9 +1276,7 @@ class SpecialEuclideanMatrixCannonicalLeftMetric(_InvariantMetricMatrix):
         return radius
 
 
-class SpecialEuclidean(
-    _SpecialEuclidean2Vectors, _SpecialEuclidean3Vectors, _SpecialEuclideanMatrices
-):
+class SpecialEuclidean:
     r"""Class for the special Euclidean groups.
 
     Parameters

--- a/geomstats/geometry/special_orthogonal.py
+++ b/geomstats/geometry/special_orthogonal.py
@@ -1711,9 +1711,7 @@ class _SpecialOrthogonal3Vectors(_SpecialOrthogonalVectors):
         return LieGroup.log(self, point, base_point)
 
 
-class SpecialOrthogonal(
-    _SpecialOrthogonal2Vectors, _SpecialOrthogonal3Vectors, _SpecialOrthogonalMatrices
-):
+class SpecialOrthogonal:
     r"""Class for the special orthogonal groups.
 
     Parameters


### PR DESCRIPTION
`GrassmanianCanonicallMetric` -> `MatricesMatrices` -> `EuclideanMetric` -> `RiemannianMetric`, therefore inheritance from  `RiemannianMetric` is redundant (-> means "inherits from").

`SpecialEuclidean` and `SpecialOrthogonal` are interfaces, so they need to inherit from anything else.