### PR TITLE
Fix pullback metric for manifolds of dim 1

### DIFF
--- a/geomstats/geometry/pullback_metric.py
+++ b/geomstats/geometry/pullback_metric.py
@@ -58,7 +58,7 @@ class PullbackMetric(RiemannianMetric):
         if tangent_immersion is None:
 
             def _tangent_immersion(v, x):
-                return gs.matvec(jacobian_immersion(x), v)
+                return gs.squeeze(gs.matvec(jacobian_immersion(x), v))
 
         self.tangent_immersion = _tangent_immersion
 
@@ -91,8 +91,12 @@ class PullbackMetric(RiemannianMetric):
         @joblib.delayed
         @joblib.wrap_non_picklable_objects
         def pickable_inner_product(i, j):
-            immersed_basis_element_i = gs.matvec(jacobian_immersion, basis_elements[i])
-            immersed_basis_element_j = gs.matvec(jacobian_immersion, basis_elements[j])
+            immersed_basis_element_i = gs.squeeze(
+                gs.matvec(jacobian_immersion, basis_elements[i])
+            )
+            immersed_basis_element_j = gs.squeeze(
+                gs.matvec(jacobian_immersion, basis_elements[j])
+            )
             return self.embedding_metric.inner_product(
                 immersed_basis_element_i,
                 immersed_basis_element_j,

--- a/tests/data/pullback_metric_data.py
+++ b/tests/data/pullback_metric_data.py
@@ -105,8 +105,8 @@ class PullbackMetricTestData(TestData):
 
     def circle_metric_matrix_test_data(self):
         smoke_data = [
-            # dict(dim=1, base_point=gs.array([0.0])),
-            # dict(dim=1, base_point=gs.array([1.0])),
+            dict(dim=1, base_point=gs.array([0.0])),
+            dict(dim=1, base_point=gs.array([1.0])),
             dict(dim=1, base_point=gs.array([4.0])),
         ]
         return self.generate_tests(smoke_data)
@@ -132,6 +132,13 @@ class PullbackMetricTestData(TestData):
         smoke_data = [
             dict(dim=2, base_point=gs.array([0.6, -1.0])),
             dict(dim=2, base_point=gs.array([0.8, -0.8])),
+        ]
+        return self.generate_tests(smoke_data)
+
+    def inverse_circle_metric_matrix_test_data(self):
+        smoke_data = [
+            dict(dim=1, base_point=gs.array([0.6])),
+            dict(dim=1, base_point=gs.array([0.8])),
         ]
         return self.generate_tests(smoke_data)
 

--- a/tests/data/pullback_metric_data.py
+++ b/tests/data/pullback_metric_data.py
@@ -57,6 +57,25 @@ class PullbackMetricTestData(TestData):
         ]
         return self.generate_tests(smoke_data)
 
+    def tangent_circle_immersion_test_data(self):
+        smoke_data = [
+            dict(
+                dim=1,
+                tangent_vec=gs.array([1.0]),
+                point=gs.array([0.0]),
+                expected=gs.array([0.0, 1.0]),
+            ),
+        ]
+        return self.generate_tests(smoke_data)
+
+    def jacobian_circle_immersion_test_data(self):
+        smoke_data = [
+            dict(dim=1, pole=gs.array([0.0])),
+            dict(dim=1, pole=gs.array([0.2])),
+            dict(dim=1, pole=gs.array([4.0])),
+        ]
+        return self.generate_tests(smoke_data)
+
     def jacobian_sphere_immersion_test_data(self):
         smoke_data = [
             dict(dim=2, pole=gs.array([0.0, 0.0])),
@@ -81,6 +100,14 @@ class PullbackMetricTestData(TestData):
             dict(dim=2, base_point=gs.array([0.0, 0.0])),
             dict(dim=2, base_point=gs.array([1.0, 1.0])),
             dict(dim=2, base_point=gs.array([0.3, 0.8])),
+        ]
+        return self.generate_tests(smoke_data)
+
+    def circle_metric_matrix_test_data(self):
+        smoke_data = [
+            # dict(dim=1, base_point=gs.array([0.0])),
+            # dict(dim=1, base_point=gs.array([1.0])),
+            dict(dim=1, base_point=gs.array([4.0])),
         ]
         return self.generate_tests(smoke_data)
 

