### PR TITLE
Fix Siegel log and exp errors for zero matrices

### DIFF
--- a/geomstats/_backend/tensorflow/__init__.py
+++ b/geomstats/_backend/tensorflow/__init__.py
@@ -66,7 +66,6 @@ _DTYPES = {
 conj = _tf.math.conj
 erf = _tf.math.erf
 imag = _tf.math.imag
-isnan = _tf.math.is_nan
 polygamma = _tf.math.polygamma
 real = _tf.math.real
 set_diag = _tf.linalg.set_diag
@@ -878,6 +877,12 @@ def linspace(start, stop, num=50, dtype=None):
 
 def is_array(x):
     return _tf.is_tensor(x)
+
+
+def isnan(x):
+    if is_complex(x):
+        return _tf.math.is_nan(real(x))
+    return _tf.math.is_nan(x)
 
 
 def matvec(A, b):

--- a/geomstats/geometry/siegel.py
+++ b/geomstats/geometry/siegel.py
@@ -425,6 +425,8 @@ class SiegelMetric(ComplexRiemannianMetric):
         frac = gs.matmul(num, inv_den)
         factor_1 = gs.linalg.logm(frac)
         factor_2 = HermitianMatrices.powerm(aux_2, -1)
+        zero = gs.zeros(factor_2.shape, dtype=factor_2.dtype)
+        factor_2 = gs.where(gs.isnan(factor_2), zero, factor_2)
         prod_1 = gs.matmul(factor_1, factor_2)
         log_at_zero = gs.matmul(prod_1, point)
         log_at_zero *= 0.5

--- a/geomstats/geometry/siegel.py
+++ b/geomstats/geometry/siegel.py
@@ -331,6 +331,8 @@ class SiegelMetric(ComplexRiemannianMetric):
         aux_4 = aux_3 + identity
         factor_2 = HermitianMatrices.powerm(aux_4, -1)
         factor_3 = HermitianMatrices.powerm(aux_2, -1)
+        zero = gs.zeros(factor_3.shape, dtype=factor_3.dtype)
+        factor_3 = gs.where(gs.isnan(factor_3), zero, factor_3)
         prod_1 = gs.matmul(factor_1, factor_2)
         prod_2 = gs.matmul(prod_1, factor_3)
         exp = gs.matmul(prod_2, tangent_vec)

--- a/geomstats/geometry/siegel.py
+++ b/geomstats/geometry/siegel.py
@@ -331,8 +331,7 @@ class SiegelMetric(ComplexRiemannianMetric):
         aux_4 = aux_3 + identity
         factor_2 = HermitianMatrices.powerm(aux_4, -1)
         factor_3 = HermitianMatrices.powerm(aux_2, -1)
-        zero = gs.zeros(factor_3.shape, dtype=factor_3.dtype)
-        factor_3 = gs.where(gs.isnan(factor_3), zero, factor_3)
+        factor_3 = gs.where(gs.isnan(factor_3), gs.zeros_like(factor_2), factor_3)
         prod_1 = gs.matmul(factor_1, factor_2)
         prod_2 = gs.matmul(prod_1, factor_3)
         exp = gs.matmul(prod_2, tangent_vec)
@@ -425,8 +424,7 @@ class SiegelMetric(ComplexRiemannianMetric):
         frac = gs.matmul(num, inv_den)
         factor_1 = gs.linalg.logm(frac)
         factor_2 = HermitianMatrices.powerm(aux_2, -1)
-        zero = gs.zeros(factor_2.shape, dtype=factor_2.dtype)
-        factor_2 = gs.where(gs.isnan(factor_2), zero, factor_2)
+        factor_2 = gs.where(gs.isnan(factor_2), gs.zeros_like(factor_2), factor_2)
         prod_1 = gs.matmul(factor_1, factor_2)
         log_at_zero = gs.matmul(prod_1, point)
         log_at_zero *= 0.5

--- a/tests/data/siegel_data.py
+++ b/tests/data/siegel_data.py
@@ -129,6 +129,13 @@ class SiegelMetricTestData(_ComplexRiemannianMetricTestData):
                     [0j, (EXP_4 - 1) / (EXP_4 + 1) * 1j],
                 ],
             ),
+            dict(
+                n=2,
+                scale=1.0,
+                tangent_vec=[[0j, 0j], [0j, 0j]],
+                base_point=[[0j, 0j], [0j, 0j]],
+                expected=[[0j, 0j], [0j, 0j]],
+            ),
         ]
         return self.generate_tests(smoke_data)
 

--- a/tests/data/siegel_data.py
+++ b/tests/data/siegel_data.py
@@ -155,5 +155,12 @@ class SiegelMetricTestData(_ComplexRiemannianMetricTestData):
                 base_point=[[0j, 0j], [0j, 0j]],
                 expected=[[LN_3 / 2 * 1j, 0j], [0j, LN_3 / 2 * 1j]],
             ),
+            dict(
+                n=2,
+                scale=1.0,
+                point=[[0j, 0j], [0j, 0j]],
+                base_point=[[0j, 0j], [0j, 0j]],
+                expected=[[0j, 0j], [0j, 0j]],
+            ),
         ]
         return self.generate_tests(smoke_data)


### PR DESCRIPTION
The Siegel Riemannian logarithm is was failing when `point` equals the null matrix.
The Siegel Riemannian exponential map is failing when `tangent_vec` equals the null matrix.
These errors are due the the matrix inversion of a null matrix.
This PR fix these errors and add the corresponding tests.