### PR TITLE
Fix wrong scaling in NormalMetric

### DIFF
--- a/geomstats/geometry/poincare_half_space.py
+++ b/geomstats/geometry/poincare_half_space.py
@@ -126,7 +126,7 @@ class PoincareHalfSpaceMetric(RiemannianMetric):
         """
         inner_prod = gs.sum(tangent_vec_a * tangent_vec_b, axis=-1)
         inner_prod = inner_prod / base_point[..., -1] ** 2
-        return inner_prod
+        return self.scale * inner_prod
 
     def exp(self, tangent_vec, base_point, **kwargs):
         """Compute the Riemannian exponential.

--- a/geomstats/geometry/pullback_metric.py
+++ b/geomstats/geometry/pullback_metric.py
@@ -304,7 +304,7 @@ class PullbackDiffeoMetric(RiemannianMetric, abc.ABC):
         self._raw_jacobian_diffeomorphism = None
         self._raw_inverse_jacobian_diffeomorphism = None
 
-        self.shape_dim = math.prod(shape)
+        self.shape_dim = math.prod(shape) if shape is not None else None
         self.embedding_space_shape_dim = math.prod(self.embedding_metric.shape)
 
     @abc.abstractmethod

--- a/geomstats/information_geometry/normal.py
+++ b/geomstats/information_geometry/normal.py
@@ -11,6 +11,7 @@ from geomstats.geometry.poincare_half_space import (
     PoincareHalfSpace,
     PoincareHalfSpaceMetric,
 )
+from geomstats.geometry.pullback_metric import PullbackDiffeoMetric
 from geomstats.information_geometry.base import InformationManifoldMixin
 
 
@@ -115,14 +116,91 @@ class NormalDistributions(InformationManifoldMixin, PoincareHalfSpace):
         return pdf
 
 
-class NormalMetric(PoincareHalfSpaceMetric):
+class NormalMetric(PullbackDiffeoMetric):
     """Class for the Fisher information metric on normal distributions.
 
-    This is the metric of the Poincare upper half-plane.
+    This is the pullback of the metric of the Poincare upper half-plane
+    by the diffeomorphism :math:`(mean, std) -> (mean, sqrt{2} std)`.
     """
 
     def __init__(self):
         super().__init__(dim=2)
+
+    def define_embedding_metric(self):
+        r"""Define the metric to pull back.
+
+        This is the metric of the Poincare upper half-plane
+        with a scaling factor of 2.
+
+        Returns
+        -------
+        embedding_metric : RiemannianMetric object
+            The metric of the Poincare upper half-plane.
+        """
+        return PoincareHalfSpaceMetric(dim=2, scale=2)
+
+    def diffeomorphism(self, base_point):
+        r"""Image of base point in the Poincare upper half-plane.
+
+        This is the image by the diffeomorphism
+        :math:`(mean, std) -> (mean, sqrt{2} std)`.
+
+        Parameters
+        ----------
+        base_point : array-like, shape=[..., 2]
+            Point representing a normal distribution. Coordinates
+            are mean and standard deviation.
+
+        Returns
+        -------
+        image_point : array-like, shape=[..., 2]
+            Image of base_point in the Poincare upper half-plane.
+        """
+        image_point = gs.copy(base_point)
+        image_point[..., 0] /= gs.sqrt(2)
+        return image_point
+
+    def inverse_diffeomorphism(self, image_point):
+        r"""Inverse image of a point in the Poincare upper half-plane.
+
+        This is the inverse image by the diffeomorphism
+        :math:`(mean, std) -> (mean, sqrt{2} std)`.
+
+        Parameters
+        ----------
+        image_point : array-like, shape=[..., 2]
+            Point in the upper half-plane.
+
+        Returns
+        -------
+        base_point : array-like, shape=[..., 2]
+            Inverse image of the image point, representing a normal
+            distribution. Coordinates are mean and standard deviation.
+        """
+        base_point = gs.copy(image_point)
+        base_point[..., 0] *= gs.sqrt(2)
+        return base_point
+
+    def tangent_diffeomorphism(self, tangent_vec, base_point):
+        r"""Image of tangent vector.
+
+        This is the image by the tangent map of the diffeomorphism
+        :math:`(mean, std) -> (mean, sqrt{2} std)`.
+
+        Parameters
+        ----------
+        tangent_vec : array-like, shape=[..., 2]
+            Tangent vector at base point.
+
+        base_point : array-like, shape=[..., 2]
+            Base point representing a normal distribution.
+
+        Returns
+        -------
+        image_tangent_vec : array-like, shape=[..., 2]
+            Image tangent vector at image of the base point.
+        """
+        return self.diffeomorphism(tangent_vec)
 
     @staticmethod
     def metric_matrix(base_point=None):

--- a/geomstats/information_geometry/normal.py
+++ b/geomstats/information_geometry/normal.py
@@ -157,7 +157,7 @@ class NormalMetric(PullbackDiffeoMetric):
             Image of base_point in the Poincare upper half-plane.
         """
         image_point = gs.copy(base_point)
-        image_point[..., 0] /= gs.sqrt(2)
+        image_point[..., 0] /= gs.sqrt(2.0)
         return image_point
 
     def inverse_diffeomorphism(self, image_point):
@@ -178,7 +178,7 @@ class NormalMetric(PullbackDiffeoMetric):
             distribution. Coordinates are mean and standard deviation.
         """
         base_point = gs.copy(image_point)
-        base_point[..., 0] *= gs.sqrt(2)
+        base_point[..., 0] *= gs.sqrt(2.0)
         return base_point
 
     def tangent_diffeomorphism(self, tangent_vec, base_point):

