### PR TITLE
Fix autograd value_and_grad to avoid duplicate computation of value

### DIFF
--- a/geomstats/_backend/autograd/autodiff.py
+++ b/geomstats/_backend/autograd/autodiff.py
@@ -129,8 +129,8 @@ def value_and_grad(func, to_numpy=False):
             Values of func's gradients at input arguments args.
         """
         n_args = len(args)
-        value = func(*args)
 
+        all_values = []
         all_grads = []
         for i in range(n_args):
 
@@ -139,12 +139,15 @@ def value_and_grad(func, to_numpy=False):
                 return func(*reorg_args)
 
             new_args = (args[i],) + args[:i] + args[i + 1 :]
-            _, grad_i = _value_and_grad(func_of_ith)(*new_args)
+            value_i, grad_i = _value_and_grad(func_of_ith)(*new_args)
+
+            all_values.append(value_i)
             all_grads.append(grad_i)
 
         if n_args == 1:
-            return value, all_grads[0]
-        return value, tuple(all_grads)
+            return all_values[0], all_grads[0]
+
+        return _np.stack(all_values), tuple(all_grads)
 
     return func_with_grad
 


### PR DESCRIPTION
value comes from free when computing gradient, so we don't need to recompute it. This is especially relevant for cases where computation of value is expensive (which is often the case in `geomstats`).