### PR TITLE
Amend errors.check_point_shape 

### DIFF
--- a/geomstats/errors.py
+++ b/geomstats/errors.py
@@ -85,13 +85,13 @@ def check_tf_error(exception, name):
     return exception
 
 
-def check_point_shape(point, manifold):
-    """Raise an error if the shape of point does not match the shape of a manifold.
+def check_point_shape(point, manifold, suppress_error=False):
+    """Check if the shape of point does not match the shape of a manifold or metric.
 
     If the final elements of the shape of point do not match the shape of manifold
-    (which may be any object with a shape attribute, such as a Riemannian metric, then
+    (which may be any object with a shape attribute, such as a Riemannian metric) then
     point cannot be an array of points on the manifold (or similar) and a ValueError is
-    raised.
+    raised. The error can be suppressed by setting suppress_error to True.
 
     Parameters
     ----------
@@ -99,6 +99,14 @@ def check_point_shape(point, manifold):
         The point to check the shape of.
     manifold : {Manifold, RiemannianMetric}
         The object to check the point against
+    suppress_error : bool
+        Whether to suppress the ShapeError if the shapes do not match. Optional, default
+        is False.
+
+    Returns
+    -------
+    shapes_match : bool
+        Whether the shape of the point matches the shape of the manifold or metric.
 
     Raises
     ------
@@ -106,14 +114,18 @@ def check_point_shape(point, manifold):
         If the final dimensions of point are not equal to the final dimensions of
         manifold.
     """
-    shape_error_msg = (
-        f"The shape of {point}, which is {point.shape}, is not"
-        f" compatible with the shape of the {type(manifold).__name__}"
-        f" object, which is {manifold.shape}."
-    )
     representation_type = -1 * len(manifold.shape)
-    if point.shape[representation_type:] != manifold.shape[representation_type:]:
+    shapes_match = (
+        point.shape[representation_type:] == manifold.shape[representation_type:]
+    )
+    if not suppress_error and not shapes_match:
+        shape_error_msg = (
+            f"The shape of {point}, which is {point.shape}, is not"
+            f" compatible with the shape of the {type(manifold).__name__}"
+            f" object, which is {manifold.shape}."
+        )
         raise ShapeError(shape_error_msg)
+    return shapes_match
 
 
 class ShapeError(ValueError):

--- a/tests/tests_geomstats/test_errors.py
+++ b/tests/tests_geomstats/test_errors.py
@@ -37,3 +37,10 @@ class TestBackends(tests.conftest.TestCase):
             geomstats.errors.check_parameter_accepted_values(
                 param, "left_or_right", accepted_values
             )
+
+    def test_check_point_shape(self):
+        euclidean = Euclidean(5)
+        point = gs.array([1, 2])
+
+        with pytest.raises(geomstats.errors.ShapeError):
+            geomstats.errors.check_point_shape(point, euclidean)

--- a/tests/tests_geomstats/test_errors.py
+++ b/tests/tests_geomstats/test_errors.py
@@ -44,3 +44,8 @@ class TestBackends(tests.conftest.TestCase):
 
         with pytest.raises(geomstats.errors.ShapeError):
             geomstats.errors.check_point_shape(point, euclidean)
+
+        same_shape = geomstats.errors.check_point_shape(
+            point, euclidean, suppress_error=True
+        )
+        self.assertFalse(same_shape)


### PR DESCRIPTION
## Description

`geomstats.errors.check_point_shape` is amended so that it does not always raise a `ShapeError` if the shapes do not match. It is possible to simply check the shape by setting the optional parameter `suppress_error=True` and obtain a boolean return value. This is as requested by other developers during the IHP hackathon

## Issue

We can use this to provide checks on inputs in methods for all `Manifold` and `RiemannianMetric` subclasses, if that seems worthwhile. In that case we should probably implement a method `check_point_shape` in those classes which wraps this, so that it can simply be called as `self.check_point_shape(point)`.