### PR TITLE
Fix point shapes

### DIFF
--- a/geomstats/_backend/autograd/__init__.py
+++ b/geomstats/_backend/autograd/__init__.py
@@ -398,7 +398,7 @@ def ndim(x):
 
 
 def copy(x):
-    return x.copy()
+    return _np.array(x, copy=True)
 
 
 def array_from_sparse(indices, data, target_shape):

--- a/geomstats/_backend/tensorflow/__init__.py
+++ b/geomstats/_backend/tensorflow/__init__.py
@@ -343,7 +343,7 @@ def _assignment_single_value(x, value, indices, mode="replace", axis=0):
     if use_vectorization:
         full_shape = shape(x)
         n_samples = full_shape[axis]
-        tile_shape = list(full_shape[:axis]) + list(full_shape[axis + 1 :])
+        tile_shape = list(full_shape[:axis]) + list(full_shape[axis + 1:])
         mask = _vectorized_mask_from_indices(
             n_samples, indices, tile_shape, axis, x.dtype
         )
@@ -571,7 +571,7 @@ def outer(x, y):
 
 
 def copy(x):
-    return _tf.Variable(x)
+    return _tf.identity(x)
 
 
 def hstack(x):

--- a/geomstats/_backend/tensorflow/__init__.py
+++ b/geomstats/_backend/tensorflow/__init__.py
@@ -343,7 +343,7 @@ def _assignment_single_value(x, value, indices, mode="replace", axis=0):
     if use_vectorization:
         full_shape = shape(x)
         n_samples = full_shape[axis]
-        tile_shape = list(full_shape[:axis]) + list(full_shape[axis + 1:])
+        tile_shape = list(full_shape[:axis]) + list(full_shape[axis + 1 :])
         mask = _vectorized_mask_from_indices(
             n_samples, indices, tile_shape, axis, x.dtype
         )

--- a/geomstats/geometry/base.py
+++ b/geomstats/geometry/base.py
@@ -32,7 +32,7 @@ class VectorSpace(Manifold, abc.ABC):
 
         Parameters
         ----------
-        point : array-like, shape=[.., {dim, [n, n]}]
+        point : array-like, shape=[.., *point_shape]
             Point to test.
         atol : float
             Unused here.
@@ -57,12 +57,12 @@ class VectorSpace(Manifold, abc.ABC):
 
         Parameters
         ----------
-        point: array-like, shape[..., {dim, [n, n]}]
+        point: array-like, shape[..., *point_shape]
             Point.
 
         Returns
         -------
-        point: array-like, shape[..., {dim, [n, n]}]
+        point: array-like, shape[..., *point_shape]
             Point.
         """
         return gs.copy(point)
@@ -75,9 +75,9 @@ class VectorSpace(Manifold, abc.ABC):
 
         Parameters
         ----------
-        vector : array-like, shape=[..., {dim, [n, n]}]
+        vector : array-like, shape=[..., *point_shape]
             Vector.
-        base_point : array-like, shape=[..., {dim, [n, n]}]
+        base_point : array-like, shape=[..., *point_shape]
             Point in the vector space.
         atol : float
             Absolute tolerance.
@@ -100,14 +100,14 @@ class VectorSpace(Manifold, abc.ABC):
 
         Parameters
         ----------
-        vector : array-like, shape=[..., {dim, [n, n]}]
+        vector : array-like, shape=[..., *point_shape]
             Vector.
-        base_point : array-like, shape=[..., {dim, [n, n]}]
+        base_point : array-like, shape=[..., *point_shape]
             Point in the vector space
 
         Returns
         -------
-        tangent_vec : array-like, shape=[..., {dim, [n, n]}]
+        tangent_vec : array-like, shape=[..., *point_shape]
             Tangent vector at base point.
         """
         tangent_vec = self.projection(vector)
@@ -129,7 +129,7 @@ class VectorSpace(Manifold, abc.ABC):
 
         Returns
         -------
-        point : array-like, shape=[..., dim]
+        point : array-like, shape=[..., *point_shape]
            Sample.
         """
         size = self.shape
@@ -184,7 +184,7 @@ class ComplexVectorSpace(ComplexManifold, abc.ABC):
 
         Parameters
         ----------
-        point : array-like, shape=[.., {dim, [n, n]}]
+        point : array-like, shape=[.., *point_shape]
             Point to test.
         atol : float
             Unused here.
@@ -209,12 +209,12 @@ class ComplexVectorSpace(ComplexManifold, abc.ABC):
 
         Parameters
         ----------
-        point: array-like, shape[..., {dim, [n, n]}]
+        point: array-like, shape[..., *point_shape]
             Point.
 
         Returns
         -------
-        point: array-like, shape[..., {dim, [n, n]}]
+        point: array-like, shape[..., *point_shape]
             Point.
         """
         return gs.copy(point)
