### PR TITLE
Fix complex manifold inheritance structure

### DIFF
--- a/geomstats/geometry/complex_manifold.py
+++ b/geomstats/geometry/complex_manifold.py
@@ -6,12 +6,13 @@ Hermitian space near each point.
 Lead author: Yann Cabanes.
 """
 
+import abc
+
 import geomstats.backend as gs
 from geomstats.geometry.complex_riemannian_metric import ComplexRiemannianMetric
-from geomstats.geometry.manifold import Manifold
 
 
-class ComplexManifold(Manifold):
+class ComplexManifold(abc.ABC):
     r"""Class for complex manifolds.
 
     Parameters


### PR DESCRIPTION
For coherence, (for now) complex objects emulate `Manifold` inheritance structure, but do not inherit from any `Manifold` object.

This will very soon need to be rethought (it will be easier now, as we have several complex objects), as it leads to a lot of (almost) code duplication.

Test inheritance structure will be make consistent soon.