### PR TITLE
Fix _pool_outputs_from_function in ProductManifold

### DIFF
--- a/geomstats/geometry/product_manifold.py
+++ b/geomstats/geometry/product_manifold.py
@@ -314,15 +314,12 @@ class ProductManifold(Manifold):
         pooled_output : array-like, shape {(...,), (..., self.shape)}
         """
         # TODO: simplify after cleaning gs.squeeze
+        all_arrays = gs.all([gs.is_array(factor_output) for factor_output in outputs])
         if (
-            gs.all(
-                [
-                    gs.is_array(factor_output) or gs.is_bool(factor_output)
-                    for factor_output in outputs
-                ]
-            )
+            all_arrays
             and all_equal([factor_output.shape for factor_output in outputs])
             and gs.all([gs.is_bool(factor_output) for factor_output in outputs])
+            or (not all_arrays)
         ):
             outputs = gs.stack(outputs)
             outputs = gs.all(outputs, axis=0)


### PR DESCRIPTION
Follows refactoring in #1689. The conditions in the initial if of `_pool_outputs_from_function` where not (properly) covering all the cases for boolean data.

Before fix, the following code raises error: 

```python
n = 3
factors = [Euclidean(n), SPDMatrices(n)]

space = ProductManifold(factors)

space.belongs(space.random_point())
```

The difficulties with this if come from some little inconsistencies in the code base, which we have already identified and are addressing.


Bug identified by @alebrigant.