@@ -227,9 +227,9 @@ class ComplexVectorSpace(ComplexManifold, abc.ABC):
 
         Parameters
         ----------
-        vector : array-like, shape=[..., {dim, [n, n]}]
+        vector : array-like, shape=[..., *point_shape]
             Vector.
-        base_point : array-like, shape=[..., {dim, [n, n]}]
+        base_point : array-like, shape=[..., *point_shape]
             Point in the vector space.
         atol : float
             Absolute tolerance.
@@ -252,14 +252,14 @@ class ComplexVectorSpace(ComplexManifold, abc.ABC):
 
         Parameters
         ----------
-        vector : array-like, shape=[..., {dim, [n, n]}]
+        vector : array-like, shape=[..., *point_shape]
             Vector.
-        base_point : array-like, shape=[..., {dim, [n, n]}]
+        base_point : array-like, shape=[..., *point_shape]
             Point in the vector space
 
         Returns
         -------
-        tangent_vec : array-like, shape=[..., {dim, [n, n]}]
+        tangent_vec : array-like, shape=[..., *point_shape]
             Tangent vector at base point.
         """
         tangent_vec = self.projection(vector)
@@ -281,7 +281,7 @@ class ComplexVectorSpace(ComplexManifold, abc.ABC):
 
         Returns
         -------
-        point : array-like, shape=[..., dim]
+        point : array-like, shape=[..., *point_shape]
            Sample.
         """
         size = self.shape
@@ -352,7 +352,7 @@ class LevelSet(Manifold, abc.ABC):
 
         Parameters
         ----------
-        point : array-like, shape=[..., dim]
+        point : array-like, shape=[..., *point_shape]
 
         Returns
         -------
@@ -365,8 +365,8 @@ class LevelSet(Manifold, abc.ABC):
 
         Parameters
         ----------
-        vector : array-like, shape=[..., dim]
-        point : array-like, shape=[..., dim]
+        vector : array-like, shape=[..., *point_shape]
+        point : array-like, shape=[..., *point_shape]
 
         Returns
         -------
@@ -378,7 +378,7 @@ class LevelSet(Manifold, abc.ABC):
 
         Parameters
         ----------
-        point : array-like, shape=[..., dim]
+        point : array-like, shape=[..., *point_shape]
             Point to evaluate.
         atol : float
             Absolute tolerance.
@@ -409,9 +409,9 @@ class LevelSet(Manifold, abc.ABC):
 
         Parameters
         ----------
-        vector : array-like, shape=[..., dim]
+        vector : array-like, shape=[..., *point_shape]
             Vector.
-        base_point : array-like, shape=[..., dim]
+        base_point : array-like, shape=[..., *point_shape]
             Point on the manifold.
         atol : float
             Absolute tolerance.
@@ -442,12 +442,12 @@ class LevelSet(Manifold, abc.ABC):
 
         Parameters
         ----------
-        point_intrinsic : array-like, shape=[..., dim]
+        point_intrinsic : array-like, shape=[..., *point_shape]
             Point in the embedded manifold in intrinsic coordinates.
 
         Returns
         -------
-        point_extrinsic : array-like, shape=[..., dim_embedding]
+        point_extrinsic : array-like, shape=[..., *embedding_space.point_shape]
             Point in the embedded manifold in extrinsic coordinates.
         """
         raise NotImplementedError("intrinsic_to_extrinsic_coords is not implemented.")
@@ -457,13 +457,13 @@ class LevelSet(Manifold, abc.ABC):
 
         Parameters
         ----------
-        point_extrinsic : array-like, shape=[..., dim_embedding]
+        point_extrinsic : array-like, shape=[..., *embedding_space.point_shape]
             Point in the embedded manifold in extrinsic coordinates,
             i. e. in the coordinates of the embedding manifold.
 
         Returns
         -------
-        point_intrinsic : array-lie, shape=[..., dim]
+        point_intrinsic : array-lie, shape=[..., *point_shape]
             Point in the embedded manifold in intrinsic coordinates.
         """
         raise NotImplementedError("extrinsic_to_intrinsic_coords is not implemented.")
@@ -474,12 +474,12 @@ class LevelSet(Manifold, abc.ABC):
 
         Parameters
         ----------
-        point : array-like, shape=[..., dim_embedding]
+        point : array-like, shape=[..., *embedding_space.point_shape]
             Point in embedding manifold.
 
         Returns
         -------
