### PR TITLE
Remove CDTYPE = gs.get_default_cdtype() from complex manifolds

### DIFF
--- a/geomstats/geometry/complex_manifold.py
+++ b/geomstats/geometry/complex_manifold.py
@@ -10,8 +10,6 @@ import geomstats.backend as gs
 from geomstats.geometry.complex_riemannian_metric import ComplexRiemannianMetric
 from geomstats.geometry.manifold import Manifold
 
-CDTYPE = gs.get_default_cdtype()
-
 
 class ComplexManifold(Manifold):
     r"""Class for complex manifolds.
@@ -80,6 +78,10 @@ class ComplexManifold(Manifold):
                 "number of samples, when different from 1."
             )
         vector = gs.cast(
-            gs.random.normal(size=(n_samples,) + self.shape), dtype=CDTYPE
-        ) + 1j * gs.cast(gs.random.normal(size=(n_samples,) + self.shape), dtype=CDTYPE)
+            gs.random.normal(size=(n_samples,) + self.shape),
+            dtype=gs.get_default_cdtype(),
+        ) + 1j * gs.cast(
+            gs.random.normal(size=(n_samples,) + self.shape),
+            dtype=gs.get_default_cdtype(),
+        )
         return gs.squeeze(self.to_tangent(vector, base_point))

--- a/geomstats/geometry/complex_riemannian_metric.py
+++ b/geomstats/geometry/complex_riemannian_metric.py
@@ -6,8 +6,6 @@ Lead author: Yann Cabanes.
 import geomstats.backend as gs
 from geomstats.geometry.riemannian_metric import RiemannianMetric
 
-CDTYPE = gs.get_default_cdtype()
-
 
 class ComplexRiemannianMetric(RiemannianMetric):
     r"""Class for Riemannian and pseudo-Riemannian metrics for Complex manifolds.
@@ -108,8 +106,9 @@ class ComplexRiemannianMetric(RiemannianMetric):
                 "Several tangent vectors is only applicable to a single base point."
             )
         random_vector = gs.squeeze(
-            gs.cast(gs.random.rand(n_vectors, *shape), dtype=CDTYPE)
-            + 1j * gs.cast(gs.random.rand(n_vectors, *shape), dtype=CDTYPE)
+            gs.cast(gs.random.rand(n_vectors, *shape), dtype=gs.get_default_cdtype())
+            + 1j
+            * gs.cast(gs.random.rand(n_vectors, *shape), dtype=gs.get_default_cdtype())
         )
         normalized_vector = self.normalize(random_vector, base_point)
         return gs.squeeze(normalized_vector)

--- a/geomstats/geometry/hermitian.py
+++ b/geomstats/geometry/hermitian.py
@@ -7,8 +7,6 @@ import geomstats.backend as gs
 from geomstats.geometry.base import ComplexVectorSpace
 from geomstats.geometry.complex_riemannian_metric import ComplexRiemannianMetric
 
-CDTYPE = gs.get_default_cdtype()
-
 
 class Hermitian(ComplexVectorSpace):
     """Class for Hermitian spaces.
@@ -33,14 +31,14 @@ class Hermitian(ComplexVectorSpace):
         -------
         identity : array-like, shape=[n]
         """
-        identity = gs.zeros(self.dim, dtype=CDTYPE)
+        identity = gs.zeros(self.dim, dtype=gs.get_default_cdtype())
         return identity
 
     identity = property(get_identity)
 
     def _create_basis(self):
         """Create the canonical basis."""
-        return gs.eye(self.dim, dtype=CDTYPE)
+        return gs.eye(self.dim, dtype=gs.get_default_cdtype())
 
     def exp(self, tangent_vec, base_point=None):
         """Compute the group exponential, which is simply the addition.
@@ -98,7 +96,7 @@ class HermitianMetric(ComplexRiemannianMetric):
         inner_prod_mat : array-like, shape=[..., dim, dim]
             Inner-product matrix.
         """
-        mat = gs.eye(self.dim, dtype=CDTYPE)
+        mat = gs.eye(self.dim, dtype=gs.get_default_cdtype())
         if base_point is not None and base_point.ndim > 1:
             mat = gs.broadcast_to(mat, base_point.shape + (self.dim,))
         return mat


### PR DESCRIPTION
Remove `CDTYPE = gs.get_default_cdtype()` from the complex manifolds hermitian.py, complex_manifold.py and complex_riemannian_metric.py.
This PR is related to the issue: https://github.com/geomstats/geomstats/issues/1696 opened by @lpereira95.