### PR TITLE
Vectorization of metric_matrix

### DIFF
--- a/geomstats/geometry/euclidean.py
+++ b/geomstats/geometry/euclidean.py
@@ -97,8 +97,8 @@ class EuclideanMetric(RiemannianMetric):
         """
         mat = gs.eye(self.dim)
         if base_point is not None:
-            if base_point.ndim == 2:
-                mat = gs.tile(mat, (base_point.shape[0], 1, 1))
+            if base_point.ndim > 1:
+                mat = gs.broadcast_to(mat, base_point.shape + (self.dim,))
         return mat
 
     def inner_product(self, tangent_vec_a, tangent_vec_b, base_point=None):

--- a/geomstats/geometry/hermitian.py
+++ b/geomstats/geometry/hermitian.py
@@ -100,7 +100,7 @@ class HermitianMetric(ComplexRiemannianMetric):
         """
         mat = gs.eye(self.dim, dtype=CDTYPE)
         if base_point is not None and base_point.ndim > 1:
-                mat = gs.broadcast_to(mat, base_point.shape + (self.dim,))
+            mat = gs.broadcast_to(mat, base_point.shape + (self.dim,))
         return mat
 
     @staticmethod

--- a/geomstats/geometry/hermitian.py
+++ b/geomstats/geometry/hermitian.py
@@ -99,8 +99,7 @@ class HermitianMetric(ComplexRiemannianMetric):
             Inner-product matrix.
         """
         mat = gs.eye(self.dim, dtype=CDTYPE)
-        if base_point is not None:
-            if base_point.ndim > 1:
+        if base_point is not None and base_point.ndim > 1:
                 mat = gs.broadcast_to(mat, base_point.shape + (self.dim,))
         return mat
 

--- a/geomstats/geometry/hermitian.py
+++ b/geomstats/geometry/hermitian.py
@@ -99,6 +99,9 @@ class HermitianMetric(ComplexRiemannianMetric):
             Inner-product matrix.
         """
         mat = gs.eye(self.dim, dtype=CDTYPE)
+        if base_point is not None:
+            if base_point.ndim > 1:
+                mat = gs.broadcast_to(mat, base_point.shape + (self.dim,))
         return mat
 
     @staticmethod

--- a/geomstats/geometry/hypersphere.py
+++ b/geomstats/geometry/hypersphere.py
@@ -676,7 +676,7 @@ class HypersphereMetric(RiemannianMetric):
         mat : array-like, shape=[..., dim + 1, dim + 1]
             Inner-product matrix.
         """
-        return gs.eye(self.dim + 1)
+        return self.embedding_metric.metric_matrix(base_point)
 
     def inner_product(self, tangent_vec_a, tangent_vec_b, base_point=None):
         """Compute the inner-product of two tangent vectors at a base point.

--- a/geomstats/geometry/minkowski.py
+++ b/geomstats/geometry/minkowski.py
@@ -65,7 +65,7 @@ class MinkowskiMetric(RiemannianMetric):
         diagonal = gs.array([-1.0] * p + [1.0] * q)
         mat = from_vector_to_diagonal_matrix(diagonal)
         if base_point is not None and base_point.ndim > 1:
-                mat = gs.broadcast_to(mat, base_point.shape + (p + q,))
+            mat = gs.broadcast_to(mat, base_point.shape + (p + q,))
         return mat
 
     def inner_product(self, tangent_vec_a, tangent_vec_b, base_point=None):

--- a/geomstats/geometry/minkowski.py
+++ b/geomstats/geometry/minkowski.py
@@ -63,7 +63,11 @@ class MinkowskiMetric(RiemannianMetric):
         """
         q, p = self.signature
         diagonal = gs.array([-1.0] * p + [1.0] * q)
-        return from_vector_to_diagonal_matrix(diagonal)
+        mat = from_vector_to_diagonal_matrix(diagonal)
+        if base_point is not None:
+            if base_point.ndim > 1:
+                mat = gs.broadcast_to(mat, base_point.shape + (p + q,))
+        return mat
 
     def inner_product(self, tangent_vec_a, tangent_vec_b, base_point=None):
         """Inner product between two tangent vectors at a base point.

--- a/geomstats/geometry/minkowski.py
+++ b/geomstats/geometry/minkowski.py
@@ -64,8 +64,7 @@ class MinkowskiMetric(RiemannianMetric):
         q, p = self.signature
         diagonal = gs.array([-1.0] * p + [1.0] * q)
         mat = from_vector_to_diagonal_matrix(diagonal)
-        if base_point is not None:
-            if base_point.ndim > 1:
+        if base_point is not None and base_point.ndim > 1:
                 mat = gs.broadcast_to(mat, base_point.shape + (p + q,))
         return mat
 

--- a/tests/tests_geomstats/test_product_manifold.py
+++ b/tests/tests_geomstats/test_product_manifold.py
@@ -43,6 +43,7 @@ class TestProductRiemannianMetric(RiemannianMetricTestCase, metaclass=Parametriz
     skip_test_scalar_curvature_shape = True
     skip_test_ricci_tensor_shape = True
     skip_test_sectional_curvature_shape = True
+    skip_test_inner_product_matrix_vector = True
 
     testing_data = ProductRiemannianMetricTestData()
 


### PR DESCRIPTION
## Description

In some subclasses of `RiemannianMetric`, the `metric_matrix` method only returned a single copy of the matrix, regardless of the array passed as `base_point`. This PR corrects that in `HermitianMetric`, `HypersphereMetric` and `MinkowskiMetric`. It amends the method in `EuclideanMetric` to use `gs.broadcast_to` instead of `gs.tile` as this method permits more flexibility in the array shape.