-        projected : array-like, shape=[..., dim_embedding]
+        projected : array-like, shape=[..., *point_shape]
             Projected point.
         """
 
@@ -489,14 +489,14 @@ class LevelSet(Manifold, abc.ABC):
 
         Parameters
         ----------
-        vector : array-like, shape=[..., dim]
+        vector : array-like, shape=[..., *point_shape]
             Vector.
-        base_point : array-like, shape=[..., dim]
+        base_point : array-like, shape=[..., *point_shape]
             Point on the manifold.
 
         Returns
         -------
-        tangent_vec : array-like, shape=[..., dim]
+        tangent_vec : array-like, shape=[..., *point_shape]
             Tangent vector at base point.
         """
 
@@ -526,9 +526,9 @@ class OpenSet(Manifold, abc.ABC):
 
         Parameters
         ----------
-        vector : array-like, shape=[..., dim]
+        vector : array-like, shape=[..., *point_shape]
             Vector.
-        base_point : array-like, shape=[..., dim]
+        base_point : array-like, shape=[..., *point_shape]
             Point on the manifold.
         atol : float
             Absolute tolerance.
@@ -549,14 +549,14 @@ class OpenSet(Manifold, abc.ABC):
 
         Parameters
         ----------
-        vector : array-like, shape=[..., dim]
+        vector : array-like, shape=[..., *point_shape]
             Vector.
-        base_point : array-like, shape=[..., dim]
+        base_point : array-like, shape=[..., *point_shape]
             Point on the manifold.
 
         Returns
         -------
-        tangent_vec : array-like, shape=[..., dim]
+        tangent_vec : array-like, shape=[..., *point_shape]
             Tangent vector at base point.
         """
         tangent_vec = self.embedding_space.projection(vector)
@@ -582,7 +582,7 @@ class OpenSet(Manifold, abc.ABC):
 
         Returns
         -------
-        samples : array-like, shape=[..., {dim, [n, n]}]
+        samples : array-like, shape=[..., *point_shape]
             Points sampled on the hypersphere.
         """
         sample = self.embedding_space.random_point(n_samples, bound)
@@ -594,12 +594,12 @@ class OpenSet(Manifold, abc.ABC):
 
         Parameters
         ----------
-        point : array-like, shape=[..., dim]
+        point : array-like, shape=[..., *point_shape]
             Point in embedding manifold.
 
         Returns
         -------
-        projected : array-like, shape=[..., dim]
+        projected : array-like, shape=[..., *point_shape]
             Projected point.
         """
 
@@ -629,9 +629,9 @@ class ComplexOpenSet(ComplexManifold, abc.ABC):
 
         Parameters
         ----------
-        vector : array-like, shape=[..., dim]
+        vector : array-like, shape=[..., *point_shape]
             Vector.
-        base_point : array-like, shape=[..., dim]
+        base_point : array-like, shape=[..., *point_shape]
             Point on the manifold.
         atol : float
             Absolute tolerance.
@@ -652,14 +652,14 @@ class ComplexOpenSet(ComplexManifold, abc.ABC):
 
         Parameters
         ----------
-        vector : array-like, shape=[..., dim]
+        vector : array-like, shape=[..., *point_shape]
             Vector.
-        base_point : array-like, shape=[..., dim]
+        base_point : array-like, shape=[..., *point_shape]
             Point on the manifold.
 
         Returns
         -------
-        tangent_vec : array-like, shape=[..., dim]
+        tangent_vec : array-like, shape=[..., *point_shape]
             Tangent vector at base point.
         """
         tangent_vec = self.embedding_space.projection(vector)
@@ -683,7 +683,7 @@ class ComplexOpenSet(ComplexManifold, abc.ABC):
 
         Returns
         -------
-        samples : array-like, shape=[..., {dim, [n, n]}]
+        samples : array-like, shape=[..., *point_shape]
             Points sampled on the hypersphere.
         """
         sample = self.embedding_space.random_point(n_samples, bound)
@@ -695,11 +695,11 @@ class ComplexOpenSet(ComplexManifold, abc.ABC):
 
         Parameters
         ----------
-        point : array-like, shape=[..., dim]
+        point : array-like, shape=[..., *point_shape]
             Point in embedding manifold.
 
         Returns
         -------
-        projected : array-like, shape=[..., dim]
+        projected : array-like, shape=[..., *point_shape]
             Projected point.
         """

--- a/geomstats/geometry/base.py
+++ b/geomstats/geometry/base.py
@@ -67,7 +67,7 @@ class VectorSpace(Manifold, abc.ABC):
         point: array-like, shape[..., {dim, [n, n]}]
             Point.
         """
-        return point
+        return gs.copy(point)
 
     def is_tangent(self, vector, base_point=None, atol=gs.atol):
         """Check whether the vector is tangent at base_point.
