### PR TITLE
Add statistical manifold of multivariate diagonal normal distributions

### DIFF
--- a/geomstats/information_geometry/multivariate_normal.py
+++ b/geomstats/information_geometry/multivariate_normal.py
@@ -1,4 +1,5 @@
-"""Statistical Manifold of multivaraite normal distributions with the Fisher metric.
+"""Information Manifold of multivariate normal distributions with
+the Fisher information metric.
 
 Lead author: Antoine Collas.
 """
@@ -17,7 +18,19 @@ from geomstats.information_geometry.normal import NormalMetric
 
 
 class MultivariateDiagonalNormalDistributions(OpenSet, InformationManifoldMixin):
-    """Class for the manifold of diagonal multivariate normal distributions."""
+    """Class for the manifold of diagonal multivariate normal distributions.
+
+    This is the class for multivariate normal distributions with diagonal
+    covariance matrices and samples on the $n$-dimensional Euclidean space.
+    Each distribution is represented by a vector of size $2n$ where the first
+    $n$ elements contain the mean vector and the $n$ last elements contain
+    the diagonal of the covariance matrix.
+
+    Parameters
+    ----------
+    n : int
+          Dimension of the sample space of the multivariate normal distribution.
+    """
 
     def __init__(self, n):
         self.n = n
@@ -30,6 +43,9 @@ class MultivariateDiagonalNormalDistributions(OpenSet, InformationManifoldMixin)
 
     def belongs(self, point, atol=gs.atol):
         """Evaluate if the point belongs to the manifold.
+
+        First $n$ elements contain the mean vector and the $n$ last
+        elements contain the diagonal of the covariance matrix.
 
         Parameters
         ----------
@@ -48,7 +64,7 @@ class MultivariateDiagonalNormalDistributions(OpenSet, InformationManifoldMixin)
         return belongs
 
     def random_point(self, n_samples=1):
-        """Sample parameters of normal distributions.
+        """Generate random parameters of multivariate diagonal normal distributions.
 
         Parameters
         ----------
@@ -73,7 +89,10 @@ class MultivariateDiagonalNormalDistributions(OpenSet, InformationManifoldMixin)
         return point
 
     def projection(self, point):
-        """Floor the eigenvalues to gs.atol.
+        """Project a point on the manifold of
+        diagonal multivariate normal distributions.
+
+        Floor the eigenvalues of the diagonal covariance matrix to gs.atol.
 
         Parameters
         ----------
@@ -92,7 +111,7 @@ class MultivariateDiagonalNormalDistributions(OpenSet, InformationManifoldMixin)
         return projected
 
     def sample(self, point, n_samples=1):
-        """Sample from the diagonal mutltivariate normal distribution.
+        """Sample from the diagonal multivariate normal distribution.
 
         Parameters
         ----------
@@ -164,7 +183,13 @@ class MultivariateDiagonalNormalDistributions(OpenSet, InformationManifoldMixin)
 
 
 class MultivariateDiagonalNormalMetric(RiemannianMetric):
-    """Class for the Fisher information metric of diagonal normal distributions."""
+    """Class for the Fisher information metric of diagonal normal distributions.
+
+    Parameters
+    ----------
+    n : int
+          Dimension of the sample space of the multivariate normal distribution.
+    """
 
     def __init__(self, n):
         self.n = n
@@ -210,19 +235,19 @@ class MultivariateDiagonalNormalMetric(RiemannianMetric):
         return point
 
     def _stacked_location_diagonal_to_1d_pairs(self, point, apply_sqrt=False):
-        """Create pairs of 1d locations and stds from nd counterparts.
+        """Create pairs of 1d parameters from nd counterparts.
 
         Parameters
         ----------
         point: array-like, shape=[..., 2*n]
-            Point.
+            Stacked point (e.g. stacked locations and diagonals).
         apply_sqrt: bool
             Determine if a square root is applied to the diagonals.
 
         Returns
         -------
         pairs : array-like, shape=[..., n, 2]
-            Pairs of locations and standard deviations.
+            Pairs of parameters (e.g. locations and variances).
         """
         location, diagonal = self._unstack_location_diagonal(point)
         if apply_sqrt:
@@ -231,20 +256,19 @@ class MultivariateDiagonalNormalMetric(RiemannianMetric):
         return point
 
     def _1d_pairs_to_stacked_location_diagonal(self, point, apply_square=False):
-        """Create nd locations and diagonal matrices from pairs of 1d counterparts.
+        """Create nd stacked parameters from pairs of 1d counterparts.
 
         Parameters
         ----------
-        point: array-like, shape=[..., 2*n]
-            Point.
+        pairs : array-like, shape=[..., n, 2]
+            Pairs of parameters (e.g. locations and variances).
         apply_square: bool
             Determine if a square is applied to the diagonals.
 
         Returns
         -------
-        pairs : array-like, shape=[..., n, 2]
-            Pairs of locations and standard deviations.
-
+        point: array-like, shape=[..., 2*n]
+            Stacked point (e.g. stacked locations and diagonals).
         """
         location = point[..., 0]
         diagonal = point[..., 1]

--- a/geomstats/information_geometry/multivariate_normal.py
+++ b/geomstats/information_geometry/multivariate_normal.py
@@ -279,6 +279,7 @@ class MultivariateDiagonalNormalMetric(RiemannianMetric):
         inner_prod = self.univariate_normal_metric.inner_product(
             tangent_vec_a, tangent_vec_b, base_point
         )
+        inner_prod = gs.sum(inner_prod, axis=-1)
         return inner_prod
 
     def exp(self, tangent_vec, base_point):

--- a/geomstats/information_geometry/multivariate_normal.py
+++ b/geomstats/information_geometry/multivariate_normal.py
@@ -118,25 +118,40 @@ class MultivariateDiagonalNormalDistributions(OpenSet, InformationManifoldMixin)
             samples.append(gs.array(multivariate_normal.rvs(loc, cov, size=n_samples)))
         return samples[0] if point.shape[0] == 1 else gs.stack(samples)
 
