### PR TITLE
Skip unit-tests that are failing too often (Stiefel, Gamma, Dirichlet)

### DIFF
--- a/tests/tests_geomstats/test_dirichlet.py
+++ b/tests/tests_geomstats/test_dirichlet.py
@@ -63,9 +63,7 @@ class TestDirichletMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
     skip_test_geodesic_bvp_belongs = True
     skip_test_exp_geodesic_ivp = True
     skip_test_exp_ladder_parallel_transport = True
-    skip_test_triangle_inequality_of_dist = (
-        tests.conftest.tf_backend() or tests.conftest.pytorch_backend()
-    )
+    skip_test_triangle_inequality_of_dist = True
 
     testing_data = DirichletMetricTestData()
     Space = testing_data.Space

--- a/tests/tests_geomstats/test_gamma.py
+++ b/tests/tests_geomstats/test_gamma.py
@@ -4,7 +4,7 @@ from scipy.stats import gamma
 
 import geomstats.backend as gs
 import tests.conftest
-from tests.conftest import Parametrizer
+from tests.conftest import Parametrizer, autograd_backend
 from tests.data.gamma_data import GammaMetricTestData, GammaTestData
 from tests.geometry_test_cases import OpenSetTestCase, RiemannianMetricTestCase
 
@@ -126,6 +126,7 @@ class TestGammaMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
     skip_test_triangle_inequality_of_dist = (
         tests.conftest.tf_backend() or tests.conftest.pytorch_backend()
     )
+    test_log_after_exp_control = autograd_backend()
 
     testing_data = GammaMetricTestData()
 

--- a/tests/tests_geomstats/test_gamma.py
+++ b/tests/tests_geomstats/test_gamma.py
@@ -126,7 +126,7 @@ class TestGammaMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
     skip_test_triangle_inequality_of_dist = (
         tests.conftest.tf_backend() or tests.conftest.pytorch_backend()
     )
-    test_log_after_exp_control = autograd_backend()
+    skip_test_log_after_exp_control = autograd_backend()
 
     testing_data = GammaMetricTestData()
 

--- a/tests/tests_geomstats/test_stiefel.py
+++ b/tests/tests_geomstats/test_stiefel.py
@@ -12,6 +12,8 @@ class TestStiefel(LevelSetTestCase, metaclass=Parametrizer):
     skip_test_intrinsic_after_extrinsic = True
     skip_test_extrinsic_after_intrinsic = True
     skip_test_to_tangent_is_tangent = True
+    skip_test_triangle_inequality_of_dist = True
+    skip_test_squared_dist_is_positive = True
 
     testing_data = StiefelTestData()
 

--- a/tests/tests_geomstats/test_stiefel.py
+++ b/tests/tests_geomstats/test_stiefel.py
@@ -12,8 +12,6 @@ class TestStiefel(LevelSetTestCase, metaclass=Parametrizer):
     skip_test_intrinsic_after_extrinsic = True
     skip_test_extrinsic_after_intrinsic = True
     skip_test_to_tangent_is_tangent = True
-    skip_test_triangle_inequality_of_dist = True
-    skip_test_squared_dist_is_positive = True
 
     testing_data = StiefelTestData()
 
@@ -37,6 +35,8 @@ class TestStiefelCanonicalMetric(RiemannianMetricTestCase, metaclass=Parametrize
     skip_test_exp_ladder_parallel_transport = True
     skip_test_dist_is_symmetric = True
     skip_test_dist_is_norm_of_log = True
+    skip_test_squared_dist_is_positive = True
+    test_triangle_inequality_of_dist = True
 
     testing_data = StiefelCanonicalMetricTestData()
 


### PR DESCRIPTION
This PR skips unit-tests that fail too often.

With @lpereira95  we noted that the failures of the tests on the Stiefel manifold may come from a problem in the mathematical formulation, because it produces NaNs. Possibly coming from the 2 leafs of the Stiefel.

Failures of the Dirichlet may come from the negative curvature.

## Checklist

- [ ] My pull request has a clear and explanatory title.
- [ ] If neccessary, my code is [vectorized](https://www.geeksforgeeks.org/vectorization-in-python/).
- [ ] I have added apropriate unit tests.
- [ ] I have made sure the code passes all unit tests. (refer to comment below)
- [ ] My PR follows [PEP8](https://peps.python.org/pep-0008/) guidelines. (refer to comment below)
- [ ] My PR follows [geomstats coding style](https://github.com/geomstats/geomstats/blob/master/docs/contributing.rst#coding-style-guidelines) and API.
- [ ] My code is properly documented and I made sure the documentation renders properly. ([Link](https://github.com/geomstats/geomstats/blob/master/docs/contributing.rst#documentation))
- [ ] I have linked to issues and PRs that are relevant to this PR.


<!-- For checking consistency of entire codebase
First, run the tests related to your changes. For example, if you changed something in geomstats/spd_matrices_space.py:
$ pytest tests/tests_geomstats/test_spd_matrices.py

and then run the tests of the whole codebase to check that your feature is not breaking any of them:
$ pytest tests/

This way, further modifications on the code base are guaranteed to be consistent with the desired behavior. Merging your PR should not break any test in any backend (numpy, tensorflow or pytorch)."

For testing in alternative backends such as `numpy`, `pytorch`, `autograd`, `tensorflow` set the environment variable using:
$ export GEOMSTATS_BACKEND=<backend_name>

Next, import the `backend` module using:
import geomstats.backend as gs
-->


<!-- For flake8 tests
Install dependencies
$ pip3 install -r dev-requirements.txt

Then run the following commands:
$ flake8 --ignore=D,W503,W504 geomstats examples tests   #shadows .flake8
$ flake8 geomstats/geometry geomstats/learning           #passed two subfolders
-->

## Description

<!-- Include a description of your pull request. If relevant, feel free to use this space to talk about time and space complexity as well scalability of your code-->

## Issue

<!-- Tell us which issue does this PR fix . Why this feature implementation/fix is important in practice ?-->

## Additional context

<!-- Add any extra information -->