### PR TITLE
Update backend random distributions to accept complex type

### DIFF
--- a/geomstats/_backend/_dtype_utils.py
+++ b/geomstats/_backend/_dtype_utils.py
@@ -337,6 +337,40 @@ def _pre_cast_out_to_input_dtype(cast, is_floating, is_complex, as_dtype, dtype_
     return _cast_out_to_input_dtype
 
 
+def _pre_allow_complex_dtype(cast, complex_dtypes):
+    def _allow_complex_dtype(target=None):
+        """Allow complex type by calling the function twice.
+
+        Assumes function do not support dtype.
+
+        How it works?
+        -------------
+        Function is called twice if dtype is complex.
+        Output is casted if not corresponding to expected dtype.
+        """
+
+        def _decorator(func):
+            @functools.wraps(func)
+            def _wrapped(*args, dtype=None, **kwargs):
+                out = func(*args, **kwargs)
+                if dtype in complex_dtypes:
+                    out = out + 1j * func(*args, **kwargs)
+
+                if out.dtype != dtype:
+                    return cast(out, dtype)
+
+                return out
+
+            return _wrapped
+
+        if target is None:
+            return _decorator
+
+        return _decorator(target)
+
+    return _allow_complex_dtype
+
+
 def _np_box_unary_scalar(target=None):
     """Update dtype if input is float in unary operations.
 

--- a/geomstats/_backend/autograd/_dtype.py
+++ b/geomstats/_backend/autograd/_dtype.py
@@ -8,6 +8,7 @@ from geomstats._backend._dtype_utils import _np_box_binary_scalar as _box_binary
 from geomstats._backend._dtype_utils import _np_box_unary_scalar as _box_unary_scalar
 from geomstats._backend._dtype_utils import (
     _pre_add_default_dtype_by_casting,
+    _pre_allow_complex_dtype,
     _pre_cast_fout_to_input_dtype,
     _pre_cast_out_from_dtype,
     _pre_cast_out_to_input_dtype,
@@ -17,6 +18,11 @@ from geomstats._backend._dtype_utils import (
 )
 
 from ._common import cast
+
+_COMPLEX_DTYPES = [
+    _np.complex64,
+    _np.complex128,
+]
 
 
 def is_floating(x):
@@ -49,3 +55,4 @@ _cast_out_to_input_dtype = _pre_cast_out_to_input_dtype(
     cast, is_floating, is_complex, as_dtype, _dtype_as_str
 )
 _cast_out_from_dtype = _pre_cast_out_from_dtype(cast, is_floating, is_complex)
+_allow_complex_dtype = _pre_allow_complex_dtype(cast, _COMPLEX_DTYPES)

--- a/geomstats/_backend/autograd/random.py
+++ b/geomstats/_backend/autograd/random.py
@@ -3,30 +3,26 @@ import autograd.numpy as _np
 from autograd.numpy.random import default_rng as _default_rng  # NOQA
 from autograd.numpy.random import randint, seed
 
-from ._common import cast as _cast
-from ._dtype import _add_default_dtype_by_casting, _modify_func_default_dtype
+from ._dtype import _allow_complex_dtype, _modify_func_default_dtype
 
-normal = _add_default_dtype_by_casting(target=_np.random.normal)
-multivariate_normal = _add_default_dtype_by_casting(
-    target=_np.random.multivariate_normal
+rand = _modify_func_default_dtype(
+    copy=False, kw_only=True, target=_allow_complex_dtype(target=_np.random.rand)
 )
-uniform = _add_default_dtype_by_casting(target=_np.random.uniform)
+
+uniform = _modify_func_default_dtype(
+    copy=False, kw_only=True, target=_allow_complex_dtype(target=_np.random.uniform)
+)
 
 
-@_modify_func_default_dtype(copy=False, kw_only=True)
-def rand(*size, dtype=None):
-    if dtype in [_np.complex64, _np.complex128]:
-        real = _np.random.rand(*size)
-        imag = 1j * _np.random.rand(*size)
-        out = real + imag
+normal = _modify_func_default_dtype(
+    copy=False, kw_only=True, target=_allow_complex_dtype(target=_np.random.normal)
+)
 
-    else:
-        out = _np.random.rand(*size)
-
-    if out.dtype != dtype:
-        return _cast(out, dtype)
-
-    return out
+multivariate_normal = _modify_func_default_dtype(
+    copy=False,
+    kw_only=True,
+    target=_allow_complex_dtype(target=_np.random.multivariate_normal),
+)
 
 
 def choice(*args, **kwargs):

--- a/geomstats/_backend/numpy/_dtype.py
+++ b/geomstats/_backend/numpy/_dtype.py
@@ -8,6 +8,7 @@ from geomstats._backend._dtype_utils import _np_box_binary_scalar as _box_binary
 from geomstats._backend._dtype_utils import _np_box_unary_scalar as _box_unary_scalar
 from geomstats._backend._dtype_utils import (
     _pre_add_default_dtype_by_casting,
+    _pre_allow_complex_dtype,
     _pre_cast_fout_to_input_dtype,
     _pre_cast_out_from_dtype,
     _pre_cast_out_to_input_dtype,
@@ -17,6 +18,11 @@ from geomstats._backend._dtype_utils import (
 )
 
 from ._common import cast
+
+_COMPLEX_DTYPES = (
+    _np.complex64,
+    _np.complex128,
+)
 
 
 def is_floating(x):
@@ -48,3 +54,4 @@ _cast_out_to_input_dtype = _pre_cast_out_to_input_dtype(
     cast, is_floating, is_complex, as_dtype, _dtype_as_str
 )
 _cast_out_from_dtype = _pre_cast_out_from_dtype(cast, is_floating, is_complex)
+_allow_complex_dtype = _pre_allow_complex_dtype(cast, _COMPLEX_DTYPES)

--- a/geomstats/_backend/numpy/random.py
+++ b/geomstats/_backend/numpy/random.py
@@ -4,30 +4,26 @@ import numpy as _np
 from numpy.random import default_rng as _default_rng
 from numpy.random import randint, seed
 
-from ._common import cast as _cast
-from ._dtype import _add_default_dtype_by_casting, _modify_func_default_dtype
+from ._dtype import _allow_complex_dtype, _modify_func_default_dtype
 
-normal = _add_default_dtype_by_casting(target=_np.random.normal)
-multivariate_normal = _add_default_dtype_by_casting(
-    target=_np.random.multivariate_normal
+rand = _modify_func_default_dtype(
+    copy=False, kw_only=True, target=_allow_complex_dtype(target=_np.random.rand)
 )
-uniform = _add_default_dtype_by_casting(target=_np.random.uniform)
+
+uniform = _modify_func_default_dtype(
+    copy=False, kw_only=True, target=_allow_complex_dtype(target=_np.random.uniform)
+)
 
 
-@_modify_func_default_dtype(copy=False, kw_only=True)
-def rand(*size, dtype=None):
-    if dtype in [_np.complex64, _np.complex128]:
-        real = _np.random.rand(*size)
-        imag = 1j * _np.random.rand(*size)
-        out = real + imag
+normal = _modify_func_default_dtype(
+    copy=False, kw_only=True, target=_allow_complex_dtype(target=_np.random.normal)
+)
 
-    else:
-        out = _np.random.rand(*size)
-
-    if out.dtype != dtype:
-        return _cast(out, dtype)
-
-    return out
+multivariate_normal = _modify_func_default_dtype(
+    copy=False,
+    kw_only=True,
+    target=_allow_complex_dtype(target=_np.random.multivariate_normal),
+)
 
 
 def choice(*args, **kwargs):

--- a/geomstats/_backend/pytorch/_dtype.py
+++ b/geomstats/_backend/pytorch/_dtype.py
@@ -6,8 +6,11 @@ from torch import complex64, complex128, float32, float64
 from geomstats._backend import _backend_config as _config
 from geomstats._backend._dtype_utils import (
     _MAP_FLOAT_TO_COMPLEX,
+    _modify_func_default_dtype,
     _pre_add_default_dtype_by_casting,
+    _pre_allow_complex_dtype,
     _pre_cast_out_to_input_dtype,
+    _update_default_dtypes,
     get_default_cdtype,
     get_default_dtype,
 )
@@ -20,6 +23,8 @@ MAP_DTYPE = {
     "complex64": complex64,
     "complex128": complex128,
 }
+
+_COMPLEX_DTYPES = (complex64, complex128)
 
 
 def is_floating(x):
@@ -55,6 +60,8 @@ def set_default_dtype(value):
     _config.DEFAULT_COMPLEX_DTYPE = as_dtype(_MAP_FLOAT_TO_COMPLEX.get(value))
     _torch.set_default_dtype(_config.DEFAULT_DTYPE)
 
+    _update_default_dtypes()
+
     return _config.DEFAULT_DTYPE
 
 
@@ -62,6 +69,7 @@ _add_default_dtype_by_casting = _pre_add_default_dtype_by_casting(cast)
 _cast_out_to_input_dtype = _pre_cast_out_to_input_dtype(
     cast, is_floating, is_complex, as_dtype, _dtype_as_str
 )
+_allow_complex_dtype = _pre_allow_complex_dtype(cast, _COMPLEX_DTYPES)
 
 
 def _preserve_input_dtype(target=None):

--- a/geomstats/_backend/pytorch/random.py
+++ b/geomstats/_backend/pytorch/random.py
@@ -6,7 +6,7 @@ from torch.distributions.multivariate_normal import (
     MultivariateNormal as _MultivariateNormal,
 )
 
-from ._dtype import _add_default_dtype_by_casting
+from ._dtype import _allow_complex_dtype, _modify_func_default_dtype
 
 
 def choice(x, a):
@@ -21,23 +21,23 @@ def seed(*args, **kwargs):
     return _torch.manual_seed(*args, **kwargs)
 
 
-@_add_default_dtype_by_casting
+@_allow_complex_dtype
 def normal(loc=0.0, scale=1.0, size=(1,)):
     if not hasattr(size, "__iter__"):
         size = (size,)
     return _torch.normal(mean=loc, std=scale, size=size)
 
 
-@_add_default_dtype_by_casting
-def uniform(low=0.0, high=1.0, size=(1,)):
+def uniform(low=0.0, high=1.0, size=(1,), dtype=None):
     if not hasattr(size, "__iter__"):
         size = (size,)
     if low >= high:
         raise ValueError("Upper bound must be higher than lower bound")
-    return (high - low) * _torch.rand(*size) + low
+    return (high - low) * rand(*size, dtype=dtype) + low
 
 
-@_add_default_dtype_by_casting
+@_modify_func_default_dtype(copy=False, kw_only=True)
+@_allow_complex_dtype
 def multivariate_normal(mean, cov, size=(1,)):
     if not hasattr(size, "__iter__"):
         size = (size,)

--- a/geomstats/_backend/tensorflow/_dtype.py
+++ b/geomstats/_backend/tensorflow/_dtype.py
@@ -7,12 +7,18 @@ from geomstats._backend import _backend_config as _config
 from geomstats._backend._dtype_utils import (
     _dyn_update_dtype,
     _modify_func_default_dtype,
+    _pre_allow_complex_dtype,
     _pre_cast_out_from_dtype,
     _pre_cast_out_to_input_dtype,
     _pre_set_default_dtype,
     _update_default_dtypes,
     get_default_cdtype,
     get_default_dtype,
+)
+
+_COMPLEX_DTYPES = (
+    _tf.complex64,
+    _tf.complex128,
 )
 
 
@@ -39,6 +45,39 @@ _cast_out_to_input_dtype = _pre_cast_out_to_input_dtype(
 )
 
 _cast_out_from_dtype = _pre_cast_out_from_dtype(_tf.cast, is_floating, is_complex)
+
+
+def _allow_complex_dtype(target=None):
+    """Allow complex type by calling the function twice.
+
+    Assumes function do not support dtype.
+
+    How it works?
+    -------------
+    Function is called twice if dtype is complex.
+    Output is casted if not corresponding to expected dtype.
+    """
+
+    def _decorator(func):
+        @functools.wraps(func)
+        def _wrapped(*args, **kwargs):
+            dtype = kwargs.get("dtype", None)
+
+            if dtype not in _COMPLEX_DTYPES:
+                return func(*args, **kwargs)
+
+            del kwargs["dtype"]
+            real = _tf.cast(func(*args, **kwargs), dtype)
+            imag = 1j * _tf.cast(func(*args, **kwargs), dtype)
+
+            return real + imag
+
+        return _wrapped
+
+    if target is None:
+        return _decorator
+
+    return _decorator(target)
 
 
 def _box_unary_scalar(target=None):

--- a/geomstats/_backend/tensorflow/_dtype.py
+++ b/geomstats/_backend/tensorflow/_dtype.py
@@ -61,7 +61,7 @@ def _allow_complex_dtype(target=None):
     def _decorator(func):
         @functools.wraps(func)
         def _wrapped(*args, **kwargs):
-            dtype = kwargs.get("dtype", None)
+            dtype = kwargs.get("dtype")
 
             if dtype not in _COMPLEX_DTYPES:
                 return func(*args, **kwargs)

--- a/geomstats/_backend/tensorflow/random.py
+++ b/geomstats/_backend/tensorflow/random.py
@@ -5,6 +5,7 @@ import tensorflow_probability as _tfp
 from tensorflow import cast
 
 from .._dtype_utils import _modify_func_default_dtype
+from ._dtype import _allow_complex_dtype
 
 _tfd = _tfp.distributions
 
@@ -33,18 +34,15 @@ def randint(low, high=None, size=None):
 
 @_modify_func_default_dtype(copy=False, kw_only=True)
 def rand(*args, dtype=None):
-    if dtype in [_tf.complex64, _tf.complex128]:
-        real = _tf.cast(_tf.random.uniform(shape=args), dtype=dtype)
-        imag = 1j * _tf.cast(_tf.random.uniform(shape=args), dtype=dtype)
-
-        return real + imag
-    return _tf.random.uniform(shape=args, dtype=dtype)
+    # TODO: use uniform
+    return uniform(size=args, dtype=dtype)
 
 
 def seed(*args):
     return _tf.compat.v1.set_random_seed(*args)
 
 
+@_allow_complex_dtype
 @_modify_func_default_dtype(copy=False, kw_only=False)
 def normal(loc=0.0, scale=1.0, size=(1,), dtype=None):
     if not hasattr(size, "__iter__"):
@@ -53,6 +51,7 @@ def normal(loc=0.0, scale=1.0, size=(1,), dtype=None):
     return _tf.random.normal(mean=loc, stddev=scale, shape=size, dtype=dtype)
 
 
+@_allow_complex_dtype
 @_modify_func_default_dtype(copy=False, kw_only=False)
 def uniform(low=0.0, high=1.0, size=(1,), dtype=None):
     if not hasattr(size, "__iter__"):
@@ -61,6 +60,7 @@ def uniform(low=0.0, high=1.0, size=(1,), dtype=None):
     return _tf.random.uniform(shape=size, minval=low, maxval=high, dtype=dtype)
 
 
+@_allow_complex_dtype
 @_modify_func_default_dtype(copy=False, kw_only=False)
 def multivariate_normal(mean, cov, size=None, dtype=None):
     if size is None:

--- a/tests/data/backends_data.py
+++ b/tests/data/backends_data.py
@@ -619,3 +619,20 @@ class DtypesTestData(TestData):
         ]
 
         return self.generate_tests(smoke_data)
+
+    def random_distrib_complex_test_data(self):
+        smoke_data = [
+            dict(
+                func_name="random.rand",
+                args=(2,),
+            ),
+            dict(func_name="random.uniform", kwargs={"size": (2,)}),
+            dict(func_name="random.normal", kwargs={"size": (2,)}),
+            dict(
+                func_name="random.multivariate_normal",
+                args=(gs.zeros(2), SPDMatrices(2).random_point()),
+                kwargs={"size": (2,)},
+            ),
+        ]
+
+        return self.generate_tests(smoke_data)

--- a/tests/tests_geomstats/test_backends2.py
+++ b/tests/tests_geomstats/test_backends2.py
@@ -463,3 +463,17 @@ class TestDtypes(TestCase, metaclass=Parametrizer):
             func_b=func_b,
             func_c=func_c,
         )
+
+    def test_random_distrib_complex(self, func_name, args=(), kwargs=None):
+        self._reset_dtype()
+        kwargs = kwargs or {}
+
+        gs_fnc = get_backend_fnc(func_name)
+
+        dtype = gs.as_dtype("complex128")
+        out = gs_fnc(*args, **kwargs, dtype=dtype)
+
+        self.assertDtype(out.dtype, dtype)
+        self.assertTrue(
+            gs.sum(gs.abs(gs.imag(out))) > gs.atol, msg="Zero imaginary part"
+        )


### PR DESCRIPTION
Generalizes #1721 by creating proper decorators and applying them to other distributions.

Additional tests were added to ensure imaginary numbers are handled properly.

Necessary for #1739.