-    @staticmethod
-    def pdf(x, point):
+    def pdf(self, x, point):
         """Generate parameterized function for pdf.
 
         Parameters
         ----------
-        x : array-like, shape=[n_points, dim]
+        x : array-like, shape=[n_samples, n]
             Points at which to compute the probability
             density function.
-        point : array-like, shape=[..., dim]
+        point : array-like, shape=[..., 2*n]
             Point representing a probability distribution.
 
         Returns
         -------
-        pdf_at_x : array-like, shape=[..., n_points]
+        pdf_at_x : array-like, shape=[..., n_samples]
             Values of pdf at x for each value of the parameters provided
             by point.
         """
-        raise NotImplementedError("The pdf method has not yet been implemented.")
+        geomstats.errors.check_belongs(point, self)
+        if point.ndim > 2:
+            raise NotImplementedError
+        point = gs.to_ndarray(point, to_ndim=2, axis=0)
+        point = point[:, None, :]
+        x = gs.to_ndarray(x, to_ndim=2, axis=0)
+        x = x[None, :, :]
+        n = self.n
+        location, diagonal = self._unstack_location_diagonal(point)
+        det_cov = gs.squeeze(gs.prod(diagonal, axis=-1))
+        tmp_0 = 1 / gs.sqrt(gs.power((2 * gs.pi), n) * det_cov)
+        tmp_1 = gs.exp(-0.5 * gs.sum(((x - location) ** 2) / diagonal, axis=-1))
+        while tmp_0.ndim < tmp_1.ndim:
+            tmp_0 = tmp_0[..., None]
+        pdf_at_x = tmp_0 * tmp_1
+        pdf_at_x = gs.squeeze(pdf_at_x)
+        return pdf_at_x
 
     @staticmethod
     def cdf(x, point):
@@ -144,15 +159,15 @@ class MultivariateDiagonalNormalDistributions(OpenSet, InformationManifoldMixin)
 
         Parameters
         ----------
-        x : array-like, shape=[n_points, dim]
-            Points at which to compute the probability
+        x : array-like, shape=[n_samples, n]
+            Points at which to compute the cumulative
             density function.
-        point : array-like, shape=[..., dim]
+        point : array-like, shape=[..., 2*n]
             Point representing a probability distribution.
 
         Returns
         -------
-        cdf_at_x : array-like, shape=[..., n_points]
+        cdf_at_x : array-like, shape=[..., n_samples]
             Values of cdf at x for each value of the parameters provided
             by point.
         """

--- a/geomstats/information_geometry/multivariate_normal.py
+++ b/geomstats/information_geometry/multivariate_normal.py
@@ -1,0 +1,201 @@
+"""Statistical Manifold of multivaraite normal distributions with the Fisher metric.
+
+Lead author: XXXX.
+"""
+
+from scipy.stats import norm, multivariate_normal
+
+import geomstats
+import geomstats.backend as gs
+from geomstats.geometry.base import OpenSet
+from geomstats.geometry.euclidean import Euclidean
+from geomstats.information_geometry.base import InformationManifoldMixin
+
+
+class MultivariateDiagonalNormalDistributions(OpenSet, InformationManifoldMixin):
+    """Class for the manifold of diagonal multivariate normal distributions."""
+
+    def __init__(self, n):
+        self.n = n
+        self.euclidean_n = Euclidean(dim=n)
+        dim = int(2 * n)
+        super().__init__(
+            dim=dim,
+            embedding_space=Euclidean(dim)
+        )
+
+    def _get_location_and_diagonal(self, point):
+        """Extract location and diagonal of the covariance matrix
+        from a given point/tangent vector.
+
+        Parameters
+        ----------
+        point : array-like, shape=[..., 2*n]
+            Input point from which locations and diagonals are extracted.
+
+        Returns
+        -------
+        location : array-like, shape=[..., n]
+            Locations from the input point.
+        diagonal : array-like, shape=[..., n]
+            Diagonals of covariance matrices from the input point.
+        """
+        location = point[..., :self.n]
+        diagonal = point[..., self.n:]
+        return location, diagonal
+
+    def _set_location_and_diagonal(self, location, diagonal):
+        """Set location and diagonal of the covariance matrix
+        into a point.
+
+        Parameters
+        ----------
+        location : array-like, shape=[..., n]
+            Locations to stack.
+        diagonal : array-like, shape=[..., n]
+            Diagonals of covariance matrices from the input point.
+
+        Returns
+        -------
+        point : array-like, shape=[..., 2*n]
+            Point with locations and diagonals covariance matrices.
+        """
+        point = gs.concatenate([location, diagonal], axis=-1)
+        return point
+
+    def belongs(self, point, atol=gs.atol):
+        """Evaluate if the point belongs to the
+        multivariate diagonal Normal distribution manifold.
+
+        Parameters
+        ----------
+        point : array-like, shape=[..., 2*n]
+            Point to test.
+
+        Returns
+        -------
+        belongs : array-like, shape=[...,]
+            Boolean evaluating if point belongs to the space.
+        """
+        point_dim = point.shape[-1]
+        belongs = point_dim == self.dim
+        _, diagonal = self._get_location_and_diagonal(point)
+        belongs = gs.logical_and(belongs, gs.all(diagonal >= atol, axis=-1))
+        return belongs
+
+    def random_point(self, n_samples=1):
+        """Sample parameters of normal distributions.
+
+        Parameters
+        ----------
+        n_samples : int
+            Number of samples.
+            Optional, default: 1.
+
+        Returns
+        -------
+        samples : array-like, shape=[..., 2*n]
+            Sample of points representing multivariate diagonal
+            normal distributions.
+        """
+        n = self.n
+        bound = 1.0
+        location = self.euclidean_n.random_point(
+            n_samples=n_samples, bound=bound)
+        if n_samples == 1:
+            diagonal = gs.array(norm.rvs(size=(n,))**2)
+        else:
+            diagonal = gs.array(norm.rvs(size=(n_samples, n))**2)
+        point = self._set_location_and_diagonal(location, diagonal)
+        return point
+
+    def projection(self, point):
+        """Project a 2*n vector on the manifold of
+        diagonal mutlivariate normal distributions.
+
+        The eigenvalues are floored to gs.atol.
+
+        Parameters
+        ----------
+        point : array-like, shape=[..., 2*n]
+            Point to project.
+
+        Returns
+        -------
+        projected: array-like, shape=[..., 2*n]
+            Point containing locations and diagonals
+            of covariance matrices.
+        """
+        location, diagonal = self._get_location_and_diagonal(point)
+        regularized = gs.where(diagonal < gs.atol, gs.atol, diagonal)
+        projected = self._set_location_and_diagonal(location, regularized)
+        return projected
+
+    def sample(self, point, n_samples=1):
+        """Sample from the diagonal mutltivariate normal distribution.
+
+        Parameters
+        ----------
+        point : array-like, shape=[..., 2*n]
+            Point on the manifold.
+        n_samples : int
+            Number of points to sample with each pair of parameters in point.
+            Optional, default: 1.
+
+        Returns
+        -------
+        samples : array-like, shape=[..., n_samples, n]
+            Sample from multivariate normal distributions.
+        """
+        geomstats.errors.check_belongs(point, self)
+        if point.ndim > 2:
+            raise NotImplementedError
+        point = gs.to_ndarray(point, to_ndim=2)
+        samples = []
+        for p in point:
+            loc, diag = self._get_location_and_diagonal(p)
+            cov = gs.vec_to_diag(diag)
+            samples.append(
+                gs.array(multivariate_normal.rvs(loc, cov, size=n_samples))
+            )
+        return samples[0] if point.shape[0] == 1 else gs.stack(samples)
+
+    @staticmethod
+    def pdf(x, point):
+        """Generate parameterized function for pdf.
+
+        Parameters
+        ----------
+        x : array-like, shape=[n_points, dim]
+            Points at which to compute the probability
+            density function.
+        point : array-like, shape=[..., dim]
+            Point representing a probability distribution.
+
+        Returns
+        -------
+        pdf_at_x : array-like, shape=[..., n_points]
+            Values of pdf at x for each value of the parameters provided
+            by point.
+        """
+        raise NotImplementedError("The pdf method has not yet been implemented.")
+
+    @staticmethod
+    def cdf(x, point):
+        """Generate parameterized function for cdf.
+
+        Parameters
+        ----------
+        x : array-like, shape=[n_points, dim]
+            Points at which to compute the probability
+            density function.
+        point : array-like, shape=[..., dim]
+            Point representing a probability distribution.
+
+        Returns
+        -------
+        cdf_at_x : array-like, shape=[..., n_points]
+            Values of cdf at x for each value of the parameters provided
+            by point.
+        """
+        raise NotImplementedError("The cdf method has not yet been implemented.")

--- a/geomstats/information_geometry/multivariate_normal.py
+++ b/geomstats/information_geometry/multivariate_normal.py
@@ -17,7 +17,7 @@ from geomstats.information_geometry.base import InformationManifoldMixin
 from geomstats.information_geometry.normal import NormalMetric
 
 
-class MultivariateDiagonalNormalDistributions(OpenSet, InformationManifoldMixin):
+class MultivariateDiagonalNormalDistributions(InformationManifoldMixin, OpenSet):
     """Class for the manifold of diagonal multivariate normal distributions.
 
     This is the class for multivariate normal distributions with diagonal