@@ -112,7 +112,10 @@ class VectorSpace(Manifold, abc.ABC):
         tangent_vec : array-like, shape=[..., {dim, [n, n]}]
             Tangent vector at base point.
         """
-        return self.projection(vector)
+        tangent_vec = self.projection(vector)
+        if base_point is not None and base_point.ndim > vector.ndim:
+            return gs.broadcast_to(tangent_vec, base_point.shape)
+        return tangent_vec
 
     def random_point(self, n_samples=1, bound=1.0):
         """Sample in the vector space with a uniform distribution in a box.

--- a/geomstats/geometry/base.py
+++ b/geomstats/geometry/base.py
@@ -540,7 +540,10 @@ class OpenSet(Manifold, abc.ABC):
         is_tangent : bool
             Boolean denoting if vector is a tangent vector at the base point.
         """
-        return self.embedding_space.belongs(vector, atol)
+        is_tangent = self.embedding_space.belongs(vector, atol)
+        if base_point is not None and base_point.ndim > vector.ndim:
+            return gs.broadcast_to(is_tangent, base_point.shape[: -self.point_ndim])
+        return is_tangent
 
     def to_tangent(self, vector, base_point=None):
         """Project a vector to a tangent space of the manifold.
@@ -557,7 +560,10 @@ class OpenSet(Manifold, abc.ABC):
         tangent_vec : array-like, shape=[..., dim]
             Tangent vector at base point.
         """
-        return self.embedding_space.projection(vector)
+        tangent_vec = self.embedding_space.projection(vector)
+        if base_point is not None and base_point.ndim > vector.ndim:
+            return gs.broadcast_to(tangent_vec, base_point.shape)
+        return tangent_vec
 
     def random_point(self, n_samples=1, bound=1.0):
         """Sample random points on the manifold.

--- a/geomstats/geometry/base.py
+++ b/geomstats/geometry/base.py
@@ -25,7 +25,6 @@ class VectorSpace(Manifold, abc.ABC):
     def __init__(self, shape, **kwargs):
         kwargs.setdefault("dim", int(gs.prod(gs.array(shape))))
         super().__init__(shape=shape, **kwargs)
-        self.shape = shape
         self._basis = None
 
     def belongs(self, point, atol=gs.atol):
@@ -45,16 +44,11 @@ class VectorSpace(Manifold, abc.ABC):
         belongs : array-like, shape=[...,]
             Boolean evaluating if point belongs to the space.
         """
-        point = gs.array(point)
-        minimal_ndim = len(self.shape)
-        if self.shape[0] == 1 and len(point.shape) <= 1:
-            point = gs.transpose(gs.to_ndarray(gs.to_ndarray(point, 1), 2))
-        belongs = point.shape[-minimal_ndim:] == self.shape
-        if point.ndim <= minimal_ndim:
-            return belongs
+        belongs = self.shape == point.shape[-self.point_ndim :]
+        shape = point.shape[: -self.point_ndim]
         if belongs:
-            return gs.ones(point.shape[:-minimal_ndim], dtype=bool)
-        return gs.zeros(point.shape[:-minimal_ndim], dtype=bool)
+            return gs.ones(shape, dtype=bool)
+        return gs.zeros(shape, dtype=bool)
 
     @staticmethod
     def projection(point):

--- a/geomstats/geometry/base.py
+++ b/geomstats/geometry/base.py
@@ -87,10 +87,13 @@ class VectorSpace(Manifold, abc.ABC):
 
         Returns
         -------
-        is_tangent : bool
+        is_tangent : array-like, shape=[...,]
             Boolean denoting if vector is a tangent vector at the base point.
         """
-        return self.belongs(vector, atol)
+        belongs = self.belongs(vector, atol)
+        if base_point is not None and base_point.ndim > vector.ndim:
+            return gs.broadcast_to(belongs, base_point.shape[: -self.point_ndim])
+        return belongs
 
     def to_tangent(self, vector, base_point=None):
         """Project a vector to a tangent space of the vector space.

--- a/geomstats/geometry/complex_manifold.py
+++ b/geomstats/geometry/complex_manifold.py
@@ -64,12 +64,12 @@ class ComplexManifold(abc.ABC):
         n_samples : int
             Number of samples.
             Optional, default: 1.
-        base_point :  array-like, shape=[..., dim]
+        base_point :  array-like, shape=[..., *point_shape]
             Point.
 
         Returns
         -------
-        tangent_vec : array-like, shape=[..., dim]
+        tangent_vec : array-like, shape=[..., *point_shape]
             Tangent vec at base point.
         """
         if (

--- a/geomstats/geometry/complex_manifold.py
+++ b/geomstats/geometry/complex_manifold.py
@@ -37,6 +37,9 @@ class ComplexManifold(abc.ABC):
         self.default_coords_type = default_coords_type
         self._metric = metric
 
+        self.point_ndim = len(self.shape)
+        self.default_point_type = "vector" if self.point_ndim == 1 else "matrix"
+
     @property
     def metric(self):
         """Riemannian metric associated to the complex manifold."""
@@ -78,11 +81,8 @@ class ComplexManifold(abc.ABC):
                 "The number of base points must be the same as the "
                 "number of samples, when different from 1."
             )
