### PR TITLE
Extend product manifold to handle factors with different fields

### DIFF
--- a/geomstats/geometry/product_manifold.py
+++ b/geomstats/geometry/product_manifold.py
@@ -11,6 +11,7 @@ from geomstats.geometry.product_riemannian_metric import (
     NFoldMetric,
     ProductRiemannianMetric,
     _all_equal,
+    _has_mixed_fields,
     _IterateOverFactorsMixins,
 )
 
@@ -76,6 +77,7 @@ class ProductManifold(_IterateOverFactorsMixins, Manifold):
 
         super().__init__(
             pool_outputs=True,
+            has_mixed_fields=_has_mixed_fields(self.factors),
             dim=dim,
             shape=shape,
             default_coords_type=default_coords_type,


### PR DESCRIPTION
Extend product manifold to handle factors with different fields (i.e. some factors are real manifold/metric, other are complex).

Product manifold points are, in this case, represented with complex arrays. Only the real part is sent for the computations within real manifolds. @YannCabanes, this is the reason I didn't want you to care about complex arrays when developing real manifolds.

Required for #1764.