--- a/geomstats/information_geometry/multivariate_normal.py
+++ b/geomstats/information_geometry/multivariate_normal.py
@@ -1,6 +1,6 @@
 """Statistical Manifold of multivaraite normal distributions with the Fisher metric.
 
-Lead author: XXXX.
+Lead author: Antoine Collas.
 """
 
 import math

--- a/geomstats/information_geometry/multivariate_normal.py
+++ b/geomstats/information_geometry/multivariate_normal.py
@@ -175,13 +175,13 @@ class MultivariateDiagonalNormalDistributions(InformationManifoldMixin, OpenSet)
             x = gs.to_ndarray(x, to_ndim=2, axis=0)
             x = x[None, :, :]
             det_cov = gs.squeeze(gs.prod(diagonal, axis=-1))
-            tmp_0 = 1 / gs.sqrt(gs.power((2 * gs.pi), n) * det_cov)
-            tmp_1 = gs.exp(-0.5 * gs.sum(((x - location) ** 2) / diagonal, axis=-1))
-            while tmp_0.ndim < tmp_1.ndim:
-                tmp_0 = tmp_0[..., None]
-            pdf_at_x = tmp_0 * tmp_1
-            pdf_at_x = gs.squeeze(pdf_at_x)
-            return pdf_at_x
+            pdf_normalization = 1 / gs.sqrt(gs.power((2 * gs.pi), n) * det_cov)
+            pdf = gs.exp(-0.5 * gs.sum(((x - location) ** 2) / diagonal, axis=-1))
+            while pdf_normalization.ndim < pdf.ndim:
+                pdf_normalization = pdf_normalization[..., None]
+            pdf = pdf_normalization * pdf
+            pdf = gs.squeeze(pdf)
+            return pdf
 
         return pdf
 

--- a/geomstats/information_geometry/multivariate_normal.py
+++ b/geomstats/information_geometry/multivariate_normal.py
@@ -302,9 +302,9 @@ class MultivariateDiagonalNormalMetric(RiemannianMetric):
         base_point = self._stacked_location_diagonal_to_1d_pairs(
             base_point, apply_sqrt=True
         )
-        point = self.univariate_normal_metric.exp(tangent_vec, base_point)
+        end_point = self.univariate_normal_metric.exp(tangent_vec, base_point)
         end_point = self._1d_pairs_to_stacked_location_diagonal(
-            point, apply_square=True
+            end_point, apply_square=True
         )
         return end_point
 

--- a/geomstats/information_geometry/multivariate_normal.py
+++ b/geomstats/information_geometry/multivariate_normal.py
@@ -75,8 +75,9 @@ class MultivariateDiagonalNormalDistributions(InformationManifoldMixin, OpenSet)
         Returns
         -------
         samples : array-like, shape=[..., 2*n]
