### PR TITLE
Allow gs.stack to receive arrays of different dtypes in tf

### DIFF
--- a/geomstats/_backend/tensorflow/__init__.py
+++ b/geomstats/_backend/tensorflow/__init__.py
@@ -31,7 +31,7 @@ from tensorflow import (
 from tensorflow import reduce_max as amax
 from tensorflow import reduce_min as amin
 from tensorflow import reduce_prod as prod
-from tensorflow import reshape, searchsorted, sort, stack, uint8, zeros_like
+from tensorflow import reshape, searchsorted, sort, uint8, zeros_like
 from tensorflow.experimental.numpy import empty_like, moveaxis
 
 from .._backend_config import tf_atol as atol
@@ -914,3 +914,8 @@ def matmul(x, y):
 
 def gamma(x):
     return _tf.exp(_tf.math.lgamma(x))
+
+
+def stack(arrays, axis=0):
+    arrays = convert_to_wider_dtype(arrays)
+    return _tf.stack(arrays, axis=axis)


### PR DESCRIPTION
Allows `gs.stack` to accepts array of different dtypes in tensorflow (this behavior is already allowed in the other backends). If conversion is needed, it converts to wider dtype.

Required for #1764.