### PR TITLE
Correct scaling in ScalarProductMetric

### DIFF
--- a/geomstats/geometry/scalar_product_metric.py
+++ b/geomstats/geometry/scalar_product_metric.py
@@ -25,7 +25,7 @@ INVERSE_LIST = [
     "sectional_curvature",
     "scalar_curvature",
 ]
-INVERSE_QUADRATIC_LIST = ["normalize", "random_unit_tangent_vec", "normal_basis"]
+INVERSE_SQRT_LIST = ["normalize", "random_unit_tangent_vec", "normal_basis"]
 
 
 def _wrap_attr(scaling_factor, func):
@@ -50,8 +50,8 @@ def _get_scaling_factor(func_name, scale):
     if func_name in INVERSE_LIST:
         return 1.0 / scale
 
-    if func_name in INVERSE_QUADRATIC_LIST:
-        return 1.0 / gs.power(scale, 2)
+    if func_name in INVERSE_SQRT_LIST:
+        return 1.0 / gs.sqrt(scale)
     return None
 
 

--- a/tests/tests_geomstats/test_scalar_product_metric.py
+++ b/tests/tests_geomstats/test_scalar_product_metric.py
@@ -37,7 +37,7 @@ class TestWrapper(TestCase):
 
         func_name = "normalize"
         scaling_factor = _get_scaling_factor(func_name, scale)
-        self.assertAllClose(1.0 / gs.power(scale, 2), scaling_factor)
+        self.assertAllClose(1.0 / gs.sqrt(scale), scaling_factor)
 
         func_name = "not_scaled"
         scaling_factor = _get_scaling_factor(func_name, scale)


### PR DESCRIPTION
Following a review by @YannCabanes in #1727 and #1761 of all the scaling factors, it is clear that INVERSE_QUADRATIC_LIST should be INVERSE_SQRT_LIST instead. This PR corrects that error.