-            Sample of points representing multivariate diagonal
-            normal distributions.
+            Sample of points representing multivariate diagonal normal distributions.
+            First $n$ elements contain the mean vector and the $n$ last elements
+            contain the diagonal of the covariance matrix.
         """
         n = self.n
         bound = 1.0
@@ -116,7 +117,8 @@ class MultivariateDiagonalNormalDistributions(InformationManifoldMixin, OpenSet)
         Parameters
         ----------
         point : array-like, shape=[..., 2*n]
-            Point on the manifold.
+            Point on the manifold. First $n$ elements contain the mean vector
+            and the $n$ last elements contain the diagonal of the covariance matrix.
         n_samples : int
             Number of points to sample with each pair of parameters in point.
             Optional, default: 1.
@@ -144,6 +146,8 @@ class MultivariateDiagonalNormalDistributions(InformationManifoldMixin, OpenSet)
         ----------
         point : array-like, shape=[..., 2*n]
             Point representing a probability distribution.
+            First $n$ elements contain the mean vector and the $n$ last elements
+            contain the diagonal of the covariance matrix.
 
         Returns
         -------

--- a/geomstats/information_geometry/multivariate_normal.py
+++ b/geomstats/information_geometry/multivariate_normal.py
@@ -1,5 +1,4 @@
-"""Information Manifold of multivariate normal distributions with
-the Fisher information metric.
+"""Information Manifold of multivariate normal distributions with the Fisher metric.
 
 Lead author: Antoine Collas.
 """
@@ -131,8 +130,7 @@ class MultivariateDiagonalNormalDistributions(InformationManifoldMixin, OpenSet)
         return point
 
     def projection(self, point):
-        """Project a point on the manifold of
-        diagonal multivariate normal distributions.
+        """Project a point on the manifold of diagonal multivariate normal distribution.
 
         Floor the eigenvalues of the diagonal covariance matrix to gs.atol.
 

--- a/tests/data/multivariate_normal.py
+++ b/tests/data/multivariate_normal.py
@@ -114,6 +114,33 @@ class MultivariateDiagonalNormalMetricTestData(_RiemannianMetricTestData):
         )
     )
 
+    def inner_product_shape_test_data(self):
+        random_data = []
+        for space, shape, n_tangent_vecs in zip(
+            self.space_list,
+            self.shape_list,
+            self.n_tangent_vecs_list,
+        ):
+            metric = space.metric
+            base_point = space.random_point()
+            tangent_vec_a = space.to_tangent(
+                gs.random.normal(scale=1e-2, size=(n_tangent_vecs,) + shape), base_point
+            )
+            tangent_vec_b = space.to_tangent(
+                gs.random.normal(scale=1e-2, size=(n_tangent_vecs,) + shape), base_point
+            )
+            expected = (tangent_vec_a.shape[0],)
+            random_data.append(
+                dict(
+                    metric=metric,
+                    tangent_vec_a=tangent_vec_a,
+                    tangent_vec_b=tangent_vec_b,
+                    base_point=base_point,
+                    expected=expected,
+                )
+            )
+        return self.generate_tests(random_data)
+
     def exp_belongs_test_data(self):
         random_data = []
         for connection_args, space, shape, n_tangent_vecs in zip(

--- a/tests/data/multivariate_normal.py
+++ b/tests/data/multivariate_normal.py
@@ -1,0 +1,127 @@
+import random
+
+import geomstats.backend as gs
+from geomstats.geometry.euclidean import Euclidean
+from geomstats.information_geometry.multivariate_normal import\
+        MultivariateDiagonalNormalDistributions
+from tests.data_generation import _OpenSetTestData
+
+
+class MultivariateDiagonalNormalDistributionsTestData(_OpenSetTestData):
+    Space = MultivariateDiagonalNormalDistributions
+    n_list = [3, 5, 10]
+    space_args_list = [(n,) for n in n_list]
+    shape_list = [(2*n,) for n in n_list]
+    n_samples_list = [1, 3, 5]
+    n_points_list = [1, 3, 5]
+    n_vecs_list = [1, 3, 5]
+
+    def belongs_test_data(self):
+        random_data = list()
+        n = self.n_list[0]
+        n_samples = self.n_samples_list[0]
+        random_data = [dict(
+            n=n,
+            point=self.Space(n).random_point(n_samples=n_samples),
+            expected=gs.array([True]*n_samples)
+        )]
+        n = self.n_list[1]
+        n_samples = self.n_samples_list[1]
+        random_data.append(dict(
+            n=n,
+            point=self.Space(n).random_point(n_samples=n_samples),
+            expected=gs.array([True]*n_samples)
+        ))
+        n = self.n_list[2]
+        euc = Euclidean(dim=2*n)
+        n_samples = self.n_samples_list[2]
+        point = euc.random_point(n_samples=n_samples)
+        point[-1] = -1
+        random_data.append(dict(
+            n=n,
+            point=point,
+            expected=gs.array([False]*n_samples)
+        ))
+        return self.generate_tests(random_data)
+
+    def random_point_shape_test_data(self):
+        random_data = list()
+        for n, n_samples in zip(self.n_list, self.n_samples_list):
+            if n_samples == 1:
+                expected = (2*n,)
+            else:
+                expected = (n_samples, 2*n)
+            random_data.append(
+                dict(
+                    point=self.Space(n).random_point(n_samples),
+                    expected=expected
+                )
+            )
+        return self.generate_tests(random_data)
+
+    def sample_test_data(self):
+        random_data = list()
+        for n, n_samples in zip(self.n_list, self.n_samples_list):
+            for n_points in self.n_points_list:
+                if n_samples == 1:
+                    if n_points == 1:
+                        expected = (n,)
+                    else:
+                        expected = (n_points, n)
+                else:
+                    if n_points == 1:
+                        expected = (n_samples, n)
+                    else:
+                        expected = (n_points, n_samples, n)
+                random_data.append(
+                    dict(
+                        n=n,
+                        point=self.Space(n).random_point(n_points),
+                        n_samples=n_samples,
+                        expected=expected
+                    )
+                )
+        return self.generate_tests(random_data)
+
+    # def sample_belongs_test_data(self):
+    #     random_data = [
+    #         dict(
+    #             n=2,
+    #             point=self.Space(2).random_point(3),
+    #             n_samples=4,
+    #             expected=gs.ones((3, 4)),
+    #         ),
+    #         dict(
+    #             n=3,
+    #             point=self.Space(3).random_point(1),
+    #             n_samples=2,
+    #             expected=gs.ones(2),
+    #         ),
+    #         dict(
+    #             n=4,
+    #             point=self.Space(4).random_point(2),
+    #             n_samples=3,
+    #             expected=gs.ones((2, 3)),
+    #         ),
+    #     ]
+    #     return self.generate_tests([], random_data)
+
+    # def point_to_pdf_test_data(self):
+    #     random_data = [
+    #         dict(
+    #             n=2,
+    #             point=self.Space(2).random_point(2),
+    #             n_samples=10,
+    #         ),
+    #         dict(
+    #             n=3,
+    #             point=self.Space(3).random_point(4),
+    #             n_samples=10,
+    #         ),
+    #         dict(
+    #             n=4,
+    #             point=self.Space(4).random_point(1),
+    #             n_samples=10,
+    #         ),
+    #     ]
+    #     return self.generate_tests([], random_data)

--- a/tests/data/multivariate_normal.py
+++ b/tests/data/multivariate_normal.py
@@ -82,6 +82,19 @@ class MultivariateDiagonalNormalDistributionsTestData(_OpenSetTestData):
                 )
         return self.generate_tests(random_data)
 