--- a/geomstats/information_geometry/normal.py
+++ b/geomstats/information_geometry/normal.py
@@ -202,6 +202,27 @@ class NormalMetric(PullbackDiffeoMetric):
         """
         return self.diffeomorphism(tangent_vec)
 
+    def inverse_tangent_diffeomorphism(self, image_tangent_vec, image_point):
+        r"""Inverse image of tangent vector.
+
+        This is the inverse image by the tangent map of the diffeomorphism
+        :math:`(mean, std) -> (mean, sqrt{2} std)`.
+
+        Parameters
+        ----------
+        image_tangent_vec : array-like, shape=[..., 2]
+            Image of a tangent vector at image_point.
+
+        image_point : array-like, shape=[..., 2]
+            Image of a point representing a normal distribution.
+
+        Returns
+        -------
+        tangent_vec : array-like, shape=[..., 2]
+            Inverse image of image_tangent_vec.
+        """
+        return self.inverse_diffeomorphism(image_tangent_vec)
+
     @staticmethod
     def metric_matrix(base_point=None):
         """Compute the metric matrix at the tangent space at base_point.

--- a/tests/data/poincare_half_space_data.py
+++ b/tests/data/poincare_half_space_data.py
@@ -59,7 +59,8 @@ class PoincareHalfSpaceTestData(_OpenSetTestData):
 
 class PoincareHalfSpaceMetricTestData(_RiemannianMetricTestData):
     dim_list = random.sample(range(2, 5), 2)
-    metric_args_list = [(dim,) for dim in dim_list]
+    scale_list = [1, 2]
+    metric_args_list = list(zip(dim_list, scale_list))  # [(dim,) for dim in dim_list]
     shape_list = [(dim,) for dim in dim_list]
     space_list = [PoincareHalfSpace(dim) for dim in dim_list]
     n_points_list = random.sample(range(1, 5), 2)
@@ -76,10 +77,11 @@ class PoincareHalfSpaceMetricTestData(_RiemannianMetricTestData):
         smoke_data = [
             dict(
                 dim=2,
+                scale=[1, 2],
                 tangent_vec_a=[[1.0, 2.0], [3.0, 4.0]],
                 tangent_vec_b=[[1.0, 2.0], [3.0, 4.0]],
                 base_point=[[0.0, 1.0], [0.0, 5.0]],
-                expected=[5.0, 1.0],
+                expected=[5.0, 2.0],
             )
         ]
         return self.generate_tests(smoke_data)

--- a/tests/data/poincare_half_space_data.py
+++ b/tests/data/poincare_half_space_data.py
@@ -77,11 +77,11 @@ class PoincareHalfSpaceMetricTestData(_RiemannianMetricTestData):
         smoke_data = [
             dict(
                 dim=2,
-                scale=[1, 2],
+                scale=2,
                 tangent_vec_a=[[1.0, 2.0], [3.0, 4.0]],
                 tangent_vec_b=[[1.0, 2.0], [3.0, 4.0]],
                 base_point=[[0.0, 1.0], [0.0, 5.0]],
-                expected=[5.0, 2.0],
+                expected=[10.0, 2.0],
             )
         ]
         return self.generate_tests(smoke_data)

--- a/tests/tests_geomstats/test_normal.py
+++ b/tests/tests_geomstats/test_normal.py
@@ -76,3 +76,15 @@ class TestNormalDistributions(tests.conftest.TestCase):
         expected = gs.stack([gs.array(pdf1), gs.array(pdf2)], axis=1)
 
         self.assertAllClose(result, expected, atol=1e-8)
+
+    def test_normal_metric(self):
+        n_samples = 3
+        base_point = self.normal.random_point(n_samples)
+        vec_a = self.normal.random_tangent_vec(base_point, n_samples)
+        vec_b = self.normal.random_tangent_vec(base_point, n_samples)
+        mat_prod = gs.einsum(
+            "ik,ikj->ij", vec_a, self.normal.metric.metric_matrix(base_point)
+        )
+        result = gs.einsum("ij,ij->i", mat_prod, vec_b)
+        expected = self.normal.metric.inner_product(vec_a, vec_b, base_point)
+        self.assertAllClose(result, expected)

--- a/tests/tests_geomstats/test_normal.py
+++ b/tests/tests_geomstats/test_normal.py
@@ -77,6 +77,7 @@ class TestNormalDistributions(tests.conftest.TestCase):
 
         self.assertAllClose(result, expected, atol=1e-8)
 
+    @tests.conftest.np_autograd_and_torch_only
     def test_normal_metric(self):
         n_samples = 3
         base_point = self.normal.random_point(n_samples)

--- a/tests/tests_geomstats/test_poincare_half_space.py
+++ b/tests/tests_geomstats/test_poincare_half_space.py
@@ -65,9 +65,9 @@ class TestPoincareHalfSpaceMetric(RiemannianMetricTestCase, metaclass=Parametriz
     testing_data = PoincareHalfSpaceMetricTestData()
 
     def test_inner_product(
-        self, dim, tangent_vec_a, tangent_vec_b, base_point, expected
+        self, dim, scale, tangent_vec_a, tangent_vec_b, base_point, expected
     ):
-        metric = self.Metric(dim)
+        metric = self.Metric(dim, scale)
         result = metric.inner_product(
             gs.array(tangent_vec_a), gs.array(tangent_vec_b), gs.array(base_point)
         )


### PR DESCRIPTION
This PR:

- redefines the metric on normal distributions using `PullbackDiffeoMetric` 
- changes the scaling of the embedding metric `PoincareHalfSpaceMetric` to 2.