### PR TITLE
Add sectional curvature of univariate normal distributions + tests

### DIFF
--- a/geomstats/information_geometry/normal.py
+++ b/geomstats/information_geometry/normal.py
@@ -247,3 +247,55 @@ class NormalMetric(PullbackDiffeoMetric):
         if metric_mat.ndim == 3 and metric_mat.shape[0] == 1:
             return metric_mat[0]
         return metric_mat
+
+    def sectional_curvature(self, tangent_vec_a, tangent_vec_b, base_point=None):
+        r"""Compute the sectional curvature.
+
+        In the literature sectional curvature is noted K.
+        For two orthonormal tangent vectors :math:`x,y` at a base point,
+        the sectional curvature is defined by :math:`K(x,y) = <R(x, y)x, y>`.
+        For non-orthonormal vectors, it is
+        :math:`K(x,y) = <R(x, y)x, y> / \\|x \wedge y\\|^2`.
+        sectional_curvature(X, Y, P) = K(X,Y) where X, Y are tangent vectors
+        at base point P.
+
+        The information manifold of univariate normal distributions has constant
+        sectional curvature given by :math:`K = - 1/2`.
+
+        Parameters
+        ----------
+        tangent_vec_a : array-like, shape=[..., n, n]
+            Tangent vector at `base_point`.
+        tangent_vec_b : array-like, shape=[..., n, n]
+            Tangent vector at `base_point`.
+        base_point : array-like, shape=[..., n, n]
+            Point in the manifold.
+
+        Returns
+        -------
+        sectional_curvature : array-like, shape=[...,]
+            Sectional curvature at `base_point`.
+
+        Reference
+        ---------
+        [CF1992] Do Carmo, M. P., & Flaherty Francis, J. (1992).
+        Riemannian geometry (Vol. 6). Boston: Birkhäuser.
+        """
+        sectional_curv = -0.5
+        if (
+            tangent_vec_a.ndim == 1
+            and tangent_vec_b.ndim == 1
+            and (base_point is None or base_point.ndim == 1)
+        ):
+            return gs.array(sectional_curv)
+
+        n_sec_curv = []
+        if base_point is not None and base_point.ndim == 2:
+            n_sec_curv.append(base_point.shape[0])
+        if tangent_vec_a.ndim == 2:
+            n_sec_curv.append(tangent_vec_a.shape[0])
+        if tangent_vec_b.ndim == 2:
+            n_sec_curv.append(tangent_vec_b.shape[0])
+        n_sec_curv = max(n_sec_curv)
+
+        return gs.tile(sectional_curv, (n_sec_curv,))

--- a/geomstats/information_geometry/normal.py
+++ b/geomstats/information_geometry/normal.py
@@ -252,10 +252,13 @@ class NormalMetric(PullbackDiffeoMetric):
         r"""Compute the sectional curvature.
 
         In the literature sectional curvature is noted K.
+
         For two orthonormal tangent vectors :math:`x,y` at a base point,
         the sectional curvature is defined by :math:`K(x,y) = <R(x, y)x, y>`.
+
         For non-orthonormal vectors, it is
-        :math:`K(x,y) = <R(x, y)x, y> / \\|x \wedge y\\|^2`.
+        :math:`K(x,y) = <R(x, y)y, x> / (<x, x><y, y> - <x, y>^2)`.
+
         sectional_curvature(X, Y, P) = K(X,Y) where X, Y are tangent vectors
         at base point P.
 
@@ -264,22 +267,17 @@ class NormalMetric(PullbackDiffeoMetric):
 
         Parameters
         ----------
-        tangent_vec_a : array-like, shape=[..., n, n]
+        tangent_vec_a : array-like, shape=[..., 2]
             Tangent vector at `base_point`.
-        tangent_vec_b : array-like, shape=[..., n, n]
+        tangent_vec_b : array-like, shape=[..., 2]
             Tangent vector at `base_point`.
-        base_point : array-like, shape=[..., n, n]
+        base_point : array-like, shape=[..., 2]
             Point in the manifold.
 
         Returns
         -------
         sectional_curvature : array-like, shape=[...,]
             Sectional curvature at `base_point`.
-
-        Reference
-        ---------
-        [CF1992] Do Carmo, M. P., & Flaherty Francis, J. (1992).
-        Riemannian geometry (Vol. 6). Boston: Birkhäuser.
         """
         sectional_curv = -0.5
         if (

--- a/tests/tests_geomstats/test_normal.py
+++ b/tests/tests_geomstats/test_normal.py
@@ -89,3 +89,13 @@ class TestNormalDistributions(tests.conftest.TestCase):
         result = gs.einsum("ij,ij->i", mat_prod, vec_b)
         expected = self.normal.metric.inner_product(vec_a, vec_b, base_point)
         self.assertAllClose(result, expected)
+
+    def test_sectional_curvature(self):
+        n_samples = 3
+        base_point = self.normal.random_point(n_samples)
+        vec_a = self.normal.random_tangent_vec(base_point, n_samples)
+        vec_b = self.normal.random_tangent_vec(base_point, n_samples)
+        result = self.normal.metric.sectional_curvature(vec_a, vec_b, base_point)
+
+        expected = gs.tile(gs.array(-1 / 2), (n_samples,))
+        self.assertAllClose(result, expected)


### PR DESCRIPTION
This PR adds the formula for the constant sectional curvature of the normal distributions (equal to -1/2).

It adds the corresponding test.

Note that the tests of the normal distributions do not leverage the hierarchy of tests.

<!--
Thank you for opening this pull request!
-->

## Checklist

- [ ] My pull request has a clear and explanatory title.
- [ ] If neccessary, my code is [vectorized](https://www.geeksforgeeks.org/vectorization-in-python/).
- [ ] I have added apropriate unit tests.
- [ ] I have made sure the code passes all unit tests. (refer to comment below)
- [ ] My PR follows [PEP8](https://peps.python.org/pep-0008/) guidelines. (refer to comment below)
- [ ] My PR follows [geomstats coding style](https://github.com/geomstats/geomstats/blob/master/docs/contributing.rst#coding-style-guidelines) and API.
- [ ] My code is properly documented and I made sure the documentation renders properly. ([Link](https://github.com/geomstats/geomstats/blob/master/docs/contributing.rst#documentation))
- [ ] I have linked to issues and PRs that are relevant to this PR.


<!-- For checking consistency of entire codebase
First, run the tests related to your changes. For example, if you changed something in geomstats/spd_matrices_space.py:
$ pytest tests/tests_geomstats/test_spd_matrices.py

and then run the tests of the whole codebase to check that your feature is not breaking any of them:
$ pytest tests/

This way, further modifications on the code base are guaranteed to be consistent with the desired behavior. Merging your PR should not break any test in any backend (numpy, tensorflow or pytorch)."

For testing in alternative backends such as `numpy`, `pytorch`, `autograd`, `tensorflow` set the environment variable using:
$ export GEOMSTATS_BACKEND=<backend_name>

Next, import the `backend` module using:
import geomstats.backend as gs
-->


<!-- For flake8 tests
Install dependencies
$ pip3 install -r dev-requirements.txt

Then run the following commands:
$ flake8 --ignore=D,W503,W504 geomstats examples tests   #shadows .flake8
$ flake8 geomstats/geometry geomstats/learning           #passed two subfolders
-->

## Description

<!-- Include a description of your pull request. If relevant, feel free to use this space to talk about time and space complexity as well scalability of your code-->

## Issue

<!-- Tell us which issue does this PR fix . Why this feature implementation/fix is important in practice ?-->

## Additional context

<!-- Add any extra information -->