+    def point_to_pdf_test_data(self):
+        random_data = list()
+        for n, n_samples in zip(self.n_list, self.n_samples_list):
+            for n_points in self.n_points_list:
+                random_data.append(
+                    dict(
+                        n=n,
+                        point=self.Space(n).random_point(n_points),
+                        n_samples=n_samples,
+                    )
+                )
+        return self.generate_tests([], random_data)
+
 
 class MultivariateDiagonalNormalMetricTestData(_RiemannianMetricTestData):
     Space = MultivariateDiagonalNormalDistributions

--- a/tests/data/multivariate_normal.py
+++ b/tests/data/multivariate_normal.py
@@ -1,17 +1,17 @@
-import random
-
 import geomstats.backend as gs
 from geomstats.geometry.euclidean import Euclidean
-from geomstats.information_geometry.multivariate_normal import\
-        MultivariateDiagonalNormalDistributions
-from tests.data_generation import _OpenSetTestData
+from geomstats.information_geometry.multivariate_normal import (
+    MultivariateDiagonalNormalDistributions,
+    MultivariateDiagonalNormalMetric,
+)
+from tests.data_generation import _OpenSetTestData, _RiemannianMetricTestData
 
 
 class MultivariateDiagonalNormalDistributionsTestData(_OpenSetTestData):
     Space = MultivariateDiagonalNormalDistributions
     n_list = [3, 5, 10]
     space_args_list = [(n,) for n in n_list]
-    shape_list = [(2*n,) for n in n_list]
+    shape_list = [(2 * n,) for n in n_list]
     n_samples_list = [1, 3, 5]
     n_points_list = [1, 3, 5]
     n_vecs_list = [1, 3, 5]
@@ -20,42 +20,41 @@ class MultivariateDiagonalNormalDistributionsTestData(_OpenSetTestData):
         random_data = list()
         n = self.n_list[0]
         n_samples = self.n_samples_list[0]
-        random_data = [dict(
-            n=n,
-            point=self.Space(n).random_point(n_samples=n_samples),
-            expected=gs.array([True]*n_samples)
-        )]
+        random_data = [
+            dict(
+                n=n,
+                point=self.Space(n).random_point(n_samples=n_samples),
+                expected=gs.array([True] * n_samples),
+            )
+        ]
         n = self.n_list[1]
         n_samples = self.n_samples_list[1]
-        random_data.append(dict(
-            n=n,
-            point=self.Space(n).random_point(n_samples=n_samples),
-            expected=gs.array([True]*n_samples)
-        ))
+        random_data.append(
+            dict(
+                n=n,
+                point=self.Space(n).random_point(n_samples=n_samples),
+                expected=gs.array([True] * n_samples),
+            )
+        )
         n = self.n_list[2]
-        euc = Euclidean(dim=2*n)
+        euc = Euclidean(dim=2 * n)
         n_samples = self.n_samples_list[2]
         point = euc.random_point(n_samples=n_samples)
         point[-1] = -1
-        random_data.append(dict(
-            n=n,
-            point=point,
-            expected=gs.array([False]*n_samples)
-        ))
+        random_data.append(
+            dict(n=n, point=point, expected=gs.array([False] * n_samples))
+        )
         return self.generate_tests(random_data)
 
     def random_point_shape_test_data(self):
         random_data = list()
         for n, n_samples in zip(self.n_list, self.n_samples_list):
             if n_samples == 1:
-                expected = (2*n,)
+                expected = (2 * n,)
             else:
-                expected = (n_samples, 2*n)
+                expected = (n_samples, 2 * n)
             random_data.append(
-                dict(
-                    point=self.Space(n).random_point(n_samples),
-                    expected=expected
-                )
+                dict(point=self.Space(n).random_point(n_samples), expected=expected)
             )
         return self.generate_tests(random_data)
 
@@ -78,50 +77,26 @@ class MultivariateDiagonalNormalDistributionsTestData(_OpenSetTestData):
                         n=n,
                         point=self.Space(n).random_point(n_points),
                         n_samples=n_samples,
-                        expected=expected
+                        expected=expected,
                     )
                 )
         return self.generate_tests(random_data)
 
