### PR TITLE
Remove unnecessary use of metric as property and fix SpecialEuclideanMatrixCanonicalLeftMetric name

### DIFF
--- a/geomstats/geometry/full_rank_correlation_matrices.py
+++ b/geomstats/geometry/full_rank_correlation_matrices.py
@@ -56,13 +56,6 @@ class FullRankCorrelationMatrices(LevelSet):
         """
         return point * gs.outer(diagonal_vec, diagonal_vec)
 
-    @property
-    def metric(self):
-        """Riemannian Metric associated to the Manifold."""
-        if self._metric is None:
-            self._metric = FullRankCorrelationAffineQuotientMetric(self.n)
-        return self._metric
-
     @classmethod
     def from_covariance(cls, point):
         r"""Compute the correlation matrix associated to an SPD matrix.

--- a/geomstats/geometry/grassmannian.py
+++ b/geomstats/geometry/grassmannian.py
@@ -93,7 +93,7 @@ def _squared_dist_grad_point_a(point_a, point_b, metric):
         Point.
     point_b : array-like, shape=[..., dim]
         Point.
-    metric : SpecialEuclideanMatrixCannonicalLeftMetric
+    metric : SpecialEuclideanMatrixCanonicalLeftMetric
         Metric defining the distance.
 
     Returns
@@ -117,7 +117,7 @@ def _squared_dist_grad_point_b(point_a, point_b, metric):
         Point.
     point_b : array-like, shape=[..., dim]
         Point.
-    metric : SpecialEuclideanMatrixCannonicalLeftMetric
+    metric : SpecialEuclideanMatrixCanonicalLeftMetric
         Metric defining the distance.
 
     Returns
@@ -139,7 +139,7 @@ def _squared_dist(point_a, point_b, metric):
     This is an auxiliary private function that:
 
     - is called by the method `squared_dist` of the class
-      SpecialEuclideanMatrixCannonicalLeftMetric,
+      SpecialEuclideanMatrixCanonicalLeftMetric,
     - has been created to support the implementation
       of custom_gradient in tensorflow backend.
 
@@ -149,7 +149,7 @@ def _squared_dist(point_a, point_b, metric):
         Point.
     point_b : array-like, shape=[..., dim]
         Point.
-    metric : SpecialEuclideanMatrixCannonicalLeftMetric
+    metric : SpecialEuclideanMatrixCanonicalLeftMetric
         Metric defining the distance.
 
     Returns

--- a/geomstats/geometry/special_euclidean.py
+++ b/geomstats/geometry/special_euclidean.py
@@ -43,7 +43,7 @@ def _squared_dist_grad_point_a(point_a, point_b, metric):
         Point.
     point_b : array-like, shape=[..., dim]
         Point.
-    metric : SpecialEuclideanMatrixCannonicalLeftMetric
+    metric : SpecialEuclideanMatrixCanonicalLeftMetric
         Metric defining the distance.
 
     Returns
@@ -67,7 +67,7 @@ def _squared_dist_grad_point_b(point_a, point_b, metric):
         Point.
     point_b : array-like, shape=[..., dim]
         Point.
-    metric : SpecialEuclideanMatrixCannonicalLeftMetric
+    metric : SpecialEuclideanMatrixCanonicalLeftMetric
         Metric defining the distance.
 
     Returns
@@ -89,7 +89,7 @@ def _squared_dist(point_a, point_b, metric):
     This is an auxiliary private function that:
 
     - is called by the method `squared_dist` of the class
-      SpecialEuclideanMatrixCannonicalLeftMetric,
+      SpecialEuclideanMatrixCanonicalLeftMetric,
     - has been created to support the implementation
       of custom_gradient in tensorflow backend.
 
@@ -99,7 +99,7 @@ def _squared_dist(point_a, point_b, metric):
         Point.
     point_b : array-like, shape=[..., dim]
         Point.
-    metric : SpecialEuclideanMatrixCannonicalLeftMetric
+    metric : SpecialEuclideanMatrixCanonicalLeftMetric
         Metric defining the distance.
 
     Returns
@@ -236,7 +236,7 @@ class _SpecialEuclideanMatrices(MatrixLieGroup, LevelSet):
         self.translations = Euclidean(dim=n)
         self.n = n
 
-        self.left_canonical_metric = SpecialEuclideanMatrixCannonicalLeftMetric(
+        self.left_canonical_metric = SpecialEuclideanMatrixCanonicalLeftMetric(
             group=self
         )
         if self._metric is None:
@@ -1021,7 +1021,7 @@ class _SpecialEuclidean3Vectors(_SpecialEuclideanVectors):
         return transform
 
 
-class SpecialEuclideanMatrixCannonicalLeftMetric(_InvariantMetricMatrix):
+class SpecialEuclideanMatrixCanonicalLeftMetric(_InvariantMetricMatrix):
     """Class for the canonical left-invariant metric on SE(n).
 
     The canonical left-invariant metric is defined by endowing the tangent
@@ -1211,7 +1211,7 @@ class SpecialEuclideanMatrixCannonicalLeftMetric(_InvariantMetricMatrix):
         This is an auxiliary private function that:
 
         - is called by the method `squared_dist` of the class
-          SpecialEuclideanMatrixCannonicalLeftMetric,
+          SpecialEuclideanMatrixCanonicalLeftMetric,
         - has been created to support the implementation
           of custom_gradient in tensorflow backend.
 

--- a/tests/data/special_euclidean_data.py
+++ b/tests/data/special_euclidean_data.py
@@ -9,7 +9,7 @@ import tests.conftest
 from geomstats.geometry.invariant_metric import InvariantMetric
 from geomstats.geometry.special_euclidean import (
     SpecialEuclidean,
-    SpecialEuclideanMatrixCannonicalLeftMetric,
+    SpecialEuclideanMatrixCanonicalLeftMetric,
     SpecialEuclideanMatrixLieAlgebra,
 )
 from geomstats.geometry.special_orthogonal import SpecialOrthogonal
@@ -286,7 +286,7 @@ class SpecialEuclideanMatrixCanonicalLeftMetricTestData(_InvariantMetricTestData
     n_rungs_list = [1] * 2
     scheme_list = ["pole"] * 2
 
-    Metric = SpecialEuclideanMatrixCannonicalLeftMetric
+    Metric = SpecialEuclideanMatrixCanonicalLeftMetric
 
     def left_metric_wrong_group_test_data(self):
         smoke_data = [


### PR DESCRIPTION
Just a bit of cleaning.