### PR TITLE
Reserve `scale` parameter to ScalarProductMetric

### DIFF
--- a/examples/plot_geodesics_poincare_polydisk.py
+++ b/examples/plot_geodesics_poincare_polydisk.py
@@ -12,7 +12,7 @@ from geomstats.geometry.poincare_polydisk import PoincarePolydisk
 
 N_DISKS = 4
 
-POINCARE_POLYDISK = PoincarePolydisk(n_disks=N_DISKS, default_coords_type="extrinsic")
+POINCARE_POLYDISK = PoincarePolydisk(n_disks=N_DISKS)
 METRIC = POINCARE_POLYDISK.metric
 
 

--- a/geomstats/geometry/_hyperbolic.py
+++ b/geomstats/geometry/_hyperbolic.py
@@ -21,7 +21,7 @@ class _Hyperbolic:
     """
 
     def __init__(self, **kwargs):
-        if "scale" in kwargs.keys():
+        if "scale" in kwargs:
             raise TypeError(
                 "Argument scale is no longer in use: instantiate the "
                 "manifold without this parameter and then use "
@@ -459,7 +459,7 @@ class HyperbolicMetric(RiemannianMetric):
     """
 
     def __init__(self, dim, default_coords_type="extrinsic", **kwargs):
-        if "scale" in kwargs.keys():
+        if "scale" in kwargs:
             raise TypeError(
                 "Argument scale is no longer in use: instantiate scaled "
                 "metrics as `scale * RiemannianMetric`. Note that the "

--- a/geomstats/geometry/_hyperbolic.py
+++ b/geomstats/geometry/_hyperbolic.py
@@ -21,6 +21,10 @@ class _Hyperbolic:
     """
 
     def __init__(self, **kwargs):
+        if 'scale' in kwargs.keys():
+            raise TypeError("Argument scale is no longer in use: instantiate the "
+                            "manifold without this parameter and then use "
+                            "`scale * metric` to rescale the standard metric.")
         super().__init__(**kwargs)
 
     @staticmethod
@@ -452,7 +456,11 @@ class HyperbolicMetric(RiemannianMetric):
         Default coordinates to represent points in hyperbolic space.
     """
 
-    def __init__(self, dim, default_coords_type="extrinsic"):
+    def __init__(self, dim, default_coords_type="extrinsic", **kwargs):
+        if 'scale' in kwargs.keys():
+            raise TypeError("Argument scale is no longer in use: instantiate scaled "
+                            "metrics as `scale * RiemannianMetric`. Note that the "
+                            "metric is scaled, not the distance.")
         super().__init__(
             dim=dim,
             signature=(dim, 0),

--- a/geomstats/geometry/_hyperbolic.py
+++ b/geomstats/geometry/_hyperbolic.py
@@ -441,6 +441,9 @@ class _Hyperbolic:
 class HyperbolicMetric(RiemannianMetric):
     """Class that defines operations using a hyperbolic metric.
 
+    This class does not contain any methods and is only defined to act as a parent
+    class for `HyperboloidMetric`, `PoincareBallMetric` and `PoincareHalfSpaceMetric`.
+
     Parameters
     ----------
     dim : int
@@ -455,90 +458,4 @@ class HyperbolicMetric(RiemannianMetric):
             signature=(dim, 0),
             shape=(dim + 1,),
             default_coords_type=default_coords_type,
-        )
-
-    def inner_product(self, tangent_vec_a, tangent_vec_b, base_point=None):
-        """Compute the inner-product of two tangent vectors at a base point.
-
-        Parameters
-        ----------
-        tangent_vec_a : array-like, shape=[..., dim + 1]
-            First tangent vector at base point.
-        tangent_vec_b : array-like, shape=[..., dim + 1]
-            Second tangent vector at base point.
-        base_point : array-like, shape=[..., dim + 1]
-            Point in hyperbolic space.
-            Optional, default: None.
-
-        Returns
-        -------
-        inner_prod : array-like, shape=[..., 1]
-            Inner-product of the two tangent vectors.
-        """
-        inner_prod = self._inner_product(tangent_vec_a, tangent_vec_b, base_point)
-        return inner_prod
-
-    def squared_norm(self, vector, base_point=None):
-        """Compute the squared norm of a vector.
-
-        Squared norm of a vector associated with the inner-product
-        at the tangent space at a base point.
-
-        Parameters
-        ----------
-        vector : array-like, shape=[..., dim + 1]
-            Vector on the tangent space of the hyperbolic space at base point.
-        base_point : array-like, shape=[..., dim + 1]
-            Point in hyperbolic space in extrinsic coordinates.
-            Optional, default: None.
-
-        Returns
-        -------
-        sq_norm : array-like, shape=[..., 1]
-            Squared norm of the vector.
-        """
-        sq_norm = self._squared_norm(vector)
-        return sq_norm
-
-    def _squared_norm(self, vector, base_point=None):
-        """Squared norm.
-
-        Squared norm of a vector associated with the inner-product
-        at the tangent space at a base point.
-
-        Parameters
-        ----------
-        vector : array-like, shape=[..., dim + 1]
-            Vector on the tangent space of the hyperbolic space at base point.
-        base_point : array-like, shape=[..., dim + 1]
-            Point in hyperbolic space in extrinsic coordinates.
-            Optional, default: None.
-
-        Returns
-        -------
-        sq_norm : array-like, shape=[..., 1]
-            Squared norm of the vector.
-        """
-        return super().squared_norm(vector, base_point=base_point)
-
-    def _inner_product(self, tangent_vec_a, tangent_vec_b, base_point=None):
-        """Compute the inner-product of two tangent vectors.
-
-        Parameters
-        ----------
-        tangent_vec_a : array-like, shape=[..., dim + 1]
-            First tangent vector at base point.
-        tangent_vec_b : array-like, shape=[..., dim + 1]
-            Second tangent vector at base point.
-        base_point : array-like, shape=[..., dim + 1]
-            Point in hyperbolic space.
-            Optional, default: None.
-
-        Returns
-        -------
-        inner_prod : array-like, shape=[..., 1]
-            Inner-product of the two tangent vectors.
-        """
-        return super().inner_product(
-            tangent_vec_a, tangent_vec_b, base_point=base_point
         )

--- a/geomstats/geometry/_hyperbolic.py
+++ b/geomstats/geometry/_hyperbolic.py
@@ -20,7 +20,7 @@ class _Hyperbolic:
     chosen representation: Hyperboloid, Poincare Ball or Poincare Half-space.
     """
 
-    def __init__(self, scaling_factor=1.0, **kwargs):
+    def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
     @staticmethod

--- a/geomstats/geometry/_hyperbolic.py
+++ b/geomstats/geometry/_hyperbolic.py
@@ -18,18 +18,10 @@ class _Hyperbolic:
     This class cannot be instantiated in itself, but a public class
     `Hyperbolic` is available, that returns the class that corresponds to the
     chosen representation: Hyperboloid, Poincare Ball or Poincare Half-space.
-
-    Parameters
-    ----------
-    scale : int
-        Scale of the hyperbolic space, defined as the set of points
-        in Minkowski space whose squared norm is equal to -scale.
-        Optional, default: 1.
     """
 
-    def __init__(self, scale=1, **kwargs):
+    def __init__(self, scaling_factor=1.0, **kwargs):
         super().__init__(**kwargs)
-        self.scale = scale
 
     @staticmethod
     def _extrinsic_to_extrinsic_coordinates(point):
@@ -455,20 +447,15 @@ class HyperbolicMetric(RiemannianMetric):
         Dimension of the hyperbolic space.
     default_coords_type : str, {'extrinsic', 'intrinsic', etc}, optional
         Default coordinates to represent points in hyperbolic space.
-    scale : int, optional
-        Scale of the hyperbolic space, defined as the set of points
-        in Minkowski space whose squared norm is equal to -scale.
     """
 
-    def __init__(self, dim, scale=1, default_coords_type="extrinsic"):
+    def __init__(self, dim, default_coords_type="extrinsic"):
         super().__init__(
             dim=dim,
             signature=(dim, 0),
             shape=(dim + 1,),
             default_coords_type=default_coords_type,
         )
-
-        self.scale = scale
 
     def inner_product(self, tangent_vec_a, tangent_vec_b, base_point=None):
         """Compute the inner-product of two tangent vectors at a base point.
@@ -489,7 +476,6 @@ class HyperbolicMetric(RiemannianMetric):
             Inner-product of the two tangent vectors.
         """
         inner_prod = self._inner_product(tangent_vec_a, tangent_vec_b, base_point)
-        inner_prod *= self.scale**2
         return inner_prod
 
     def squared_norm(self, vector, base_point=None):
@@ -512,14 +498,13 @@ class HyperbolicMetric(RiemannianMetric):
             Squared norm of the vector.
         """
         sq_norm = self._squared_norm(vector)
-        sq_norm *= self.scale**2
         return sq_norm
 
     def _squared_norm(self, vector, base_point=None):
-        """Squared norm with hyperbolic scale 1.
+        """Squared norm.
 
         Squared norm of a vector associated with the inner-product
-        at the tangent space at a base point with scale=1.
+        at the tangent space at a base point.
 
         Parameters
         ----------
@@ -537,7 +522,7 @@ class HyperbolicMetric(RiemannianMetric):
         return super().squared_norm(vector, base_point=base_point)
 
     def _inner_product(self, tangent_vec_a, tangent_vec_b, base_point=None):
-        """Compute the inner-product of two tangent vectors with scale=1.
+        """Compute the inner-product of two tangent vectors.
 
         Parameters
         ----------

--- a/geomstats/geometry/_hyperbolic.py
+++ b/geomstats/geometry/_hyperbolic.py
@@ -21,10 +21,12 @@ class _Hyperbolic:
     """
 
     def __init__(self, **kwargs):
-        if 'scale' in kwargs.keys():
-            raise TypeError("Argument scale is no longer in use: instantiate the "
-                            "manifold without this parameter and then use "
-                            "`scale * metric` to rescale the standard metric.")
+        if "scale" in kwargs.keys():
+            raise TypeError(
+                "Argument scale is no longer in use: instantiate the "
+                "manifold without this parameter and then use "
+                "`scale * metric` to rescale the standard metric."
+            )
         super().__init__(**kwargs)
 
     @staticmethod
@@ -457,10 +459,12 @@ class HyperbolicMetric(RiemannianMetric):
     """
 
     def __init__(self, dim, default_coords_type="extrinsic", **kwargs):
-        if 'scale' in kwargs.keys():
-            raise TypeError("Argument scale is no longer in use: instantiate scaled "
-                            "metrics as `scale * RiemannianMetric`. Note that the "
-                            "metric is scaled, not the distance.")
+        if "scale" in kwargs.keys():
+            raise TypeError(
+                "Argument scale is no longer in use: instantiate scaled "
+                "metrics as `scale * RiemannianMetric`. Note that the "
+                "metric is scaled, not the distance."
+            )
         super().__init__(
             dim=dim,
             signature=(dim, 0),

--- a/geomstats/geometry/complex_poincare_disk.py
+++ b/geomstats/geometry/complex_poincare_disk.py
@@ -31,22 +31,15 @@ class ComplexPoincareDisk(ComplexOpenSet):
 
     The Poincaré disk is a representation of the Hyperbolic
     space of dimension 2. Its complex dimension is 1.
-
-    Parameters
-    ----------
-    scale : float
-        Scale of the complex Poincaré metric.
-        Optional, default: 1.
     """
 
-    def __init__(self, scale=1.0, **kwargs):
+    def __init__(self, **kwargs):
         super().__init__(
             dim=1,
             embedding_space=Hermitian(dim=1),
-            metric=ComplexPoincareDiskMetric(scale=scale),
+            metric=ComplexPoincareDiskMetric(),
             **kwargs
         )
-        self.scale = scale
 
     @staticmethod
     def belongs(point, atol=gs.atol):
@@ -123,22 +116,14 @@ class ComplexPoincareDisk(ComplexOpenSet):
 
 
 class ComplexPoincareDiskMetric(ComplexRiemannianMetric):
-    """Class for the complex Poincaré metric.
+    """Class for the complex Poincaré metric."""
 
-    Parameters
-    ----------
-    scale : float
-        Scale of the complex Poincaré metric.
-        Optional, default: 1.
-    """
-
-    def __init__(self, scale=1.0):
+    def __init__(self):
         super().__init__(
             dim=1,
             shape=(1,),
             signature=(1, 0),
         )
-        self.scale = scale
 
     def metric_matrix(self, base_point):
         """Compute the metric matrix at base point.
@@ -155,7 +140,6 @@ class ComplexPoincareDiskMetric(ComplexRiemannianMetric):
         """
         inner_prod_mat = 1 / (1 - gs.abs(base_point) ** 2) ** 2
         inner_prod_mat = gs.cast(inner_prod_mat, dtype=gs.get_default_cdtype())
-        inner_prod_mat *= self.scale**2
         return gs.expand_dims(inner_prod_mat, axis=-1)
 
     @staticmethod
@@ -271,7 +255,7 @@ class ComplexPoincareDiskMetric(ComplexRiemannianMetric):
             Riemannian squared distance.
         """
         sq_dist = self._tau(point_a, point_b, atol=atol)
-        return self.scale**2 * gs.power(sq_dist, 2)
+        return gs.power(sq_dist, 2)
 
     def dist(self, point_a, point_b, atol=gs.atol):
         """Compute the complex Poincaré disk distance.
@@ -293,4 +277,4 @@ class ComplexPoincareDiskMetric(ComplexRiemannianMetric):
         dist : array-like, shape=[...]
             Riemannian distance.
         """
-        return self.scale * self._tau(point_a, point_b, atol=atol)
+        return self._tau(point_a, point_b, atol=atol)

--- a/geomstats/geometry/complex_poincare_disk.py
+++ b/geomstats/geometry/complex_poincare_disk.py
@@ -34,7 +34,7 @@ class ComplexPoincareDisk(ComplexOpenSet):
     """
 
     def __init__(self, **kwargs):
-        if "scale" in kwargs.keys():
+        if "scale" in kwargs:
             raise TypeError(
                 "Argument scale is no longer in use: instantiate the "
                 "manifold without this parameter and then use "
@@ -125,7 +125,7 @@ class ComplexPoincareDiskMetric(ComplexRiemannianMetric):
     """Class for the complex Poincaré metric."""
 
     def __init__(self, **kwargs):
-        if "scale" in kwargs.keys():
+        if "scale" in kwargs:
             raise TypeError(
                 "Argument scale is no longer in use: instantiate scaled "
                 "metrics as `scale * RiemannianMetric`. Note that the "

--- a/geomstats/geometry/complex_poincare_disk.py
+++ b/geomstats/geometry/complex_poincare_disk.py
@@ -34,6 +34,10 @@ class ComplexPoincareDisk(ComplexOpenSet):
     """
 
     def __init__(self, **kwargs):
+        if 'scale' in kwargs.keys():
+            raise TypeError("Argument scale is no longer in use: instantiate the "
+                            "manifold without this parameter and then use "
+                            "`scale * metric` to rescale the standard metric.")
         super().__init__(
             dim=1,
             embedding_space=Hermitian(dim=1),
@@ -118,7 +122,11 @@ class ComplexPoincareDisk(ComplexOpenSet):
 class ComplexPoincareDiskMetric(ComplexRiemannianMetric):
     """Class for the complex Poincaré metric."""
 
-    def __init__(self):
+    def __init__(self, **kwargs):
+        if 'scale' in kwargs.keys():
+            raise TypeError("Argument scale is no longer in use: instantiate scaled "
+                            "metrics as `scale * RiemannianMetric`. Note that the "
+                            "metric is scaled, not the distance.")
         super().__init__(
             dim=1,
             shape=(1,),

--- a/geomstats/geometry/complex_poincare_disk.py
+++ b/geomstats/geometry/complex_poincare_disk.py
@@ -34,10 +34,12 @@ class ComplexPoincareDisk(ComplexOpenSet):
     """
 
     def __init__(self, **kwargs):
-        if 'scale' in kwargs.keys():
-            raise TypeError("Argument scale is no longer in use: instantiate the "
-                            "manifold without this parameter and then use "
-                            "`scale * metric` to rescale the standard metric.")
+        if "scale" in kwargs.keys():
+            raise TypeError(
+                "Argument scale is no longer in use: instantiate the "
+                "manifold without this parameter and then use "
+                "`scale * metric` to rescale the standard metric."
+            )
         super().__init__(
             dim=1,
             embedding_space=Hermitian(dim=1),
@@ -123,10 +125,12 @@ class ComplexPoincareDiskMetric(ComplexRiemannianMetric):
     """Class for the complex Poincaré metric."""
 
     def __init__(self, **kwargs):
-        if 'scale' in kwargs.keys():
-            raise TypeError("Argument scale is no longer in use: instantiate scaled "
-                            "metrics as `scale * RiemannianMetric`. Note that the "
-                            "metric is scaled, not the distance.")
+        if "scale" in kwargs.keys():
+            raise TypeError(
+                "Argument scale is no longer in use: instantiate scaled "
+                "metrics as `scale * RiemannianMetric`. Note that the "
+                "metric is scaled, not the distance."
+            )
         super().__init__(
             dim=1,
             shape=(1,),

--- a/geomstats/geometry/hpd_matrices.py
+++ b/geomstats/geometry/hpd_matrices.py
@@ -503,7 +503,7 @@ class HPDAffineMetric(ComplexRiemannianMetric):
     """
 
     def __init__(self, n, power_affine=1, **kwargs):
-        if "scale" in kwargs.keys():
+        if "scale" in kwargs:
             raise TypeError(
                 "Argument scale is no longer in use: instantiate scaled "
                 "metrics as `scale * RiemannianMetric`. Note that the "

--- a/geomstats/geometry/hpd_matrices.py
+++ b/geomstats/geometry/hpd_matrices.py
@@ -25,9 +25,6 @@ class HPDMatrices(OpenSet):
     ----------
     n : int
         Integer representing the shape of the matrices: n x n.
-    scale : float
-        Scale of the HPD matrices metric.
-        Optional, default: 1.
 
     References
     ----------
@@ -40,11 +37,10 @@ class HPDMatrices(OpenSet):
         https://epubs.siam.org/doi/pdf/10.1137/15M102112X
     """
 
-    def __init__(self, n, scale=1.0, **kwargs):
-        kwargs.setdefault("metric", HPDAffineMetric(n, scale=scale))
+    def __init__(self, n, **kwargs):
+        kwargs.setdefault("metric", HPDAffineMetric(n))
         super().__init__(dim=n**2, embedding_space=HermitianMatrices(n), **kwargs)
         self.n = n
-        self.scale = scale
 
     def belongs(self, mat, atol=gs.atol):
         """Check if a matrix is Hermitian with positive eigenvalues.
@@ -494,9 +490,6 @@ class HPDAffineMetric(ComplexRiemannianMetric):
     power_affine : int
         Power transformation of the classical HPD metric.
         Optional, default: 1.
-    scale : float
-        Scale of the HPD matrices metric.
-        Optional, default: 1.
 
     References
     ----------
@@ -509,7 +502,7 @@ class HPDAffineMetric(ComplexRiemannianMetric):
         https://epubs.siam.org/doi/pdf/10.1137/15M102112X
     """
 
-    def __init__(self, n, power_affine=1, scale=1.0):
+    def __init__(self, n, power_affine=1):
         dim = int(n * (n + 1) / 2)
         super().__init__(
             dim=dim,
@@ -518,7 +511,6 @@ class HPDAffineMetric(ComplexRiemannianMetric):
         )
         self.n = n
         self.power_affine = power_affine
-        self.scale = scale
 
     @staticmethod
     def _aux_inner_product(tangent_vec_a, tangent_vec_b, inv_base_point):
@@ -583,7 +575,6 @@ class HPDAffineMetric(ComplexRiemannianMetric):
 
             inner_product = inner_product / (power_affine**2)
 
-        inner_product *= self.scale**2
         return inner_product
 
     @staticmethod

--- a/geomstats/geometry/hpd_matrices.py
+++ b/geomstats/geometry/hpd_matrices.py
@@ -503,10 +503,12 @@ class HPDAffineMetric(ComplexRiemannianMetric):
     """
 
     def __init__(self, n, power_affine=1, **kwargs):
-        if 'scale' in kwargs.keys():
-            raise TypeError("Argument scale is no longer in use: instantiate scaled "
-                            "metrics as `scale * RiemannianMetric`. Note that the "
-                            "metric is scaled, not the distance.")
+        if "scale" in kwargs.keys():
+            raise TypeError(
+                "Argument scale is no longer in use: instantiate scaled "
+                "metrics as `scale * RiemannianMetric`. Note that the "
+                "metric is scaled, not the distance."
+            )
         dim = int(n * (n + 1) / 2)
         super().__init__(
             dim=dim,

--- a/geomstats/geometry/hpd_matrices.py
+++ b/geomstats/geometry/hpd_matrices.py
@@ -502,7 +502,11 @@ class HPDAffineMetric(ComplexRiemannianMetric):
         https://epubs.siam.org/doi/pdf/10.1137/15M102112X
     """
 
-    def __init__(self, n, power_affine=1):
+    def __init__(self, n, power_affine=1, **kwargs):
+        if 'scale' in kwargs.keys():
+            raise TypeError("Argument scale is no longer in use: instantiate scaled "
+                            "metrics as `scale * RiemannianMetric`. Note that the "
+                            "metric is scaled, not the distance.")
         dim = int(n * (n + 1) / 2)
         super().__init__(
             dim=dim,

--- a/geomstats/geometry/hyperbolic.py
+++ b/geomstats/geometry/hyperbolic.py
@@ -15,8 +15,9 @@ class Hyperbolic:
     This class is a common interface to the different models of hyperbolic
     geometry:
 
-    - the hyperboloid, embedded in Minkowski space of dimension dim + 1. This
-      representation is called `extrinsic` here.
+    - the hyperboloid, embedded in Minkowski space of dimension dim + 1 as the set of
+      points whose squared norm is equal to -1. This representation is called
+      `extrinsic` here.
     - the Poincare ball, the open ball of the Euclidean space of dimension dim.
     - the Poincare half-space, the open space of points of the Euclidean
       space of  dimension dim, whose last coordinate is positive.
@@ -28,10 +29,6 @@ class Hyperbolic:
     default_coords_type : str, {'extrinsic', 'ball', 'half-space'}
         Default coordinates to represent points in hyperbolic space.
         Optional, default: 'extrinsic'.
-    scale : int
-        Scale of the hyperbolic space, defined as the set of points
-        in Minkowski space whose squared norm is equal to -scale.
-        Optional, default: 1.
     """
 
     def __new__(cls, *args, default_coords_type="extrinsic", **kwargs):

--- a/geomstats/geometry/hyperboloid.py
+++ b/geomstats/geometry/hyperboloid.py
@@ -36,7 +36,7 @@ class Hyperboloid(_Hyperbolic, LevelSet):
     """
 
     def __init__(self, dim, default_coords_type="extrinsic", **kwargs):
-        if "scale" in kwargs.keys():
+        if "scale" in kwargs:
             raise TypeError(
                 "Argument scale is no longer in use: instantiate the "
                 "manifold without this parameter and then use "

--- a/geomstats/geometry/hyperboloid.py
+++ b/geomstats/geometry/hyperboloid.py
@@ -36,10 +36,12 @@ class Hyperboloid(_Hyperbolic, LevelSet):
     """
 
     def __init__(self, dim, default_coords_type="extrinsic", **kwargs):
-        if 'scale' in kwargs.keys():
-            raise TypeError("Argument scale is no longer in use: instantiate the "
-                            "manifold without this parameter and then use "
-                            "`scale * metric` to rescale the standard metric.")
+        if "scale" in kwargs.keys():
+            raise TypeError(
+                "Argument scale is no longer in use: instantiate the "
+                "manifold without this parameter and then use "
+                "`scale * metric` to rescale the standard metric."
+            )
         self.dim = dim
         kwargs.setdefault("metric", HyperboloidMetric(dim, default_coords_type))
         super().__init__(dim=dim, default_coords_type=default_coords_type, **kwargs)

--- a/geomstats/geometry/hyperboloid.py
+++ b/geomstats/geometry/hyperboloid.py
@@ -285,7 +285,7 @@ class HyperboloidMetric(HyperbolicMetric):
         """
         return self.embedding_metric.metric_matrix(base_point)
 
-    def _inner_product(self, tangent_vec_a, tangent_vec_b, base_point=None):
+    def inner_product(self, tangent_vec_a, tangent_vec_b, base_point=None):
         """Compute the inner-product of two tangent vectors at a base point.
 
         Parameters
@@ -307,7 +307,7 @@ class HyperboloidMetric(HyperbolicMetric):
         )
         return inner_prod
 
-    def _squared_norm(self, vector, base_point=None):
+    def squared_norm(self, vector, base_point=None):
         """Compute the squared norm of a vector.
 
         Squared norm of a vector associated with the inner-product

--- a/geomstats/geometry/hyperboloid.py
+++ b/geomstats/geometry/hyperboloid.py
@@ -19,12 +19,12 @@ from geomstats.geometry.minkowski import Minkowski, MinkowskiMetric
 class Hyperboloid(_Hyperbolic, LevelSet):
     """Class for the n-dimensional hyperboloid space.
 
-    Class for the n-dimensional hyperboloid space as embedded in (
-    n+1)-dimensional Minkowski space. For other representations of
-    hyperbolic spaces see the `Hyperbolic` class.
+    Class for the n-dimensional hyperboloid space as embedded in (n+1)-dimensional
+    Minkowski space as the set of points with squared norm equal to -1. For other
+    representations of hyperbolic spaces see the `Hyperbolic` class.
 
-    The default_coords_type parameter allows to choose the
-    representation of the points as input.
+    The default_coords_type parameter allows to choose the representation of the
+    points as input.
 
     Parameters
     ----------
@@ -33,17 +33,13 @@ class Hyperboloid(_Hyperbolic, LevelSet):
     default_coords_type : str, {'extrinsic', 'intrinsic'}
         Default coordinates to represent points in hyperbolic space.
         Optional, default: 'extrinsic'.
-    scale : int
-        Scale of the hyperbolic space, defined as the set of points
-        in Minkowski space whose squared norm is equal to -scale.
-        Optional, default: 1.
     """
 
-    def __init__(self, dim, default_coords_type="extrinsic", scale=1, **kwargs):
+    def __init__(self, dim, default_coords_type="extrinsic", **kwargs):
         self.dim = dim
-        kwargs.setdefault("metric", HyperboloidMetric(dim, default_coords_type, scale))
+        kwargs.setdefault("metric", HyperboloidMetric(dim, default_coords_type))
         super().__init__(
-            dim=dim, default_coords_type=default_coords_type, scale=scale, **kwargs
+            dim=dim, default_coords_type=default_coords_type, **kwargs
         )
 
     def _define_embedding_space(self):
@@ -269,16 +265,11 @@ class HyperboloidMetric(HyperbolicMetric):
     default_coords_type : str, {'extrinsic', 'intrinsic', etc}
         Default coordinates to represent points in hyperbolic space.
         Optional, default: 'extrinsic'.
-    scale : int
-        Scale of the hyperbolic space, defined as the set of points
-        in Minkowski space whose squared norm is equal to -scale.
-        Optional, default: 1.
     """
 
-    def __init__(self, dim, default_coords_type="extrinsic", scale=1):
-        super().__init__(dim=dim, scale=scale, default_coords_type=default_coords_type)
+    def __init__(self, dim, default_coords_type="extrinsic"):
+        super().__init__(dim=dim, default_coords_type=default_coords_type)
         self.embedding_metric = MinkowskiMetric(dim + 1)
-        self.scale = scale
 
     def metric_matrix(self, base_point=None):
         """Compute the inner product matrix.
@@ -392,7 +383,7 @@ class HyperboloidMetric(HyperbolicMetric):
             Tangent vector at the base point equal to the Riemannian logarithm
             of point at the base point.
         """
-        angle = self.dist(base_point, point) / self.scale
+        angle = self.dist(base_point, point)
 
         coef_1_ = utils.taylor_exp_even_func(
             angle**2, utils.inv_sinch_close_0, order=4
@@ -429,7 +420,6 @@ class HyperboloidMetric(HyperbolicMetric):
         cosh_angle = gs.clip(cosh_angle, 1.0, 1e24)
 
         dist = gs.arccosh(cosh_angle)
-        dist *= self.scale
         return dist
 
     def parallel_transport(

--- a/geomstats/geometry/hyperboloid.py
+++ b/geomstats/geometry/hyperboloid.py
@@ -36,6 +36,10 @@ class Hyperboloid(_Hyperbolic, LevelSet):
     """
 
     def __init__(self, dim, default_coords_type="extrinsic", **kwargs):
+        if 'scale' in kwargs.keys():
+            raise TypeError("Argument scale is no longer in use: instantiate the "
+                            "manifold without this parameter and then use "
+                            "`scale * metric` to rescale the standard metric.")
         self.dim = dim
         kwargs.setdefault("metric", HyperboloidMetric(dim, default_coords_type))
         super().__init__(dim=dim, default_coords_type=default_coords_type, **kwargs)

--- a/geomstats/geometry/hyperboloid.py
+++ b/geomstats/geometry/hyperboloid.py
@@ -38,9 +38,7 @@ class Hyperboloid(_Hyperbolic, LevelSet):
     def __init__(self, dim, default_coords_type="extrinsic", **kwargs):
         self.dim = dim
         kwargs.setdefault("metric", HyperboloidMetric(dim, default_coords_type))
-        super().__init__(
-            dim=dim, default_coords_type=default_coords_type, **kwargs
-        )
+        super().__init__(dim=dim, default_coords_type=default_coords_type, **kwargs)
 
     def _define_embedding_space(self):
         return Minkowski(self.dim + 1)

--- a/geomstats/geometry/manifold.py
+++ b/geomstats/geometry/manifold.py
@@ -11,6 +11,7 @@ import abc
 import geomstats.backend as gs
 import geomstats.errors
 from geomstats.geometry.riemannian_metric import RiemannianMetric
+from geomstats.geometry.scalar_product_metric import ScalarProductMetric
 
 
 class Manifold(abc.ABC):
@@ -159,7 +160,7 @@ class Manifold(abc.ABC):
     @metric.setter
     def metric(self, metric):
         if metric is not None:
-            if not isinstance(metric, RiemannianMetric):
+            if not isinstance(metric, (RiemannianMetric, ScalarProductMetric)):
                 raise ValueError("The argument must be a RiemannianMetric object")
             if metric.dim != self.dim:
                 metric.dim = self.dim

--- a/geomstats/geometry/poincare_ball.py
+++ b/geomstats/geometry/poincare_ball.py
@@ -34,7 +34,11 @@ class PoincareBall(_Hyperbolic, OpenSet):
         Dimension of the hyperbolic space.
     """
 
-    def __init__(self, dim):
+    def __init__(self, dim, **kwargs):
+        if 'scale' in kwargs.keys():
+            raise TypeError("Argument scale is no longer in use: instantiate the "
+                            "manifold without this parameter and then use "
+                            "`scale * metric` to rescale the standard metric.")
         super().__init__(
             dim=dim,
             embedding_space=Euclidean(dim),
@@ -104,7 +108,11 @@ class PoincareBallMetric(RiemannianMetric):
         Dimension of the hyperbolic space.
     """
 
-    def __init__(self, dim):
+    def __init__(self, dim, **kwargs):
+        if 'scale' in kwargs.keys():
+            raise TypeError("Argument scale is no longer in use: instantiate scaled "
+                            "metrics as `scale * RiemannianMetric`. Note that the "
+                            "metric is scaled, not the distance.")
         super().__init__(
             dim=dim,
             signature=(dim, 0),

--- a/geomstats/geometry/poincare_ball.py
+++ b/geomstats/geometry/poincare_ball.py
@@ -35,7 +35,7 @@ class PoincareBall(_Hyperbolic, OpenSet):
     """
 
     def __init__(self, dim, **kwargs):
-        if "scale" in kwargs.keys():
+        if "scale" in kwargs:
             raise TypeError(
                 "Argument scale is no longer in use: instantiate the "
                 "manifold without this parameter and then use "
@@ -111,7 +111,7 @@ class PoincareBallMetric(RiemannianMetric):
     """
 
     def __init__(self, dim, **kwargs):
-        if "scale" in kwargs.keys():
+        if "scale" in kwargs:
             raise TypeError(
                 "Argument scale is no longer in use: instantiate scaled "
                 "metrics as `scale * RiemannianMetric`. Note that the "

--- a/geomstats/geometry/poincare_ball.py
+++ b/geomstats/geometry/poincare_ball.py
@@ -32,18 +32,13 @@ class PoincareBall(_Hyperbolic, OpenSet):
     ----------
     dim : int
         Dimension of the hyperbolic space.
-    scale : int
-        Scale of the hyperbolic space, defined as the set of points
-        in Minkowski space whose squared norm is equal to -scale.
-        Optional, default: 1.
     """
 
-    def __init__(self, dim, scale=1):
+    def __init__(self, dim):
         super().__init__(
             dim=dim,
             embedding_space=Euclidean(dim),
-            scale=scale,
-            metric=PoincareBallMetric(dim, scale),
+            metric=PoincareBallMetric(dim),
             default_coords_type=_COORDS_TYPE,
         )
 
@@ -107,19 +102,14 @@ class PoincareBallMetric(RiemannianMetric):
     ----------
     dim : int
         Dimension of the hyperbolic space.
-    scale : int
-        Scale of the hyperbolic space, defined as the set of points
-        in Minkowski space whose squared norm is equal to -scale.
-        Optional, default 1.
     """
 
-    def __init__(self, dim, scale=1):
+    def __init__(self, dim):
         super().__init__(
             dim=dim,
             signature=(dim, 0),
             default_coords_type=_COORDS_TYPE,
         )
-        self.scale = scale
 
     def exp(self, tangent_vec, base_point, **kwargs):
         """Compute the Riemannian exponential of a tangent vector.
@@ -203,7 +193,7 @@ class PoincareBallMetric(RiemannianMetric):
         mobius_add : array-like, shape=[..., dim]
             Result of the Mobius addition.
         """
-        ball_manifold = PoincareBall(self.dim, scale=self.scale)
+        ball_manifold = PoincareBall(self.dim)
         if project_first:
             point_a = ball_manifold.projection(point_a)
             point_b = ball_manifold.projection(point_b)
@@ -248,7 +238,6 @@ class PoincareBallMetric(RiemannianMetric):
         norm_function = 1 + 2 * diff_norm / ((1 - point_a_norm) * (1 - point_b_norm))
 
         dist = gs.log(norm_function + gs.sqrt(norm_function**2 - 1))
-        dist *= self.scale
         return dist
 
     def retraction(self, tangent_vec, base_point):
@@ -273,7 +262,7 @@ class PoincareBallMetric(RiemannianMetric):
         .. [1] Nickel et.al, "Poincaré Embedding for
             Learning Hierarchical Representation", 2017.
         """
-        ball_manifold = PoincareBall(self.dim, scale=self.scale)
+        ball_manifold = PoincareBall(self.dim)
         base_point_belong = ball_manifold.belongs(base_point)
 
         if not gs.all(base_point_belong):

--- a/geomstats/geometry/poincare_ball.py
+++ b/geomstats/geometry/poincare_ball.py
@@ -35,10 +35,12 @@ class PoincareBall(_Hyperbolic, OpenSet):
     """
 
     def __init__(self, dim, **kwargs):
-        if 'scale' in kwargs.keys():
-            raise TypeError("Argument scale is no longer in use: instantiate the "
-                            "manifold without this parameter and then use "
-                            "`scale * metric` to rescale the standard metric.")
+        if "scale" in kwargs.keys():
+            raise TypeError(
+                "Argument scale is no longer in use: instantiate the "
+                "manifold without this parameter and then use "
+                "`scale * metric` to rescale the standard metric."
+            )
         super().__init__(
             dim=dim,
             embedding_space=Euclidean(dim),
@@ -109,10 +111,12 @@ class PoincareBallMetric(RiemannianMetric):
     """
 
     def __init__(self, dim, **kwargs):
-        if 'scale' in kwargs.keys():
-            raise TypeError("Argument scale is no longer in use: instantiate scaled "
-                            "metrics as `scale * RiemannianMetric`. Note that the "
-                            "metric is scaled, not the distance.")
+        if "scale" in kwargs.keys():
+            raise TypeError(
+                "Argument scale is no longer in use: instantiate scaled "
+                "metrics as `scale * RiemannianMetric`. Note that the "
+                "metric is scaled, not the distance."
+            )
         super().__init__(
             dim=dim,
             signature=(dim, 0),

--- a/geomstats/geometry/poincare_half_space.py
+++ b/geomstats/geometry/poincare_half_space.py
@@ -28,7 +28,7 @@ class PoincareHalfSpace(_Hyperbolic, OpenSet):
     """
 
     def __init__(self, dim, **kwargs):
-        if "scale" in kwargs.keys():
+        if "scale" in kwargs:
             raise TypeError(
                 "Argument scale is no longer in use: instantiate the "
                 "manifold without this parameter and then use "
@@ -97,7 +97,7 @@ class PoincareHalfSpaceMetric(RiemannianMetric):
     """
 
     def __init__(self, dim, **kwargs):
-        if "scale" in kwargs.keys():
+        if "scale" in kwargs:
             raise TypeError(
                 "Argument scale is no longer in use: instantiate scaled "
                 "metrics as `scale * RiemannianMetric`. Note that the "

--- a/geomstats/geometry/poincare_half_space.py
+++ b/geomstats/geometry/poincare_half_space.py
@@ -25,17 +25,13 @@ class PoincareHalfSpace(_Hyperbolic, OpenSet):
     ----------
     dim : int
         Dimension of the hyperbolic space.
-    scale : int, optional
-        Scale of the hyperbolic space, defined as the set of points
-        in Minkowski space whose squared norm is equal to -scale.
     """
 
-    def __init__(self, dim, scale=1):
+    def __init__(self, dim):
         super().__init__(
             dim=dim,
             embedding_space=Euclidean(dim),
-            scale=scale,
-            metric=PoincareHalfSpaceMetric(dim, scale),
+            metric=PoincareHalfSpaceMetric(dim),
             default_coords_type="half-space",
         )
 
@@ -92,20 +88,15 @@ class PoincareHalfSpaceMetric(RiemannianMetric):
     ----------
     dim : int
         Dimension of the hyperbolic space.
-    scale : int
-        Scale of the hyperbolic space, defined as the set of points
-        in Minkowski space whose squared norm is equal to -scale.
-        Optional, default: 1.
     """
 
-    def __init__(self, dim, scale=1.0):
-        self.poincare_ball = PoincareBall(dim=dim, scale=scale)
+    def __init__(self, dim):
+        self.poincare_ball = PoincareBall(dim=dim)
         super().__init__(
             dim=dim,
             signature=(dim, 0),
             default_coords_type=self.poincare_ball.default_coords_type,
         )
-        self.scale = scale
 
     def inner_product(self, tangent_vec_a, tangent_vec_b, base_point):
         """Compute the inner-product of two tangent vectors at a base point.
@@ -126,7 +117,7 @@ class PoincareHalfSpaceMetric(RiemannianMetric):
         """
         inner_prod = gs.sum(tangent_vec_a * tangent_vec_b, axis=-1)
         inner_prod = inner_prod / base_point[..., -1] ** 2
-        return self.scale * inner_prod
+        return inner_prod
 
     def exp(self, tangent_vec, base_point, **kwargs):
         """Compute the Riemannian exponential.

--- a/geomstats/geometry/poincare_half_space.py
+++ b/geomstats/geometry/poincare_half_space.py
@@ -27,7 +27,11 @@ class PoincareHalfSpace(_Hyperbolic, OpenSet):
         Dimension of the hyperbolic space.
     """
 
-    def __init__(self, dim):
+    def __init__(self, dim, **kwargs):
+        if 'scale' in kwargs.keys():
+            raise TypeError("Argument scale is no longer in use: instantiate the "
+                            "manifold without this parameter and then use "
+                            "`scale * metric` to rescale the standard metric.")
         super().__init__(
             dim=dim,
             embedding_space=Euclidean(dim),
@@ -90,7 +94,11 @@ class PoincareHalfSpaceMetric(RiemannianMetric):
         Dimension of the hyperbolic space.
     """
 
-    def __init__(self, dim):
+    def __init__(self, dim, **kwargs):
+        if 'scale' in kwargs.keys():
+            raise TypeError("Argument scale is no longer in use: instantiate scaled "
+                            "metrics as `scale * RiemannianMetric`. Note that the "
+                            "metric is scaled, not the distance.")
         self.poincare_ball = PoincareBall(dim=dim)
         super().__init__(
             dim=dim,

--- a/geomstats/geometry/poincare_half_space.py
+++ b/geomstats/geometry/poincare_half_space.py
@@ -28,10 +28,12 @@ class PoincareHalfSpace(_Hyperbolic, OpenSet):
     """
 
     def __init__(self, dim, **kwargs):
-        if 'scale' in kwargs.keys():
-            raise TypeError("Argument scale is no longer in use: instantiate the "
-                            "manifold without this parameter and then use "
-                            "`scale * metric` to rescale the standard metric.")
+        if "scale" in kwargs.keys():
+            raise TypeError(
+                "Argument scale is no longer in use: instantiate the "
+                "manifold without this parameter and then use "
+                "`scale * metric` to rescale the standard metric."
+            )
         super().__init__(
             dim=dim,
             embedding_space=Euclidean(dim),
@@ -95,10 +97,12 @@ class PoincareHalfSpaceMetric(RiemannianMetric):
     """
 
     def __init__(self, dim, **kwargs):
-        if 'scale' in kwargs.keys():
-            raise TypeError("Argument scale is no longer in use: instantiate scaled "
-                            "metrics as `scale * RiemannianMetric`. Note that the "
-                            "metric is scaled, not the distance.")
+        if "scale" in kwargs.keys():
+            raise TypeError(
+                "Argument scale is no longer in use: instantiate scaled "
+                "metrics as `scale * RiemannianMetric`. Note that the "
+                "metric is scaled, not the distance."
+            )
         self.poincare_ball = PoincareBall(dim=dim)
         super().__init__(
             dim=dim,

--- a/geomstats/geometry/poincare_polydisk.py
+++ b/geomstats/geometry/poincare_polydisk.py
@@ -16,11 +16,11 @@ References
 import geomstats.backend as gs
 from geomstats.geometry._hyperbolic import _Hyperbolic
 from geomstats.geometry.hyperboloid import Hyperboloid, HyperboloidMetric
-from geomstats.geometry.product_manifold import ProductManifold
-from geomstats.geometry.product_riemannian_metric import ProductRiemannianMetric  # NOQA
+from geomstats.geometry.product_manifold import NFoldManifold
+from geomstats.geometry.product_riemannian_metric import ProductRiemannianMetric
 
 
-class PoincarePolydisk(ProductManifold):
+class PoincarePolydisk(NFoldManifold):
     r"""Class for the Poincare polydisk.
 
     The Poincare polydisk is a direct product of n Poincare disks,
@@ -35,15 +35,13 @@ class PoincarePolydisk(ProductManifold):
         Optional, default: \'extrinsic\'.
     """
 
-    def __init__(self, n_disks, default_coords_type="extrinsic"):
+    def __init__(self, n_disks):
         self.n_disks = n_disks
-        disk = Hyperboloid(2, default_coords_type=default_coords_type)
-        list_disks = [
-            disk,
-        ] * n_disks
-        super().__init__(factors=list_disks, default_point_type="matrix")
-        self._metric = PoincarePolydiskMetric(
-            n_disks=n_disks, default_coords_type=default_coords_type
+        super().__init__(
+            base_manifold=Hyperboloid(2),
+            n_copies=n_disks,
+            metric=PoincarePolydiskMetric(n_disks=n_disks),
+            default_coords_type="extrinsic",
         )
 
     @staticmethod
@@ -91,9 +89,6 @@ class PoincarePolydiskMetric(ProductRiemannianMetric):
     ----------
     n_disks : int
         Number of disks.
-    default_coords_type : str, {\'intrinsic\', \'extrinsic\', etc}
-        Coordinate type.
-        Optional, default: \'extrinsic\'.
 
     References
     ----------
@@ -102,11 +97,10 @@ class PoincarePolydiskMetric(ProductRiemannianMetric):
         https://epubs.siam.org/doi/pdf/10.1137/15M102112X
     """
 
-    def __init__(self, n_disks, default_coords_type="extrinsic"):
+    def __init__(self, n_disks):
         self.n_disks = n_disks
-        list_metrics = []
-        for i_disk in range(n_disks):
-            scale_i = (n_disks - i_disk) ** 0.5
-            metric_i = scale_i * HyperboloidMetric(2, default_coords_type)
-            list_metrics.append(metric_i)
+        base_metric = HyperboloidMetric(2)
+        list_metrics = [
+            (n_disks - i_disk) ** 0.5 * base_metric for i_disk in range(n_disks)
+        ]
         super().__init__(metrics=list_metrics, default_point_type="matrix")

--- a/geomstats/geometry/poincare_polydisk.py
+++ b/geomstats/geometry/poincare_polydisk.py
@@ -107,6 +107,6 @@ class PoincarePolydiskMetric(ProductRiemannianMetric):
         list_metrics = []
         for i_disk in range(n_disks):
             scale_i = (n_disks - i_disk) ** 0.5
-            metric_i = HyperboloidMetric(2, default_coords_type, scale_i)
+            metric_i = scale_i * HyperboloidMetric(2, default_coords_type)
             list_metrics.append(metric_i)
         super().__init__(metrics=list_metrics, default_point_type="matrix")

--- a/geomstats/geometry/poincare_polydisk.py
+++ b/geomstats/geometry/poincare_polydisk.py
@@ -101,6 +101,6 @@ class PoincarePolydiskMetric(ProductRiemannianMetric):
         self.n_disks = n_disks
         base_metric = HyperboloidMetric(2)
         list_metrics = [
-            (n_disks - i_disk) ** 0.5 * base_metric for i_disk in range(n_disks)
+            float(n_disks - i_disk)  * base_metric for i_disk in range(n_disks)
         ]
         super().__init__(metrics=list_metrics, default_point_type="matrix")

--- a/geomstats/geometry/poincare_polydisk.py
+++ b/geomstats/geometry/poincare_polydisk.py
@@ -101,6 +101,6 @@ class PoincarePolydiskMetric(ProductRiemannianMetric):
         self.n_disks = n_disks
         base_metric = HyperboloidMetric(2)
         list_metrics = [
-            float(n_disks - i_disk)  * base_metric for i_disk in range(n_disks)
+            float(n_disks - i_disk) * base_metric for i_disk in range(n_disks)
         ]
         super().__init__(metrics=list_metrics, default_point_type="matrix")

--- a/geomstats/geometry/positive_reals.py
+++ b/geomstats/geometry/positive_reals.py
@@ -51,22 +51,15 @@ class PositiveReals(OpenSet):
     """Class for the manifold of positive reals.
 
     The real positive axis endowed with the Information geometry metric.
-
-    Parameters
-    ----------
-    scale : float
-        Scale of the positive reals metric.
-        Optional, default: 1.
     """
 
-    def __init__(self, scale=1.0, **kwargs):
+    def __init__(self, **kwargs):
         super().__init__(
             dim=1,
             embedding_space=Euclidean(1),
-            metric=PositiveRealsMetric(scale=scale),
+            metric=PositiveRealsMetric(),
             **kwargs
         )
-        self.scale = scale
 
     @staticmethod
     def belongs(point, atol=gs.atol):
@@ -150,16 +143,9 @@ class PositiveRealsMetric(RiemannianMetric):
     It is a particular case in dimension 1
     of the SPD affine-invariant metric
     with a power affine coefficient equal to one.
-
-    Parameters
-    ----------
-    scale : float
-        Scale of the positive reals metric.
-        Optional, default: 1.
     """
 
-    def __init__(self, scale=1.0):
-        self.scale = scale
+    def __init__(self):
         super().__init__(dim=1)
 
     def metric_matrix(self, base_point):
@@ -176,7 +162,6 @@ class PositiveRealsMetric(RiemannianMetric):
             Inner product matrix.
         """
         inner_prod_mat = 1 / base_point**2
-        inner_prod_mat *= self.scale**2
         return gs.expand_dims(inner_prod_mat, axis=-1)
 
     @staticmethod
@@ -237,7 +222,7 @@ class PositiveRealsMetric(RiemannianMetric):
             Riemannian squared distance.
         """
         ratio = gs.squeeze(point_b / point_a, axis=-1)
-        return (self.scale * gs.log(ratio)) ** 2
+        return (gs.log(ratio)) ** 2
 
     def dist(self, point_a, point_b):
         """Compute the positive reals distance.
@@ -257,4 +242,4 @@ class PositiveRealsMetric(RiemannianMetric):
             Riemannian distance.
         """
         ratio = gs.squeeze(point_b / point_a, axis=-1)
-        return self.scale * gs.abs(gs.log(ratio))
+        return gs.abs(gs.log(ratio))

--- a/geomstats/geometry/positive_reals.py
+++ b/geomstats/geometry/positive_reals.py
@@ -54,10 +54,12 @@ class PositiveReals(OpenSet):
     """
 
     def __init__(self, **kwargs):
-        if 'scale' in kwargs.keys():
-            raise TypeError("Argument scale is no longer in use: instantiate the "
-                            "manifold without this parameter and then use "
-                            "`scale * metric` to rescale the standard metric.")
+        if "scale" in kwargs.keys():
+            raise TypeError(
+                "Argument scale is no longer in use: instantiate the "
+                "manifold without this parameter and then use "
+                "`scale * metric` to rescale the standard metric."
+            )
         super().__init__(
             dim=1, embedding_space=Euclidean(1), metric=PositiveRealsMetric(), **kwargs
         )
@@ -147,10 +149,12 @@ class PositiveRealsMetric(RiemannianMetric):
     """
 
     def __init__(self, **kwargs):
-        if 'scale' in kwargs.keys():
-            raise TypeError("Argument scale is no longer in use: instantiate scaled "
-                            "metrics as `scale * RiemannianMetric`. Note that the "
-                            "metric is scaled, not the distance.")
+        if "scale" in kwargs.keys():
+            raise TypeError(
+                "Argument scale is no longer in use: instantiate scaled "
+                "metrics as `scale * RiemannianMetric`. Note that the "
+                "metric is scaled, not the distance."
+            )
         super().__init__(dim=1)
 
     def metric_matrix(self, base_point):

--- a/geomstats/geometry/positive_reals.py
+++ b/geomstats/geometry/positive_reals.py
@@ -54,7 +54,7 @@ class PositiveReals(OpenSet):
     """
 
     def __init__(self, **kwargs):
-        if "scale" in kwargs.keys():
+        if "scale" in kwargs:
             raise TypeError(
                 "Argument scale is no longer in use: instantiate the "
                 "manifold without this parameter and then use "
@@ -149,7 +149,7 @@ class PositiveRealsMetric(RiemannianMetric):
     """
 
     def __init__(self, **kwargs):
-        if "scale" in kwargs.keys():
+        if "scale" in kwargs:
             raise TypeError(
                 "Argument scale is no longer in use: instantiate scaled "
                 "metrics as `scale * RiemannianMetric`. Note that the "

--- a/geomstats/geometry/positive_reals.py
+++ b/geomstats/geometry/positive_reals.py
@@ -54,6 +54,10 @@ class PositiveReals(OpenSet):
     """
 
     def __init__(self, **kwargs):
+        if 'scale' in kwargs.keys():
+            raise TypeError("Argument scale is no longer in use: instantiate the "
+                            "manifold without this parameter and then use "
+                            "`scale * metric` to rescale the standard metric.")
         super().__init__(
             dim=1, embedding_space=Euclidean(1), metric=PositiveRealsMetric(), **kwargs
         )
@@ -142,7 +146,11 @@ class PositiveRealsMetric(RiemannianMetric):
     with a power affine coefficient equal to one.
     """
 
-    def __init__(self):
+    def __init__(self, **kwargs):
+        if 'scale' in kwargs.keys():
+            raise TypeError("Argument scale is no longer in use: instantiate scaled "
+                            "metrics as `scale * RiemannianMetric`. Note that the "
+                            "metric is scaled, not the distance.")
         super().__init__(dim=1)
 
     def metric_matrix(self, base_point):

--- a/geomstats/geometry/positive_reals.py
+++ b/geomstats/geometry/positive_reals.py
@@ -55,10 +55,7 @@ class PositiveReals(OpenSet):
 
     def __init__(self, **kwargs):
         super().__init__(
-            dim=1,
-            embedding_space=Euclidean(1),
-            metric=PositiveRealsMetric(),
-            **kwargs
+            dim=1, embedding_space=Euclidean(1), metric=PositiveRealsMetric(), **kwargs
         )
 
     @staticmethod

--- a/geomstats/geometry/riemannian_metric.py
+++ b/geomstats/geometry/riemannian_metric.py
@@ -66,7 +66,7 @@ class RiemannianMetric(Connection, ABC):
         from geomstats.geometry.scalar_product_metric import ScalarProductMetric
 
         if not isinstance(scalar, float):
-            raise NotImplementedError(f"Expected `float` instead of `{type(scalar)}`")
+            return NotImplemented
         return ScalarProductMetric(self, scalar)
 
     def __rmul__(self, scalar):

--- a/geomstats/geometry/scalar_product_metric.py
+++ b/geomstats/geometry/scalar_product_metric.py
@@ -131,7 +131,7 @@ class ScalarProductMetric:
             The metric multiplied by the scalar
         """
         if not isinstance(scalar, float):
-            raise NotImplementedError(f"Expected `float` instead of `{type(scalar)}`")
+            return NotImplemented
         return ScalarProductMetric(self, scalar)
 
     def __rmul__(self, scalar):

--- a/geomstats/geometry/scalar_product_metric.py
+++ b/geomstats/geometry/scalar_product_metric.py
@@ -110,7 +110,5 @@ class ScalarProductMetric:
                         raise ex
             else:
                 scale = _get_scaling_factor(attr_name, self.scale)
-                method = (
-                    attr if scale is None else _wrap_attr(scale, attr)
-                )
+                method = attr if scale is None else _wrap_attr(scale, attr)
                 setattr(self, attr_name, method)

--- a/geomstats/geometry/scalar_product_metric.py
+++ b/geomstats/geometry/scalar_product_metric.py
@@ -7,6 +7,7 @@ Lead author: John Harvey.
 from functools import wraps
 
 import geomstats.backend as gs
+from geomstats.geometry.riemannian_metric import RiemannianMetric
 
 SQRT_LIST = ["norm", "dist", "dist_broadcast", "dist_pairwise", "diameter"]
 LINEAR_LIST = [
@@ -55,7 +56,7 @@ def _get_scaling_factor(func_name, scale):
     return None
 
 
-class ScalarProductMetric:
+class ScalarProductMetric(RiemannianMetric):
     """Class for scalar products of Riemannian and pseudo-Riemannian metrics.
 
     This class multiplies the (0,2) metric tensor 'underlying_metric' by a scalar

--- a/geomstats/geometry/scalar_product_metric.py
+++ b/geomstats/geometry/scalar_product_metric.py
@@ -130,8 +130,6 @@ class ScalarProductMetric:
         metric : ScalarProductMetric
             The metric multiplied by the scalar
         """
-        from geomstats.geometry.scalar_product_metric import ScalarProductMetric
-
         if not isinstance(scalar, float):
             raise NotImplementedError(f"Expected `float` instead of `{type(scalar)}`")
         return ScalarProductMetric(self, scalar)

--- a/geomstats/geometry/scalar_product_metric.py
+++ b/geomstats/geometry/scalar_product_metric.py
@@ -7,7 +7,6 @@ Lead author: John Harvey.
 from functools import wraps
 
 import geomstats.backend as gs
-from geomstats.geometry.riemannian_metric import RiemannianMetric
 
 SQRT_LIST = ["norm", "dist", "dist_broadcast", "dist_pairwise", "diameter"]
 LINEAR_LIST = [
@@ -56,7 +55,7 @@ def _get_scaling_factor(func_name, scale):
     return None
 
 
-class ScalarProductMetric(RiemannianMetric):
+class ScalarProductMetric:
     """Class for scalar products of Riemannian and pseudo-Riemannian metrics.
 
     This class multiplies the (0,2) metric tensor 'underlying_metric' by a scalar

--- a/geomstats/geometry/scalar_product_metric.py
+++ b/geomstats/geometry/scalar_product_metric.py
@@ -112,3 +112,45 @@ class ScalarProductMetric:
                 scale = _get_scaling_factor(attr_name, self.scale)
                 method = attr if scale is None else _wrap_attr(scale, attr)
                 setattr(self, attr_name, method)
+
+    def __mul__(self, scalar):
+        """Multiply the metric by a scalar.
+
+        This method multiplies the (0,2) metric tensor by a scalar. Note that this does
+        not scale distances by the scalar. That would require multiplication by the
+        square of the scalar.
+
+        Parameters
+        ----------
+        scalar : float
+            The number by which to multiply the metric.
+
+        Returns
+        -------
+        metric : ScalarProductMetric
+            The metric multiplied by the scalar
+        """
+        from geomstats.geometry.scalar_product_metric import ScalarProductMetric
+
+        if not isinstance(scalar, float):
+            raise NotImplementedError(f"Expected `float` instead of `{type(scalar)}`")
+        return ScalarProductMetric(self, scalar)
+
+    def __rmul__(self, scalar):
+        """Multiply the metric by a scalar.
+
+        This method multiplies the (0,2) metric tensor by a scalar. Note that this does
+        not scale distances by the scalar. That would require multiplication by the
+        square of the scalar.
+
+        Parameters
+        ----------
+        scalar : float
+            The number by which to multiply the metric.
+
+        Returns
+        -------
+        metric : ScalarProductMetric
+            The metric multiplied by the scalar.
+        """
+        return self * scalar

--- a/geomstats/geometry/scalar_product_metric.py
+++ b/geomstats/geometry/scalar_product_metric.py
@@ -79,21 +79,21 @@ class ScalarProductMetric:
     ----------
     underlying_metric : RiemannianMetric
         The original metric of the manifold which is being scaled.
-    scaling_factor : float
+    scale : float
         The value by which to scale the metric. Note that this rescales the (0,2)
         metric tensor, so distances are rescaled by the square root of this.
     """
 
-    def __init__(self, underlying_metric, scaling_factor):
+    def __init__(self, underlying_metric, scale):
         """Load all attributes from the underlying metric."""
         if hasattr(underlying_metric, "underlying_metric"):
             self.underlying_metric = underlying_metric.underlying_metric
-            self.scaling_factor = scaling_factor * underlying_metric.scaling_factor
+            self.scale = scale * underlying_metric.scale
         else:
             self.underlying_metric = underlying_metric
-            self.scaling_factor = scaling_factor
+            self.scale = scale
 
-        reserved_names = ("underlying_metric", "scaling_factor")
+        reserved_names = ("underlying_metric", "scale")
         for attr_name in dir(self.underlying_metric):
             if attr_name.startswith("_") or attr_name in reserved_names:
                 continue
@@ -109,8 +109,8 @@ class ScalarProductMetric:
                     ):
                         raise ex
             else:
-                scaling_factor = _get_scaling_factor(attr_name, self.scaling_factor)
+                scale = _get_scaling_factor(attr_name, self.scale)
                 method = (
-                    attr if scaling_factor is None else _wrap_attr(scaling_factor, attr)
+                    attr if scale is None else _wrap_attr(scale, attr)
                 )
                 setattr(self, attr_name, method)

--- a/geomstats/geometry/siegel.py
+++ b/geomstats/geometry/siegel.py
@@ -68,19 +68,15 @@ class Siegel(ComplexOpenSet):
         If symmetric is True, add a symmetry condition
         on the matrices to belong to the Siegel space.
         Optional, default: False.
-    scale : float
-        Scale of the complex Poincare metric.
-        Optional, default: 1.
     """
 
-    def __init__(self, n, symmetric=False, scale=1.0, **kwargs):
+    def __init__(self, n, symmetric=False, **kwargs):
         kwargs.setdefault("metric", SiegelMetric(n))
         super().__init__(
             dim=n**2, embedding_space=ComplexMatrices(m=n, n=n), **kwargs
         )
         self.n = n
         self.symmetric = symmetric
-        self.scale = scale
 
     def belongs(self, point, atol=gs.atol):
         """Check if a matrix belongs to the Siegel space.
@@ -206,12 +202,9 @@ class SiegelMetric(ComplexRiemannianMetric):
     ----------
     n : int
         Integer representing the shape of the matrices: n x n.
-    scale : float
-        Scale of the complex Poincare metric.
-        Optional, default: 1.
     """
 
-    def __init__(self, n, scale=1.0, **kwargs):
+    def __init__(self, n, **kwargs):
         dim = int(n**2)
         super().__init__(
             dim=dim,
@@ -219,7 +212,6 @@ class SiegelMetric(ComplexRiemannianMetric):
             signature=(dim, 0),
         )
         self.n = n
-        self.scale = scale
 
     def inner_product(self, tangent_vec_a, tangent_vec_b, base_point):
         """Compute the Siegel inner-product.
@@ -274,7 +266,6 @@ class SiegelMetric(ComplexRiemannianMetric):
 
         inner_product = trace_1 + trace_2
         inner_product *= 0.5
-        inner_product *= self.scale**2
 
         return inner_product
 
@@ -544,7 +535,6 @@ class SiegelMetric(ComplexRiemannianMetric):
         sq_dist = ComplexMatrices.trace_product(logarithm, logarithm)
         sq_dist *= 0.25
         sq_dist = gs.real(sq_dist)
-        sq_dist *= self.scale**2
         sq_dist = gs.maximum(sq_dist, 0)
         return sq_dist
 
@@ -593,7 +583,7 @@ class SiegelMetric(ComplexRiemannianMetric):
         term2 = gs.matmul(tangent_vec_a_transconj, tangent_vec_b)
         term2 -= gs.matmul(tangent_vec_b_transconj, tangent_vec_a)
         norm_term2 = gs.linalg.norm(term2, axis=(-2, -1)) ** 2
-        return -0.5 * (norm_term1 + norm_term2) * self.scale**2
+        return -0.5 * (norm_term1 + norm_term2)
 
     def sectional_curvature(
         self, tangent_vec_a, tangent_vec_b, base_point=None, atol=gs.atol

--- a/geomstats/geometry/siegel.py
+++ b/geomstats/geometry/siegel.py
@@ -71,7 +71,7 @@ class Siegel(ComplexOpenSet):
     """
 
     def __init__(self, n, symmetric=False, **kwargs):
-        if "scale" in kwargs.keys():
+        if "scale" in kwargs:
             raise TypeError(
                 "Argument scale is no longer in use: instantiate the "
                 "manifold without this parameter and then use "
@@ -211,7 +211,7 @@ class SiegelMetric(ComplexRiemannianMetric):
     """
 
     def __init__(self, n, **kwargs):
-        if "scale" in kwargs.keys():
+        if "scale" in kwargs:
             raise TypeError(
                 "Argument scale is no longer in use: instantiate scaled "
                 "metrics as `scale * RiemannianMetric`. Note that the "

--- a/geomstats/geometry/siegel.py
+++ b/geomstats/geometry/siegel.py
@@ -71,10 +71,12 @@ class Siegel(ComplexOpenSet):
     """
 
     def __init__(self, n, symmetric=False, **kwargs):
-        if 'scale' in kwargs.keys():
-            raise TypeError("Argument scale is no longer in use: instantiate the "
-                            "manifold without this parameter and then use "
-                            "`scale * metric` to rescale the standard metric.")
+        if "scale" in kwargs.keys():
+            raise TypeError(
+                "Argument scale is no longer in use: instantiate the "
+                "manifold without this parameter and then use "
+                "`scale * metric` to rescale the standard metric."
+            )
         kwargs.setdefault("metric", SiegelMetric(n))
         super().__init__(
             dim=n**2, embedding_space=ComplexMatrices(m=n, n=n), **kwargs
@@ -209,10 +211,12 @@ class SiegelMetric(ComplexRiemannianMetric):
     """
 
     def __init__(self, n, **kwargs):
-        if 'scale' in kwargs.keys():
-            raise TypeError("Argument scale is no longer in use: instantiate scaled "
-                            "metrics as `scale * RiemannianMetric`. Note that the "
-                            "metric is scaled, not the distance.")
+        if "scale" in kwargs.keys():
+            raise TypeError(
+                "Argument scale is no longer in use: instantiate scaled "
+                "metrics as `scale * RiemannianMetric`. Note that the "
+                "metric is scaled, not the distance."
+            )
         dim = int(n**2)
         super().__init__(
             dim=dim,

--- a/geomstats/geometry/siegel.py
+++ b/geomstats/geometry/siegel.py
@@ -71,6 +71,10 @@ class Siegel(ComplexOpenSet):
     """
 
     def __init__(self, n, symmetric=False, **kwargs):
+        if 'scale' in kwargs.keys():
+            raise TypeError("Argument scale is no longer in use: instantiate the "
+                            "manifold without this parameter and then use "
+                            "`scale * metric` to rescale the standard metric.")
         kwargs.setdefault("metric", SiegelMetric(n))
         super().__init__(
             dim=n**2, embedding_space=ComplexMatrices(m=n, n=n), **kwargs
@@ -205,6 +209,10 @@ class SiegelMetric(ComplexRiemannianMetric):
     """
 
     def __init__(self, n, **kwargs):
+        if 'scale' in kwargs.keys():
+            raise TypeError("Argument scale is no longer in use: instantiate scaled "
+                            "metrics as `scale * RiemannianMetric`. Note that the "
+                            "metric is scaled, not the distance.")
         dim = int(n**2)
         super().__init__(
             dim=dim,

--- a/geomstats/information_geometry/normal.py
+++ b/geomstats/information_geometry/normal.py
@@ -595,7 +595,7 @@ class UnivariateNormalMetric(PullbackDiffeoMetric):
         embedding_metric : RiemannianMetric object
             The metric of the Poincare upper half-plane.
         """
-        return PoincareHalfSpaceMetric(dim=2, scale=2)
+        return 2.0 * PoincareHalfSpaceMetric(dim=2)
 
     def diffeomorphism(self, base_point):
         r"""Image of base point in the Poincare upper half-plane.

--- a/tests/data/complex_poincare_disk_data.py
+++ b/tests/data/complex_poincare_disk_data.py
@@ -19,10 +19,10 @@ SQRT_8 = math.sqrt(8.0)
 
 class ComplexPoincareDiskTestData(_ComplexOpenSetTestData):
 
-    smoke_space_args_list = [(1,), (1,), (1,), (1,)]
+    smoke_space_args_list = [(), (), (), ()]
     smoke_n_points_list = [1, 2, 1, 2]
     n_list = random.sample(range(2, 5), 2)
-    space_args_list = [(n,) for n in n_list]
+    space_args_list = [() for n in n_list]
     n_points_list = random.sample(range(1, 5), 2)
     shape_list = [(1,) for _ in n_list]
     n_vecs_list = random.sample(range(2, 10), 2)
@@ -75,7 +75,7 @@ class ComplexPoincareDiskTestData(_ComplexOpenSetTestData):
 class ComplexPoincareDiskMetricTestData(_ComplexRiemannianMetricTestData):
 
     n_manifolds = 2
-    metric_args_list = list(zip(random.sample(range(2, 5), 2)))
+    metric_args_list = [() for i_manifold in range(n_manifolds)]
     shape_list = [(1,) for i_manifold in range(n_manifolds)]
     space_list = [ComplexPoincareDisk() for i_manifold in range(n_manifolds)]
     n_points_list = random.sample(range(1, 5), 2)

--- a/tests/data/complex_poincare_disk_data.py
+++ b/tests/data/complex_poincare_disk_data.py
@@ -91,10 +91,25 @@ class ComplexPoincareDiskMetricTestData(_ComplexRiemannianMetricTestData):
     def inner_product_test_data(self):
         smoke_data = [
             dict(
+                scale=0.25,
+                tangent_vec_a=[[1j]],
+                tangent_vec_b=[[1j]],
+                base_point=[[0j]],
+                expected=[1 / 4],
+            ),
+            dict(
+                scale=1.0,
                 tangent_vec_a=[[3.0 + 4j]],
                 tangent_vec_b=[[3.0 + 4j]],
                 base_point=[[0.0]],
                 expected=[25],
+            ),
+            dict(
+                scale=4.0,
+                tangent_vec_a=[[1j], [1j], [1j]],
+                tangent_vec_b=[[1j], [2j], [3j]],
+                base_point=[[0j], [0j], [0j]],
+                expected=[4, 8, 12],
             ),
         ]
         return self.generate_tests(smoke_data)
@@ -102,11 +117,19 @@ class ComplexPoincareDiskMetricTestData(_ComplexRiemannianMetricTestData):
     def exp_test_data(self):
         smoke_data = [
             dict(
+                scale=1.0,
                 tangent_vec=[[2.0 + 0j]],
                 base_point=[[0.0 + 0j]],
                 expected=[[(EXP_4 - 1) / (EXP_4 + 1)]],
             ),
             dict(
+                scale=100.0,
+                tangent_vec=[[2.0 + 0j]],
+                base_point=[[0.0 + 0j]],
+                expected=[[(EXP_4 - 1) / (EXP_4 + 1)]],
+            ),
+            dict(
+                scale=1.0,
                 tangent_vec=[[2.0 + 2j]],
                 base_point=[[0.0 + 0j]],
                 expected=[
@@ -124,6 +147,7 @@ class ComplexPoincareDiskMetricTestData(_ComplexRiemannianMetricTestData):
     def log_test_data(self):
         smoke_data = [
             dict(
+                scale=1.0,
                 point=[[0.5]],
                 base_point=[[0.0]],
                 expected=[[LN_3 / 2]],

--- a/tests/data/complex_poincare_disk_data.py
+++ b/tests/data/complex_poincare_disk_data.py
@@ -91,25 +91,22 @@ class ComplexPoincareDiskMetricTestData(_ComplexRiemannianMetricTestData):
     def inner_product_test_data(self):
         smoke_data = [
             dict(
-                scale=0.25,
                 tangent_vec_a=[[1j]],
                 tangent_vec_b=[[1j]],
                 base_point=[[0j]],
-                expected=[1 / 4],
+                expected=[1],
             ),
             dict(
-                scale=1.0,
                 tangent_vec_a=[[3.0 + 4j]],
                 tangent_vec_b=[[3.0 + 4j]],
                 base_point=[[0.0]],
                 expected=[25],
             ),
             dict(
-                scale=4.0,
                 tangent_vec_a=[[1j], [1j], [1j]],
                 tangent_vec_b=[[1j], [2j], [3j]],
                 base_point=[[0j], [0j], [0j]],
-                expected=[4, 8, 12],
+                expected=[1, 2, 3],
             ),
         ]
         return self.generate_tests(smoke_data)
@@ -117,19 +114,16 @@ class ComplexPoincareDiskMetricTestData(_ComplexRiemannianMetricTestData):
     def exp_test_data(self):
         smoke_data = [
             dict(
-                scale=1.0,
                 tangent_vec=[[2.0 + 0j]],
                 base_point=[[0.0 + 0j]],
                 expected=[[(EXP_4 - 1) / (EXP_4 + 1)]],
             ),
             dict(
-                scale=100.0,
                 tangent_vec=[[2.0 + 0j]],
                 base_point=[[0.0 + 0j]],
                 expected=[[(EXP_4 - 1) / (EXP_4 + 1)]],
             ),
             dict(
-                scale=1.0,
                 tangent_vec=[[2.0 + 2j]],
                 base_point=[[0.0 + 0j]],
                 expected=[
@@ -147,7 +141,6 @@ class ComplexPoincareDiskMetricTestData(_ComplexRiemannianMetricTestData):
     def log_test_data(self):
         smoke_data = [
             dict(
-                scale=1.0,
                 point=[[0.5]],
                 base_point=[[0.0]],
                 expected=[[LN_3 / 2]],

--- a/tests/data/complex_poincare_disk_data.py
+++ b/tests/data/complex_poincare_disk_data.py
@@ -91,25 +91,10 @@ class ComplexPoincareDiskMetricTestData(_ComplexRiemannianMetricTestData):
     def inner_product_test_data(self):
         smoke_data = [
             dict(
-                scale=0.5,
-                tangent_vec_a=[[1j]],
-                tangent_vec_b=[[1j]],
-                base_point=[[0j]],
-                expected=[1 / 4],
-            ),
-            dict(
-                scale=1,
                 tangent_vec_a=[[3.0 + 4j]],
                 tangent_vec_b=[[3.0 + 4j]],
                 base_point=[[0.0]],
                 expected=[25],
-            ),
-            dict(
-                scale=2,
-                tangent_vec_a=[[1j], [1j], [1j]],
-                tangent_vec_b=[[1j], [2j], [3j]],
-                base_point=[[0j], [0j], [0j]],
-                expected=[4, 8, 12],
             ),
         ]
         return self.generate_tests(smoke_data)
@@ -117,19 +102,11 @@ class ComplexPoincareDiskMetricTestData(_ComplexRiemannianMetricTestData):
     def exp_test_data(self):
         smoke_data = [
             dict(
-                scale=1.0,
                 tangent_vec=[[2.0 + 0j]],
                 base_point=[[0.0 + 0j]],
                 expected=[[(EXP_4 - 1) / (EXP_4 + 1)]],
             ),
             dict(
-                scale=10.0,
-                tangent_vec=[[2.0 + 0j]],
-                base_point=[[0.0 + 0j]],
-                expected=[[(EXP_4 - 1) / (EXP_4 + 1)]],
-            ),
-            dict(
-                scale=1.0,
                 tangent_vec=[[2.0 + 2j]],
                 base_point=[[0.0 + 0j]],
                 expected=[
@@ -147,7 +124,6 @@ class ComplexPoincareDiskMetricTestData(_ComplexRiemannianMetricTestData):
     def log_test_data(self):
         smoke_data = [
             dict(
-                scale=1.0,
                 point=[[0.5]],
                 base_point=[[0.0]],
                 expected=[[LN_3 / 2]],

--- a/tests/data/hyperboloid_data.py
+++ b/tests/data/hyperboloid_data.py
@@ -133,9 +133,7 @@ class HyperboloidMetricTestData(_RiemannianMetricTestData):
         space = Hyperboloid(3)
         base_point = space.from_coordinates(gs.array([1.0, 1.0, 1.0]), "intrinsic")
         tangent_vec = space.to_tangent(gs.array([1.0, 2.0, 3.0, 4.0]), base_point)
-        smoke_data = [
-            dict(dim=3, tangent_vec=tangent_vec, base_point=base_point)
-        ]
+        smoke_data = [dict(dim=3, tangent_vec=tangent_vec, base_point=base_point)]
         return self.generate_tests(smoke_data)
 
     def scaled_dist_test_data(self):

--- a/tests/data/hyperboloid_data.py
+++ b/tests/data/hyperboloid_data.py
@@ -114,6 +114,37 @@ class HyperboloidMetricTestData(_RiemannianMetricTestData):
         ]
         return self.generate_tests(smoke_data)
 
+    def scaled_inner_product_test_data(self):
+        space = Hyperboloid(3)
+        base_point = space.from_coordinates(gs.array([1.0, 1.0, 1.0]), "intrinsic")
+        tangent_vec_a = space.to_tangent(gs.array([1.0, 2.0, 3.0, 4.0]), base_point)
+        tangent_vec_b = space.to_tangent(gs.array([5.0, 6.0, 7.0, 8.0]), base_point)
+        smoke_data = [
+            dict(
+                dim=3,
+                tangent_vec_a=tangent_vec_a,
+                tangent_vec_b=tangent_vec_b,
+                base_point=base_point,
+            )
+        ]
+        return self.generate_tests(smoke_data)
+
+    def scaled_squared_norm_test_data(self):
+        space = Hyperboloid(3)
+        base_point = space.from_coordinates(gs.array([1.0, 1.0, 1.0]), "intrinsic")
+        tangent_vec = space.to_tangent(gs.array([1.0, 2.0, 3.0, 4.0]), base_point)
+        smoke_data = [
+            dict(dim=3, tangent_vec=tangent_vec, base_point=base_point)
+        ]
+        return self.generate_tests(smoke_data)
+
+    def scaled_dist_test_data(self):
+        space = Hyperboloid(3)
+        point_a = space.from_coordinates(gs.array([1.0, 2.0, 3.0]), "intrinsic")
+        point_b = space.from_coordinates(gs.array([4.0, 5.0, 6.0]), "intrinsic")
+        smoke_data = [dict(dim=3, point_a=point_a, point_b=point_b)]
+        return self.generate_tests(smoke_data)
+
     def log_after_exp_test_data(self):
         return super().log_after_exp_test_data(amplitude=10.0)
 

--- a/tests/data/hyperboloid_data.py
+++ b/tests/data/hyperboloid_data.py
@@ -114,38 +114,6 @@ class HyperboloidMetricTestData(_RiemannianMetricTestData):
         ]
         return self.generate_tests(smoke_data)
 
-    def scaled_inner_product_test_data(self):
-        space = Hyperboloid(3)
-        base_point = space.from_coordinates(gs.array([1.0, 1.0, 1.0]), "intrinsic")
-        tangent_vec_a = space.to_tangent(gs.array([1.0, 2.0, 3.0, 4.0]), base_point)
-        tangent_vec_b = space.to_tangent(gs.array([5.0, 6.0, 7.0, 8.0]), base_point)
-        smoke_data = [
-            dict(
-                dim=3,
-                scale=2,
-                tangent_vec_a=tangent_vec_a,
-                tangent_vec_b=tangent_vec_b,
-                base_point=base_point,
-            )
-        ]
-        return self.generate_tests(smoke_data)
-
-    def scaled_squared_norm_test_data(self):
-        space = Hyperboloid(3)
-        base_point = space.from_coordinates(gs.array([1.0, 1.0, 1.0]), "intrinsic")
-        tangent_vec = space.to_tangent(gs.array([1.0, 2.0, 3.0, 4.0]), base_point)
-        smoke_data = [
-            dict(dim=3, scale=2, tangent_vec=tangent_vec, base_point=base_point)
-        ]
-        return self.generate_tests(smoke_data)
-
-    def scaled_dist_test_data(self):
-        space = Hyperboloid(3)
-        point_a = space.from_coordinates(gs.array([1.0, 2.0, 3.0]), "intrinsic")
-        point_b = space.from_coordinates(gs.array([4.0, 5.0, 6.0]), "intrinsic")
-        smoke_data = [dict(dim=3, scale=2, point_a=point_a, point_b=point_b)]
-        return self.generate_tests(smoke_data)
-
     def log_after_exp_test_data(self):
         return super().log_after_exp_test_data(amplitude=10.0)
 

--- a/tests/data/poincare_half_space_data.py
+++ b/tests/data/poincare_half_space_data.py
@@ -59,8 +59,7 @@ class PoincareHalfSpaceTestData(_OpenSetTestData):
 
 class PoincareHalfSpaceMetricTestData(_RiemannianMetricTestData):
     dim_list = random.sample(range(2, 5), 2)
-    scale_list = [1, 2]
-    metric_args_list = list(zip(dim_list, scale_list))  # [(dim,) for dim in dim_list]
+    metric_args_list = [(dim,) for dim in dim_list]
     shape_list = [(dim,) for dim in dim_list]
     space_list = [PoincareHalfSpace(dim) for dim in dim_list]
     n_points_list = random.sample(range(1, 5), 2)
@@ -77,11 +76,10 @@ class PoincareHalfSpaceMetricTestData(_RiemannianMetricTestData):
         smoke_data = [
             dict(
                 dim=2,
-                scale=2,
                 tangent_vec_a=[[1.0, 2.0], [3.0, 4.0]],
                 tangent_vec_b=[[1.0, 2.0], [3.0, 4.0]],
                 base_point=[[0.0, 1.0], [0.0, 5.0]],
-                expected=[10.0, 2.0],
+                expected=[5.0, 1.0],
             )
         ]
         return self.generate_tests(smoke_data)

--- a/tests/data/poincare_polydisk_data.py
+++ b/tests/data/poincare_polydisk_data.py
@@ -13,7 +13,7 @@ class PoincarePolydiskTestData(_OpenSetTestData):
 
     n_disks_list = random.sample(range(2, 4), 2)
     space_args_list = [(n_disks,) for n_disks in n_disks_list]
-    shape_list = [(n_disks, 3) for n_disks in n_disks_list]
+    shape_list = [(n_disks,) for n_disks in n_disks_list]
     n_points_list = random.sample(range(2, 5), 2)
     n_vecs_list = random.sample(range(2, 5), 2)
 
@@ -28,7 +28,7 @@ class PoincarePolydiskMetricTestData(TestData):
 
     n_disks_list = random.sample(range(2, 4), 2)
     metric_args_list = [(n_disks,) for n_disks in n_disks_list]
-    shape_list = [(n_disks, 3) for n_disks in n_disks_list]
+    shape_list = [(n_disks,) for n_disks in n_disks_list]
     space_list = [PoincarePolydisk(n_disks) for n_disks in n_disks_list]
     n_points_list = random.sample(range(1, 4), 2)
     n_tangent_vecs_list = random.sample(range(1, 4), 2)

--- a/tests/data/poincare_polydisk_data.py
+++ b/tests/data/poincare_polydisk_data.py
@@ -59,8 +59,16 @@ class PoincarePolydiskMetricTestData(TestData):
         )
         smoke_data = [
             dict(
+                m_disks=1,
+                n_disks=2,
                 point_a_extrinsic=point_a_extrinsic,
                 point_b_extrinsic=point_b_extrinsic,
-            )
+            ),
+            dict(
+                m_disks=1,
+                n_disks=3,
+                point_a_extrinsic=point_a_extrinsic,
+                point_b_extrinsic=point_b_extrinsic,
+            ),
         ]
         return self.generate_tests(smoke_data)

--- a/tests/data/poincare_polydisk_data.py
+++ b/tests/data/poincare_polydisk_data.py
@@ -47,7 +47,7 @@ class PoincarePolydiskMetricTestData(TestData):
         ]
         return self.generate_tests(smoke_data)
 
-    def product_distance_extrinsic_representation_test_data(self):
+    def product_distance_test_data(self):
         point_a_intrinsic = gs.array([0.01, 0.0])
         point_b_intrinsic = gs.array([0.0, 0.0])
         hyperbolic_space = Hyperboloid(dim=2)
@@ -59,7 +59,6 @@ class PoincarePolydiskMetricTestData(TestData):
         )
         smoke_data = [
             dict(
-                n_disks=1,
                 point_a_extrinsic=point_a_extrinsic,
                 point_b_extrinsic=point_b_extrinsic,
             )

--- a/tests/data/poincare_polydisk_data.py
+++ b/tests/data/poincare_polydisk_data.py
@@ -13,7 +13,7 @@ class PoincarePolydiskTestData(_OpenSetTestData):
 
     n_disks_list = random.sample(range(2, 4), 2)
     space_args_list = [(n_disks,) for n_disks in n_disks_list]
-    shape_list = [(n_disks,) for n_disks in n_disks_list]
+    shape_list = [(n_disks, 3) for n_disks in n_disks_list]
     n_points_list = random.sample(range(2, 5), 2)
     n_vecs_list = random.sample(range(2, 5), 2)
 
@@ -28,7 +28,7 @@ class PoincarePolydiskMetricTestData(TestData):
 
     n_disks_list = random.sample(range(2, 4), 2)
     metric_args_list = [(n_disks,) for n_disks in n_disks_list]
-    shape_list = [(n_disks,) for n_disks in n_disks_list]
+    shape_list = [(n_disks, 3) for n_disks in n_disks_list]
     space_list = [PoincarePolydisk(n_disks) for n_disks in n_disks_list]
     n_points_list = random.sample(range(1, 4), 2)
     n_tangent_vecs_list = random.sample(range(1, 4), 2)

--- a/tests/data/positive_reals_data.py
+++ b/tests/data/positive_reals_data.py
@@ -15,7 +15,7 @@ class PositiveRealsTestData(_OpenSetTestData):
     smoke_space_args_list = [(1,), (1,), (1,), (1,)]
     smoke_n_points_list = [1, 2, 1, 2]
     n_list = random.sample(range(2, 5), 2)
-    space_args_list = [(n,) for n in n_list]
+    space_args_list = [() for n in n_list]
     n_points_list = random.sample(range(1, 5), 2)
     shape_list = [(1,) for _ in n_list]
     n_vecs_list = random.sample(range(1, 10), 2)
@@ -49,7 +49,7 @@ class PositiveRealsTestData(_OpenSetTestData):
 
 class PositiveRealsMetricTestData(_RiemannianMetricTestData):
     n_manifolds = 2
-    metric_args_list = list(zip(random.sample(range(2, 5), 2)))
+    metric_args_list = [() for n in range(n_manifolds)]
     shape_list = [(1,) for i_manifold in range(n_manifolds)]
     space_list = [PositiveReals() for i_manifold in range(n_manifolds)]
     n_points_list = random.sample(range(1, 5), 2)

--- a/tests/data/siegel_data.py
+++ b/tests/data/siegel_data.py
@@ -72,8 +72,7 @@ class SiegelTestData(_ComplexOpenSetTestData):
 
 class SiegelMetricTestData(_ComplexRiemannianMetricTestData):
     n_list = random.sample(range(2, 5), 2)
-    scale_list = [1.0, 2]
-    metric_args_list = list(zip(n_list, scale_list))
+    metric_args_list = [(n,) for n in n_list]
     shape_list = [(n, n) for n in n_list]
     space_list = [Siegel(n) for n in n_list]
     n_points_list = random.sample(range(1, 5), 2)
@@ -90,19 +89,17 @@ class SiegelMetricTestData(_ComplexRiemannianMetricTestData):
         smoke_data = [
             dict(
                 n=3,
-                scale=0.5,
                 tangent_vec_a=[[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
                 tangent_vec_b=[[1.0, 0.0, 0.0], [0.0, 2.0, 0.0], [0.0, 0.0, 3.0]],
                 base_point=[[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
-                expected=3 / 2,
+                expected=6,
             ),
             dict(
                 n=3,
-                scale=0.5,
                 tangent_vec_a=[[1j, 0j, 0j], [0j, 1j, 0j], [0j, 0j, 1j]],
                 tangent_vec_b=[[1j, 0j, 0j], [0j, 2j, 0j], [0j, 0j, 3j]],
                 base_point=[[0j, 0j, 0j], [0j, 0j, 0j], [0j, 0j, 0j]],
-                expected=3 / 2,
+                expected=6,
             ),
         ]
         return self.generate_tests(smoke_data)
@@ -111,7 +108,6 @@ class SiegelMetricTestData(_ComplexRiemannianMetricTestData):
         smoke_data = [
             dict(
                 n=2,
-                scale=1.0,
                 tangent_vec=[[2.0, 0.0], [0.0, 2.0]],
                 base_point=[[0.0, 0.0], [0.0, 0.0]],
                 expected=[
@@ -121,7 +117,6 @@ class SiegelMetricTestData(_ComplexRiemannianMetricTestData):
             ),
             dict(
                 n=2,
-                scale=1.0,
                 tangent_vec=[[2j, 0j], [0j, 2j]],
                 base_point=[[0j, 0j], [0j, 0j]],
                 expected=[
@@ -131,7 +126,6 @@ class SiegelMetricTestData(_ComplexRiemannianMetricTestData):
             ),
             dict(
                 n=2,
-                scale=1.0,
                 tangent_vec=[[0j, 0j], [0j, 0j]],
                 base_point=[[0j, 0j], [0j, 0j]],
                 expected=[[0j, 0j], [0j, 0j]],
@@ -143,21 +137,18 @@ class SiegelMetricTestData(_ComplexRiemannianMetricTestData):
         smoke_data = [
             dict(
                 n=2,
-                scale=1.0,
                 point=[[0.5, 0.0], [0.0, 0.5]],
                 base_point=[[0.0, 0.0], [0.0, 0.0]],
                 expected=[[LN_3 / 2, 0.0], [0.0, LN_3 / 2]],
             ),
             dict(
                 n=2,
-                scale=1.0,
                 point=[[0.5j, 0j], [0j, 0.5j]],
                 base_point=[[0j, 0j], [0j, 0j]],
                 expected=[[LN_3 / 2 * 1j, 0j], [0j, LN_3 / 2 * 1j]],
             ),
             dict(
                 n=2,
-                scale=1.0,
                 point=[[0j, 0j], [0j, 0j]],
                 base_point=[[0j, 0j], [0j, 0j]],
                 expected=[[0j, 0j], [0j, 0j]],
@@ -169,7 +160,6 @@ class SiegelMetricTestData(_ComplexRiemannianMetricTestData):
         smoke_data = [
             dict(
                 n=2,
-                scale=1.0,
                 tangent_vec_a=[[1.0, 0.0], [0.0, 0.0]],
                 tangent_vec_b=[[0.0, 0.0], [0.0, 1.0]],
                 base_point=[[0.0, 0.0], [0.0, 0.0]],
@@ -177,7 +167,6 @@ class SiegelMetricTestData(_ComplexRiemannianMetricTestData):
             ),
             dict(
                 n=2,
-                scale=1.0,
                 tangent_vec_a=[[1j, 0j], [0j, 1j]],
                 tangent_vec_b=[[-1j, 0j], [0j, -1j]],
                 base_point=[[0j, 0j], [0j, 0j]],
@@ -185,7 +174,6 @@ class SiegelMetricTestData(_ComplexRiemannianMetricTestData):
             ),
             dict(
                 n=2,
-                scale=1.0,
                 tangent_vec_a=[[1.0 + 0j, 0j], [0j, 0j]],
                 tangent_vec_b=[[0j, 1j], [0j, 0j]],
                 base_point=[[0j, 0j], [0j, 0j]],
@@ -193,59 +181,17 @@ class SiegelMetricTestData(_ComplexRiemannianMetricTestData):
             ),
             dict(
                 n=2,
-                scale=1.0,
                 tangent_vec_a=[[2 + 0j, 0j], [0j, 0j]],
                 tangent_vec_b=[[0j, 2j], [0j, 0j]],
                 base_point=[[0j, 0j], [0j, 0j]],
                 expected=-1,
             ),
             dict(
-                n=2,
-                scale=2.0,
-                tangent_vec_a=[[0.25 + 0j, 0j], [0j, 0j]],
-                tangent_vec_b=[[0j, 0.25j], [0j, 0j]],
-                base_point=[[0j, 0j], [0j, 0j]],
-                expected=-0.25,
-            ),
-            dict(
                 n=3,
-                scale=0.5,
-                tangent_vec_a=[[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
-                tangent_vec_b=[[1.0, 0.0, 0.0], [0.0, 2.0, 0.0], [0.0, 0.0, 3.0]],
-                base_point=[[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
-                expected=0,
-            ),
-            dict(
-                n=3,
-                scale=0.5,
-                tangent_vec_a=[[1j, 0j, 0j], [0j, 1j, 0j], [0j, 0j, 1j]],
-                tangent_vec_b=[[1j, 0j, 0j], [0j, 2j, 0j], [0j, 0j, 3j]],
-                base_point=[[0j, 0j, 0j], [0j, 0j, 0j], [0j, 0j, 0j]],
-                expected=0,
-            ),
-            dict(
-                n=3,
-                scale=1,
                 tangent_vec_a=[[1.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
                 tangent_vec_b=[[0.0, 0.0, 1.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
                 base_point=[[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
                 expected=-1,
-            ),
-            dict(
-                n=3,
-                scale=2.0,
-                tangent_vec_a=[[1.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
-                tangent_vec_b=[[0.0, 0.0, 1.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
-                base_point=[[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
-                expected=-0.25,
-            ),
-            dict(
-                n=3,
-                scale=1 / 3,
-                tangent_vec_a=[[1j, 0j, 0j], [0j, 0j, 0j], [0j, 0j, 0j]],
-                tangent_vec_b=[[0j, 0j, 1j], [0j, 0j, 0j], [0j, 0j, 0j]],
-                base_point=[[0j, 0j, 0j], [0j, 0j, 0j], [0j, 0j, 0j]],
-                expected=-9,
             ),
         ]
         return self.generate_tests(smoke_data)

--- a/tests/data/siegel_data.py
+++ b/tests/data/siegel_data.py
@@ -89,17 +89,19 @@ class SiegelMetricTestData(_ComplexRiemannianMetricTestData):
         smoke_data = [
             dict(
                 n=3,
+                scale=0.25,
                 tangent_vec_a=[[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
                 tangent_vec_b=[[1.0, 0.0, 0.0], [0.0, 2.0, 0.0], [0.0, 0.0, 3.0]],
                 base_point=[[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
-                expected=6,
+                expected=3 / 2,
             ),
             dict(
                 n=3,
+                scale=0.25,
                 tangent_vec_a=[[1j, 0j, 0j], [0j, 1j, 0j], [0j, 0j, 1j]],
                 tangent_vec_b=[[1j, 0j, 0j], [0j, 2j, 0j], [0j, 0j, 3j]],
                 base_point=[[0j, 0j, 0j], [0j, 0j, 0j], [0j, 0j, 0j]],
-                expected=6,
+                expected=3 / 2,
             ),
         ]
         return self.generate_tests(smoke_data)
@@ -108,6 +110,7 @@ class SiegelMetricTestData(_ComplexRiemannianMetricTestData):
         smoke_data = [
             dict(
                 n=2,
+                scale=1.0,
                 tangent_vec=[[2.0, 0.0], [0.0, 2.0]],
                 base_point=[[0.0, 0.0], [0.0, 0.0]],
                 expected=[
@@ -117,6 +120,7 @@ class SiegelMetricTestData(_ComplexRiemannianMetricTestData):
             ),
             dict(
                 n=2,
+                scale=1.0,
                 tangent_vec=[[2j, 0j], [0j, 2j]],
                 base_point=[[0j, 0j], [0j, 0j]],
                 expected=[
@@ -126,6 +130,7 @@ class SiegelMetricTestData(_ComplexRiemannianMetricTestData):
             ),
             dict(
                 n=2,
+                scale=1.0,
                 tangent_vec=[[0j, 0j], [0j, 0j]],
                 base_point=[[0j, 0j], [0j, 0j]],
                 expected=[[0j, 0j], [0j, 0j]],
@@ -137,18 +142,21 @@ class SiegelMetricTestData(_ComplexRiemannianMetricTestData):
         smoke_data = [
             dict(
                 n=2,
+                scale=1.0,
                 point=[[0.5, 0.0], [0.0, 0.5]],
                 base_point=[[0.0, 0.0], [0.0, 0.0]],
                 expected=[[LN_3 / 2, 0.0], [0.0, LN_3 / 2]],
             ),
             dict(
                 n=2,
+                scale=1.0,
                 point=[[0.5j, 0j], [0j, 0.5j]],
                 base_point=[[0j, 0j], [0j, 0j]],
                 expected=[[LN_3 / 2 * 1j, 0j], [0j, LN_3 / 2 * 1j]],
             ),
             dict(
                 n=2,
+                scale=1.0,
                 point=[[0j, 0j], [0j, 0j]],
                 base_point=[[0j, 0j], [0j, 0j]],
                 expected=[[0j, 0j], [0j, 0j]],
@@ -160,6 +168,7 @@ class SiegelMetricTestData(_ComplexRiemannianMetricTestData):
         smoke_data = [
             dict(
                 n=2,
+                scale=1.0,
                 tangent_vec_a=[[1.0, 0.0], [0.0, 0.0]],
                 tangent_vec_b=[[0.0, 0.0], [0.0, 1.0]],
                 base_point=[[0.0, 0.0], [0.0, 0.0]],
@@ -167,6 +176,7 @@ class SiegelMetricTestData(_ComplexRiemannianMetricTestData):
             ),
             dict(
                 n=2,
+                scale=1.0,
                 tangent_vec_a=[[1j, 0j], [0j, 1j]],
                 tangent_vec_b=[[-1j, 0j], [0j, -1j]],
                 base_point=[[0j, 0j], [0j, 0j]],
@@ -174,6 +184,7 @@ class SiegelMetricTestData(_ComplexRiemannianMetricTestData):
             ),
             dict(
                 n=2,
+                scale=1.0,
                 tangent_vec_a=[[1.0 + 0j, 0j], [0j, 0j]],
                 tangent_vec_b=[[0j, 1j], [0j, 0j]],
                 base_point=[[0j, 0j], [0j, 0j]],
@@ -181,17 +192,59 @@ class SiegelMetricTestData(_ComplexRiemannianMetricTestData):
             ),
             dict(
                 n=2,
+                scale=1.0,
                 tangent_vec_a=[[2 + 0j, 0j], [0j, 0j]],
                 tangent_vec_b=[[0j, 2j], [0j, 0j]],
                 base_point=[[0j, 0j], [0j, 0j]],
                 expected=-1,
             ),
             dict(
+                n=2,
+                scale=4.0,
+                tangent_vec_a=[[0.25 + 0j, 0j], [0j, 0j]],
+                tangent_vec_b=[[0j, 0.25j], [0j, 0j]],
+                base_point=[[0j, 0j], [0j, 0j]],
+                expected=-0.25,
+            ),
+            dict(
                 n=3,
+                scale=0.25,
+                tangent_vec_a=[[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
+                tangent_vec_b=[[1.0, 0.0, 0.0], [0.0, 2.0, 0.0], [0.0, 0.0, 3.0]],
+                base_point=[[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
+                expected=0,
+            ),
+            dict(
+                n=3,
+                scale=0.25,
+                tangent_vec_a=[[1j, 0j, 0j], [0j, 1j, 0j], [0j, 0j, 1j]],
+                tangent_vec_b=[[1j, 0j, 0j], [0j, 2j, 0j], [0j, 0j, 3j]],
+                base_point=[[0j, 0j, 0j], [0j, 0j, 0j], [0j, 0j, 0j]],
+                expected=0,
+            ),
+            dict(
+                n=3,
+                scale=1.0,
                 tangent_vec_a=[[1.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
                 tangent_vec_b=[[0.0, 0.0, 1.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
                 base_point=[[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
                 expected=-1,
+            ),
+            dict(
+                n=3,
+                scale=4.0,
+                tangent_vec_a=[[1.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
+                tangent_vec_b=[[0.0, 0.0, 1.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
+                base_point=[[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
+                expected=-0.25,
+            ),
+            dict(
+                n=3,
+                scale=1 / 9,
+                tangent_vec_a=[[1j, 0j, 0j], [0j, 0j, 0j], [0j, 0j, 0j]],
+                tangent_vec_b=[[0j, 0j, 1j], [0j, 0j, 0j], [0j, 0j, 0j]],
+                base_point=[[0j, 0j, 0j], [0j, 0j, 0j], [0j, 0j, 0j]],
+                expected=-9,
             ),
         ]
         return self.generate_tests(smoke_data)

--- a/tests/data/siegel_data.py
+++ b/tests/data/siegel_data.py
@@ -89,19 +89,17 @@ class SiegelMetricTestData(_ComplexRiemannianMetricTestData):
         smoke_data = [
             dict(
                 n=3,
-                scale=0.25,
                 tangent_vec_a=[[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
                 tangent_vec_b=[[1.0, 0.0, 0.0], [0.0, 2.0, 0.0], [0.0, 0.0, 3.0]],
                 base_point=[[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
-                expected=3 / 2,
+                expected=6,
             ),
             dict(
                 n=3,
-                scale=0.25,
                 tangent_vec_a=[[1j, 0j, 0j], [0j, 1j, 0j], [0j, 0j, 1j]],
                 tangent_vec_b=[[1j, 0j, 0j], [0j, 2j, 0j], [0j, 0j, 3j]],
                 base_point=[[0j, 0j, 0j], [0j, 0j, 0j], [0j, 0j, 0j]],
-                expected=3 / 2,
+                expected=6,
             ),
         ]
         return self.generate_tests(smoke_data)
@@ -110,7 +108,6 @@ class SiegelMetricTestData(_ComplexRiemannianMetricTestData):
         smoke_data = [
             dict(
                 n=2,
-                scale=1.0,
                 tangent_vec=[[2.0, 0.0], [0.0, 2.0]],
                 base_point=[[0.0, 0.0], [0.0, 0.0]],
                 expected=[
@@ -120,7 +117,6 @@ class SiegelMetricTestData(_ComplexRiemannianMetricTestData):
             ),
             dict(
                 n=2,
-                scale=1.0,
                 tangent_vec=[[2j, 0j], [0j, 2j]],
                 base_point=[[0j, 0j], [0j, 0j]],
                 expected=[
@@ -130,7 +126,6 @@ class SiegelMetricTestData(_ComplexRiemannianMetricTestData):
             ),
             dict(
                 n=2,
-                scale=1.0,
                 tangent_vec=[[0j, 0j], [0j, 0j]],
                 base_point=[[0j, 0j], [0j, 0j]],
                 expected=[[0j, 0j], [0j, 0j]],
@@ -142,21 +137,18 @@ class SiegelMetricTestData(_ComplexRiemannianMetricTestData):
         smoke_data = [
             dict(
                 n=2,
-                scale=1.0,
                 point=[[0.5, 0.0], [0.0, 0.5]],
                 base_point=[[0.0, 0.0], [0.0, 0.0]],
                 expected=[[LN_3 / 2, 0.0], [0.0, LN_3 / 2]],
             ),
             dict(
                 n=2,
-                scale=1.0,
                 point=[[0.5j, 0j], [0j, 0.5j]],
                 base_point=[[0j, 0j], [0j, 0j]],
                 expected=[[LN_3 / 2 * 1j, 0j], [0j, LN_3 / 2 * 1j]],
             ),
             dict(
                 n=2,
-                scale=1.0,
                 point=[[0j, 0j], [0j, 0j]],
                 base_point=[[0j, 0j], [0j, 0j]],
                 expected=[[0j, 0j], [0j, 0j]],
@@ -168,7 +160,6 @@ class SiegelMetricTestData(_ComplexRiemannianMetricTestData):
         smoke_data = [
             dict(
                 n=2,
-                scale=1.0,
                 tangent_vec_a=[[1.0, 0.0], [0.0, 0.0]],
                 tangent_vec_b=[[0.0, 0.0], [0.0, 1.0]],
                 base_point=[[0.0, 0.0], [0.0, 0.0]],
@@ -176,7 +167,6 @@ class SiegelMetricTestData(_ComplexRiemannianMetricTestData):
             ),
             dict(
                 n=2,
-                scale=1.0,
                 tangent_vec_a=[[1j, 0j], [0j, 1j]],
                 tangent_vec_b=[[-1j, 0j], [0j, -1j]],
                 base_point=[[0j, 0j], [0j, 0j]],
@@ -184,7 +174,6 @@ class SiegelMetricTestData(_ComplexRiemannianMetricTestData):
             ),
             dict(
                 n=2,
-                scale=1.0,
                 tangent_vec_a=[[1.0 + 0j, 0j], [0j, 0j]],
                 tangent_vec_b=[[0j, 1j], [0j, 0j]],
                 base_point=[[0j, 0j], [0j, 0j]],
@@ -192,7 +181,6 @@ class SiegelMetricTestData(_ComplexRiemannianMetricTestData):
             ),
             dict(
                 n=2,
-                scale=1.0,
                 tangent_vec_a=[[2 + 0j, 0j], [0j, 0j]],
                 tangent_vec_b=[[0j, 2j], [0j, 0j]],
                 base_point=[[0j, 0j], [0j, 0j]],
@@ -200,15 +188,13 @@ class SiegelMetricTestData(_ComplexRiemannianMetricTestData):
             ),
             dict(
                 n=2,
-                scale=4.0,
                 tangent_vec_a=[[0.25 + 0j, 0j], [0j, 0j]],
                 tangent_vec_b=[[0j, 0.25j], [0j, 0j]],
                 base_point=[[0j, 0j], [0j, 0j]],
-                expected=-0.25,
+                expected=-1,
             ),
             dict(
                 n=3,
-                scale=0.25,
                 tangent_vec_a=[[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
                 tangent_vec_b=[[1.0, 0.0, 0.0], [0.0, 2.0, 0.0], [0.0, 0.0, 3.0]],
                 base_point=[[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
@@ -216,7 +202,6 @@ class SiegelMetricTestData(_ComplexRiemannianMetricTestData):
             ),
             dict(
                 n=3,
-                scale=0.25,
                 tangent_vec_a=[[1j, 0j, 0j], [0j, 1j, 0j], [0j, 0j, 1j]],
                 tangent_vec_b=[[1j, 0j, 0j], [0j, 2j, 0j], [0j, 0j, 3j]],
                 base_point=[[0j, 0j, 0j], [0j, 0j, 0j], [0j, 0j, 0j]],
@@ -224,7 +209,6 @@ class SiegelMetricTestData(_ComplexRiemannianMetricTestData):
             ),
             dict(
                 n=3,
-                scale=1.0,
                 tangent_vec_a=[[1.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
                 tangent_vec_b=[[0.0, 0.0, 1.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
                 base_point=[[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
@@ -232,19 +216,17 @@ class SiegelMetricTestData(_ComplexRiemannianMetricTestData):
             ),
             dict(
                 n=3,
-                scale=4.0,
                 tangent_vec_a=[[1.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
                 tangent_vec_b=[[0.0, 0.0, 1.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
                 base_point=[[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
-                expected=-0.25,
+                expected=-1,
             ),
             dict(
                 n=3,
-                scale=1 / 9,
                 tangent_vec_a=[[1j, 0j, 0j], [0j, 0j, 0j], [0j, 0j, 0j]],
                 tangent_vec_b=[[0j, 0j, 1j], [0j, 0j, 0j], [0j, 0j, 0j]],
                 base_point=[[0j, 0j, 0j], [0j, 0j, 0j], [0j, 0j, 0j]],
-                expected=-9,
+                expected=-1,
             ),
         ]
         return self.generate_tests(smoke_data)

--- a/tests/tests_geomstats/test_complex_poincare_disk.py
+++ b/tests/tests_geomstats/test_complex_poincare_disk.py
@@ -46,9 +46,9 @@ class TestComplexPoincareDiskMetric(
     testing_data = ComplexPoincareDiskMetricTestData()
 
     def test_inner_product(
-        self, scale, tangent_vec_a, tangent_vec_b, base_point, expected
+        self, tangent_vec_a, tangent_vec_b, base_point, expected
     ):
-        metric = self.Metric(scale)
+        metric = self.Metric()
         result = metric.inner_product(
             gs.array(tangent_vec_a),
             gs.array(tangent_vec_b),
@@ -56,8 +56,8 @@ class TestComplexPoincareDiskMetric(
         )
         self.assertAllClose(result, expected)
 
-    def test_exp(self, scale, tangent_vec, base_point, expected):
-        metric = self.Metric(scale)
+    def test_exp(self, tangent_vec, base_point, expected):
+        metric = self.Metric()
         self.assertAllClose(
             metric.exp(
                 gs.array(tangent_vec),
@@ -66,8 +66,8 @@ class TestComplexPoincareDiskMetric(
             gs.array(expected),
         )
 
-    def test_log(self, scale, point, base_point, expected):
-        metric = self.Metric(scale)
+    def test_log(self, point, base_point, expected):
+        metric = self.Metric()
         self.assertAllClose(
             metric.log(
                 gs.array(point),

--- a/tests/tests_geomstats/test_complex_poincare_disk.py
+++ b/tests/tests_geomstats/test_complex_poincare_disk.py
@@ -45,10 +45,8 @@ class TestComplexPoincareDiskMetric(
 
     testing_data = ComplexPoincareDiskMetricTestData()
 
-    def test_inner_product(
-        self, scale, tangent_vec_a, tangent_vec_b, base_point, expected
-    ):
-        metric = scale * self.Metric()
+    def test_inner_product(self, tangent_vec_a, tangent_vec_b, base_point, expected):
+        metric = self.Metric()
         result = metric.inner_product(
             gs.array(tangent_vec_a),
             gs.array(tangent_vec_b),
@@ -56,8 +54,8 @@ class TestComplexPoincareDiskMetric(
         )
         self.assertAllClose(result, expected)
 
-    def test_exp(self, scale, tangent_vec, base_point, expected):
-        metric = scale * self.Metric()
+    def test_exp(self, tangent_vec, base_point, expected):
+        metric = self.Metric()
         self.assertAllClose(
             metric.exp(
                 gs.array(tangent_vec),
@@ -66,8 +64,8 @@ class TestComplexPoincareDiskMetric(
             gs.array(expected),
         )
 
-    def test_log(self, scale, point, base_point, expected):
-        metric = scale * self.Metric()
+    def test_log(self, point, base_point, expected):
+        metric = self.Metric()
         self.assertAllClose(
             metric.log(
                 gs.array(point),

--- a/tests/tests_geomstats/test_complex_poincare_disk.py
+++ b/tests/tests_geomstats/test_complex_poincare_disk.py
@@ -45,9 +45,7 @@ class TestComplexPoincareDiskMetric(
 
     testing_data = ComplexPoincareDiskMetricTestData()
 
-    def test_inner_product(
-        self, tangent_vec_a, tangent_vec_b, base_point, expected
-    ):
+    def test_inner_product(self, tangent_vec_a, tangent_vec_b, base_point, expected):
         metric = self.Metric()
         result = metric.inner_product(
             gs.array(tangent_vec_a),

--- a/tests/tests_geomstats/test_complex_poincare_disk.py
+++ b/tests/tests_geomstats/test_complex_poincare_disk.py
@@ -45,8 +45,10 @@ class TestComplexPoincareDiskMetric(
 
     testing_data = ComplexPoincareDiskMetricTestData()
 
-    def test_inner_product(self, tangent_vec_a, tangent_vec_b, base_point, expected):
-        metric = self.Metric()
+    def test_inner_product(
+        self, scale, tangent_vec_a, tangent_vec_b, base_point, expected
+    ):
+        metric = scale * self.Metric()
         result = metric.inner_product(
             gs.array(tangent_vec_a),
             gs.array(tangent_vec_b),
@@ -54,8 +56,8 @@ class TestComplexPoincareDiskMetric(
         )
         self.assertAllClose(result, expected)
 
-    def test_exp(self, tangent_vec, base_point, expected):
-        metric = self.Metric()
+    def test_exp(self, scale, tangent_vec, base_point, expected):
+        metric = scale * self.Metric()
         self.assertAllClose(
             metric.exp(
                 gs.array(tangent_vec),
@@ -64,8 +66,8 @@ class TestComplexPoincareDiskMetric(
             gs.array(expected),
         )
 
-    def test_log(self, point, base_point, expected):
-        metric = self.Metric()
+    def test_log(self, scale, point, base_point, expected):
+        metric = scale * self.Metric()
         self.assertAllClose(
             metric.log(
                 gs.array(point),

--- a/tests/tests_geomstats/test_hyperboloid.py
+++ b/tests/tests_geomstats/test_hyperboloid.py
@@ -81,9 +81,7 @@ class TestHyperboloidMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
         )
         self.assertAllClose(result, expected)
 
-    def test_scaled_inner_product(
-        self, dim, tangent_vec_a, tangent_vec_b, base_point
-    ):
+    def test_scaled_inner_product(self, dim, tangent_vec_a, tangent_vec_b, base_point):
         default_space = Hyperboloid(dim=dim)
         default_metric = default_space.metric
         scaled_metric = 2.0 * default_metric
@@ -106,9 +104,7 @@ class TestHyperboloidMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
         squared_norm_default_metric = default_metric.squared_norm(
             tangent_vec, base_point
         )
-        squared_norm_scaled_metric = scaled_metric.squared_norm(
-            tangent_vec, base_point
-        )
+        squared_norm_scaled_metric = scaled_metric.squared_norm(tangent_vec, base_point)
         result = squared_norm_scaled_metric
         expected = 2.0 * squared_norm_default_metric
         self.assertAllClose(result, expected)

--- a/tests/tests_geomstats/test_hyperboloid.py
+++ b/tests/tests_geomstats/test_hyperboloid.py
@@ -81,6 +81,49 @@ class TestHyperboloidMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
         )
         self.assertAllClose(result, expected)
 
+    def test_scaled_inner_product(
+        self, dim, tangent_vec_a, tangent_vec_b, base_point
+    ):
+        default_space = Hyperboloid(dim=dim)
+        default_metric = default_space.metric
+        scaled_metric = 2.0 * default_metric
+
+        inner_product_default_metric = default_metric.inner_product(
+            tangent_vec_a, tangent_vec_b, base_point
+        )
+        inner_product_scaled_metric = scaled_metric.inner_product(
+            tangent_vec_a, tangent_vec_b, base_point
+        )
+        result = inner_product_scaled_metric
+        expected = 2.0 * inner_product_default_metric
+        self.assertAllClose(result, expected)
+
+    def test_scaled_squared_norm(self, dim, tangent_vec, base_point):
+        default_space = Hyperboloid(dim=dim)
+        default_metric = default_space.metric
+        scaled_metric = 2.0 * default_metric
+
+        squared_norm_default_metric = default_metric.squared_norm(
+            tangent_vec, base_point
+        )
+        squared_norm_scaled_metric = scaled_metric.squared_norm(
+            tangent_vec, base_point
+        )
+        result = squared_norm_scaled_metric
+        expected = 2.0 * squared_norm_default_metric
+        self.assertAllClose(result, expected)
+
+    def test_scaled_dist(self, dim, point_a, point_b):
+        default_space = Hyperboloid(dim=dim)
+        default_metric = default_space.metric
+        scaled_metric = 2.0 * default_metric
+
+        distance_default_metric = default_metric.dist(point_a, point_b)
+        distance_scaled_metric = scaled_metric.dist(point_a, point_b)
+        result = distance_scaled_metric
+        expected = gs.sqrt(2.0) * distance_default_metric
+        self.assertAllClose(result, expected)
+
     def test_exp_after_log_intrinsic_ball_extrinsic(
         self, dim, x_intrinsic, y_intrinsic
     ):

--- a/tests/tests_geomstats/test_hyperboloid.py
+++ b/tests/tests_geomstats/test_hyperboloid.py
@@ -81,43 +81,6 @@ class TestHyperboloidMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
         )
         self.assertAllClose(result, expected)
 
-    def test_scaled_inner_product(
-        self, dim, scale, tangent_vec_a, tangent_vec_b, base_point
-    ):
-        default_space = Hyperboloid(dim=dim)
-        scaled_space = Hyperboloid(dim=dim, scale=scale)
-        inner_product_default_metric = default_space.metric.inner_product(
-            tangent_vec_a, tangent_vec_b, base_point
-        )
-        inner_product_scaled_metric = scaled_space.metric.inner_product(
-            tangent_vec_a, tangent_vec_b, base_point
-        )
-        result = inner_product_scaled_metric
-        expected = scale**2 * inner_product_default_metric
-        self.assertAllClose(result, expected)
-
-    def test_scaled_squared_norm(self, dim, scale, tangent_vec, base_point):
-        default_space = Hyperboloid(dim=dim)
-        scaled_space = Hyperboloid(dim=dim, scale=scale)
-        squared_norm_default_metric = default_space.metric.squared_norm(
-            tangent_vec, base_point
-        )
-        squared_norm_scaled_metric = scaled_space.metric.squared_norm(
-            tangent_vec, base_point
-        )
-        result = squared_norm_scaled_metric
-        expected = scale**2 * squared_norm_default_metric
-        self.assertAllClose(result, expected)
-
-    def test_scaled_dist(self, dim, scale, point_a, point_b):
-        default_space = Hyperboloid(dim=dim)
-        scaled_space = Hyperboloid(dim=dim, scale=scale)
-        distance_default_metric = default_space.metric.dist(point_a, point_b)
-        distance_scaled_metric = scaled_space.metric.dist(point_a, point_b)
-        result = distance_scaled_metric
-        expected = scale * distance_default_metric
-        self.assertAllClose(result, expected)
-
     def test_exp_after_log_intrinsic_ball_extrinsic(
         self, dim, x_intrinsic, y_intrinsic
     ):

--- a/tests/tests_geomstats/test_poincare_half_space.py
+++ b/tests/tests_geomstats/test_poincare_half_space.py
@@ -65,9 +65,9 @@ class TestPoincareHalfSpaceMetric(RiemannianMetricTestCase, metaclass=Parametriz
     testing_data = PoincareHalfSpaceMetricTestData()
 
     def test_inner_product(
-        self, dim, scale, tangent_vec_a, tangent_vec_b, base_point, expected
+        self, dim, tangent_vec_a, tangent_vec_b, base_point, expected
     ):
-        metric = self.Metric(dim, scale)
+        metric = self.Metric(dim)
         result = metric.inner_product(
             gs.array(tangent_vec_a), gs.array(tangent_vec_b), gs.array(base_point)
         )

--- a/tests/tests_geomstats/test_poincare_polydisk.py
+++ b/tests/tests_geomstats/test_poincare_polydisk.py
@@ -39,10 +39,8 @@ class TestPoincarePolydiskMetric(TestCase, metaclass=Parametrizer):
         duplicate_point_a = gs.stack([point_a_extrinsic, point_a_extrinsic], axis=0)
         duplicate_point_b = gs.stack([point_b_extrinsic, point_b_extrinsic], axis=0)
 
-        single_disk = PoincarePolydisk(n_disks=n_disks, default_coords_type="extrinsic")
-        two_disks = PoincarePolydisk(
-            n_disks=2 * n_disks, default_coords_type="extrinsic"
-        )
+        single_disk = PoincarePolydisk(n_disks=n_disks)
+        two_disks = PoincarePolydisk(n_disks=2 * n_disks)
 
         distance_single_disk = single_disk.metric.dist(
             point_a_extrinsic[None, :], point_b_extrinsic[None, :]

--- a/tests/tests_geomstats/test_poincare_polydisk.py
+++ b/tests/tests_geomstats/test_poincare_polydisk.py
@@ -33,14 +33,12 @@ class TestPoincarePolydiskMetric(TestCase, metaclass=Parametrizer):
         self.assertAllClose(metric.signature, expected)
 
     @tests.conftest.np_autograd_and_torch_only
-    def test_product_distance_extrinsic_representation(
-        self, n_disks, point_a_extrinsic, point_b_extrinsic
-    ):
+    def test_product_distance(self, point_a_extrinsic, point_b_extrinsic):
         duplicate_point_a = gs.stack([point_a_extrinsic, point_a_extrinsic], axis=0)
         duplicate_point_b = gs.stack([point_b_extrinsic, point_b_extrinsic], axis=0)
 
-        single_disk = PoincarePolydisk(n_disks=n_disks)
-        two_disks = PoincarePolydisk(n_disks=2 * n_disks)
+        single_disk = PoincarePolydisk(n_disks=1)
+        two_disks = PoincarePolydisk(n_disks=2)
 
         distance_single_disk = single_disk.metric.dist(
             point_a_extrinsic[None, :], point_b_extrinsic[None, :]

--- a/tests/tests_geomstats/test_poincare_polydisk.py
+++ b/tests/tests_geomstats/test_poincare_polydisk.py
@@ -47,5 +47,5 @@ class TestPoincarePolydiskMetric(TestCase, metaclass=Parametrizer):
         )
         distance_two_disks = two_disks.metric.dist(duplicate_point_a, duplicate_point_b)
         result = distance_two_disks
-        expected = distance_single_disk
+        expected = 3 ** 0.5 * distance_single_disk
         self.assertAllClose(result, expected)

--- a/tests/tests_geomstats/test_poincare_polydisk.py
+++ b/tests/tests_geomstats/test_poincare_polydisk.py
@@ -49,5 +49,5 @@ class TestPoincarePolydiskMetric(TestCase, metaclass=Parametrizer):
         )
         distance_two_disks = two_disks.metric.dist(duplicate_point_a, duplicate_point_b)
         result = distance_two_disks
-        expected = 3**0.5 * distance_single_disk
+        expected = distance_single_disk
         self.assertAllClose(result, expected)

--- a/tests/tests_geomstats/test_poincare_polydisk.py
+++ b/tests/tests_geomstats/test_poincare_polydisk.py
@@ -33,17 +33,19 @@ class TestPoincarePolydiskMetric(TestCase, metaclass=Parametrizer):
         self.assertAllClose(metric.signature, expected)
 
     @tests.conftest.np_autograd_and_torch_only
-    def test_product_distance(self, point_a_extrinsic, point_b_extrinsic):
-        duplicate_point_a = gs.stack([point_a_extrinsic, point_a_extrinsic], axis=0)
-        duplicate_point_b = gs.stack([point_b_extrinsic, point_b_extrinsic], axis=0)
+    def test_product_distance(
+        self, m_disks, n_disks, point_a_extrinsic, point_b_extrinsic
+    ):
+        stacked_point_a = gs.stack([point_a_extrinsic for n in range(n_disks)], axis=0)
+        stacked_point_b = gs.stack([point_b_extrinsic for n in range(n_disks)], axis=0)
 
-        single_disk = PoincarePolydisk(n_disks=1)
-        two_disks = PoincarePolydisk(n_disks=2)
+        single_disk = PoincarePolydisk(n_disks=m_disks)
+        multiple_disks = PoincarePolydisk(n_disks=m_disks * n_disks)
 
         distance_single_disk = single_disk.metric.dist(
             point_a_extrinsic[None, :], point_b_extrinsic[None, :]
         )
-        distance_two_disks = two_disks.metric.dist(duplicate_point_a, duplicate_point_b)
-        result = distance_two_disks
-        expected = 3 ** 0.5 * distance_single_disk
+        distance_n_disks = multiple_disks.metric.dist(stacked_point_a, stacked_point_b)
+        result = distance_n_disks
+        expected = (n_disks * (n_disks + 1) / 2) ** 0.5 * distance_single_disk
         self.assertAllClose(result, expected)

--- a/tests/tests_geomstats/test_scalar_product_metric.py
+++ b/tests/tests_geomstats/test_scalar_product_metric.py
@@ -74,3 +74,9 @@ class TestInstantiation(TestCase):
 
         self.assertAllClose(scale * dist, dist_1)
         self.assertAllClose(scale**2 * dist, dist_2)
+
+    def test_assigning_scalar_metric_to_space(self):
+        space = Euclidean(dim=3)
+        scale = 2.0
+        scaled_metric = ScalarProductMetric(space.metric, scale)
+        space.metric = scaled_metric

--- a/tests/tests_geomstats/test_scalar_product_metric.py
+++ b/tests/tests_geomstats/test_scalar_product_metric.py
@@ -65,15 +65,21 @@ class TestInstantiation(TestCase):
         scale = 2.0
 
         scaled_metric_1 = ScalarProductMetric(space.metric, scale)
-        scaled_metric_2 = ScalarProductMetric(scaled_metric_1, scale)
+        scaled_metric_2_a = ScalarProductMetric(scaled_metric_1, scale)
+        scaled_metric_2_b = scale * scaled_metric_1
+        scaled_metric_2_c = scaled_metric_1 * scale
 
         point_a, point_b = space.random_point(2)
         dist = space.metric.squared_dist(point_a, point_b)
         dist_1 = scaled_metric_1.squared_dist(point_a, point_b)
-        dist_2 = scaled_metric_2.squared_dist(point_a, point_b)
+        dist_2_a = scaled_metric_2_a.squared_dist(point_a, point_b)
+        dist_2_b = scaled_metric_2_b.squared_dist(point_a, point_b)
+        dist_2_c = scaled_metric_2_c.squared_dist(point_a, point_b)
 
         self.assertAllClose(scale * dist, dist_1)
-        self.assertAllClose(scale**2 * dist, dist_2)
+        self.assertAllClose(scale**2 * dist, dist_2_a)
+        self.assertAllClose(dist_2_b, dist_2_a)
+        self.assertAllClose(dist_2_c, dist_2_a)
 
     def test_assigning_scalar_metric_to_space(self):
         space = Euclidean(dim=3)

--- a/tests/tests_geomstats/test_siegel.py
+++ b/tests/tests_geomstats/test_siegel.py
@@ -40,8 +40,10 @@ class TestSiegelMetric(ComplexRiemannianMetricTestCase, metaclass=Parametrizer):
 
     testing_data = SiegelMetricTestData()
 
-    def test_inner_product(self, n, tangent_vec_a, tangent_vec_b, base_point, expected):
-        metric = self.Metric(n)
+    def test_inner_product(
+        self, n, scale, tangent_vec_a, tangent_vec_b, base_point, expected
+    ):
+        metric = scale * self.Metric(n)
         result = metric.inner_product(
             gs.array(tangent_vec_a),
             gs.array(tangent_vec_b),
@@ -49,8 +51,8 @@ class TestSiegelMetric(ComplexRiemannianMetricTestCase, metaclass=Parametrizer):
         )
         self.assertAllClose(result, expected)
 
-    def test_exp(self, n, tangent_vec, base_point, expected):
-        metric = self.Metric(n)
+    def test_exp(self, n, scale, tangent_vec, base_point, expected):
+        metric = scale * self.Metric(n)
         self.assertAllClose(
             metric.exp(
                 gs.array(tangent_vec),
@@ -59,8 +61,8 @@ class TestSiegelMetric(ComplexRiemannianMetricTestCase, metaclass=Parametrizer):
             gs.array(expected),
         )
 
-    def test_log(self, n, point, base_point, expected):
-        metric = self.Metric(n)
+    def test_log(self, n, scale, point, base_point, expected):
+        metric = scale * self.Metric(n)
         self.assertAllClose(
             metric.log(
                 gs.array(point),
@@ -70,9 +72,9 @@ class TestSiegelMetric(ComplexRiemannianMetricTestCase, metaclass=Parametrizer):
         )
 
     def test_sectional_curvature(
-        self, n, tangent_vec_a, tangent_vec_b, base_point, expected
+        self, n, scale, tangent_vec_a, tangent_vec_b, base_point, expected
     ):
-        metric = self.Metric(n)
+        metric = scale * self.Metric(n)
         result = metric.sectional_curvature(
             gs.array(tangent_vec_a),
             gs.array(tangent_vec_b),

--- a/tests/tests_geomstats/test_siegel.py
+++ b/tests/tests_geomstats/test_siegel.py
@@ -41,9 +41,9 @@ class TestSiegelMetric(ComplexRiemannianMetricTestCase, metaclass=Parametrizer):
     testing_data = SiegelMetricTestData()
 
     def test_inner_product(
-        self, n, scale, tangent_vec_a, tangent_vec_b, base_point, expected
+        self, n, tangent_vec_a, tangent_vec_b, base_point, expected
     ):
-        metric = self.Metric(n, scale)
+        metric = self.Metric(n)
         result = metric.inner_product(
             gs.array(tangent_vec_a),
             gs.array(tangent_vec_b),
@@ -51,8 +51,8 @@ class TestSiegelMetric(ComplexRiemannianMetricTestCase, metaclass=Parametrizer):
         )
         self.assertAllClose(result, expected)
 
-    def test_exp(self, n, scale, tangent_vec, base_point, expected):
-        metric = self.Metric(n, scale)
+    def test_exp(self, n, tangent_vec, base_point, expected):
+        metric = self.Metric(n)
         self.assertAllClose(
             metric.exp(
                 gs.array(tangent_vec),
@@ -61,8 +61,8 @@ class TestSiegelMetric(ComplexRiemannianMetricTestCase, metaclass=Parametrizer):
             gs.array(expected),
         )
 
-    def test_log(self, n, scale, point, base_point, expected):
-        metric = self.Metric(n, scale)
+    def test_log(self, n, point, base_point, expected):
+        metric = self.Metric(n)
         self.assertAllClose(
             metric.log(
                 gs.array(point),
@@ -72,9 +72,9 @@ class TestSiegelMetric(ComplexRiemannianMetricTestCase, metaclass=Parametrizer):
         )
 
     def test_sectional_curvature(
-        self, n, scale, tangent_vec_a, tangent_vec_b, base_point, expected
+        self, n, tangent_vec_a, tangent_vec_b, base_point, expected
     ):
-        metric = self.Metric(n, scale)
+        metric = self.Metric(n)
         result = metric.sectional_curvature(
             gs.array(tangent_vec_a),
             gs.array(tangent_vec_b),

--- a/tests/tests_geomstats/test_siegel.py
+++ b/tests/tests_geomstats/test_siegel.py
@@ -40,10 +40,8 @@ class TestSiegelMetric(ComplexRiemannianMetricTestCase, metaclass=Parametrizer):
 
     testing_data = SiegelMetricTestData()
 
-    def test_inner_product(
-        self, n, scale, tangent_vec_a, tangent_vec_b, base_point, expected
-    ):
-        metric = scale * self.Metric(n)
+    def test_inner_product(self, n, tangent_vec_a, tangent_vec_b, base_point, expected):
+        metric = self.Metric(n)
         result = metric.inner_product(
             gs.array(tangent_vec_a),
             gs.array(tangent_vec_b),
@@ -51,8 +49,8 @@ class TestSiegelMetric(ComplexRiemannianMetricTestCase, metaclass=Parametrizer):
         )
         self.assertAllClose(result, expected)
 
-    def test_exp(self, n, scale, tangent_vec, base_point, expected):
-        metric = scale * self.Metric(n)
+    def test_exp(self, n, tangent_vec, base_point, expected):
+        metric = self.Metric(n)
         self.assertAllClose(
             metric.exp(
                 gs.array(tangent_vec),
@@ -61,8 +59,8 @@ class TestSiegelMetric(ComplexRiemannianMetricTestCase, metaclass=Parametrizer):
             gs.array(expected),
         )
 
-    def test_log(self, n, scale, point, base_point, expected):
-        metric = scale * self.Metric(n)
+    def test_log(self, n, point, base_point, expected):
+        metric = self.Metric(n)
         self.assertAllClose(
             metric.log(
                 gs.array(point),
@@ -72,9 +70,9 @@ class TestSiegelMetric(ComplexRiemannianMetricTestCase, metaclass=Parametrizer):
         )
 
     def test_sectional_curvature(
-        self, n, scale, tangent_vec_a, tangent_vec_b, base_point, expected
+        self, n, tangent_vec_a, tangent_vec_b, base_point, expected
     ):
-        metric = scale * self.Metric(n)
+        metric = self.Metric(n)
         result = metric.sectional_curvature(
             gs.array(tangent_vec_a),
             gs.array(tangent_vec_b),

--- a/tests/tests_geomstats/test_siegel.py
+++ b/tests/tests_geomstats/test_siegel.py
@@ -40,9 +40,7 @@ class TestSiegelMetric(ComplexRiemannianMetricTestCase, metaclass=Parametrizer):
 
     testing_data = SiegelMetricTestData()
 
-    def test_inner_product(
-        self, n, tangent_vec_a, tangent_vec_b, base_point, expected
-    ):
+    def test_inner_product(self, n, tangent_vec_a, tangent_vec_b, base_point, expected):
         metric = self.Metric(n)
         result = metric.inner_product(
             gs.array(tangent_vec_a),


### PR DESCRIPTION
Closes #1757 and closes #1758 by removing the `scale` parameter from various manifolds.

These are the `Hyperbolic`, `HPDMatrices` and `PoincarePolydisk` manifolds, along with all their related classes.

@YannCabanes The tests are failing on `PoincarePolydisk` and I don't understand the objects well enough to remedy the issue. Maybe you could have a look?