-    # def sample_belongs_test_data(self):
-    #     random_data = [
-    #         dict(
-    #             n=2,
-    #             point=self.Space(2).random_point(3),
-    #             n_samples=4,
-    #             expected=gs.ones((3, 4)),
-    #         ),
-    #         dict(
-    #             n=3,
-    #             point=self.Space(3).random_point(1),
-    #             n_samples=2,
-    #             expected=gs.ones(2),
-    #         ),
-    #         dict(
-    #             n=4,
-    #             point=self.Space(4).random_point(2),
-    #             n_samples=3,
-    #             expected=gs.ones((2, 3)),
-    #         ),
-    #     ]
-    #     return self.generate_tests([], random_data)
 
-    # def point_to_pdf_test_data(self):
-    #     random_data = [
-    #         dict(
-    #             n=2,
-    #             point=self.Space(2).random_point(2),
-    #             n_samples=10,
-    #         ),
-    #         dict(
-    #             n=3,
-    #             point=self.Space(3).random_point(4),
-    #             n_samples=10,
-    #         ),
-    #         dict(
-    #             n=4,
-    #             point=self.Space(4).random_point(1),
-    #             n_samples=10,
-    #         ),
-    #     ]
-    #     return self.generate_tests([], random_data)
+class MultivariateDiagonalNormalMetricTestData(_RiemannianMetricTestData):
+    Space = MultivariateDiagonalNormalDistributions
+    Metric = MultivariateDiagonalNormalMetric
+
+    n_list = [3, 5, 10]
+    space_list = [MultivariateDiagonalNormalDistributions(n) for n in n_list]
+    shape_list = [(2 * n,) for n in n_list]
+    space_args_list = [(n,) for n in n_list]
+    connection_args_list = [(2 * n,) for n in n_list]
+    n_samples_list = [1, 3, 5]
+    n_points_list = n_points_a_list = n_points_b_list = [1, 3, 5]
+    n_tangent_vecs_list = [1, 3, 5]
+    metric_args_list = list(
+        zip(
+            n_list,
+        )
+    )

--- a/tests/data/multivariate_normal.py
+++ b/tests/data/multivariate_normal.py
@@ -151,7 +151,7 @@ class MultivariateDiagonalNormalMetricTestData(_RiemannianMetricTestData):
         ):
             base_point = space.random_point()
             tangent_vec = space.to_tangent(
-                gs.random.normal(scale=1e-2, size=(n_tangent_vecs,) + shape), base_point
+                gs.random.normal(scale=1, size=(n_tangent_vecs,) + shape), base_point
             )
             random_data.append(
                 dict(
@@ -159,6 +159,7 @@ class MultivariateDiagonalNormalMetricTestData(_RiemannianMetricTestData):
                     space=space,
                     tangent_vec=tangent_vec,
                     base_point=base_point,
+                    atol=0
                 )
             )
         return self.generate_tests([], random_data)

--- a/tests/data/multivariate_normal.py
+++ b/tests/data/multivariate_normal.py
@@ -100,3 +100,46 @@ class MultivariateDiagonalNormalMetricTestData(_RiemannianMetricTestData):
             n_list,
         )
     )
+
+    def exp_belongs_test_data(self):
+        random_data = []
+        for connection_args, space, shape, n_tangent_vecs in zip(
+            self.metric_args_list,
+            self.space_list,
+            self.shape_list,
+            self.n_tangent_vecs_list,
+        ):
+            base_point = space.random_point()
+            tangent_vec = space.to_tangent(
+                gs.random.normal(scale=1e-2, size=(n_tangent_vecs,) + shape), base_point
+            )
+            random_data.append(
+                dict(
+                    connection_args=connection_args,
+                    space=space,
+                    tangent_vec=tangent_vec,
+                    base_point=base_point,
+                )
+            )
+        return self.generate_tests([], random_data)
+
+    def log_after_exp_test_data(self):
+        random_data = []
+        for connection_args, space, shape, n_tangent_vecs in zip(
+            self.metric_args_list,
+            self.space_list,
+            self.shape_list,
+            self.n_tangent_vecs_list,
+        ):
+            base_point = space.random_point()
+            tangent_vec = space.to_tangent(
+                gs.random.normal(scale=1e-2, size=(n_tangent_vecs,) + shape), base_point
+            )
+            random_data.append(
+                dict(
+                    connection_args=connection_args,
+                    tangent_vec=tangent_vec,
+                    base_point=base_point,
+                )
+            )
+        return self.generate_tests([], random_data)

--- a/tests/data/multivariate_normal.py
+++ b/tests/data/multivariate_normal.py
@@ -159,7 +159,7 @@ class MultivariateDiagonalNormalMetricTestData(_RiemannianMetricTestData):
                     space=space,
                     tangent_vec=tangent_vec,
                     base_point=base_point,
-                    atol=0
+                    atol=0,
                 )
             )
         return self.generate_tests([], random_data)
@@ -172,15 +172,15 @@ class MultivariateDiagonalNormalMetricTestData(_RiemannianMetricTestData):
             self.shape_list,
             self.n_tangent_vecs_list,
         ):
-            base_point = space.random_point()
-            tangent_vec = space.to_tangent(
-                gs.random.normal(scale=1e-2, size=(n_tangent_vecs,) + shape), base_point
-            )
+            n = space.n
+            base_point = 10 * space.random_point()
+            tangent_vec = space.to_tangent(0.1 * gs.ones((2 * n)), base_point)
             random_data.append(
                 dict(
                     connection_args=connection_args,
                     tangent_vec=tangent_vec,
                     base_point=base_point,
+                    atol=gs.atol,
                 )
             )
         return self.generate_tests([], random_data)

