### PR TITLE
Create abstract ImmersedSet class and use it to have an Hypersphere in hyperspherical coords

### DIFF
--- a/geomstats/geometry/base.py
+++ b/geomstats/geometry/base.py
@@ -309,6 +309,134 @@ class ComplexVectorSpace(ComplexManifold, abc.ABC):
         """Create a canonical basis."""
 
 
+class ImmersedSet(Manifold, abc.ABC):
+    """Class for manifolds embedded in a vector space by an immersion.
+
+    Parameters
+    ----------
+    dim : int
+        Dimension of the embedded manifold.
+    embedding_space : VectorSpace
+        Embedding space.
+    default_coords_type : str, {'intrinsic', 'extrinsic', etc}
+        Coordinate type.
+        Optional, default: 'intrinsic'.
+    """
+
+    def __init__(self, dim, embedding_space, default_coords_type="intrinsic", **kwargs):
+        kwargs.setdefault("shape", (dim,))
+        super().__init__(dim=dim, default_coords_type=default_coords_type, **kwargs)
+        self.embedding_space = embedding_space
+        self.embedding_metric = embedding_space.metric
+
+    @abc.abstractmethod
+    def belongs(self, point, atol=gs.atol):
+        """Evaluate if a point belongs to the manifold.
+
+        Parameters
+        ----------
+        point : array-like, shape=[..., dim]
+            Point to evaluate.
+        atol : float
+            Absolute tolerance.
+            Optional, default: backend atol.
+
+        Returns
+        -------
+        belongs : array-like, shape=[...,]
+            Boolean evaluating if point belongs to the manifold.
+        """
+        pass
+
+    @abc.abstractmethod
+    def is_tangent(self, vector, base_point, atol=gs.atol):
+        """Check whether the vector is tangent at base_point.
+
+        Parameters
+        ----------
+        vector : array-like, shape=[..., dim]
+            Vector.
+        base_point : array-like, shape=[..., dim]
+            Point on the manifold.
+        atol : float
+            Absolute tolerance.
+            Optional, default: backend atol.
+
+        Returns
+        -------
+        is_tangent : bool
+            Boolean denoting if vector is a tangent vector at the base point.
+        """
+        pass
+
+    def intrinsic_to_extrinsic_coords(self, point_intrinsic):
+        """Convert from intrinsic to extrinsic coordinates.
+
+        Parameters
+        ----------
+        point_intrinsic : array-like, shape=[..., dim]
+            Point in the embedded manifold in intrinsic coordinates.
+
+        Returns
+        -------
+        point_extrinsic : array-like, shape=[..., dim_embedding]
+            Point in the embedded manifold in extrinsic coordinates.
+        """
+        return self.immersion(point_intrinsic)
+
+    def extrinsic_to_intrinsic_coords(self, point_extrinsic):
+        """Convert from extrinsic to intrinsic coordinates.
+
+        Parameters
+        ----------
+        point_extrinsic : array-like, shape=[..., dim_embedding]
+            Point in the embedded manifold in extrinsic coordinates,
+            i. e. in the coordinates of the embedding manifold.
+
+        Returns
+        -------
+        point_intrinsic : array-lie, shape=[..., dim]
+            Point in the embedded manifold in intrinsic coordinates.
+        """
+        raise NotImplementedError("extrinsic_to_intrinsic_coords is not implemented.")
+
+    def projection(self, point):
+        """Project a point to the embedded manifold.
+
+        This is simply point, since we are in intrinsic coordinates.
+
+        Parameters
+        ----------
+        point : array-like, shape=[..., dim_embedding]
+            Point in the embedding manifold.
+
+        Returns
+        -------
+        projected_point : array-like, shape=[..., dim]
+            Point in the embedded manifold.
+        """
+        return point
+
+    def to_tangent(self, vector, base_point):
+        """Project a vector to a tangent space of the manifold.
+
+        This is simply the vector since we are in intrinsic coordinates.
+
+        Parameters
+        ----------
+        vector : array-like, shape=[..., dim_embedding]
+            Vector.
+        base_point : array-like, shape=[..., dim]
+            Point in the embedded manifold.
+
+        Returns
+        -------
+        tangent_vec : array-like, shape=[..., dim]
+            Tangent vector at base point.
+        """
+        return vector
+
+
 class LevelSet(Manifold, abc.ABC):
     """Class for manifolds embedded in a vector space by a submersion.
 

--- a/tests/data/hypersphere_data.py
+++ b/tests/data/hypersphere_data.py
@@ -4,8 +4,16 @@ from contextlib import nullcontext as does_not_raise
 import pytest
 
 import geomstats.backend as gs
-from geomstats.geometry.hypersphere import Hypersphere, HypersphereMetric
-from tests.data_generation import _LevelSetTestData, _RiemannianMetricTestData
+from geomstats.geometry.hypersphere import (
+    Hypersphere,
+    HypersphereMetric,
+    _HypersphereIntrinsic,
+)
+from tests.data_generation import (
+    _LevelSetTestData,
+    _ManifoldTestData,
+    _RiemannianMetricTestData,
+)
 
 
 class HypersphereTestData(_LevelSetTestData):
@@ -430,3 +438,13 @@ class HypersphereMetricTestData(_RiemannianMetricTestData):
             )
         ]
         return self.generate_tests(smoke_data)
+
+
+class HypersphereIntrinsicTestData(_ManifoldTestData):
+    space_args_list = [(2,), (3,)]
+    shape_list = [(10, 2), (10, 3)]
+    n_samples_list = random.sample(range(2, 5), 2)
+    n_points_list = random.sample(range(2, 5), 2)
+    n_vecs_list = random.sample(range(2, 5), 2)
+
+    Space = _HypersphereIntrinsic

--- a/tests/tests_geomstats/test_hypersphere.py
+++ b/tests/tests_geomstats/test_hypersphere.py
@@ -7,8 +7,16 @@ import tests.conftest
 from geomstats.geometry.hypersphere import Hypersphere
 from geomstats.learning.frechet_mean import FrechetMean
 from tests.conftest import Parametrizer, np_backend
-from tests.data.hypersphere_data import HypersphereMetricTestData, HypersphereTestData
-from tests.geometry_test_cases import LevelSetTestCase, RiemannianMetricTestCase
+from tests.data.hypersphere_data import (
+    HypersphereIntrinsicTestData,
+    HypersphereMetricTestData,
+    HypersphereTestData,
+)
+from tests.geometry_test_cases import (
+    LevelSetTestCase,
+    ManifoldTestCase,
+    RiemannianMetricTestCase,
+)
 
 MEAN_ESTIMATION_TOL = 1e-1
 KAPPA_ESTIMATION_TOL = 1e-1
@@ -275,3 +283,8 @@ class TestHypersphereMetric(HypersphereMetricTestCase, metaclass=Parametrizer):
     skip_test_ricci_tensor_spherical_coords = np_backend()
 
     testing_data = HypersphereMetricTestData()
+
+
+class TestHypersphereIntrinsic(ManifoldTestCase, metaclass=Parametrizer):
+
+    testing_data = HypersphereIntrinsicTestData()


### PR DESCRIPTION
This PR creates an abstract class that allows users to represent manifold as immersions, for example using a parameterization of the points on the manifold. For example, points on the hypersphere can be represented in hyperspherical coordinates, thus represent an immersion of [0, pi] x [0, pi] x ... x [0, 2pi] into R^(dim+1).

One problem to discuss @alebrigant @lpereira95 @ymontmarin  : 

I wanted to equip each manifold inheriting from ImmersedSet with a pullback metric. The problem is that in ImmersedSet, `immersion` is an abstract method as opposed to an argument to the constructor. Thus, `pullback_metric` cannot be created as an attribute of `ImmersedSet`.


## Checklist

- [ ] My pull request has a clear and explanatory title.
- [ ] If neccessary, my code is [vectorized](https://www.geeksforgeeks.org/vectorization-in-python/).
- [ ] I have added apropriate unit tests.
- [ ] I have made sure the code passes all unit tests. (refer to comment below)
- [ ] My PR follows [PEP8](https://peps.python.org/pep-0008/) guidelines. (refer to comment below)
- [ ] My PR follows [geomstats coding style](https://github.com/geomstats/geomstats/blob/master/docs/contributing.rst#coding-style-guidelines) and API.
- [ ] My code is properly documented and I made sure the documentation renders properly. ([Link](https://github.com/geomstats/geomstats/blob/master/docs/contributing.rst#documentation))
- [ ] I have linked to issues and PRs that are relevant to this PR.


<!-- For checking consistency of entire codebase
First, run the tests related to your changes. For example, if you changed something in geomstats/spd_matrices_space.py:
$ pytest tests/tests_geomstats/test_spd_matrices.py

and then run the tests of the whole codebase to check that your feature is not breaking any of them:
$ pytest tests/

This way, further modifications on the code base are guaranteed to be consistent with the desired behavior. Merging your PR should not break any test in any backend (numpy, tensorflow or pytorch)."

For testing in alternative backends such as `numpy`, `pytorch`, `autograd`, `tensorflow` set the environment variable using:
$ export GEOMSTATS_BACKEND=<backend_name>

Next, import the `backend` module using:
import geomstats.backend as gs
-->


<!-- For flake8 tests
Install dependencies
$ pip3 install -r dev-requirements.txt

Then run the following commands:
$ flake8 --ignore=D,W503,W504 geomstats examples tests   #shadows .flake8
$ flake8 geomstats/geometry geomstats/learning           #passed two subfolders
-->

## Description

<!-- Include a description of your pull request. If relevant, feel free to use this space to talk about time and space complexity as well scalability of your code-->

## Issue

<!-- Tell us which issue does this PR fix . Why this feature implementation/fix is important in practice ?-->

## Additional context

<!-- Add any extra information -->