--- a/tests/data/pullback_metric_data.py
+++ b/tests/data/pullback_metric_data.py
@@ -7,7 +7,7 @@ class PullbackMetricTestData(TestData):
 
     Metric = PullbackMetric
 
-    def immersion_test_data(self):
+    def sphere_immersion_test_data(self):
         smoke_data = [
             dict(
                 spherical_coords=gs.array([0.0, 0.0]),
@@ -24,11 +24,11 @@ class PullbackMetricTestData(TestData):
         ]
         return self.generate_tests(smoke_data)
 
-    def immersion_and_spherical_to_extrinsic_test_data(self):
+    def sphere_immersion_and_spherical_to_extrinsic_test_data(self):
         smoke_data = [dict(dim=2, point=gs.array([0.0, 0.0]))]
         return self.generate_tests(smoke_data)
 
-    def tangent_immersion_test_data(self):
+    def tangent_sphere_immersion_test_data(self):
         smoke_data = [
             dict(
                 dim=2,
@@ -57,7 +57,7 @@ class PullbackMetricTestData(TestData):
         ]
         return self.generate_tests(smoke_data)
 
-    def jacobian_immersion_test_data(self):
+    def jacobian_sphere_immersion_test_data(self):
         smoke_data = [
             dict(dim=2, pole=gs.array([0.0, 0.0])),
             dict(dim=2, pole=gs.array([0.22, 0.1])),
@@ -76,7 +76,7 @@ class PullbackMetricTestData(TestData):
         ]
         return self.generate_tests(smoke_data)
 
-    def metric_matrix_test_data(self):
+    def sphere_metric_matrix_test_data(self):
         smoke_data = [
             dict(dim=2, base_point=gs.array([0.0, 0.0])),
             dict(dim=2, base_point=gs.array([1.0, 1.0])),
@@ -101,7 +101,7 @@ class PullbackMetricTestData(TestData):
         ]
         return self.generate_tests(smoke_data)
 
-    def inverse_metric_matrix_test_data(self):
+    def inverse_sphere_metric_matrix_test_data(self):
         smoke_data = [
             dict(dim=2, base_point=gs.array([0.6, -1.0])),
             dict(dim=2, base_point=gs.array([0.8, -0.8])),

--- a/tests/tests_geomstats/test_pullback_metric.py
+++ b/tests/tests_geomstats/test_pullback_metric.py
@@ -9,6 +9,15 @@ from tests.conftest import Parametrizer, TestCase
 from tests.data.pullback_metric_data import PullbackMetricTestData
 
 
+def _circle_immersion(point):
+    return gs.array(
+        [
+            gs.cos(point),
+            gs.sin(point),
+        ]
+    )
+
+
 def _sphere_immersion(spherical_coords):
     theta = spherical_coords[..., 0]
     phi = spherical_coords[..., 1]
@@ -21,7 +30,17 @@ def _sphere_immersion(spherical_coords):
     )
 
 
-def _expected_jacobian_immersion(point):
+def _expected_jacobian_circle_immersion(point):
+    jacobian = gs.array(
+        [
+            [-gs.sin(point)],
+            [gs.cos(point)],
+        ]
+    )
+    return jacobian
+
+
+def _expected_jacobian_sphere_immersion(point):
     theta = point[..., 0]
     phi = point[..., 1]
     jacobian = gs.array(
@@ -34,20 +53,30 @@ def _expected_jacobian_immersion(point):
     return jacobian
 
 
-def _expected_metric_matrix(point):
+def _expected_circle_metric_matrix(point):
+    mat = gs.array([[1.0]])
+    return mat
+
+
+def _expected_sphere_metric_matrix(point):
     theta = point[..., 0]
     mat = gs.array([[1.0, 0.0], [0.0, gs.sin(theta) ** 2]])
     return mat
 
 
-def _expected_inverse_metric_matrix(point):
+def _expected_inverse_circle_metric_matrix(point):
+    mat = gs.array([[1.0]])
+    return mat
+
+
+def _expected_inverse_sphere_metric_matrix(point):
     theta = point[..., 0]
     mat = gs.array([[1.0, 0.0], [0.0, gs.sin(theta) ** (-2)]])
     return mat
 
 
-immersion = _sphere_immersion
-expected_jacobian_immersion = _expected_jacobian_immersion
+# immersion = _sphere_immersion
+# _expected_jacobian_sphere_immersion = _expected_jacobian_sphere_immersion
 
 
 @geomstats.tests.autograd_tf_and_torch_only
@@ -56,45 +85,45 @@ class TestPullbackMetric(TestCase, metaclass=Parametrizer):
     testing_data = PullbackMetricTestData()
     Metric = testing_data.Metric
 
-    def test_immersion(self, spherical_coords, expected):
-        result = immersion(spherical_coords)
+    def test_sphere_immersion(self, spherical_coords, expected):
+        result = _sphere_immersion(spherical_coords)
         self.assertAllClose(result, expected)
 
-    def test_immersion_and_spherical_to_extrinsic(self, dim, point):
-        expected = immersion(point)
+    def test_sphere_immersion_and_spherical_to_extrinsic(self, dim, point):
+        expected = _sphere_immersion(point)
         result = Hypersphere(dim).spherical_to_extrinsic(point)
         self.assertAllClose(result, expected)
 
-    def test_jacobian_immersion(self, dim, pole):
+    def test_jacobian_sphere_immersion(self, dim, pole):
         pullback_metric = self.Metric(
-            dim=dim, embedding_dim=dim + 1, immersion=immersion
+            dim=dim, embedding_dim=dim + 1, immersion=_sphere_immersion
         )
         result = pullback_metric.jacobian_immersion(pole)
-        expected = _expected_jacobian_immersion(pole)
+        expected = _expected_jacobian_sphere_immersion(pole)
         self.assertAllClose(result, expected)
 
-    def test_tangent_immersion(self, dim, tangent_vec, point, expected):
+    def test_tangent_sphere_immersion(self, dim, tangent_vec, point, expected):
         pullback_metric = self.Metric(
-            dim=dim, embedding_dim=dim + 1, immersion=immersion
+            dim=dim, embedding_dim=dim + 1, immersion=_sphere_immersion
         )
         result = pullback_metric.tangent_immersion(tangent_vec, point)
         self.assertAllClose(result, expected)
 
-    def test_metric_matrix(self, dim, base_point):
+    def test_sphere_metric_matrix(self, dim, base_point):
         pullback_metric = self.Metric(
-            dim=dim, embedding_dim=dim + 1, immersion=immersion
+            dim=dim, embedding_dim=dim + 1, immersion=_sphere_immersion
         )
         result = pullback_metric.metric_matrix(base_point)
-        expected = _expected_metric_matrix(base_point)
+        expected = _expected_sphere_metric_matrix(base_point)
         self.assertAllClose(result, expected)
 
-    def test_inverse_metric_matrix(self, dim, base_point):
+    def test_inverse_sphere_metric_matrix(self, dim, base_point):
         pullback_metric = self.Metric(
-            dim=dim, embedding_dim=dim + 1, immersion=immersion
+            dim=dim, embedding_dim=dim + 1, immersion=_sphere_immersion
         )
 
         result = pullback_metric.cometric_matrix(base_point)
-        expected = _expected_inverse_metric_matrix(base_point)
+        expected = _expected_inverse_sphere_metric_matrix(base_point)
         self.assertAllClose(result, expected)
 
     def test_inner_product_and_sphere_inner_product(
@@ -113,9 +142,9 @@ class TestPullbackMetric(TestCase, metaclass=Parametrizer):
         of the spherical coordinates.
         """
         pullback_metric = self.Metric(
-            dim=dim, embedding_dim=dim + 1, immersion=immersion
+            dim=dim, embedding_dim=dim + 1, immersion=_sphere_immersion
         )
-        immersed_base_point = immersion(base_point)
+        immersed_base_point = _sphere_immersion(base_point)
         jac_immersion = pullback_metric.jacobian_immersion(base_point)
         immersed_tangent_vec_a = gs.matvec(jac_immersion, tangent_vec_a)
         immersed_tangent_vec_b = gs.matvec(jac_immersion, tangent_vec_b)
@@ -141,7 +170,7 @@ class TestPullbackMetric(TestCase, metaclass=Parametrizer):
         in terms of the spherical coordinates.
         """
         pullback_metric = self.Metric(
-            dim=dim, embedding_dim=dim + 1, immersion=immersion
+            dim=dim, embedding_dim=dim + 1, immersion=_sphere_immersion
         )
         result = pullback_metric.christoffels(base_point)
         expected = Hypersphere(2).metric.christoffels(base_point)
@@ -157,9 +186,9 @@ class TestPullbackMetric(TestCase, metaclass=Parametrizer):
         in terms of the spherical coordinates.
         """
         pullback_metric = self.Metric(
-            dim=dim, embedding_dim=dim + 1, immersion=immersion
+            dim=dim, embedding_dim=dim + 1, immersion=_sphere_immersion
         )
-        immersed_base_point = immersion(base_point)
+        immersed_base_point = _sphere_immersion(base_point)
         jac_immersion = pullback_metric.jacobian_immersion(base_point)
         immersed_tangent_vec_a = gs.matvec(jac_immersion, tangent_vec)
         result = pullback_metric.exp(tangent_vec, base_point=base_point)
@@ -182,9 +211,9 @@ class TestPullbackMetric(TestCase, metaclass=Parametrizer):
         in terms of the spherical coordinates.
         """
         pullback_metric = self.Metric(
-            dim=dim, embedding_dim=dim + 1, immersion=immersion
+            dim=dim, embedding_dim=dim + 1, immersion=_sphere_immersion
         )
-        immersed_base_point = immersion(base_point)
+        immersed_base_point = _sphere_immersion(base_point)
         jac_immersion = pullback_metric.jacobian_immersion(base_point)
         immersed_tangent_vec_a = gs.matvec(jac_immersion, tangent_vec_a)
         immersed_tangent_vec_b = gs.matvec(jac_immersion, tangent_vec_b)

--- a/tests/tests_geomstats/test_pullback_metric.py
+++ b/tests/tests_geomstats/test_pullback_metric.py
@@ -75,10 +75,6 @@ def _expected_inverse_sphere_metric_matrix(point):
     return mat
 
 
-# immersion = _sphere_immersion
-# _expected_jacobian_sphere_immersion = _expected_jacobian_sphere_immersion
-
-
 @geomstats.tests.autograd_tf_and_torch_only
 class TestPullbackMetric(TestCase, metaclass=Parametrizer):
 
@@ -147,6 +143,15 @@ class TestPullbackMetric(TestCase, metaclass=Parametrizer):
 
         result = pullback_metric.cometric_matrix(base_point)
         expected = _expected_inverse_sphere_metric_matrix(base_point)
+        self.assertAllClose(result, expected)
+
+    def test_inverse_circle_metric_matrix(self, dim, base_point):
+        pullback_metric = self.Metric(
+            dim=dim, embedding_dim=dim + 1, immersion=_circle_immersion
+        )
+
+        result = pullback_metric.cometric_matrix(base_point)
+        expected = _expected_inverse_circle_metric_matrix(base_point)
         self.assertAllClose(result, expected)
 
     def test_inner_product_and_sphere_inner_product(

--- a/tests/tests_geomstats/test_pullback_metric.py
+++ b/tests/tests_geomstats/test_pullback_metric.py
@@ -102,9 +102,24 @@ class TestPullbackMetric(TestCase, metaclass=Parametrizer):
         expected = _expected_jacobian_sphere_immersion(pole)
         self.assertAllClose(result, expected)
 
+    def test_jacobian_circle_immersion(self, dim, pole):
+        pullback_metric = self.Metric(
+            dim=dim, embedding_dim=dim + 1, immersion=_circle_immersion
+        )
+        result = pullback_metric.jacobian_immersion(pole)
+        expected = _expected_jacobian_circle_immersion(pole)
+        self.assertAllClose(result, expected)
+
     def test_tangent_sphere_immersion(self, dim, tangent_vec, point, expected):
         pullback_metric = self.Metric(
             dim=dim, embedding_dim=dim + 1, immersion=_sphere_immersion
+        )
+        result = pullback_metric.tangent_immersion(tangent_vec, point)
+        self.assertAllClose(result, expected)
+
+    def test_tangent_circle_immersion(self, dim, tangent_vec, point, expected):
+        pullback_metric = self.Metric(
+            dim=dim, embedding_dim=dim + 1, immersion=_circle_immersion
         )
         result = pullback_metric.tangent_immersion(tangent_vec, point)
         self.assertAllClose(result, expected)
@@ -115,6 +130,14 @@ class TestPullbackMetric(TestCase, metaclass=Parametrizer):
         )
         result = pullback_metric.metric_matrix(base_point)
         expected = _expected_sphere_metric_matrix(base_point)
+        self.assertAllClose(result, expected)
+
+    def test_circle_metric_matrix(self, dim, base_point):
+        pullback_metric = self.Metric(
+            dim=dim, embedding_dim=dim + 1, immersion=_circle_immersion
+        )
+        result = pullback_metric.metric_matrix(base_point)
+        expected = _expected_circle_metric_matrix(base_point)
         self.assertAllClose(result, expected)
 
     def test_inverse_sphere_metric_matrix(self, dim, base_point):


### PR DESCRIPTION
This PR:
- fixes a bug in the computation of the pullback metric when manifold has dim 1.
- adds unit-tests to test_pullback_metric, ensuring that the computations work in the case of an immersed circle.


## Checklist

- [x] My pull request has a clear and explanatory title.
- [x] If neccessary, my code is [vectorized](https://www.geeksforgeeks.org/vectorization-in-python/).
- [x] I have added apropriate unit tests.
- [ ] I have made sure the code passes all unit tests. (refer to comment below)
- [x] My PR follows [PEP8](https://peps.python.org/pep-0008/) guidelines. (refer to comment below)
- [x] My PR follows [geomstats coding style](https://github.com/geomstats/geomstats/blob/master/docs/contributing.rst#coding-style-guidelines) and API.
- [x] My code is properly documented and I made sure the documentation renders properly. ([Link](https://github.com/geomstats/geomstats/blob/master/docs/contributing.rst#documentation))
- [x] I have linked to issues and PRs that are relevant to this PR.


<!-- For checking consistency of entire codebase
First, run the tests related to your changes. For example, if you changed something in geomstats/spd_matrices_space.py:
$ pytest tests/tests_geomstats/test_spd_matrices.py

and then run the tests of the whole codebase to check that your feature is not breaking any of them:
$ pytest tests/

This way, further modifications on the code base are guaranteed to be consistent with the desired behavior. Merging your PR should not break any test in any backend (numpy, tensorflow or pytorch)."

For testing in alternative backends such as `numpy`, `pytorch`, `autograd`, `tensorflow` set the environment variable using:
$ export GEOMSTATS_BACKEND=<backend_name>

Next, import the `backend` module using:
import geomstats.backend as gs
-->


<!-- For flake8 tests
Install dependencies
$ pip3 install -r dev-requirements.txt

Then run the following commands:
$ flake8 --ignore=D,W503,W504 geomstats examples tests   #shadows .flake8
$ flake8 geomstats/geometry geomstats/learning           #passed two subfolders
-->

## Description

<!-- Include a description of your pull request. If relevant, feel free to use this space to talk about time and space complexity as well scalability of your code-->

## Issue

<!-- Tell us which issue does this PR fix . Why this feature implementation/fix is important in practice ?-->

## Additional context

<!-- Add any extra information -->