### PR TITLE
Fix expm due to changes in scipy.linalg.expm

### DIFF
--- a/geomstats/_backend/autograd/linalg.py
+++ b/geomstats/_backend/autograd/linalg.py
@@ -3,8 +3,7 @@
 import functools as _functools
 
 import autograd.numpy as _np
-import autograd.scipy.linalg as _asp
-import scipy as _scipy
+import autograd.scipy as _ascp
 from autograd.extend import defvjp as _defvjp
 from autograd.extend import primitive as _primitive
 from autograd.numpy.linalg import (  # NOQA
@@ -19,6 +18,7 @@ from autograd.numpy.linalg import (  # NOQA
     solve,
     svd,
 )
+from autograd.scipy.linalg import expm
 
 from ._common import to_ndarray as _to_ndarray
 from ._dtype import _cast_fout_to_input_dtype
@@ -26,18 +26,13 @@ from ._dtype import _cast_fout_to_input_dtype
 _diag_vec = _np.vectorize(_np.diag, signature="(n)->(n,n)")
 
 _logm_vec = _cast_fout_to_input_dtype(
-    target=_np.vectorize(_scipy.linalg.logm, signature="(n,m)->(n,m)")
+    target=_np.vectorize(_ascp.linalg.logm, signature="(n,m)->(n,m)")
 )
 
 
 def _is_symmetric(x, tol=1e-12):
     new_x = _to_ndarray(x, to_ndim=3)
     return (_np.abs(new_x - _np.transpose(new_x, axes=(0, 2, 1))) < tol).all()
-
-
-@_primitive
-def expm(x):
-    return _np.vectorize(_asp.expm, signature="(n,m)->(n,m)")(x)
 
 
 def _adjoint(_ans, x, fn):
@@ -97,17 +92,17 @@ def solve_sylvester(a, b, q):
                 return eigvecs @ tilde_x @ _np.transpose(eigvecs, axes)
 
     return _np.vectorize(
-        _scipy.linalg.solve_sylvester, signature="(m,m),(n,n),(m,n)->(m,n)"
+        _ascp.linalg.solve_sylvester, signature="(m,m),(n,n),(m,n)->(m,n)"
     )(a, b, q)
 
 
 @_cast_fout_to_input_dtype
 def sqrtm(x):
-    return _np.vectorize(_scipy.linalg.sqrtm, signature="(n,m)->(n,m)")(x)
+    return _np.vectorize(_ascp.linalg.sqrtm, signature="(n,m)->(n,m)")(x)
 
 
 def quadratic_assignment(a, b, options):
-    return list(_scipy.optimize.quadratic_assignment(a, b, options=options).col_ind)
+    return list(_ascp.optimize.quadratic_assignment(a, b, options=options).col_ind)
 
 
 def qr(*args, **kwargs):

--- a/geomstats/_backend/numpy/linalg.py
+++ b/geomstats/_backend/numpy/linalg.py
@@ -14,6 +14,7 @@ from numpy.linalg import (  # NOQA
     solve,
     svd,
 )
+from scipy.linalg import expm
 
 from ._common import atol
 from ._common import to_ndarray as _to_ndarray
@@ -29,10 +30,6 @@ _logm_vec = _cast_fout_to_input_dtype(
 def _is_symmetric(x, tol=atol):
     new_x = _to_ndarray(x, to_ndim=3)
     return (_np.abs(new_x - _np.transpose(new_x, axes=(0, 2, 1))) < tol).all()
-
-
-def expm(x):
-    return _np.vectorize(_scipy.linalg.expm, signature="(n,m)->(n,m)")(x)
 
 
 def logm(x):

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     numpy >= 1.18.1
     pandas >= 1.1.5
     scikit-learn >= 0.22.1
-    scipy >= 1.4.1, < 1.9
+    scipy >= 1.9
 
 
 [options.packages.find]


### PR DESCRIPTION
`scipy.linalg.expm` is vectorized since 1.9.1. This PR changes `gs.linalg.expm` for `numpy` and `autograd` backends to work with `scipy` (1.9.1). 

It breaks compatibility with previous versions of `scipy`, but I think it is better to use the most up-to-date version.

closes #1620, #1637, #1657.