-        vector = gs.cast(
-            gs.random.normal(size=(n_samples,) + self.shape),
-            dtype=gs.get_default_cdtype(),
-        ) + 1j * gs.cast(
-            gs.random.normal(size=(n_samples,) + self.shape),
-            dtype=gs.get_default_cdtype(),
+        batch_size = () if n_samples == 1 else (n_samples,)
+        vector = gs.random.normal(
+            size=batch_size + self.shape, dtype=gs.get_default_cdtype()
         )
-        return gs.squeeze(self.to_tangent(vector, base_point))
+        return self.to_tangent(vector, base_point)

--- a/geomstats/geometry/euclidean.py
+++ b/geomstats/geometry/euclidean.py
@@ -39,7 +39,7 @@ class Euclidean(VectorSpace):
         """Create the canonical basis."""
         return gs.eye(self.dim)
 
-    def exp(self, tangent_vec, base_point=None):
+    def exp(self, tangent_vec, base_point):
         """Compute the group exponential, which is simply the addition.
 
         Parameters

--- a/geomstats/geometry/manifold.py
+++ b/geomstats/geometry/manifold.py
@@ -60,7 +60,7 @@ class Manifold(abc.ABC):
 
         Parameters
         ----------
-        point : array-like, shape=[..., dim]
+        point : array-like, shape=[..., *point_shape]
             Point to evaluate.
         atol : float
             Absolute tolerance.
@@ -78,9 +78,9 @@ class Manifold(abc.ABC):
 
         Parameters
         ----------
-        vector : array-like, shape=[..., dim]
+        vector : array-like, shape=[..., *point_shape]
             Vector.
-        base_point : array-like, shape=[..., dim]
+        base_point : array-like, shape=[..., *point_shape]
             Point on the manifold.
         atol : float
             Absolute tolerance.
@@ -98,14 +98,14 @@ class Manifold(abc.ABC):
 
         Parameters
         ----------
-        vector : array-like, shape=[..., dim]
+        vector : array-like, shape=[..., *point_shape]
             Vector.
-        base_point : array-like, shape=[..., dim]
+        base_point : array-like, shape=[..., *point_shape]
             Point on the manifold.
 
         Returns
         -------
-        tangent_vec : array-like, shape=[..., dim]
+        tangent_vec : array-like, shape=[..., *point_shape]
             Tangent vector at base point.
         """
 
@@ -126,7 +126,7 @@ class Manifold(abc.ABC):
 
         Returns
         -------
-        samples : array-like, shape=[..., {dim, [n, n]}]
+        samples : array-like, shape=[..., *point_shape]
             Points sampled on the manifold.
         """
 
@@ -140,7 +140,7 @@ class Manifold(abc.ABC):
 
         Returns
         -------
-        regularized_point : array-like, shape=[..., dim]
+        regularized_point : array-like, shape=[..., *point_shape]
             Regularized point.
         """
         regularized_point = point
@@ -168,12 +168,12 @@ class Manifold(abc.ABC):
         n_samples : int
             Number of samples.
             Optional, default: 1.
-        base_point :  array-like, shape={[n_samples, dim], [dim,]}
+        base_point :  array-like, shape={[n_samples, *point_shape], [*point_shape,]}
             Point.
 
         Returns
         -------
-        tangent_vec : array-like, shape=[..., dim]
+        tangent_vec : array-like, shape=[..., *point_shape]
             Tangent vec at base point.
         """
         if (

--- a/geomstats/geometry/manifold.py
+++ b/geomstats/geometry/manifold.py
@@ -185,8 +185,7 @@ class Manifold(abc.ABC):
                 "The number of base points must be the same as the "
                 "number of samples, when the number of base points is different from 1."
             )
-        return gs.squeeze(
-            self.to_tangent(
-                gs.random.normal(size=(n_samples,) + self.shape), base_point
-            )
+        batch_size = () if n_samples == 1 else (n_samples,)
+        return self.to_tangent(
+            gs.random.normal(size=batch_size + self.shape), base_point
         )

--- a/geomstats/geometry/manifold.py
+++ b/geomstats/geometry/manifold.py
@@ -28,6 +28,13 @@ class Manifold(abc.ABC):
     default_coords_type : str, {\'intrinsic\', \'extrinsic\', etc}
         Coordinate type.
         Optional, default: 'intrinsic'.
+
+    Attributes
+    ----------
+    point_ndim : int
+        Dimension of point array.
+    default_point_type : str
+        Point type: "vector" or "matrix"
     """
 
     def __init__(
@@ -44,15 +51,8 @@ class Manifold(abc.ABC):
         self.default_coords_type = default_coords_type
         self._metric = metric
 
-    @property
-    def default_point_type(self):
-        """Point type.
-
-        `vector` or `matrix`.
-        """
-        if len(self.shape) == 1:
-            return "vector"
-        return "matrix"
+        self.point_ndim = len(self.shape)
+        self.default_point_type = "vector" if self.point_ndim == 1 else "matrix"
 
     @abc.abstractmethod
     def belongs(self, point, atol=gs.atol):

--- a/geomstats/geometry/matrices.py
+++ b/geomstats/geometry/matrices.py
@@ -31,32 +31,6 @@ class Matrices(VectorSpace):
         m, n = self.m, self.n
         return gs.reshape(gs.eye(n * m), (n * m, m, n))
 
-    def belongs(self, point, atol=gs.atol):
-        """Check if point belongs to the Matrices space.
-
-        Parameters
-        ----------
-        point : array-like, shape=[..., m, n]
-            Point to be checked.
-        atol : float
-            Unused here.
-
-        Returns
-        -------
-        belongs : array-like, shape=[...,]
-            Boolean evaluating if point belongs to the Matrices space.
-        """
-        ndim = point.ndim
-        if ndim == 1:
-            return False
-        mat_dim_1, mat_dim_2 = point.shape[-2:]
-        belongs = (mat_dim_1 == self.m) and (mat_dim_2 == self.n)
-        if ndim == 2:
-            return belongs
-        if belongs:
-            return gs.ones(point.shape[:-2], dtype=bool)
-        return gs.zeros(point.shape[:-2], dtype=bool)
-
     @staticmethod
     def equal(mat_a, mat_b, atol=gs.atol):
         """Test if matrices a and b are close.

--- a/geomstats/geometry/skew_symmetric_matrices.py
+++ b/geomstats/geometry/skew_symmetric_matrices.py
@@ -50,12 +50,12 @@ class SkewSymmetricMatrices(MatrixLieAlgebra):
 
         return gs.array_from_sparse(indices, data, (k + 1, n, n))
 
-    def belongs(self, mat, atol=gs.atol):
-        """Evaluate if mat is a skew-symmetric matrix.
+    def belongs(self, point, atol=gs.atol):
+        """Evaluate if point is a skew-symmetric matrix.
 
         Parameters
         ----------
-        mat : array-like, shape=[..., n, n]
+        point : array-like, shape=[..., n, n]
             Square matrix to check.
         atol : float
             Tolerance for the equality evaluation.
@@ -66,9 +66,9 @@ class SkewSymmetricMatrices(MatrixLieAlgebra):
         belongs : array-like, shape=[...,]
             Boolean evaluating if matrix is skew symmetric.
         """
-        has_right_shape = self.embedding_space.belongs(mat)
+        has_right_shape = self.embedding_space.belongs(point)
         if gs.all(has_right_shape):
-            return Matrices.is_skew_symmetric(mat=mat, atol=atol)
+            return Matrices.is_skew_symmetric(mat=point, atol=atol)
         return has_right_shape
 
     def random_point(self, n_samples=1, bound=1.0):

--- a/geomstats/geometry/special_euclidean.py
+++ b/geomstats/geometry/special_euclidean.py
@@ -1361,12 +1361,12 @@ class SpecialEuclideanMatrixLieAlgebra(MatrixLieAlgebra):
 
         return gs.vstack([basis, add_basis])
 
-    def belongs(self, mat, atol=ATOL):
-        """Evaluate if the rotation part of mat is a skew-symmetric matrix.
+    def belongs(self, point, atol=ATOL):
+        """Evaluate if the rotation part of point is a skew-symmetric matrix.
 
         Parameters
         ----------
-        mat : array-like, shape=[..., n + 1, n + 1]
+        point : array-like, shape=[..., n + 1, n + 1]
             Square matrix to check.
         atol : float
             Tolerance for the equality evaluation.
@@ -1377,15 +1377,15 @@ class SpecialEuclideanMatrixLieAlgebra(MatrixLieAlgebra):
         belongs : array-like, shape=[...,]
             Boolean evaluating if rotation part of matrix is skew symmetric.
         """
-        point_dim1, point_dim2 = mat.shape[-2:]
+        point_dim1, point_dim2 = point.shape[-2:]
         belongs = point_dim1 == point_dim2 == self.n + 1
 
-        rotation = mat[..., : self.n, : self.n]
+        rotation = point[..., : self.n, : self.n]
         rot_belongs = self.skew.belongs(rotation, atol=atol)
 
         belongs = gs.logical_and(belongs, rot_belongs)
 
-        last_line = mat[..., -1, :]
+        last_line = point[..., -1, :]
         all_zeros = ~gs.any(last_line, axis=-1)
 
         belongs = gs.logical_and(belongs, all_zeros)

--- a/tests/data/binomial_data.py
+++ b/tests/data/binomial_data.py
@@ -22,7 +22,7 @@ class BinomialTestData(_OpenSetTestData):
             dict(n_draws=2, point=gs.array([-1.0]), expected=False),
             dict(n_draws=1, point=gs.array([0.1]), expected=True),
             dict(n_draws=7, point=gs.array([-0.8]), expected=False),
-            dict(n_draws=8, point=gs.array([8]), expected=False),
+            dict(n_draws=8, point=gs.array([8.]), expected=False),
             dict(n_draws=2, point=gs.array([-1.0]), expected=False),
             dict(n_draws=1, point=gs.array([5.0]), expected=False),
             dict(n_draws=1, point=gs.array([-0.2]), expected=False),

--- a/tests/data/binomial_data.py
+++ b/tests/data/binomial_data.py
@@ -16,18 +16,20 @@ class BinomialTestData(_OpenSetTestData):
 
     def belongs_test_data(self):
         smoke_data = [
-            dict(n_draws=10, point=0.1, expected=True),
-            dict(n_draws=8, point=-0.8, expected=False),
-            dict(n_draws=5, point=0.1, expected=True),
-            dict(n_draws=2, point=-1.0, expected=False),
-            dict(n_draws=1, point=0.1, expected=True),
-            dict(n_draws=7, point=gs.array(-0.8), expected=False),
-            dict(n_draws=8, point=8, expected=False),
-            dict(n_draws=2, point=-1.0, expected=False),
+            dict(n_draws=10, point=gs.array([0.1]), expected=True),
+            dict(n_draws=8, point=gs.array([-0.8]), expected=False),
+            dict(n_draws=5, point=gs.array([0.1]), expected=True),
+            dict(n_draws=2, point=gs.array([-1.0]), expected=False),
+            dict(n_draws=1, point=gs.array([0.1]), expected=True),
+            dict(n_draws=7, point=gs.array([-0.8]), expected=False),
+            dict(n_draws=8, point=gs.array([8]), expected=False),
+            dict(n_draws=2, point=gs.array([-1.0]), expected=False),
             dict(n_draws=1, point=gs.array([5.0]), expected=False),
-            dict(n_draws=1, point=gs.array(-0.2), expected=False),
+            dict(n_draws=1, point=gs.array([-0.2]), expected=False),
             dict(
-                n_draws=3, point=gs.array([0.9, -1]), expected=gs.array([True, False])
+                n_draws=3,
+                point=gs.array([[0.9], [-1]]),
+                expected=gs.array([True, False]),
             ),
             dict(
                 n_draws=5,
@@ -37,22 +39,24 @@ class BinomialTestData(_OpenSetTestData):
         ]
         return self.generate_tests(smoke_data)
 
-    def random_point_test_data(self):
+    def random_point_shape_test_data(self):
         random_data = [
-            dict(point=self.Space(5).random_point(3), expected=(3,)),
-            dict(point=self.Space(10).random_point(2), expected=(2,)),
-            dict(point=self.Space(3).random_point(1), expected=()),
+            dict(point=self.Space(5).random_point(3), expected=(3, 1)),
+            dict(point=self.Space(10).random_point(2), expected=(2, 1)),
+            dict(point=self.Space(3).random_point(1), expected=(1,)),
         ]
         return self.generate_tests([], random_data)
 
-    def sample_test_data(self):
+    def sample_shape_test_data(self):
         smoke_data = [
-            dict(n_draws=5, point=gs.array([0.2, 0.3]), n_samples=2, expected=(2, 2)),
+            dict(
+                n_draws=5, point=gs.array([[0.2], [0.3]]), n_samples=2, expected=(2, 2)
+            ),
             dict(
                 n_draws=10,
-                point=gs.array([0.1, 0.2, 0.3]),
+                point=gs.array([[0.1], [0.2], [0.3]]),
                 n_samples=1,
-                expected=(3,),
+                expected=(3, 1),
             ),
         ]
         return self.generate_tests(smoke_data)

--- a/tests/data/binomial_data.py
+++ b/tests/data/binomial_data.py
@@ -22,7 +22,7 @@ class BinomialTestData(_OpenSetTestData):
             dict(n_draws=2, point=gs.array([-1.0]), expected=False),
             dict(n_draws=1, point=gs.array([0.1]), expected=True),
             dict(n_draws=7, point=gs.array([-0.8]), expected=False),
-            dict(n_draws=8, point=gs.array([8.]), expected=False),
+            dict(n_draws=8, point=gs.array([8.0]), expected=False),
             dict(n_draws=2, point=gs.array([-1.0]), expected=False),
             dict(n_draws=1, point=gs.array([5.0]), expected=False),
             dict(n_draws=1, point=gs.array([-0.2]), expected=False),

--- a/tests/geometry_test_cases.py
+++ b/tests/geometry_test_cases.py
@@ -186,8 +186,8 @@ class OpenSetTestCase(ManifoldTestCase):
             Absolute tolerance for the is_tangent function.
         """
         space = self.Space(*space_args)
-        tangent_vec = space.to_tangent(gs.array(vector), gs.array(base_point))
-        result = gs.all(space.embedding_space.is_tangent(tangent_vec, atol))
+        tangent_vec = space.to_tangent(vector, base_point)
+        result = gs.all(space.embedding_space.is_tangent(tangent_vec, base_point, atol))
         self.assertTrue(result)
 
 

--- a/tests/geometry_test_cases.py
+++ b/tests/geometry_test_cases.py
@@ -162,7 +162,7 @@ class ManifoldTestCase(TestCase):
         space = self.Space(*space_args)
         tangent_vec = space.random_tangent_vec(base_point, n_samples)
         result = space.is_tangent(tangent_vec, base_point, atol)
-        self.assertAllEqual(result, gs.squeeze(gs.ones(n_samples)))
+        self.assertAllEqual(result, gs.squeeze(gs.ones(n_samples, dtype=bool)))
 
 
 class OpenSetTestCase(ManifoldTestCase):

--- a/tests/tests_geomstats/test_binomial.py
+++ b/tests/tests_geomstats/test_binomial.py
@@ -15,10 +15,10 @@ class TestBinomial(OpenSetTestCase, metaclass=Parametrizer):
     def test_belongs(self, n_draws, point, expected):
         self.assertAllClose(self.Space(n_draws).belongs(point), expected)
 
-    def test_random_point(self, point, expected):
+    def test_random_point_shape(self, point, expected):
         self.assertAllClose(point.shape, expected)
 
-    def test_sample(self, n_draws, point, n_samples, expected):
+    def test_sample_shape(self, n_draws, point, n_samples, expected):
         self.assertAllClose(
             self.Space(n_draws).sample(point, n_samples).shape, expected
         )

--- a/tests/tests_geomstats/test_geodesic_regression.py
+++ b/tests/tests_geomstats/test_geodesic_regression.py
@@ -344,6 +344,8 @@ class TestGeodesicRegression(tests.conftest.TestCase):
 
         objective_with_grad = gs.autodiff.value_and_grad(loss_of_param, to_numpy=True)
         loss_value, loss_grad = objective_with_grad(self.param_se2_guess)
+        # TODO: fix autodiff to output proper type
+        loss_value, loss_grad = gs.array(loss_value), gs.array(loss_grad)
         expected_grad_shape = (
             2,
             self.shape_se2[0] * self.shape_se2[1],


### PR DESCRIPTION
This PR:

**1)** sets the expectations for point shapes of manifolds of dimension 1 (relevant for you @YannCabanes):

* point: `(1,)`; multiple points `(n_points, 1)`
* several reasons for this:

i. spaces that also work with higher dimensions naturally represent points for case `dim=1` as `(1,)` (e.g. `Euclidean`)
ii. `()` treatment would require several exceptions in the code: e.g. `ProductManifold`; `gs.random.rand` use to create a generic function to create random points 

* points are represented by `gs.array`, never `float`

**2)** fixes several general functions in abstract classes (building on top of previous point)

**3)** fixes several vectorizations in abstract classes when `point` is ignored

**4)** fixes docstrings of abstract classes regarding points shapes

**5)** modifies `BinomialDistributions` to apply **1)** (@alebrigant can you please review to ensure I do not introduce any error?)


@YannCabanes can you please review the changes in complex manifolds abstract classes to ensure I haven't missed anything out?