--- a/tests/tests_geomstats/test_multivariate_normal.py
+++ b/tests/tests_geomstats/test_multivariate_normal.py
@@ -63,3 +63,10 @@ class TestMultivariateDiagonalNormalMetric(
 
     testing_data = MultivariateDiagonalNormalMetricTestData()
     Space = testing_data.Space
+
+    def test_inner_product_shape(
+        self, metric, tangent_vec_a, tangent_vec_b, base_point, expected
+    ):
+        result = metric.inner_product(tangent_vec_a, tangent_vec_b, base_point)
+        result = result.shape
+        self.assertAllClose(result, expected)

--- a/tests/tests_geomstats/test_multivariate_normal.py
+++ b/tests/tests_geomstats/test_multivariate_normal.py
@@ -1,15 +1,11 @@
 """Unit tests for the MultivariateDiagonalNormalDistributions manifold."""
 
-from tests.conftest import Parametrizer, np_backend, pytorch_backend, tf_backend
+from tests.conftest import Parametrizer
 from tests.data.multivariate_normal import (
     MultivariateDiagonalNormalDistributionsTestData,
     MultivariateDiagonalNormalMetricTestData,
 )
 from tests.geometry_test_cases import OpenSetTestCase, RiemannianMetricTestCase
-
-TF_OR_PYTORCH_BACKEND = tf_backend() or pytorch_backend()
-
-NOT_AUTOGRAD = tf_backend() or pytorch_backend() or np_backend()
 
 
 class TestMultivariateDiagonalNormalDistributions(

--- a/tests/tests_geomstats/test_multivariate_normal.py
+++ b/tests/tests_geomstats/test_multivariate_normal.py
@@ -1,14 +1,20 @@
 """Unit tests for the MultivariateDiagonalNormalDistributions manifold."""
 
-import geomstats.backend as gs
-import tests.conftest
 from tests.conftest import Parametrizer, np_backend, pytorch_backend, tf_backend
-from tests.data.multivariate_normal import\
-        MultivariateDiagonalNormalDistributionsTestData
+from tests.data.multivariate_normal import (
+    MultivariateDiagonalNormalDistributionsTestData,
+    MultivariateDiagonalNormalMetricTestData,
+)
 from tests.geometry_test_cases import OpenSetTestCase, RiemannianMetricTestCase
 
+TF_OR_PYTORCH_BACKEND = tf_backend() or pytorch_backend()
 
-class TestMultivariateDiagonalNormalDistributions(OpenSetTestCase, metaclass=Parametrizer):
+NOT_AUTOGRAD = tf_backend() or pytorch_backend() or np_backend()
+
+
+class TestMultivariateDiagonalNormalDistributions(
+    OpenSetTestCase, metaclass=Parametrizer
+):
     testing_data = MultivariateDiagonalNormalDistributionsTestData()
 
     def test_belongs(self, n, point, expected):
@@ -18,19 +24,40 @@ class TestMultivariateDiagonalNormalDistributions(OpenSetTestCase, metaclass=Par
         self.assertAllClose(point.shape, expected)
 
     def test_sample(self, n, point, n_samples, expected):
-        self.assertAllClose(
-            self.Space(n).sample(point, n_samples).shape, expected)
+        self.assertAllClose(self.Space(n).sample(point, n_samples).shape, expected)
 
-    # @tests.conftest.np_and_autograd_only
-    # def test_point_to_pdf(self, n, point, n_samples):
-    #     point = gs.to_ndarray(point, 2)
-    #     n_points = point.shape[0]
-    #     pdf = self.Space(n).point_to_pdf(point)
-    #     alpha = gs.ones(n)
-    #     samples = self.Space(n).sample(alpha, n_samples)
-    #     result = pdf(samples)
-    #     pdf = []
-    #     for i in range(n_points):
-    #         pdf.append(gs.array([dirichlet.pdf(x, point[i, :]) for x in samples]))
-    #     expected = gs.squeeze(gs.stack(pdf, axis=0))
-    #     self.assertAllClose(result, expected)
+
+class TestMultivariateDiagonalNormalMetric(
+    RiemannianMetricTestCase, metaclass=Parametrizer
+):
+    skip_test_exp_shape = True  # because several base points for one vector
+    skip_test_log_shape = TF_OR_PYTORCH_BACKEND
+    # skip_test_exp_belongs = TF_OR_PYTORCH_BACKEND
+    skip_test_exp_belongs = True
+    skip_test_log_is_tangent = TF_OR_PYTORCH_BACKEND
+    skip_test_dist_is_symmetric = TF_OR_PYTORCH_BACKEND
+    skip_test_dist_is_positive = TF_OR_PYTORCH_BACKEND
+    skip_test_squared_dist_is_symmetric = True
+    skip_test_squared_dist_is_positive = TF_OR_PYTORCH_BACKEND
+    skip_test_dist_is_norm_of_log = TF_OR_PYTORCH_BACKEND
+    skip_test_dist_point_to_itself_is_zero = TF_OR_PYTORCH_BACKEND
+    skip_test_log_after_exp = True
+    skip_test_exp_after_log = True
+    skip_test_parallel_transport_ivp_is_isometry = True
+    skip_test_parallel_transport_bvp_is_isometry = True
+    skip_test_geodesic_ivp_belongs = True
+    skip_test_geodesic_bvp_belongs = True
+    skip_test_exp_geodesic_ivp = True
+    skip_test_exp_ladder_parallel_transport = True
+    skip_test_triangle_inequality_of_dist = True
+    skip_test_riemann_tensor_shape = NOT_AUTOGRAD
+    skip_test_ricci_tensor_shape = NOT_AUTOGRAD
+    skip_test_scalar_curvature_shape = NOT_AUTOGRAD
+    skip_test_covariant_riemann_tensor_is_skew_symmetric_1 = NOT_AUTOGRAD
+    skip_test_covariant_riemann_tensor_is_skew_symmetric_2 = NOT_AUTOGRAD
+    skip_test_covariant_riemann_tensor_bianchi_identity = NOT_AUTOGRAD
+    skip_test_covariant_riemann_tensor_is_interchange_symmetric = NOT_AUTOGRAD
+    skip_test_sectional_curvature_shape = NOT_AUTOGRAD
+
+    testing_data = MultivariateDiagonalNormalMetricTestData()
+    Space = testing_data.Space

--- a/tests/tests_geomstats/test_multivariate_normal.py
+++ b/tests/tests_geomstats/test_multivariate_normal.py
@@ -30,34 +30,20 @@ class TestMultivariateDiagonalNormalDistributions(
 class TestMultivariateDiagonalNormalMetric(
     RiemannianMetricTestCase, metaclass=Parametrizer
 ):
-    skip_test_exp_shape = True  # because several base points for one vector
-    skip_test_log_shape = TF_OR_PYTORCH_BACKEND
-    # skip_test_exp_belongs = TF_OR_PYTORCH_BACKEND
-    skip_test_exp_belongs = True
-    skip_test_log_is_tangent = TF_OR_PYTORCH_BACKEND
-    skip_test_dist_is_symmetric = TF_OR_PYTORCH_BACKEND
-    skip_test_dist_is_positive = TF_OR_PYTORCH_BACKEND
-    skip_test_squared_dist_is_symmetric = True
-    skip_test_squared_dist_is_positive = TF_OR_PYTORCH_BACKEND
-    skip_test_dist_is_norm_of_log = TF_OR_PYTORCH_BACKEND
-    skip_test_dist_point_to_itself_is_zero = TF_OR_PYTORCH_BACKEND
-    skip_test_log_after_exp = True
-    skip_test_exp_after_log = True
     skip_test_parallel_transport_ivp_is_isometry = True
     skip_test_parallel_transport_bvp_is_isometry = True
     skip_test_geodesic_ivp_belongs = True
     skip_test_geodesic_bvp_belongs = True
     skip_test_exp_geodesic_ivp = True
     skip_test_exp_ladder_parallel_transport = True
-    skip_test_triangle_inequality_of_dist = True
-    skip_test_riemann_tensor_shape = NOT_AUTOGRAD
-    skip_test_ricci_tensor_shape = NOT_AUTOGRAD
-    skip_test_scalar_curvature_shape = NOT_AUTOGRAD
-    skip_test_covariant_riemann_tensor_is_skew_symmetric_1 = NOT_AUTOGRAD
-    skip_test_covariant_riemann_tensor_is_skew_symmetric_2 = NOT_AUTOGRAD
-    skip_test_covariant_riemann_tensor_bianchi_identity = NOT_AUTOGRAD
-    skip_test_covariant_riemann_tensor_is_interchange_symmetric = NOT_AUTOGRAD
-    skip_test_sectional_curvature_shape = NOT_AUTOGRAD
+    skip_test_riemann_tensor_shape = True
+    skip_test_ricci_tensor_shape = True
+    skip_test_scalar_curvature_shape = True
+    skip_test_covariant_riemann_tensor_is_skew_symmetric_1 = True
+    skip_test_covariant_riemann_tensor_is_skew_symmetric_2 = True
+    skip_test_covariant_riemann_tensor_bianchi_identity = True
+    skip_test_covariant_riemann_tensor_is_interchange_symmetric = True
+    skip_test_sectional_curvature_shape = True
 
     testing_data = MultivariateDiagonalNormalMetricTestData()
     Space = testing_data.Space

--- a/tests/tests_geomstats/test_multivariate_normal.py
+++ b/tests/tests_geomstats/test_multivariate_normal.py
@@ -40,7 +40,7 @@ class TestMultivariateDiagonalNormalDistributions(
                 tmp.append(multivariate_normal.pdf(x, mean=loc, cov=cov))
             expected.append(gs.array(tmp))
         expected = gs.squeeze(gs.stack(expected, axis=0))
-        self.assertAllClose(Space.pdf(samples, point), expected)
+        self.assertAllClose(Space.point_to_pdf(point)(samples), expected)
 
 
 class TestMultivariateDiagonalNormalMetric(

--- a/tests/tests_geomstats/test_multivariate_normal.py
+++ b/tests/tests_geomstats/test_multivariate_normal.py
@@ -33,7 +33,7 @@ class TestMultivariateDiagonalNormalDistributions(
 
         expected = []
         for i in range(point.shape[0]):
-            loc, cov = Space._unstack_location_diagonal(point[i, ...])
+            loc, cov = Space._unstack_location_diagonal(n, point[i, ...])
             tmp = list()
             for j in range(samples.shape[0]):
                 x = samples[j, ...]

--- a/tests/tests_geomstats/test_multivariate_normal.py
+++ b/tests/tests_geomstats/test_multivariate_normal.py
@@ -1,0 +1,36 @@
+"""Unit tests for the MultivariateDiagonalNormalDistributions manifold."""
+
+import geomstats.backend as gs
+import tests.conftest
+from tests.conftest import Parametrizer, np_backend, pytorch_backend, tf_backend
+from tests.data.multivariate_normal import\
+        MultivariateDiagonalNormalDistributionsTestData
+from tests.geometry_test_cases import OpenSetTestCase, RiemannianMetricTestCase
+
+
+class TestMultivariateDiagonalNormalDistributions(OpenSetTestCase, metaclass=Parametrizer):
+    testing_data = MultivariateDiagonalNormalDistributionsTestData()
+
+    def test_belongs(self, n, point, expected):
+        self.assertAllClose(self.Space(n).belongs(point), expected)
+
+    def test_random_point_shape(self, point, expected):
+        self.assertAllClose(point.shape, expected)
+
+    def test_sample(self, n, point, n_samples, expected):
+        self.assertAllClose(
+            self.Space(n).sample(point, n_samples).shape, expected)
+
+    # @tests.conftest.np_and_autograd_only
+    # def test_point_to_pdf(self, n, point, n_samples):
+    #     point = gs.to_ndarray(point, 2)
+    #     n_points = point.shape[0]
+    #     pdf = self.Space(n).point_to_pdf(point)
+    #     alpha = gs.ones(n)
+    #     samples = self.Space(n).sample(alpha, n_samples)
+    #     result = pdf(samples)
+    #     pdf = []
+    #     for i in range(n_points):
+    #         pdf.append(gs.array([dirichlet.pdf(x, point[i, :]) for x in samples]))
+    #     expected = gs.squeeze(gs.stack(pdf, axis=0))
+    #     self.assertAllClose(result, expected)


### PR DESCRIPTION
## Description

Add the statistical manifold of multivariate diagonal normal distributions.

It is a product manifold of the statistical manifold of univariate normal distributions.

## Additional context

`MultivariateDiagonalNormalDistributions` and `MultivariateDiagonalNormalMetric` store data points and tangent vectors by stacking the location (mean vector) and the diagonal of the covariance matrix in a vector.
