### PR TITLE
Fix learning algorithms to work with last sklearn version

### DIFF
--- a/geomstats/learning/_sklearn_wrapper.py
+++ b/geomstats/learning/_sklearn_wrapper.py
@@ -7,9 +7,30 @@ import geomstats.backend as gs
 class WrappedPCA(PCA):
     # TODO: wrap by manipulating __new__?
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
+    def __init__(
+        self,
+        n_components=None,
+        *,
+        copy=True,
+        whiten=False,
+        svd_solver="auto",
+        tol=0.0,
+        iterated_power="auto",
+        n_oversamples=10,
+        power_iteration_normalizer="auto",
+        random_state=None,
+    ):
+        super().__init__(
+            n_components,
+            copy=copy,
+            whiten=whiten,
+            svd_solver=svd_solver,
+            tol=tol,
+            iterated_power=iterated_power,
+            n_oversamples=n_oversamples,
+            power_iteration_normalizer=power_iteration_normalizer,
+            random_state=random_state,
+        )
         self._init_shape = None
 
     def __repr__(self):
@@ -52,8 +73,17 @@ class WrappedPCA(PCA):
 class WrappedLinearRegression(LinearRegression):
     # TODO: wrap by manipulating __new__?
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(
+        self,
+        *,
+        fit_intercept=True,
+        copy_X=True,
+        n_jobs=None,
+        positive=False,
+    ):
+        super().__init__(
+            fit_intercept=fit_intercept, copy_X=copy_X, n_jobs=n_jobs, positive=positive
+        )
 
         self._init_shape_X = None
         self._init_shape_y = None

--- a/geomstats/learning/agglomerative_hierarchical_clustering.py
+++ b/geomstats/learning/agglomerative_hierarchical_clustering.py
@@ -101,6 +101,7 @@ class AgglomerativeHierarchicalClustering(AgglomerativeClustering):
         linkage="average",
         distance_threshold=None,
     ):
+        self.distance = distance
 
         if isinstance(distance, str):
             affinity = distance

--- a/geomstats/learning/kernel_density_estimation_classifier.py
+++ b/geomstats/learning/kernel_density_estimation_classifier.py
@@ -151,6 +151,10 @@ class KernelDensityEstimationClassifier(RadiusNeighborsClassifier):
         if callable(distance):
             distance = wrap(distance)
 
+        self.distance = distance
+        self.distance_params = distance_params
+        self.kernel = kernel
+
         super().__init__(
             radius=radius,
             weights=weights,

--- a/geomstats/learning/knn.py
+++ b/geomstats/learning/knn.py
@@ -77,6 +77,8 @@ class KNearestNeighborsClassifier(KNeighborsClassifier):
         n_jobs=None,
         **kwargs
     ):
+        self.distance = distance
+        self.distance_params = distance_params
 
         super().__init__(
             n_neighbors=n_neighbors,


### PR DESCRIPTION
Last sklearn release ([1.2.0](https://pypi.org/project/scikit-learn/1.2.0/)) needs all the class parameters to be stored as class attributes when inheriting from a sklearn estimator object. This is done in this PR to ensure compatibility. No backwards compatibility broken. 