### PR TITLE
Fix bug in the autodiff of pullback metric matrix

### DIFF
--- a/geomstats/_backend/__init__.py
+++ b/geomstats/_backend/__init__.py
@@ -152,7 +152,7 @@ BACKEND_ATTRIBUTES = {
         "zeros_like",
         "trapz",
     ],
-    "autodiff": ["custom_gradient", "detach", "jacobian", "value_and_grad"],
+    "autodiff": ["custom_gradient", "detach", "hessian", "jacobian", "value_and_grad"],
     "linalg": [
         "cholesky",
         "det",

--- a/geomstats/_backend/__init__.py
+++ b/geomstats/_backend/__init__.py
@@ -152,7 +152,14 @@ BACKEND_ATTRIBUTES = {
         "zeros_like",
         "trapz",
     ],
-    "autodiff": ["custom_gradient", "detach", "hessian", "jacobian", "value_and_grad"],
+    "autodiff": [
+        "custom_gradient",
+        "detach",
+        "hessian",
+        "jacobian",
+        "jacobian_and_hessian",
+        "value_and_grad",
+    ],
     "linalg": [
         "cholesky",
         "det",

--- a/geomstats/_backend/autograd/__init__.py
+++ b/geomstats/_backend/autograd/__init__.py
@@ -58,7 +58,6 @@ from autograd.numpy import (
     shape,
     sort,
     split,
-    squeeze,
     stack,
     std,
     sum,
@@ -134,6 +133,15 @@ tanh = _box_unary_scalar(target=_np.tanh)
 arctan2 = _box_binary_scalar(target=_np.arctan2)
 mod = _box_binary_scalar(target=_np.mod)
 power = _box_binary_scalar(target=_np.power)
+
+
+def squeeze(x, axis=None):
+    if axis is None:
+        return _np.squeeze(x)
+    x_shape = x.shape
+    if x_shape[axis] != 1:
+        return x
+    return _np.squeeze(x, axis=axis)
 
 
 def angle(z, deg=False):

--- a/geomstats/_backend/autograd/__init__.py
+++ b/geomstats/_backend/autograd/__init__.py
@@ -138,8 +138,7 @@ power = _box_binary_scalar(target=_np.power)
 def squeeze(x, axis=None):
     if axis is None:
         return _np.squeeze(x)
-    x_shape = x.shape
-    if x_shape[axis] != 1:
+    if x.shape[axis] != 1:
         return x
     return _np.squeeze(x, axis=axis)
 

--- a/geomstats/_backend/autograd/autodiff.py
+++ b/geomstats/_backend/autograd/autodiff.py
@@ -1,5 +1,6 @@
 """Wrapper around autograd functions to be consistent with backends."""
 
+from autograd import hessian as _hessian
 from autograd import jacobian as _jacobian
 from autograd import value_and_grad as _value_and_grad
 from autograd.extend import defvjp as _defvjp
@@ -107,6 +108,23 @@ def jacobian(func):
         the jacobian of func at x.
     """
     return _jacobian(func)
+
+
+def hessian(func):
+    """Return a function that returns the hessian of func.
+
+    Parameters
+    ----------
+    func : callable
+        Function whose Hessian is computed.
+
+    Returns
+    -------
+    _ : callable
+        Function taking point as input and returning
+        the hessian of func at point.
+    """
+    return _hessian(func)
 
 
 def value_and_grad(func, to_numpy=False):

--- a/geomstats/_backend/autograd/autodiff.py
+++ b/geomstats/_backend/autograd/autodiff.py
@@ -1,7 +1,6 @@
 """Wrapper around autograd functions to be consistent with backends."""
 
-from autograd import hessian as _hessian
-from autograd import jacobian as _jacobian
+from autograd import hessian, jacobian
 from autograd import value_and_grad as _value_and_grad
 from autograd.extend import defvjp as _defvjp
 from autograd.extend import primitive as _primitive
@@ -93,40 +92,6 @@ def custom_gradient(*grad_funcs):
     return decorator
 
 
-def jacobian(func):
-    """Wrap autograd's jacobian function.
-
-    Parameters
-    ----------
-    func : callable
-        Function whose Jacobian is computed.
-
-    Returns
-    -------
-    _ : callable
-        Function taking x as input and returning
-        the jacobian of func at x.
-    """
-    return _jacobian(func)
-
-
-def hessian(func):
-    """Return a function that returns the hessian of func.
-
-    Parameters
-    ----------
-    func : callable
-        Function whose Hessian is computed.
-
-    Returns
-    -------
-    _ : callable
-        Function taking point as input and returning
-        the hessian of func at point.
-    """
-    return _hessian(func)
-
-
 def value_and_grad(func, to_numpy=False):
     """Wrap autograd value_and_grad function.
 
@@ -179,3 +144,42 @@ def value_and_grad(func, to_numpy=False):
         return value, tuple(all_grads)
 
     return func_with_grad
+
+
+def jacobian_and_hessian(func):
+    """Wrap autograd jacobian and hessian functions.
+
+    Parameters
+    ----------
+    func : callable
+        Function whose jacobian and hessian values
+        will be computed.
+
+    Returns
+    -------
+    func_with_jacobian_and_hessian : callable
+        Function that returns func's jacobian and
+        func's hessian values at its inputs args.
+    """
+
+    def _jacobian_and_hessian(*args):
+        """Return func's jacobian and func's hessian values at args.
+
+        Parameters
+        ----------
+        args : list
+            Argument to function func and its gradients.
+
+        Returns
+        -------
+        jacobian : array-like
+            Jacobian of func at input arguments args.
+        hessian : array-like
+            Hessian of func at input arguments args.
+        """
+        jacobian_func = jacobian(func)
+        jacobian_ = jacobian_func(*args)
+        hessian_ = jacobian(jacobian_func)(*args)
+        return jacobian_, hessian_
+
+    return _jacobian_and_hessian

--- a/geomstats/_backend/numpy/__init__.py
+++ b/geomstats/_backend/numpy/__init__.py
@@ -58,7 +58,6 @@ from numpy import (
     shape,
     sort,
     split,
-    squeeze,
     stack,
     std,
     sum,
@@ -177,6 +176,14 @@ def to_numpy(x):
 
 def from_numpy(x):
     return x
+
+
+def squeeze(x, axis=None):
+    if axis is None:
+        return _np.squeeze(x)
+    if x.shape[axis] != 1:
+        return x
+    return _np.squeeze(x, axis=axis)
 
 
 def _get_wider_dtype(tensor_list):

--- a/geomstats/_backend/numpy/autodiff.py
+++ b/geomstats/_backend/numpy/autodiff.py
@@ -48,6 +48,16 @@ def hessian(func):
     )
 
 
+def jacobian_and_hessian(func):
+    """Return an error when using automatic differentiation with numpy."""
+    raise RuntimeError(
+        "Automatic differentiation is not supported with numpy backend. "
+        "Use autograd, pytorch or tensorflow backend instead.\n"
+        "Change backend via the command "
+        "export GEOMSTATS_BACKEND=autograd in a terminal."
+    )
+
+
 def custom_gradient(*grad_funcs):
     """Decorate a function to define its custom gradient(s).
 

--- a/geomstats/_backend/numpy/autodiff.py
+++ b/geomstats/_backend/numpy/autodiff.py
@@ -38,6 +38,16 @@ def jacobian(func):
     )
 
 
+def hessian(func):
+    """Return an error when using automatic differentiation with numpy."""
+    raise RuntimeError(
+        "Automatic differentiation is not supported with numpy backend. "
+        "Use autograd, pytorch or tensorflow backend instead.\n"
+        "Change backend via the command "
+        "export GEOMSTATS_BACKEND=autograd in a terminal."
+    )
+
+
 def custom_gradient(*grad_funcs):
     """Decorate a function to define its custom gradient(s).
 

--- a/geomstats/_backend/pytorch/autodiff.py
+++ b/geomstats/_backend/pytorch/autodiff.py
@@ -137,6 +137,7 @@ def jacobian_and_hessian(func):
         Function that returns func's jacobian and
         func's hessian at its inputs args.
     """
+
     def _jacobian_and_hessian(*args, **kwargs):
         """Return func's jacobian and func's hessian at args.
 
@@ -154,7 +155,6 @@ def jacobian_and_hessian(func):
         hessian : any
             Value of func's hessian at input arguments args.
         """
-
         return jacobian(func)(*args), hessian(func)(*args)
 
     return _jacobian_and_hessian

--- a/geomstats/_backend/pytorch/autodiff.py
+++ b/geomstats/_backend/pytorch/autodiff.py
@@ -2,6 +2,7 @@
 
 import numpy as _np
 import torch as _torch
+from torch.autograd.functional import hessian as _torch_hess
 from torch.autograd.functional import jacobian as _torch_jac
 
 
@@ -94,6 +95,23 @@ def jacobian(func):
         the jacobian of func at x.
     """
     return lambda x: _torch_jac(func, x)
+
+
+def hessian(func):
+    """Return a function that returns the hessian of func.
+
+    Parameters
+    ----------
+    func : callable
+        Function whose Hessian is computed.
+
+    Returns
+    -------
+    _ : callable
+        Function taking point as input and returning
+        the hessian of func at point.
+    """
+    return lambda point: _torch_hess(func=lambda x: func(x), inputs=point, strict=True)
 
 
 def value_and_grad(func, to_numpy=False):

--- a/geomstats/_backend/pytorch/autodiff.py
+++ b/geomstats/_backend/pytorch/autodiff.py
@@ -2,8 +2,8 @@
 
 import numpy as _np
 import torch as _torch
-from torch.autograd.functional import hessian as _torch_hess
-from torch.autograd.functional import jacobian as _torch_jac
+from torch.autograd.functional import hessian as _torch_hessian
+from torch.autograd.functional import jacobian as _torch_jacobian
 
 
 def detach(x):
@@ -86,15 +86,19 @@ def jacobian(func):
     Parameters
     ----------
     func : callable
-        Function whose Jacobian is computed.
+        Function whose jacobian is computed.
 
     Returns
     -------
     _ : callable
-        Function taking x as input and returning
-        the jacobian of func at x.
+        Function taking point as input and returning
+        the jacobian of func at point.
     """
-    return lambda x: _torch_jac(func, x)
+
+    def _jacobian(point):
+        return _torch_jacobian(func=lambda x: func(x), inputs=point)
+
+    return _jacobian
 
 
 def hessian(func):
@@ -111,7 +115,49 @@ def hessian(func):
         Function taking point as input and returning
         the hessian of func at point.
     """
-    return lambda point: _torch_hess(func=lambda x: func(x), inputs=point, strict=True)
+
+    def _hessian(point):
+        return _torch_hessian(func=lambda x: func(x), inputs=point, strict=True)
+
+    return _hessian
+
+
+def jacobian_and_hessian(func):
+    """Return a function that returns func's jacobian and hessian.
+
+    Parameters
+    ----------
+    func : callable
+        Function whose jacobian and hessian
+        will be computed. It must be real-valued.
+
+    Returns
+    -------
+    func_with_jacobian_and_hessian : callable
+        Function that returns func's jacobian and
+        func's hessian at its inputs args.
+    """
+    def _jacobian_and_hessian(*args, **kwargs):
+        """Return func's jacobian and func's hessian at args.
+
+        Parameters
+        ----------
+        args : list
+            Argument to function func and its gradients.
+        kwargs : dict
+            Keyword arguments to function func and its gradients.
+
+        Returns
+        -------
+        jacobian : any
+            Value of func's jacobian at input arguments args.
+        hessian : any
+            Value of func's hessian at input arguments args.
+        """
+
+        return jacobian(func)(*args), hessian(func)(*args)
+
+    return _jacobian_and_hessian
 
 
 def value_and_grad(func, to_numpy=False):

--- a/geomstats/_backend/tensorflow/__init__.py
+++ b/geomstats/_backend/tensorflow/__init__.py
@@ -115,8 +115,7 @@ def from_numpy(x):
 def squeeze(x, axis=None):
     if axis is None:
         return _tf.squeeze(x)
-    x_shape = x.shape
-    if x_shape[axis] != 1:
+    if x.shape[axis] != 1:
         return x
     return _tf.squeeze(x, axis=axis)
 

--- a/geomstats/_backend/tensorflow/__init__.py
+++ b/geomstats/_backend/tensorflow/__init__.py
@@ -31,7 +31,7 @@ from tensorflow import (
 from tensorflow import reduce_max as amax
 from tensorflow import reduce_min as amin
 from tensorflow import reduce_prod as prod
-from tensorflow import reshape, searchsorted, sort, squeeze, stack, uint8, zeros_like
+from tensorflow import reshape, searchsorted, sort, stack, uint8, zeros_like
 from tensorflow.experimental.numpy import empty_like, moveaxis
 
 from .._backend_config import tf_atol as atol
@@ -110,6 +110,15 @@ def to_numpy(x):
 
 def from_numpy(x):
     return _tf.convert_to_tensor(x)
+
+
+def squeeze(x, axis=None):
+    if axis is None:
+        return _tf.squeeze(x)
+    x_shape = x.shape
+    if x_shape[axis] != 1:
+        return x
+    return _tf.squeeze(x, axis=axis)
 
 
 def arange(start_or_stop, /, stop=None, step=1, dtype=None, **kwargs):

--- a/geomstats/_backend/tensorflow/autodiff.py
+++ b/geomstats/_backend/tensorflow/autodiff.py
@@ -163,3 +163,49 @@ def jacobian(func):
         return g.jacobian(y, x)
 
     return jac
+
+
+def hessian(func):
+    """Return a function that returns the hessian of func.
+
+    Parameters
+    ----------
+    func : callable
+        Function whose Hessian is computed.
+
+    Returns
+    -------
+    hess : callable
+        Function taking x as input and returning
+        the hessian of func at x.
+    """
+
+    def hess(x):
+        """Return the hessian of func at x.
+
+        Parameters
+        ----------
+        x : array-like
+            Input to function func or its hessian.
+
+        Returns
+        -------
+        _ : array-like
+            Value of the hessian of func at x.
+        """
+        # Note: this is a temporary implementation
+        # that uses the jacobian of the gradient.
+        # inspired from https://github.com/tensorflow/tensorflow/issues/29781
+        # waiting for the hessian function to be implemented in GradientTape.
+        if isinstance(x, _np.ndarray):
+            x = _tf.Variable(x)
+
+        with _tf.GradientTape(persistent=True) as g:
+            g.watch(x)
+            y = func(x)
+            grads = g.gradient(y, [x])
+
+        hessians = g.jacobian(grads[0], [x])
+        return hessians[0]
+
+    return hess

--- a/geomstats/_backend/tensorflow/autodiff.py
+++ b/geomstats/_backend/tensorflow/autodiff.py
@@ -209,3 +209,49 @@ def hessian(func):
         return hessians[0]
 
     return hess
+
+
+def jacobian_and_hessian(func):
+    """Return a function that returns the jacobian and hessian of func.
+
+    Parameters
+    ----------
+    func : callable
+        Function whose Jacobian and Hessian are computed.
+
+    Returns
+    -------
+    jac_and_hess : callable
+        Function taking x as input and returning
+        the jacobian and hessian of func at x.
+    """
+
+    def jac_and_hess(x):
+        """Return the jacobian and hessian of func at x.
+
+        Parameters
+        ----------
+        x : array-like
+            Input to function func or its jacobian and hessian.
+
+        Returns
+        -------
+        _ : array-like
+            Value of the jacobian and hessian of func at x.
+        """
+        # Note: this is a temporary implementation
+        # that uses the jacobian of the gradient.
+        # inspired from https://github.com/tensorflow/tensorflow/issues/29781
+        # waiting for the hessian function to be implemented in GradientTape.
+        if isinstance(x, _np.ndarray):
+            x = _tf.Variable(x)
+
+        with _tf.GradientTape(persistent=True) as g:
+            g.watch(x)
+            y = func(x)
+            grads = g.gradient(y, [x])
+
+        hessians = g.jacobian(grads[0], [x])
+        return grads[0], hessians[0]
+
+    return jac_and_hess

--- a/geomstats/geometry/pullback_metric.py
+++ b/geomstats/geometry/pullback_metric.py
@@ -145,24 +145,11 @@ class PullbackMetric(RiemannianMetric):
             jacobian_ai.append(jacobian_a)
 
         hessian_aij = gs.stack(hessian_aij, axis=0)
-        assert hessian_aij.shape == (
-            self.embedding_dim,
-            self.dim,
-            self.dim,
-        ), hessian_aij.shape
         jacobian_ai = gs.stack(jacobian_ai, axis=0)
-        assert jacobian_ai.shape == (self.embedding_dim, self.dim), jacobian_ai.shape
         inner_prod_deriv_mat = gs.einsum(
             "aki,aj->kij", hessian_aij, jacobian_ai
         ) + gs.einsum("akj,ai->kij", hessian_aij, jacobian_ai)
 
-        assert inner_prod_deriv_mat.shape == (
-            self.dim,
-            self.dim,
-            self.dim,
-        )
-
-        # for compatibility with geomstats
         inner_prod_deriv_mat = gs.transpose(inner_prod_deriv_mat, axes=(2, 1, 0))
         return inner_prod_deriv_mat
 

--- a/geomstats/geometry/pullback_metric.py
+++ b/geomstats/geometry/pullback_metric.py
@@ -136,8 +136,12 @@ class PullbackMetric(RiemannianMetric):
             def immersion_a(x):
                 return self.immersion(x)[a]
 
+            # print(immersion_a(gs.array(0.)).shape)
+            # print(immersion_a(gs.array([0.])).shape)
+            # print(immersion_a(gs.array([[0.]])).shape)
             hessian_a = gs.autodiff.hessian(immersion_a)(base_point)
-            hessian_a = gs.squeeze(hessian_a, axis=-1)
+            if self.dim == 1 and hessian_a.ndim > 2:
+                hessian_a = gs.squeeze(hessian_a, axis=-1)
             # print("HESSIAN")
             # print(type(hessian_a))
             # print(hessian_a)

--- a/geomstats/geometry/pullback_metric.py
+++ b/geomstats/geometry/pullback_metric.py
@@ -126,9 +126,6 @@ class PullbackMetric(RiemannianMetric):
         inner_prod_deriv_mat : array-like, shape=[..., dim, dim, dim]
             Inner-product derivative matrix.
         """
-        # hessian_aij = gs.zeros((self.embedding_dim, self.dim, self.dim))
-        # jacobian_ai = gs.zeros((self.embedding_dim, self.dim))
-
         hessian_aij = []
         jacobian_ai = []
         for a in range(self.embedding_dim):
@@ -136,27 +133,15 @@ class PullbackMetric(RiemannianMetric):
             def immersion_a(x):
                 return self.immersion(x)[a]
 
-            # print(immersion_a(gs.array(0.)).shape)
-            # print(immersion_a(gs.array([0.])).shape)
-            # print(immersion_a(gs.array([[0.]])).shape)
             hessian_a = gs.autodiff.hessian(immersion_a)(base_point)
             if self.dim == 1 and hessian_a.ndim > 2:
                 hessian_a = gs.squeeze(hessian_a, axis=-1)
-            # print("HESSIAN")
-            # print(type(hessian_a))
-            # print(hessian_a)
             hessian_aij.append(hessian_a)
-            # hessian_aij[a] = hessian_a
 
             jacobian_a = gs.autodiff.jacobian(immersion_a)(base_point)
             jacobian_a = gs.squeeze(jacobian_a, axis=0)
             if len(jacobian_a.shape) == 0:
                 jacobian_a = gs.to_ndarray(jacobian_a, to_ndim=1)
-            # jacobian_ai.append(jacobian_a)
-            # print(type(jacobian_ai))
-            # print(type(jacobian_a))
-            # print(type(gs.to_numpy(jacobian_a)))
-            # print(jacobian_a.shape)
             jacobian_ai.append(jacobian_a)
 
         hessian_aij = gs.stack(hessian_aij, axis=0)

--- a/geomstats/geometry/pullback_metric.py
+++ b/geomstats/geometry/pullback_metric.py
@@ -50,6 +50,7 @@ class PullbackMetric(RiemannianMetric):
         tangent_immersion=None,
     ):
         super().__init__(dim=dim)
+        self.embedding_dim = embedding_dim
         self.embedding_metric = EuclideanMetric(embedding_dim)
         self.immersion = immersion
         if jacobian_immersion is None:
@@ -137,7 +138,7 @@ class PullbackMetric(RiemannianMetric):
             hessian_aij[a, :, :] = hessian_a
 
             jacobian_a = gs.autodiff.jacobian(immersion_a)(base_point)
-            jacobian_a = gs.squeeze(jacobian_a, dim=0)
+            jacobian_a = gs.squeeze(jacobian_a, axis=0)
             if len(jacobian_a.shape) == 0:
                 jacobian_a = gs.to_ndarray(jacobian_a, to_ndim=1)
             jacobian_ai[a, :] = jacobian_a

--- a/geomstats/geometry/pullback_metric.py
+++ b/geomstats/geometry/pullback_metric.py
@@ -50,7 +50,6 @@ class PullbackMetric(RiemannianMetric):
         tangent_immersion=None,
     ):
         super().__init__(dim=dim)
-        self.embedding_dim = embedding_dim
         self.embedding_metric = EuclideanMetric(embedding_dim)
         self.immersion = immersion
         if jacobian_immersion is None:
@@ -128,17 +127,19 @@ class PullbackMetric(RiemannianMetric):
         """
         hessian_aij = []
         jacobian_ai = []
-        for a in range(self.embedding_dim):
+        embedding_dim = self.embedding_metric.dim
+        for a in range(embedding_dim):
 
             def immersion_a(x):
                 return self.immersion(x)[a]
 
-            hessian_a = gs.autodiff.hessian(immersion_a)(base_point)
+            jacobian_a, hessian_a = gs.autodiff.jacobian_and_hessian(immersion_a)(
+                base_point
+            )
             if self.dim == 1 and hessian_a.ndim > 2:
                 hessian_a = gs.squeeze(hessian_a, axis=-1)
             hessian_aij.append(hessian_a)
 
-            jacobian_a = gs.autodiff.jacobian(immersion_a)(base_point)
             jacobian_a = gs.squeeze(jacobian_a, axis=0)
             if len(jacobian_a.shape) == 0:
                 jacobian_a = gs.to_ndarray(jacobian_a, to_ndim=1)

--- a/geomstats/geometry/pullback_metric.py
+++ b/geomstats/geometry/pullback_metric.py
@@ -137,6 +137,7 @@ class PullbackMetric(RiemannianMetric):
                 return self.immersion(x)[a]
 
             hessian_a = gs.autodiff.hessian(immersion_a)(base_point)
+            hessian_a = gs.squeeze(hessian_a, axis=-1)
             # print("HESSIAN")
             # print(type(hessian_a))
             # print(hessian_a)
@@ -155,9 +156,13 @@ class PullbackMetric(RiemannianMetric):
             jacobian_ai.append(jacobian_a)
 
         hessian_aij = gs.stack(hessian_aij, axis=0)
-        assert hessian_aij.shape == (self.embedding_dim, self.dim, self.dim)
+        assert hessian_aij.shape == (
+            self.embedding_dim,
+            self.dim,
+            self.dim,
+        ), hessian_aij.shape
         jacobian_ai = gs.stack(jacobian_ai, axis=0)
-        assert jacobian_ai.shape == (self.embedding_dim, self.dim)
+        assert jacobian_ai.shape == (self.embedding_dim, self.dim), jacobian_ai.shape
         inner_prod_deriv_mat = gs.einsum(
             "aki,aj->kij", hessian_aij, jacobian_ai
         ) + gs.einsum("akj,ai->kij", hessian_aij, jacobian_ai)

--- a/geomstats/geometry/riemannian_metric.py
+++ b/geomstats/geometry/riemannian_metric.py
@@ -126,6 +126,7 @@ class RiemannianMetric(Connection, ABC):
         """
         cometric_mat_at_point = self.cometric_matrix(base_point)
         metric_derivative_at_point = self.inner_product_derivative_matrix(base_point)
+
         term_1 = gs.einsum(
             "...lk,...jli->...kij", cometric_mat_at_point, metric_derivative_at_point
         )

--- a/tests/data/pullback_metric_data.py
+++ b/tests/data/pullback_metric_data.py
@@ -156,6 +156,13 @@ class PullbackMetricTestData(TestData):
         ]
         return self.generate_tests(smoke_data)
 
+    def christoffels_circle_test_data(self):
+        smoke_data = [
+            dict(dim=1, base_point=gs.array([0.1])),
+            dict(dim=1, base_point=gs.array([0.7])),
+        ]
+        return self.generate_tests(smoke_data)
+
     def exp_and_sphere_exp_test_data(self):
         smoke_data = [
             dict(

--- a/tests/data/pullback_metric_data.py
+++ b/tests/data/pullback_metric_data.py
@@ -135,6 +135,13 @@ class PullbackMetricTestData(TestData):
         ]
         return self.generate_tests(smoke_data)
 
+    def inner_product_derivative_matrix_s2_test_data(self):
+        smoke_data = [
+            dict(dim=2, base_point=gs.array([0.6, -1.0])),
+            dict(dim=2, base_point=gs.array([0.8, -0.8])),
+        ]
+        return self.generate_tests(smoke_data)
+
     def inverse_circle_metric_matrix_test_data(self):
         smoke_data = [
             dict(dim=1, base_point=gs.array([0.6])),

--- a/tests/data/pullback_metric_data.py
+++ b/tests/data/pullback_metric_data.py
@@ -156,6 +156,13 @@ class PullbackMetricTestData(TestData):
         ]
         return self.generate_tests(smoke_data)
 
+    def christoffels_sphere_test_data(self):
+        smoke_data = [
+            dict(dim=2, base_point=gs.array([0.1, 0.2])),
+            dict(dim=2, base_point=gs.array([0.7, 0.233])),
+        ]
+        return self.generate_tests(smoke_data)
+
     def christoffels_circle_test_data(self):
         smoke_data = [
             dict(dim=1, base_point=gs.array([0.1])),

--- a/tests/tests_geomstats/test_pullback_metric.py
+++ b/tests/tests_geomstats/test_pullback_metric.py
@@ -200,13 +200,9 @@ class TestPullbackMetric(TestCase, metaclass=Parametrizer):
         # derivative with respect to phi
         expected_2 = gs.zeros((2, 2))
 
-        self.assertAllClose(derivative_matrix.shape, (2, 2, 2)), derivative_matrix.shape
-        self.assertAllClose(derivative_matrix[:, :, 0], expected_1), derivative_matrix[
-            0
-        ]
-        self.assertAllClose(derivative_matrix[:, :, 1], expected_2), derivative_matrix[
-            1
-        ]
+        self.assertAllClose(derivative_matrix.shape, (2, 2, 2))
+        self.assertAllClose(derivative_matrix[:, :, 0], expected_1)
+        self.assertAllClose(derivative_matrix[:, :, 1], expected_2)
 
     def test_christoffels_and_sphere_christoffels(self, dim, base_point):
         """Test consistency between sphere's christoffels.
@@ -232,22 +228,21 @@ class TestPullbackMetric(TestCase, metaclass=Parametrizer):
 
         christoffels = pullback_metric.christoffels(base_point)
 
-        self.assertAllClose(christoffels.shape, (2, 2, 2)), christoffels.shape
-        assert ~gs.allclose(christoffels, gs.zeros((2, 2, 2))), "christoffels are zero"
+        self.assertAllClose(christoffels.shape, (2, 2, 2))
 
         expected_1_11 = expected_2_11 = expected_2_22 = expected_1_12 = 0
 
-        self.assertAllClose(christoffels[0, 0, 0], expected_1_11), christoffels[0, 0, 0]
-        self.assertAllClose(christoffels[1, 0, 0], expected_2_11), christoffels[1, 0, 0]
-        self.assertAllClose(christoffels[1, 1, 1], expected_2_22), christoffels[1, 1, 1]
-        self.assertAllClose(christoffels[0, 0, 1], expected_1_12), christoffels[0, 0, 1]
+        self.assertAllClose(christoffels[0, 0, 0], expected_1_11)
+        self.assertAllClose(christoffels[1, 0, 0], expected_2_11)
+        self.assertAllClose(christoffels[1, 1, 1], expected_2_22)
+        self.assertAllClose(christoffels[0, 0, 1], expected_1_12)
 
         expected_1_22 = -gs.sin(theta) * gs.cos(theta)
         expected_2_12 = expected_2_21 = gs.cos(theta) / gs.sin(theta)
 
-        self.assertAllClose(christoffels[0, 1, 1], expected_1_22), christoffels[0, 1, 1]
-        self.assertAllClose(christoffels[1, 0, 1], expected_2_12), christoffels[1, 0, 1]
-        self.assertAllClose(christoffels[1, 1, 0], expected_2_21), christoffels[1, 1, 0]
+        self.assertAllClose(christoffels[0, 1, 1], expected_1_22)
+        self.assertAllClose(christoffels[1, 0, 1], expected_2_12)
+        self.assertAllClose(christoffels[1, 1, 0], expected_2_21)
 
     def test_christoffels_circle(self, dim, base_point):
         """Test consistency between sphere's christoffels.
@@ -263,7 +258,7 @@ class TestPullbackMetric(TestCase, metaclass=Parametrizer):
         )
         result = pullback_metric.christoffels(base_point)
 
-        self.assertAllClose(result.shape, (1, 1, 1)), result.shape
+        self.assertAllClose(result.shape, (1, 1, 1))
         self.assertAllClose(result, gs.zeros((1, 1, 1)))
 
     def test_exp_and_sphere_exp(self, dim, tangent_vec, base_point):

--- a/tests/tests_geomstats/test_pullback_metric.py
+++ b/tests/tests_geomstats/test_pullback_metric.py
@@ -191,6 +191,7 @@ class TestPullbackMetric(TestCase, metaclass=Parametrizer):
         )
         theta, _ = base_point[0], base_point[1]
 
+        print("WHAT")
         derivative_matrix = metric.inner_product_derivative_matrix(base_point)
 
         assert ~gs.allclose(derivative_matrix, gs.zeros((dim, dim, dim)))

--- a/tests/tests_geomstats/test_pullback_metric.py
+++ b/tests/tests_geomstats/test_pullback_metric.py
@@ -1,7 +1,5 @@
 """Unit tests for the pull-back metrics."""
 
-import pytest
-
 import geomstats.backend as gs
 import tests.conftest
 from geomstats.geometry.hypersphere import Hypersphere
@@ -194,7 +192,6 @@ class TestPullbackMetric(TestCase, metaclass=Parametrizer):
         theta, _ = base_point[0], base_point[1]
 
         derivative_matrix = metric.inner_product_derivative_matrix(base_point)
-        print(derivative_matrix)
 
         assert ~gs.allclose(derivative_matrix, gs.zeros((dim, dim, dim)))
 
@@ -203,11 +200,14 @@ class TestPullbackMetric(TestCase, metaclass=Parametrizer):
         # derivative with respect to phi
         expected_2 = gs.zeros(1)
 
-        assert gs.allclose(derivative_matrix.shape, (2, 2, 2)), derivative_matrix.shape
-        assert gs.allclose(derivative_matrix[:, :, 0], expected_1), derivative_matrix[0]
-        assert gs.allclose(derivative_matrix[:, :, 1], expected_2), derivative_matrix[1]
+        self.assertAllClose(derivative_matrix.shape, (2, 2, 2)), derivative_matrix.shape
+        self.assertAllClose(derivative_matrix[:, :, 0], expected_1), derivative_matrix[
+            0
+        ]
+        self.assertAllClose(derivative_matrix[:, :, 1], expected_2), derivative_matrix[
+            1
+        ]
 
-    @pytest.mark.skip("earlier it was commented.")
     def test_christoffels_and_sphere_christoffels(self, dim, base_point):
         """Test consistency between sphere's christoffels.
 
@@ -223,6 +223,23 @@ class TestPullbackMetric(TestCase, metaclass=Parametrizer):
         result = pullback_metric.christoffels(base_point)
         expected = Hypersphere(2).metric.christoffels(base_point)
         self.assertAllClose(result, expected)
+
+    def test_christoffels_circle(self, dim, base_point):
+        """Test consistency between sphere's christoffels.
+
+        The christoffels of the class Hypersphere are
+        defined in terms of spherical coordinates.
+
+        The christoffels of pullback_metric are also defined
+        in terms of the spherical coordinates.
+        """
+        pullback_metric = self.Metric(
+            dim=dim, embedding_dim=dim + 1, immersion=_circle_immersion
+        )
+        result = pullback_metric.christoffels(base_point)
+
+        self.assertAllClose(result.shape, (1, 1, 1)), result.shape
+        self.assertAllClose(result, gs.zeros((1, 1, 1)))
 
     def test_exp_and_sphere_exp(self, dim, tangent_vec, base_point):
         """Test consistency between sphere's Riemannian exp.

--- a/tests/tests_geomstats/test_pullback_metric.py
+++ b/tests/tests_geomstats/test_pullback_metric.py
@@ -322,4 +322,4 @@ class TestPullbackMetric(TestCase, metaclass=Parametrizer):
             base_point=immersed_base_point,
             direction=immersed_tangent_vec_b,
         )
-        self.assertAllClose(result, expected, atol=1e-5)
+        self.assertAllClose(result, expected, atol=1e-4)

--- a/tests/tests_geomstats/test_pullback_metric.py
+++ b/tests/tests_geomstats/test_pullback_metric.py
@@ -187,6 +187,29 @@ class TestPullbackMetric(TestCase, metaclass=Parametrizer):
         )
         self.assertAllClose(result, expected)
 
+    def test_inner_product_derivative_matrix_s2(self, dim, base_point):
+        metric = self.Metric(
+            dim=dim, embedding_dim=dim + 1, immersion=_sphere_immersion
+        )
+        theta, _ = base_point[0], base_point[1]
+
+        derivative_matrix = metric.inner_product_derivative_matrix(base_point)
+        print(derivative_matrix)
+
+        assert ~gs.allclose(derivative_matrix, gs.zeros((dim, dim, dim)))
+
+        # derivative with respect to theta
+        expected_1 = gs.array([[0, 0], [0, gs.cos(theta)]])
+
+        # derivative with respect to phi
+        # expected_2 = gs.array([[0, 0], [0, 0]])
+
+        assert gs.allclose(derivative_matrix.shape, (2, 2, 2)), derivative_matrix.shape
+        assert gs.allclose(
+            derivative_matrix[0].shape, expected_1.shape
+        ), derivative_matrix[0].shape
+        assert gs.allclose(derivative_matrix[:, :, 0], expected_1), derivative_matrix[0]
+
     @pytest.mark.skip("earlier it was commented.")
     def test_christoffels_and_sphere_christoffels(self, dim, base_point):
         """Test consistency between sphere's christoffels.

--- a/tests/tests_geomstats/test_pullback_metric.py
+++ b/tests/tests_geomstats/test_pullback_metric.py
@@ -261,6 +261,7 @@ class TestPullbackMetric(TestCase, metaclass=Parametrizer):
         self.assertAllClose(result.shape, (1, 1, 1))
         self.assertAllClose(result, gs.zeros((1, 1, 1)))
 
+    @tests.conftest.autograd_and_torch_only
     def test_exp_and_sphere_exp(self, dim, tangent_vec, base_point):
         """Test consistency between sphere's Riemannian exp.
 
@@ -270,6 +271,7 @@ class TestPullbackMetric(TestCase, metaclass=Parametrizer):
         The exp map of pullback_metric is defined
         in terms of the spherical coordinates.
         """
+        # Note: this works in tf too, but takes a very long time.
         pullback_metric = self.Metric(
             dim=dim, embedding_dim=dim + 1, immersion=_sphere_immersion
         )

--- a/tests/tests_geomstats/test_pullback_metric.py
+++ b/tests/tests_geomstats/test_pullback_metric.py
@@ -288,7 +288,7 @@ class TestPullbackMetric(TestCase, metaclass=Parametrizer):
         )
         self.assertAllClose(result, expected, atol=1e-1)
 
-    @tests.conftest.autograd_and_torch_only
+    @tests.conftest.torch_only
     def test_parallel_transport_and_sphere_parallel_transport(
         self, dim, tangent_vec_a, tangent_vec_b, base_point
     ):
@@ -299,6 +299,8 @@ class TestPullbackMetric(TestCase, metaclass=Parametrizer):
 
         The parallel transport of pullback_metric is defined
         in terms of the spherical coordinates.
+
+        Note: this test passes in autograd and in tf but takes a very long time.
         """
         pullback_metric = self.Metric(
             dim=dim, embedding_dim=dim + 1, immersion=_sphere_immersion
@@ -321,4 +323,4 @@ class TestPullbackMetric(TestCase, metaclass=Parametrizer):
             base_point=immersed_base_point,
             direction=immersed_tangent_vec_b,
         )
-        self.assertAllClose(result, expected, atol=1e-4)
+        self.assertAllClose(result, expected, atol=5e-3)

--- a/tests/tests_geomstats/test_pullback_metric.py
+++ b/tests/tests_geomstats/test_pullback_metric.py
@@ -199,16 +199,13 @@ class TestPullbackMetric(TestCase, metaclass=Parametrizer):
         assert ~gs.allclose(derivative_matrix, gs.zeros((dim, dim, dim)))
 
         # derivative with respect to theta
-        expected_1 = gs.array([[0, 0], [0, gs.cos(theta)]])
-
+        expected_1 = gs.array([[0, 0], [0, 2 * gs.cos(theta) * gs.sin(theta)]])
         # derivative with respect to phi
-        # expected_2 = gs.array([[0, 0], [0, 0]])
+        expected_2 = gs.zeros(1)
 
         assert gs.allclose(derivative_matrix.shape, (2, 2, 2)), derivative_matrix.shape
-        assert gs.allclose(
-            derivative_matrix[0].shape, expected_1.shape
-        ), derivative_matrix[0].shape
         assert gs.allclose(derivative_matrix[:, :, 0], expected_1), derivative_matrix[0]
+        assert gs.allclose(derivative_matrix[:, :, 1], expected_2), derivative_matrix[1]
 
     @pytest.mark.skip("earlier it was commented.")
     def test_christoffels_and_sphere_christoffels(self, dim, base_point):

--- a/tests/tests_geomstats/test_pullback_metric.py
+++ b/tests/tests_geomstats/test_pullback_metric.py
@@ -191,7 +191,6 @@ class TestPullbackMetric(TestCase, metaclass=Parametrizer):
         )
         theta, _ = base_point[0], base_point[1]
 
-        print("WHAT")
         derivative_matrix = metric.inner_product_derivative_matrix(base_point)
 
         assert ~gs.allclose(derivative_matrix, gs.zeros((dim, dim, dim)))

--- a/tests/tests_geomstats/test_pullback_metric.py
+++ b/tests/tests_geomstats/test_pullback_metric.py
@@ -224,6 +224,31 @@ class TestPullbackMetric(TestCase, metaclass=Parametrizer):
         expected = Hypersphere(2).metric.christoffels(base_point)
         self.assertAllClose(result, expected)
 
+    def test_christoffels_sphere(self, dim, base_point):
+        pullback_metric = self.Metric(
+            dim=dim, embedding_dim=dim + 1, immersion=_sphere_immersion
+        )
+        theta, _ = base_point[0], base_point[1]
+
+        christoffels = pullback_metric.christoffels(base_point)
+
+        self.assertAllClose(christoffels.shape, (2, 2, 2)), christoffels.shape
+        assert ~gs.allclose(christoffels, gs.zeros((2, 2, 2))), "christoffels are zero"
+
+        expected_1_11 = expected_2_11 = expected_2_22 = expected_1_12 = 0
+
+        self.assertAllClose(christoffels[0, 0, 0], expected_1_11), christoffels[0, 0, 0]
+        self.assertAllClose(christoffels[1, 0, 0], expected_2_11), christoffels[1, 0, 0]
+        self.assertAllClose(christoffels[1, 1, 1], expected_2_22), christoffels[1, 1, 1]
+        self.assertAllClose(christoffels[0, 0, 1], expected_1_12), christoffels[0, 0, 1]
+
+        expected_1_22 = -gs.sin(theta) * gs.cos(theta)
+        expected_2_12 = expected_2_21 = gs.cos(theta) / gs.sin(theta)
+
+        self.assertAllClose(christoffels[0, 1, 1], expected_1_22), christoffels[0, 1, 1]
+        self.assertAllClose(christoffels[1, 0, 1], expected_2_12), christoffels[1, 0, 1]
+        self.assertAllClose(christoffels[1, 1, 0], expected_2_21), christoffels[1, 1, 0]
+
     def test_christoffels_circle(self, dim, base_point):
         """Test consistency between sphere's christoffels.
 

--- a/tests/tests_geomstats/test_pullback_metric.py
+++ b/tests/tests_geomstats/test_pullback_metric.py
@@ -198,7 +198,7 @@ class TestPullbackMetric(TestCase, metaclass=Parametrizer):
         # derivative with respect to theta
         expected_1 = gs.array([[0, 0], [0, 2 * gs.cos(theta) * gs.sin(theta)]])
         # derivative with respect to phi
-        expected_2 = gs.zeros(1)
+        expected_2 = gs.zeros((2, 2))
 
         self.assertAllClose(derivative_matrix.shape, (2, 2, 2)), derivative_matrix.shape
         self.assertAllClose(derivative_matrix[:, :, 0], expected_1), derivative_matrix[


### PR DESCRIPTION
This PR:
- overwrites the method `inner_product_derivative_matrix` in PullbackMetric, childclass of RiemannianMetric
to fix a bug in the automatic differentiation required in this method,
- adds corresponding unit tests.

The parallel transport of the pullback metric is extremely slow, thus its test is skipped in autograd and tensorflow to avoid slowing down the CI.

The bug:
In pullback metric, the metric matrix comes from the automatic differentiation of the immersion defining the pullback.
Differentiating again the result of this differentiation was creating an error.

The fix:
In the case of the pullback metric, we have a closed form for the derivative of the metric matrix that we can use.
This closed form requires the computation of the hessian of the immersion.
For this reason, `hessian` has been added in the autodiff backends.

## Checklist

- [x] My pull request has a clear and explanatory title.
- [ ] If neccessary, my code is [vectorized](https://www.geeksforgeeks.org/vectorization-in-python/).
- [x] I have added apropriate unit tests.
- [ ] I have made sure the code passes all unit tests. (refer to comment below)
- [x] My PR follows [PEP8](https://peps.python.org/pep-0008/) guidelines. (refer to comment below)
- [x] My PR follows [geomstats coding style](https://github.com/geomstats/geomstats/blob/master/docs/contributing.rst#coding-style-guidelines) and API.
- [x] My code is properly documented and I made sure the documentation renders properly. ([Link](https://github.com/geomstats/geomstats/blob/master/docs/contributing.rst#documentation))
- [ ] I have linked to issues and PRs that are relevant to this PR.


<!-- For checking consistency of entire codebase
First, run the tests related to your changes. For example, if you changed something in geomstats/spd_matrices_space.py:
$ pytest tests/tests_geomstats/test_spd_matrices.py

and then run the tests of the whole codebase to check that your feature is not breaking any of them:
$ pytest tests/

This way, further modifications on the code base are guaranteed to be consistent with the desired behavior. Merging your PR should not break any test in any backend (numpy, tensorflow or pytorch)."

For testing in alternative backends such as `numpy`, `pytorch`, `autograd`, `tensorflow` set the environment variable using:
$ export GEOMSTATS_BACKEND=<backend_name>

Next, import the `backend` module using:
import geomstats.backend as gs
-->


<!-- For flake8 tests
Install dependencies
$ pip3 install -r dev-requirements.txt

Then run the following commands:
$ flake8 --ignore=D,W503,W504 geomstats examples tests   #shadows .flake8
$ flake8 geomstats/geometry geomstats/learning           #passed two subfolders
-->

## Description

<!-- Include a description of your pull request. If relevant, feel free to use this space to talk about time and space complexity as well scalability of your code-->

## Issue

<!-- Tell us which issue does this PR fix . Why this feature implementation/fix is important in practice ?-->

## Additional context

<!-- Add any extra information -->