### PR TITLE
Fix FisherRaoMetric inner product derivative matrix

### DIFF
--- a/geomstats/information_geometry/fisher_rao_metric.py
+++ b/geomstats/information_geometry/fisher_rao_metric.py
@@ -41,10 +41,17 @@ class FisherRaoMetric(RiemannianMetric):
         at the tangent space at base point.
 
         .. math::
-            I(\theta) = \mathbb{E}[(\partial_{\theta}(\log(f_{\theta}(x))))^2]
+
+            I(\theta) = \mathbb{E}[YY^T]
+
+        where,
+
+        ..math::
+
+            Y = \nabla_{\theta} \log f_{\theta}(x)
 
 
-        or, in indicial notation
+        After manipulation and in indicial notation
 
         .. math::
              I_{ij} = \int \
@@ -122,18 +129,24 @@ class FisherRaoMetric(RiemannianMetric):
 
         .. math::
 
-            I(\theta) = \partial_{\theta} \
-            \mathbb{E}[(\partial_{\theta}(\log(f_{\theta}(x))))^2]
+            I(\theta) = \partial_{\theta} \mathbb{E}[YY^T]
+
+        where,
+
+        ..math::
+
+            Y = \nabla_{\theta} \log f_{\theta}(x)
 
         or, in indicial notation:
 
         .. math::
+
             \partial_k I_{ij} = \int\
             \partial_{ki}^2 f\partial_j f \frac{1}{f} + \
             \partial_{kj}^2 f\partial_i f \frac{1}{f} - \
             \partial_i f \partial_j f \partial_k f \frac{1}{f^2}
 
-        with :math:`f = f_{\theta}(x)
+        with :math:`f = f_{\theta}(x)`
 
 
         Parameters

--- a/geomstats/information_geometry/fisher_rao_metric.py
+++ b/geomstats/information_geometry/fisher_rao_metric.py
@@ -76,46 +76,31 @@ class FisherRaoMetric(RiemannianMetric):
             Differential Geometric Methods in Statistics, Berlin, Springer – Verlag.
         """
 
-        def log_pdf_at_x(x):
-            """Compute the log function of the pdf for a fixed value on the support.
+        def pdf(x):
+            """Compute pdf at a fixed point on the support.
 
             Parameters
             ----------
             x : float, shape (,)
                 Point on the support of the distribution
             """
-            return lambda point: gs.log(
-                self.information_manifold.point_to_pdf(point)(x)
+            return lambda point: self.information_manifold.point_to_pdf(point)(x)
+
+        def _function_to_integrate(x):
+            pdf_x = pdf(x)
+            pdf_x_at_base_point = pdf_x(base_point)
+            pdf_x_derivative = gs.autodiff.jacobian(pdf_x)
+            pdf_x_derivative_at_base_point = pdf_x_derivative(base_point)
+            return (
+                gs.einsum(
+                    "...i,...j->...ij",
+                    pdf_x_derivative_at_base_point,
+                    pdf_x_derivative_at_base_point,
+                )
+                / pdf_x_at_base_point
             )
 
-        def log_pdf_derivative(x):
-            """Compute the derivative of the log-pdf with respect to the parameters.
-
-            Parameters
-            ----------
-            x : float, shape (,)
-                Point on the support of the distribution
-            """
-            return gs.autodiff.jacobian(log_pdf_at_x(x))(base_point)
-
-        def log_pdf_derivative_squared(x):
-            """Compute the square (in matrix terms) of dlog.
-
-            This is the variable whose expectance is the Fisher-Rao information.
-
-            Parameters
-            ----------
-            x : float, shape (,)
-                Point on the support of the distribution
-            """
-            dlog = log_pdf_derivative(x)
-            return gs.einsum("...i, ...j -> ...ij", dlog, dlog)
-
-        metric_mat = quad_vec(
-            lambda x: log_pdf_derivative_squared(x)
-            * self.information_manifold.point_to_pdf(base_point)(x),
-            *self.support
-        )[0]
+        metric_mat = quad_vec(_function_to_integrate, *self.support)[0]
 
         if metric_mat.ndim == 3 and metric_mat.shape[0] == 1:
             return metric_mat[0]

--- a/tests/data/fisher_rao_metric_data.py
+++ b/tests/data/fisher_rao_metric_data.py
@@ -4,6 +4,7 @@ import geomstats.backend as gs
 from geomstats.information_geometry.exponential import ExponentialDistributions
 from geomstats.information_geometry.fisher_rao_metric import FisherRaoMetric
 from geomstats.information_geometry.normal import (
+    NormalDistributions,
     UnivariateNormalDistributions,
     UnivariateNormalMetric,
 )
@@ -66,5 +67,19 @@ class FisherRaoMetricTestData(_RiemannianMetricTestData):
                 closed_form_metric=UnivariateNormalMetric(),
                 base_point=gs.array([0.1, 0.8]),
             )
+        ]
+        return self.generate_tests(smoke_data)
+
+    def inner_product_and_closed_form_inner_product_test_data(self):
+        normal_dists = NormalDistributions(sample_dim=1)
+        smoke_data = [
+            dict(
+                information_manifold=normal_dists,
+                support=(-20, 20),
+                closed_form_metric=normal_dists.metric,
+                tangent_vec_a=gs.array([1.0, 2.0]),
+                tangent_vec_b=gs.array([1.0, 2.0]),
+                base_point=gs.array([1.0, 2.0]),
+            ),
         ]
         return self.generate_tests(smoke_data)

--- a/tests/tests_geomstats/test_fisher_rao_metric.py
+++ b/tests/tests_geomstats/test_fisher_rao_metric.py
@@ -48,3 +48,25 @@ class TestFisherRaoMetric(TestCase, metaclass=Parametrizer):
             base_point=base_point,
         )
         self.assertAllClose(inner_prod_mat, normal_metric_mat)
+
+    def test_inner_product_and_closed_form_inner_product(
+        self,
+        information_manifold,
+        support,
+        closed_form_metric,
+        tangent_vec_a,
+        tangent_vec_b,
+        base_point,
+    ):
+        metric = self.Metric(information_manifold=information_manifold, support=support)
+        inner_prod_mat = metric.inner_product(
+            tangent_vec_a=tangent_vec_a,
+            tangent_vec_b=tangent_vec_b,
+            base_point=base_point,
+        )
+        normal_metric_mat = closed_form_metric.inner_product(
+            tangent_vec_a=tangent_vec_a,
+            tangent_vec_b=tangent_vec_b,
+            base_point=base_point,
+        )
+        self.assertAllClose(inner_prod_mat, normal_metric_mat)


### PR DESCRIPTION
Fix `FisherRaoMetric.inner_product_derivative_matrix`.

Previous formula was incorrect. Validation done against univariate normal distributions (further validation to be done soon).

Updated docstrings and added back earlier removed tests.


Done with @alebrigant.