### PR TITLE
Consistency fix in visualization of Sphere/Circle

### DIFF
--- a/geomstats/visualization/hypersphere.py
+++ b/geomstats/visualization/hypersphere.py
@@ -16,7 +16,7 @@ class Circle:
     """Class used to draw a circle."""
 
     def __init__(self, n_angles=100, points=None):
-        angles = gs.linspace(0, 2 * gs.pi, n_angles + 1)
+        angles = gs.linspace(0.0, 2 * gs.pi, n_angles + 1)
         self.circle_x = gs.cos(angles)
         self.circle_y = gs.sin(angles)
         self.points = []
@@ -79,8 +79,8 @@ class Sphere:
             n_circles_latitude = max(n_meridians // 2, 4)
 
         u, v = gs.meshgrid(
-            gs.linspace(0, 2 * gs.pi, n_meridians + 1),
-            gs.linspace(0, gs.pi, n_circles_latitude + 1),
+            gs.linspace(0.0, 2 * gs.pi, n_meridians + 1),
+            gs.linspace(0.0, gs.pi, n_circles_latitude + 1),
         )
 
         self.center = gs.zeros(3)

--- a/geomstats/visualization/hypersphere.py
+++ b/geomstats/visualization/hypersphere.py
@@ -16,7 +16,7 @@ class Circle:
     """Class used to draw a circle."""
 
     def __init__(self, n_angles=100, points=None):
-        angles = gs.linspace(0, 2 * gs.pi, n_angles+1)
+        angles = gs.linspace(0, 2 * gs.pi, n_angles + 1)
         self.circle_x = gs.cos(angles)
         self.circle_y = gs.sin(angles)
         self.points = []
@@ -79,8 +79,8 @@ class Sphere:
             n_circles_latitude = max(n_meridians // 2, 4)
 
         u, v = gs.meshgrid(
-            gs.linspace(0, 2 * gs.pi, n_meridians+1),
-            gs.linspace(0, gs.pi, n_circles_latitude+1),
+            gs.linspace(0, 2 * gs.pi, n_meridians + 1),
+            gs.linspace(0, gs.pi, n_circles_latitude + 1),
         )
 
         self.center = gs.zeros(3)


### PR DESCRIPTION
## Description


The visualization library for the Circle and the Sphere is inconsistent in the use of ```gs.linspace``` and ```gs.arange``` in the creation of the mesh.

In addition there is an overlap in the mesh in the circle class (n_angles are actually n_angles-1 unique angles, since two are overlapping) and there is a visible gap in both meridian and latitude circles due to the ```gs.arange``` function excluding the end value.

According to the numpy [1.23] documentation:
> When using a non-integer step, such as 0.1, it is often better to use ```numpy.linspace```.

therefore ```gs.linspace``` is used for consistency.