### PR TITLE
Fixes and improvements coming from test refactoring

### DIFF
--- a/geomstats/geometry/base.py
+++ b/geomstats/geometry/base.py
@@ -145,14 +145,6 @@ class VectorSpace(Manifold, abc.ABC):
             self._basis = self._create_basis()
         return self._basis
 
-    @basis.setter
-    def basis(self, basis):
-        if len(basis) < self.dim:
-            raise ValueError(
-                "The basis should have length equal to the " "dimension of the space."
-            )
-        self._basis = basis
-
     @abc.abstractmethod
     def _create_basis(self):
         """Create a canonical basis."""

--- a/geomstats/geometry/euclidean.py
+++ b/geomstats/geometry/euclidean.py
@@ -23,17 +23,15 @@ class Euclidean(VectorSpace):
             metric=EuclideanMetric(dim, shape=(dim,)),
         )
 
-    def get_identity(self):
-        """Get the identity of the group.
+    @property
+    def identity(self):
+        """Identity of the group.
 
         Returns
         -------
         identity : array-like, shape=[n]
         """
-        identity = gs.zeros(self.dim)
-        return identity
-
-    identity = property(get_identity)
+        return gs.zeros(self.dim)
 
     def _create_basis(self):
         """Create the canonical basis."""
@@ -54,8 +52,6 @@ class Euclidean(VectorSpace):
         point : array-like, shape=[..., n]
             Group exponential.
         """
-        if not self.belongs(tangent_vec):
-            raise ValueError("The update must be of the same dimension")
         return tangent_vec + base_point
 
 

--- a/geomstats/geometry/full_rank_correlation_matrices.py
+++ b/geomstats/geometry/full_rank_correlation_matrices.py
@@ -55,7 +55,11 @@ class FullRankCorrelationMatrices(LevelSet):
         -------
         submersed_vector : array-like, shape=[..., n]
         """
-        return Matrices.diagonal(vector)
+        submersed_vector = Matrices.diagonal(vector)
+        if point is not None and point.ndim > vector.ndim:
+            return gs.broadcast_to(submersed_vector, point.shape[:-1])
+
+        return submersed_vector
 
     @staticmethod
     def diag_action(diagonal_vec, point):

--- a/geomstats/geometry/general_linear.py
+++ b/geomstats/geometry/general_linear.py
@@ -29,9 +29,10 @@ class GeneralLinear(MatrixLieGroup, OpenSet):
         kwargs.setdefault("dim", n**2)
         kwargs.setdefault("metric", embedding_space.metric)
 
+        self.n = n
         super().__init__(
             embedding_space=embedding_space,
-            n=n,
+            n_lg=n,
             lie_algebra=SquareMatrices(n),
             **kwargs
         )
@@ -181,12 +182,13 @@ class SquareMatrices(MatrixLieAlgebra):
     """
 
     def __init__(self, n):
-        super().__init__(n=n, dim=n**2)
-        self.mat_space = Matrices(n, n)
+        self.n = n
+        super().__init__(n_la=n, dim=n**2)
+        self._mat_space = Matrices(n, n)
 
     def _create_basis(self):
         """Create the canonical basis of the space of matrices."""
-        return self.mat_space.basis
+        return self._mat_space.basis
 
     def basis_representation(self, matrix_representation):
         """Compute the coefficient in the usual matrix basis.
@@ -203,7 +205,7 @@ class SquareMatrices(MatrixLieAlgebra):
         basis_representation : array-like, shape=[..., dim]
             Representation in the basis.
         """
-        return self.mat_space.flatten(matrix_representation)
+        return self._mat_space.flatten(matrix_representation)
 
     def matrix_representation(self, basis_representation):
         """Compute the matrix representation for the given basis coefficients.
@@ -220,4 +222,4 @@ class SquareMatrices(MatrixLieAlgebra):
         matrix_representation : array-like, shape=[..., n, n]
             Matrix.
         """
-        return self.mat_space.reshape(basis_representation)
+        return self._mat_space.reshape(basis_representation)

--- a/geomstats/geometry/general_linear.py
+++ b/geomstats/geometry/general_linear.py
@@ -32,7 +32,7 @@ class GeneralLinear(MatrixLieGroup, OpenSet):
         self.n = n
         super().__init__(
             embedding_space=embedding_space,
-            n_lg=n,
+            representation_dim=n,
             lie_algebra=SquareMatrices(n),
             **kwargs
         )
@@ -183,7 +183,7 @@ class SquareMatrices(MatrixLieAlgebra):
 
     def __init__(self, n):
         self.n = n
-        super().__init__(n_la=n, dim=n**2)
+        super().__init__(dim=n**2, representation_dim=n)
         self._mat_space = Matrices(n, n)
 
     def _create_basis(self):

--- a/geomstats/geometry/heisenberg.py
+++ b/geomstats/geometry/heisenberg.py
@@ -33,16 +33,15 @@ class HeisenbergVectors(LieGroup, VectorSpace):
         """Create the canonical basis."""
         return gs.eye(3)
 
-    def get_identity(self):
-        """Get the identity of the 3D Heisenberg group.
+    @property
+    def identity(self):
+        """Identity of the 3D Heisenberg group.
 
         Returns
         -------
         _ : array-like, shape=[3,]
         """
         return gs.zeros(self.dim)
-
-    identity = property(get_identity)
 
     def compose(self, point_a, point_b):
         """Compute the group product of elements `point_a` and `point_b`.
@@ -88,7 +87,7 @@ class HeisenbergVectors(LieGroup, VectorSpace):
         """
         return -point
 
-    def jacobian_translation(self, point, left_or_right="left"):
+    def jacobian_translation(self, point, left=True):
         """Compute the Jacobian matrix of left/right translation by a point.
 
         This calculates the differential of the left translation L_(point)
@@ -100,10 +99,10 @@ class HeisenbergVectors(LieGroup, VectorSpace):
         ----------
         point : array-like, shape=[..., 3]
             Point.
-        left_or_right : str, {'left', 'right'}
+        left : bool
             Indicate whether to calculate the differential of left or right
             translations.
-            Optional, default: 'left'.
+            Optional, default: True.
 
         Returns
         -------
@@ -113,7 +112,7 @@ class HeisenbergVectors(LieGroup, VectorSpace):
         e31 = gs.array_from_sparse([(2, 0)], [1.0], (3, 3))
         e32 = gs.array_from_sparse([(2, 1)], [1.0], (3, 3))
 
-        if left_or_right == "left":
+        if left:
             return (
                 gs.eye(3)
                 + gs.einsum("..., ij -> ...ij", -point[..., 1] / 2, e31)

--- a/geomstats/geometry/hermitian.py
+++ b/geomstats/geometry/hermitian.py
@@ -24,17 +24,15 @@ class Hermitian(ComplexVectorSpace):
         kwargs.setdefault("metric", HermitianMetric(dim, shape=(dim,)))
         super().__init__(shape=(dim,), **kwargs)
 
-    def get_identity(self):
-        """Get the identity of the group.
+    @property
+    def identity(self):
+        """Identity of the group.
 
         Returns
         -------
         identity : array-like, shape=[n]
         """
-        identity = gs.zeros(self.dim, dtype=gs.get_default_cdtype())
-        return identity
-
-    identity = property(get_identity)
+        return gs.zeros(self.dim, dtype=gs.get_default_cdtype())
 
     def _create_basis(self):
         """Create the canonical basis."""

--- a/geomstats/geometry/lie_algebra.py
+++ b/geomstats/geometry/lie_algebra.py
@@ -26,17 +26,17 @@ class MatrixLieAlgebra(VectorSpace, abc.ABC):
     ----------
     dim : int
         Dimension of the Lie algebra as a real vector space.
-    n_la : int
+    representation_dim : int
         Amount of rows and columns in the matrix representation of the
         Lie algebra.
     """
 
-    def __init__(self, dim, n_la, **kwargs):
-        super().__init__(shape=(n_la, n_la), **kwargs)
+    def __init__(self, dim, representation_dim, **kwargs):
+        super().__init__(shape=(representation_dim, representation_dim), **kwargs)
         geomstats.errors.check_integer(dim, "dim")
-        geomstats.errors.check_integer(n_la, "n_la")
+        geomstats.errors.check_integer(representation_dim, "representation_dim")
         self.dim = dim
-        self.n_la = n_la
+        self.representation_dim = representation_dim
 
     bracket = Matrices.bracket
 
@@ -54,7 +54,8 @@ class MatrixLieAlgebra(VectorSpace, abc.ABC):
 
         Parameters
         ----------
-        matrix_a, matrix_b : array-like, shape=[..., n_la, n_la]
+        matrix_a : array-like, shape=[..., *point_shape]
+        matrix_b : array-like, shape=[..., *point_shape]
             Matrices.
         order : int
             The order to which the approximation is calculated. Note that this
@@ -95,7 +96,7 @@ class MatrixLieAlgebra(VectorSpace, abc.ABC):
 
         Parameters
         ----------
-        matrix_representation : array-like, shape=[..., n_la, n_la]
+        matrix_representation : array-like, shape=[..., *point_shape]
             Matrix.
 
         Returns
@@ -118,7 +119,7 @@ class MatrixLieAlgebra(VectorSpace, abc.ABC):
 
         Returns
         -------
-        matrix_representation : array-like, shape=[..., n_la, n_la]
+        matrix_representation : array-like, shape=[..., *point_shape]
             Matrix.
         """
         if self.basis is None:

--- a/geomstats/geometry/lie_algebra.py
+++ b/geomstats/geometry/lie_algebra.py
@@ -26,17 +26,17 @@ class MatrixLieAlgebra(VectorSpace, abc.ABC):
     ----------
     dim : int
         Dimension of the Lie algebra as a real vector space.
-    n : int
+    n_la : int
         Amount of rows and columns in the matrix representation of the
         Lie algebra.
     """
 
-    def __init__(self, dim, n, **kwargs):
-        super().__init__(shape=(n, n), **kwargs)
+    def __init__(self, dim, n_la, **kwargs):
+        super().__init__(shape=(n_la, n_la), **kwargs)
         geomstats.errors.check_integer(dim, "dim")
-        geomstats.errors.check_integer(n, "n")
+        geomstats.errors.check_integer(n_la, "n_la")
         self.dim = dim
-        self.n = n
+        self.n_la = n_la
 
     bracket = Matrices.bracket
 
@@ -54,7 +54,7 @@ class MatrixLieAlgebra(VectorSpace, abc.ABC):
 
         Parameters
         ----------
-        matrix_a, matrix_b : array-like, shape=[..., n, n]
+        matrix_a, matrix_b : array-like, shape=[..., n_la, n_la]
             Matrices.
         order : int
             The order to which the approximation is calculated. Note that this
@@ -95,7 +95,7 @@ class MatrixLieAlgebra(VectorSpace, abc.ABC):
 
         Parameters
         ----------
-        matrix_representation : array-like, shape=[..., n, n]
+        matrix_representation : array-like, shape=[..., n_la, n_la]
             Matrix.
 
         Returns
@@ -118,7 +118,7 @@ class MatrixLieAlgebra(VectorSpace, abc.ABC):
 
         Returns
         -------
-        matrix_representation : array-like, shape=[..., n, n]
+        matrix_representation : array-like, shape=[..., n_la, n_la]
             Matrix.
         """
         if self.basis is None:

--- a/geomstats/geometry/lie_group.py
+++ b/geomstats/geometry/lie_group.py
@@ -16,10 +16,12 @@ ATOL = 1e-6
 class MatrixLieGroup(Manifold, abc.ABC):
     """Class for matrix Lie groups."""
 
-    def __init__(self, dim, n_lg, lie_algebra=None, **kwargs):
-        super().__init__(dim=dim, shape=(n_lg, n_lg), **kwargs)
+    def __init__(self, dim, representation_dim, lie_algebra=None, **kwargs):
+        super().__init__(
+            dim=dim, shape=(representation_dim, representation_dim), **kwargs
+        )
         self.lie_algebra = lie_algebra
-        self.n_lg = n_lg
+        self.representation_dim = representation_dim
         self.left_canonical_metric = InvariantMetric(
             group=self,
             metric_mat_at_identity=gs.eye(self.dim),
@@ -35,7 +37,7 @@ class MatrixLieGroup(Manifold, abc.ABC):
     @property
     def identity(self):
         """Matrix identity."""
-        return gs.eye(self.n_lg)
+        return gs.eye(self.representation_dim)
 
     @staticmethod
     def compose(point_a, point_b):

--- a/geomstats/geometry/lie_group.py
+++ b/geomstats/geometry/lie_group.py
@@ -6,7 +6,6 @@ Lead author: Nina Miolane.
 import abc
 
 import geomstats.backend as gs
-import geomstats.errors as errors
 from geomstats.geometry.invariant_metric import InvariantMetric
 from geomstats.geometry.manifold import Manifold
 from geomstats.geometry.matrices import Matrices
@@ -17,22 +16,26 @@ ATOL = 1e-6
 class MatrixLieGroup(Manifold, abc.ABC):
     """Class for matrix Lie groups."""
 
-    def __init__(self, dim, n, lie_algebra=None, **kwargs):
-        super().__init__(dim=dim, shape=(n, n), **kwargs)
+    def __init__(self, dim, n_lg, lie_algebra=None, **kwargs):
+        super().__init__(dim=dim, shape=(n_lg, n_lg), **kwargs)
         self.lie_algebra = lie_algebra
-        self.n = n
+        self.n_lg = n_lg
         self.left_canonical_metric = InvariantMetric(
-            group=self, metric_mat_at_identity=gs.eye(self.dim), left_or_right="left"
+            group=self,
+            metric_mat_at_identity=gs.eye(self.dim),
+            left=True,
         )
 
         self.right_canonical_metric = InvariantMetric(
-            group=self, metric_mat_at_identity=gs.eye(self.dim), left_or_right="right"
+            group=self,
+            metric_mat_at_identity=gs.eye(self.dim),
+            left=False,
         )
 
     @property
     def identity(self):
         """Matrix identity."""
-        return gs.eye(self.n)
+        return gs.eye(self.n_lg)
 
     @staticmethod
     def compose(point_a, point_b):
@@ -70,7 +73,7 @@ class MatrixLieGroup(Manifold, abc.ABC):
         """
         return gs.linalg.inv(point)
 
-    def tangent_translation_map(self, point, left_or_right="left", inverse=False):
+    def tangent_translation_map(self, point, left=True, inverse=False):
         r"""Compute the push-forward map by the left/right translation.
 
         Compute the push-forward map, of the left/right translation by the
@@ -85,10 +88,10 @@ class MatrixLieGroup(Manifold, abc.ABC):
         ----------
         point : array-like, shape=[..., {dim, [n, n]]
             Point.
-        left_or_right : str, {'left', 'right'}
+        left : bool
             Whether to calculate the differential of left or right
             translations.
-            Optional, default: 'left'
+            Optional, default: True
         inverse : bool,
             Whether to inverse the jacobian matrix. If True, the push forward
             by the translation by the inverse of point is returned.
@@ -100,12 +103,9 @@ class MatrixLieGroup(Manifold, abc.ABC):
             Tangent map of the left/right translation by point. It can be
             applied to tangent vectors.
         """
-        errors.check_parameter_accepted_values(
-            left_or_right, "left_or_right", ["left", "right"]
-        )
         if inverse:
             point = self.inverse(point)
-        if left_or_right == "left":
+        if left:
             return lambda tangent_vec: self.compose(point, tangent_vec)
         return lambda tangent_vec: self.compose(tangent_vec, point)
 
@@ -166,8 +166,7 @@ class MatrixLieGroup(Manifold, abc.ABC):
             tangent_vec_at_id = vector
         else:
             tangent_vec_at_id = self.compose(self.inverse(base_point), vector)
-        is_tangent = self.lie_algebra.belongs(tangent_vec_at_id, atol)
-        return is_tangent
+        return self.lie_algebra.belongs(tangent_vec_at_id, atol)
 
     def to_tangent(self, vector, base_point=None):
         """Project a vector onto the tangent space at a base point.
@@ -300,18 +299,22 @@ class LieGroup(Manifold, abc.ABC):
 
         self.lie_algebra = lie_algebra
         self.left_canonical_metric = InvariantMetric(
-            group=self, metric_mat_at_identity=gs.eye(self.dim), left_or_right="left"
+            group=self,
+            metric_mat_at_identity=gs.eye(self.dim),
+            left=True,
         )
 
         self.right_canonical_metric = InvariantMetric(
-            group=self, metric_mat_at_identity=gs.eye(self.dim), left_or_right="right"
+            group=self,
+            metric_mat_at_identity=gs.eye(self.dim),
+            left=False,
         )
 
         self.metric = self.left_canonical_metric
-        self.metrics = []
 
-    def get_identity(self):
-        """Get the identity of the group.
+    @property
+    def identity(self):
+        """Identity of the group.
 
         Returns
         -------
@@ -319,8 +322,6 @@ class LieGroup(Manifold, abc.ABC):
             Identity of the Lie group.
         """
         raise NotImplementedError("The Lie group identity is not implemented.")
-
-    identity = property(get_identity)
 
     def compose(self, point_a, point_b):
         """Perform function composition corresponding to the Lie group.
@@ -357,7 +358,7 @@ class LieGroup(Manifold, abc.ABC):
         """
         raise NotImplementedError("The Lie group inverse is not implemented.")
 
-    def jacobian_translation(self, point, left_or_right="left"):
+    def jacobian_translation(self, point, left=True):
         """Compute the Jacobian of left/right translation by a point.
 
         Compute the Jacobian matrix of the left translation by the point.
@@ -366,10 +367,10 @@ class LieGroup(Manifold, abc.ABC):
         ----------
         point : array-like, shape=[..., {dim, [n, n]]
             Point.
-        left_or_right : str, {'left', 'right'}
+        left : bool
             Indicate whether to calculate the differential of left or right
             translations.
-            Optional, default: 'left'.
+            Optional, default: True.
 
         Returns
         -------
@@ -380,7 +381,7 @@ class LieGroup(Manifold, abc.ABC):
             "The jacobian of the Lie group translation is not implemented."
         )
 
-    def tangent_translation_map(self, point, left_or_right="left", inverse=False):
+    def tangent_translation_map(self, point, left=True, inverse=False):
         r"""Compute the push-forward map by the left/right translation.
 
         Compute the push-forward map, of the left/right translation by the
@@ -395,10 +396,10 @@ class LieGroup(Manifold, abc.ABC):
         ----------
         point : array-like, shape=[..., {dim, [n, n]]
             Point.
-        left_or_right : str, {'left', 'right'}
+        left: bool
             Whether to calculate the differential of left or right
             translations.
-            Optional, default: 'left'
+            Optional, default: True.
         inverse : bool,
             Whether to inverse the jacobian matrix. If True, the push forward
             by the translation by the inverse of point is returned.
@@ -410,17 +411,14 @@ class LieGroup(Manifold, abc.ABC):
             Tangent map of the left/right translation by point. It can be
             applied to tangent vectors.
         """
-        errors.check_parameter_accepted_values(
-            left_or_right, "left_or_right", ["left", "right"]
-        )
         if self.default_point_type == "matrix":
             if inverse:
                 point = self.inverse(point)
-            if left_or_right == "left":
+            if left:
                 return lambda tangent_vec: Matrices.mul(point, tangent_vec)
             return lambda tangent_vec: Matrices.mul(tangent_vec, point)
 
-        jacobian = self.jacobian_translation(point, left_or_right)
+        jacobian = self.jacobian_translation(point, left)
         if inverse:
             jacobian = gs.linalg.inv(jacobian)
         return lambda tangent_vec: gs.einsum("...ij,...j->...i", jacobian, tangent_vec)
@@ -459,7 +457,7 @@ class LieGroup(Manifold, abc.ABC):
         """
         if self.default_point_type == "vector":
             tangent_translation = self.tangent_translation_map(
-                point=base_point, left_or_right="left", inverse=True
+                point=base_point, left=True, inverse=True
             )
 
             tangent_vec_at_id = tangent_translation(tangent_vec)
@@ -487,7 +485,7 @@ class LieGroup(Manifold, abc.ABC):
         result : array-like, shape=[..., {dim, [n, n]}]
             Group exponential.
         """
-        identity = self.get_identity()
+        identity = self.identity
 
         if base_point is None:
             base_point = identity
@@ -533,7 +531,8 @@ class LieGroup(Manifold, abc.ABC):
         """
         if self.default_point_type == "vector":
             tangent_translation = self.tangent_translation_map(
-                point=base_point, left_or_right="left"
+                point=base_point,
+                left=True,
             )
             point_near_id = self.compose(self.inverse(base_point), point)
             log_from_id = self.log_from_identity(point=point_near_id)
@@ -561,7 +560,7 @@ class LieGroup(Manifold, abc.ABC):
         """
         # TODO (ninamiolane): Build a standalone decorator that *only*
         # deals with point_type None and base_point None
-        identity = self.get_identity()
+        identity = self.identity
         if base_point is None:
             base_point = identity
 
@@ -573,16 +572,6 @@ class LieGroup(Manifold, abc.ABC):
         else:
             result = self.log_not_from_identity(point, base_point)
         return result
-
-    def add_metric(self, metric):
-        """Add a metric to the instance's list of metrics.
-
-        Parameters
-        ----------
-        metric : RiemannianMetric
-            Metric to add.
-        """
-        self.metrics.append(metric)
 
     def lie_bracket(self, tangent_vector_a, tangent_vector_b, base_point=None):
         """Compute the lie bracket of two tangent vectors.
@@ -606,7 +595,7 @@ class LieGroup(Manifold, abc.ABC):
             Lie bracket.
         """
         if base_point is None:
-            base_point = self.get_identity()
+            base_point = self.identity
         inverse_base_point = self.inverse(base_point)
 
         first_term = Matrices.mul(inverse_base_point, tangent_vector_b)

--- a/geomstats/geometry/lower_triangular_matrices.py
+++ b/geomstats/geometry/lower_triangular_matrices.py
@@ -30,8 +30,8 @@ class LowerTriangularMatrices(VectorSpace):
         basis : array-like, shape=[dim, n, n]
             Basis matrices of the space.
         """
+        # TODO: check one_hot
         tril_idxs = gs.ravel_tril_indices(self.n)
-        # TODO: use default dtype when available
         vector_bases = gs.cast(
             gs.one_hot(tril_idxs, self.n * self.n),
             dtype=gs.get_default_dtype(),
@@ -75,6 +75,21 @@ class LowerTriangularMatrices(VectorSpace):
         """
         return gs.tril_to_vec(mat)
 
+    def from_vector(self, vec):
+        """Convert a vector into a lower triangular matrix.
+
+        Parameters
+        ----------
+        vec : array-like, shape=[..., n(n+1)/2]
+            Vector.
+
+        Returns
+        -------
+        mat : array-like, shape=[..., n, n]
+            Lower triangular matrix.
+        """
+        return gs.einsum("...i,...ijk->...jk", vec, self.basis)
+
     def projection(self, point):
         """Make a square matrix lower triangular by zeroing out other elements.
 
@@ -88,7 +103,7 @@ class LowerTriangularMatrices(VectorSpace):
         sym : array-like, shape=[..., n, n]
             Symmetric matrix.
         """
-        return Matrices.to_lower_triangular(point)
+        return gs.tril(point)
 
     def random_point(self, n_samples=1, bound=1.0):
         """Sample a lower triangular matrix with a uniform distribution in a box.
@@ -108,4 +123,4 @@ class LowerTriangularMatrices(VectorSpace):
            Sample.
         """
         sample = super().random_point(n_samples, bound)
-        return Matrices.to_lower_triangular(sample)
+        return gs.tril(sample)

--- a/geomstats/geometry/skew_symmetric_matrices.py
+++ b/geomstats/geometry/skew_symmetric_matrices.py
@@ -25,7 +25,7 @@ class SkewSymmetricMatrices(MatrixLieAlgebra):
     def __init__(self, n):
         self.n = n
         dim = int(n * (n - 1) / 2)
-        super().__init__(dim, n)
+        super().__init__(dim=dim, representation_dim=n)
         self.embedding_space = Matrices(n, n)
 
     def _create_basis(self):

--- a/geomstats/geometry/skew_symmetric_matrices.py
+++ b/geomstats/geometry/skew_symmetric_matrices.py
@@ -23,6 +23,7 @@ class SkewSymmetricMatrices(MatrixLieAlgebra):
     """
 
     def __init__(self, n):
+        self.n = n
         dim = int(n * (n - 1) / 2)
         super().__init__(dim, n)
         self.embedding_space = Matrices(n, n)

--- a/geomstats/geometry/special_euclidean.py
+++ b/geomstats/geometry/special_euclidean.py
@@ -201,8 +201,8 @@ class _SpecialEuclideanMatrices(MatrixLieGroup, LevelSet):
         self._value = gs.eye(n + 1)
 
         super().__init__(
-            n_lg=n + 1,
             dim=int((n * (n + 1)) / 2),
+            representation_dim=n + 1,
             lie_algebra=SpecialEuclideanMatrixLieAlgebra(n=n),
             **kwargs
         )
@@ -354,8 +354,7 @@ class _SpecialEuclideanVectors(LieGroup):
 
     def __init__(self, n, epsilon=0.0):
         dim = n * (n + 1) // 2
-        LieGroup.__init__(
-            self,
+        super().__init__(
             dim=dim,
             shape=(dim,),
             lie_algebra=Euclidean(dim),
@@ -1318,7 +1317,7 @@ class SpecialEuclideanMatrixLieAlgebra(MatrixLieAlgebra):
     def __init__(self, n):
         self.n = n
         dim = int(n * (n + 1) / 2)
-        super().__init__(dim, n + 1)
+        super().__init__(dim=dim, representation_dim=n + 1)
 
         self.skew = SkewSymmetricMatrices(n)
 

--- a/geomstats/geometry/special_euclidean.py
+++ b/geomstats/geometry/special_euclidean.py
@@ -110,7 +110,7 @@ def _squared_dist(point_a, point_b, metric):
     return metric.private_squared_dist(point_a, point_b)
 
 
-def homogeneous_representation(rotation, translation, output_shape, constant=1.0):
+def homogeneous_representation(rotation, translation, constant=1.0):
     r"""Embed rotation, translation couples into n+1 square matrices.
 
     Construct a block matrix of size :math:`n + 1 \times n + 1` of the form
@@ -127,8 +127,6 @@ def homogeneous_representation(rotation, translation, output_shape, constant=1.0
         Square Matrix.
     translation : array-like, shape=[..., n]
         Vector.
-    output_shape : tuple of int
-        Desired output shape. This is need for vectorization.
     constant : float or array-like of shape [...]
         Constant to use at the last line and column of the square matrix.
         Optional, default: 1.
@@ -139,15 +137,38 @@ def homogeneous_representation(rotation, translation, output_shape, constant=1.0
         Square Matrix of size n + 1. It can represent an element of the
         special euclidean group or its Lie algebra.
     """
+    if rotation.ndim > 2 or translation.ndim > 1:
+        if rotation.ndim == 2:
+            rotation = gs.broadcast_to(
+                rotation, (translation.shape[0], *rotation.shape)
+            )
+
+        if translation.ndim == 1:
+            translation = gs.broadcast_to(
+                translation, (rotation.shape[0], *translation.shape)
+            )
+
     mat = gs.concatenate((rotation, translation[..., None]), axis=-1)
-    last_line = gs.zeros(output_shape)[..., -1]
-    if isinstance(constant, float):
-        last_col = constant * gs.ones_like(translation)[..., None, -1]
-    else:
-        last_col = constant[..., None]
-    last_line = gs.concatenate([last_line[..., :-1], last_col], axis=-1)
-    mat = gs.concatenate((mat, last_line[..., None, :]), axis=-2)
-    return mat
+
+    if not gs.is_array(constant) or constant.ndim == 0:
+        constant = gs.array([constant])
+
+    zeros = gs.zeros(mat.shape[:-1])
+    if zeros.ndim > 1 or constant.shape[0] > 1:
+        if zeros.ndim == 1:
+            zeros = gs.broadcast_to(zeros, (constant.shape[0], *zeros.shape))
+
+        if constant.shape[0] == 1:
+            constant = gs.broadcast_to(constant, (zeros.shape[0], *constant.shape))
+        else:
+            constant = constant[..., None]
+
+    last_row = gs.concatenate([zeros, constant], axis=-1)
+
+    if mat.ndim == 2 and last_row.ndim > 1:
+        mat = gs.broadcast_to(mat, (last_row.shape[0], *mat.shape))
+
+    return gs.concatenate([mat, last_row[..., None, :]], axis=-2)
 
 
 class _SpecialEuclideanMatrices(MatrixLieGroup, LevelSet):
@@ -180,15 +201,13 @@ class _SpecialEuclideanMatrices(MatrixLieGroup, LevelSet):
         self._value = gs.eye(n + 1)
 
         super().__init__(
-            n=n + 1,
+            n_lg=n + 1,
             dim=int((n * (n + 1)) / 2),
             lie_algebra=SpecialEuclideanMatrixLieAlgebra(n=n),
             **kwargs
         )
         self.rotations = SpecialOrthogonal(n=n)
         self.translations = Euclidean(dim=n)
-        # TODO: remove after solve naming clash
-        self.n = n
 
         self.left_canonical_metric = SpecialEuclideanMatrixCanonicalLeftMetric(
             group=self
@@ -212,13 +231,13 @@ class _SpecialEuclideanMatrices(MatrixLieGroup, LevelSet):
         submersed_point : array-like, shape=[..., n + 1, n + 1]
             Submersed Point.
         """
-        n = point.shape[-1] - 1
+        n = self.n
         rot = point[..., :n, :n]
         vec = point[..., n, :n]
         scalar = point[..., n, n]
         submersed_rot = Matrices.mul(rot, Matrices.transpose(rot))
         return (
-            homogeneous_representation(submersed_rot, vec, point.shape, constant=scalar)
+            homogeneous_representation(submersed_rot, vec, constant=scalar)
             - self._value
         )
 
@@ -237,21 +256,15 @@ class _SpecialEuclideanMatrices(MatrixLieGroup, LevelSet):
         submersed_vector : array-like, shape=[..., n + 1, n + 1]
             Submersed Vector.
         """
-        n = point.shape[-1] - 1
+        n = self.n
         rot = point[..., :n, :n]
         skew = vector[..., :n, :n]
         vec = vector[..., n, :n]
         scalar = vector[..., n, n]
-        submersed_rot = Matrices.mul(Matrices.transpose(skew), rot)
-        submersed_rot = Matrices.to_symmetric(submersed_rot)
-        return homogeneous_representation(
-            submersed_rot, vec, point.shape, constant=scalar
+        submersed_rot = Matrices.to_symmetric(
+            Matrices.mul(Matrices.transpose(skew), rot)
         )
-
-    @property
-    def identity(self):
-        """Return the identity matrix."""
-        return gs.eye(self.n + 1, self.n + 1)
+        return homogeneous_representation(submersed_rot, vec, constant=scalar)
 
     def random_point(self, n_samples=1, bound=1.0):
         """Sample in SE(n) from the product distribution.
@@ -276,12 +289,7 @@ class _SpecialEuclideanMatrices(MatrixLieGroup, LevelSet):
         """
         random_translation = self.translations.random_point(n_samples)
         random_rotation = self.rotations.random_uniform(n_samples)
-        output_shape = (
-            (n_samples, self.n + 1, self.n + 1) if n_samples != 1 else (self.n + 1,) * 2
-        )
-        random_point = homogeneous_representation(
-            random_rotation, random_translation, output_shape
-        )
+        random_point = homogeneous_representation(random_rotation, random_translation)
         return random_point
 
     @classmethod
@@ -302,7 +310,7 @@ class _SpecialEuclideanMatrices(MatrixLieGroup, LevelSet):
         transposed_rot = Matrices.transpose(point[..., :n, :n])
         translation = point[..., :n, -1]
         translation = gs.einsum("...ij,...j->...i", transposed_rot, translation)
-        return homogeneous_representation(transposed_rot, -translation, point.shape)
+        return homogeneous_representation(transposed_rot, -translation)
 
     def projection(self, mat):
         """Project a matrix on SE(n).
@@ -321,10 +329,10 @@ class _SpecialEuclideanMatrices(MatrixLieGroup, LevelSet):
         projected : array-like, shape=[..., n + 1, n + 1]
             Rotation-translation matrix in homogeneous representation.
         """
-        n = mat.shape[-1] - 1
+        n = self.n
         projected_rot = self.rotations.projection(mat[..., :n, :n])
         translation = mat[..., :n, -1]
-        return homogeneous_representation(projected_rot, translation, mat.shape)
+        return homogeneous_representation(projected_rot, translation)
 
 
 class _SpecialEuclideanVectors(LieGroup):
@@ -358,21 +366,9 @@ class _SpecialEuclideanVectors(LieGroup):
         self.rotations = SpecialOrthogonal(n=n, point_type="vector", epsilon=epsilon)
         self.translations = Euclidean(dim=n)
 
-    def get_identity(self):
-        """Get the identity of the group.
-
-        Returns
-        -------
-        identity : array-like, shape={[dim], [n + 1, n + 1]}
-        """
-        identity = gs.zeros(self.dim)
-        return identity
-
-    identity = property(get_identity)
-
-    def get_point_type_shape(self):
-        """Get the shape of the instance given the default_point_style."""
-        return self.get_identity().shape
+    @property
+    def identity(self):
+        return gs.zeros(self.dim)
 
     def belongs(self, point, atol=gs.atol):
         """Evaluate if a point belongs to SE(2) or SE(3).
@@ -470,17 +466,11 @@ class _SpecialEuclideanVectors(LieGroup):
             Matrix.
         """
         vec = self.regularize(vec)
-        output_shape = (
-            (vec.shape[0], self.n + 1, self.n + 1)
-            if vec.ndim == 2
-            else (self.n + 1,) * 2
-        )
-
         rot_vec = vec[..., : self.rotations.dim]
         trans_vec = vec[..., self.rotations.dim :]
 
         rot_mat = self.rotations.matrix_from_rotation_vector(rot_vec)
-        return homogeneous_representation(rot_mat, trans_vec, output_shape)
+        return homogeneous_representation(rot_mat, trans_vec)
 
     @geomstats.vectorization.decorator(["else", "vector", "vector"])
     def compose(self, point_a, point_b):
@@ -706,7 +696,7 @@ class _SpecialEuclidean2Vectors(_SpecialEuclideanVectors):
         )
 
     @geomstats.vectorization.decorator(["else", "vector", "else"])
-    def jacobian_translation(self, point, left_or_right="left"):
+    def jacobian_translation(self, point, left=True):
         """Compute the Jacobian matrix resulting from translation.
 
         Compute the matrix of the differential of the left/right translations
@@ -716,18 +706,15 @@ class _SpecialEuclidean2Vectors(_SpecialEuclideanVectors):
         ----------
         point: array-like, shape=[..., 3]
             Point.
-        left_or_right: str, {'left', 'right'}
+        left: bool
             Whether to compute the jacobian of the left or right translation.
-            Optional, default: 'left'.
+            Optional, default: True.
 
         Returns
         -------
         jacobian : array-like, shape=[..., 3]
             Jacobian of the left / right translation.
         """
-        if left_or_right not in ("left", "right"):
-            raise ValueError("`left_or_right` must be `left` or `right`.")
-
         point = self.regularize(point)
 
         n_points, _ = point.shape
@@ -813,7 +800,7 @@ class _SpecialEuclidean3Vectors(_SpecialEuclideanVectors):
         rot_metric = InvariantMetric(
             group=rotations,
             metric_mat_at_identity=rot_metric_mat,
-            left_or_right=metric.left_or_right,
+            left=metric.left,
         )
 
         rotations_vec = rotations.regularize_tangent_vec(
@@ -825,7 +812,7 @@ class _SpecialEuclidean3Vectors(_SpecialEuclideanVectors):
         )
 
     @geomstats.vectorization.decorator(["else", "vector", "else"])
-    def jacobian_translation(self, point, left_or_right="left"):
+    def jacobian_translation(self, point, left=True):
         """Compute the Jacobian matrix resulting from translation.
 
         Compute the matrix of the differential of the left/right translations
@@ -835,18 +822,15 @@ class _SpecialEuclidean3Vectors(_SpecialEuclideanVectors):
         ----------
         point: array-like, shape=[..., 3]
             Point.
-        left_or_right: str, {'left', 'right'}
+        left: bool
             Whether to compute the jacobian of the left or right translation.
-            Optional, default: 'left'.
+            Optional, default: True.
 
         Returns
         -------
         jacobian : array-like, shape=[..., 3]
             Jacobian of the left / right translation.
         """
-        if left_or_right not in ("left", "right"):
-            raise ValueError("`left_or_right` must be `left` or `right`.")
-
         rotations = self.rotations
         translations = self.translations
         dim_rotations = rotations.dim
@@ -858,14 +842,12 @@ class _SpecialEuclidean3Vectors(_SpecialEuclideanVectors):
 
         rot_vec = point[:, :dim_rotations]
 
-        jacobian_rot = self.rotations.jacobian_translation(
-            point=rot_vec, left_or_right=left_or_right
-        )
+        jacobian_rot = self.rotations.jacobian_translation(point=rot_vec, left=left)
         jacobian_rot = gs.to_ndarray(jacobian_rot, to_ndim=3)
         block_zeros_1 = gs.zeros((n_points, dim_rotations, dim_translations))
         jacobian_block_line_1 = gs.concatenate([jacobian_rot, block_zeros_1], axis=2)
 
-        if left_or_right == "left":
+        if left:
             rot_mat = self.rotations.matrix_from_rotation_vector(rot_vec)
             jacobian_trans = rot_mat
             block_zeros_2 = gs.zeros((n_points, dim_translations, dim_rotations))
@@ -1115,9 +1097,7 @@ class SpecialEuclideanMatrixCanonicalLeftMetric(_InvariantMetricMatrix):
             tangent_vec[..., : self.n, self.n] + base_point[..., : self.n, self.n]
         )
 
-        exp = homogeneous_representation(
-            rotation_exp, translation_exp, tangent_vec.shape, 1.0
-        )
+        exp = homogeneous_representation(rotation_exp, translation_exp, 1.0)
         return exp
 
     def log(self, point, base_point=None, **kwargs):
@@ -1149,7 +1129,6 @@ class SpecialEuclideanMatrixCanonicalLeftMetric(_InvariantMetricMatrix):
             no. 4 (August 1998): 576–89.
             https://doi.org/10.1109/70.704225.
         """
-        max_shape = point.shape if point.ndim == 3 else base_point.shape
         rotation_bp = base_point[..., : self.n, : self.n]
         rotation_p = point[..., : self.n, : self.n]
         rotation_log = GeneralLinear.log(rotation_p, rotation_bp)
@@ -1157,8 +1136,7 @@ class SpecialEuclideanMatrixCanonicalLeftMetric(_InvariantMetricMatrix):
             point[..., : self.n, self.n] - base_point[..., : self.n, self.n]
         )
 
-        log = homogeneous_representation(rotation_log, translation_log, max_shape, 0.0)
-        return log
+        return homogeneous_representation(rotation_log, translation_log, 0.0)
 
     def parallel_transport(
         self, tangent_vec, base_point, direction=None, end_point=None, **kwargs
@@ -1208,11 +1186,8 @@ class SpecialEuclideanMatrixCanonicalLeftMetric(_InvariantMetricMatrix):
             rot_a, rot_bp, rot_b
         )
         translation = tangent_vec[..., : self.n, self.n]
-        max_shape = tangent_vec.shape
-        if (direction.ndim == 3) and (tangent_vec.ndim == 2):
-            translation = gs.stack([translation] * direction.shape[0])
-            max_shape = direction.shape
-        return homogeneous_representation(transported_rot, translation, max_shape, 0.0)
+
+        return homogeneous_representation(transported_rot, translation, 0.0)
 
     def private_squared_dist(self, point_a, point_b):
         """Compute geodesic distance between two points.
@@ -1239,6 +1214,7 @@ class SpecialEuclideanMatrixCanonicalLeftMetric(_InvariantMetricMatrix):
         _ : array-like, shape=[...,]
             Geodesic distance between point_a and point_b.
         """
+        # TODO: rename
         dist = super().squared_dist(point_a, point_b)
         return dist
 
@@ -1340,11 +1316,11 @@ class SpecialEuclideanMatrixLieAlgebra(MatrixLieAlgebra):
     """
 
     def __init__(self, n):
+        self.n = n
         dim = int(n * (n + 1) / 2)
         super().__init__(dim, n + 1)
 
         self.skew = SkewSymmetricMatrices(n)
-        self.n = n
 
     def _create_basis(self):
         """Create the canonical basis."""
@@ -1352,7 +1328,6 @@ class SpecialEuclideanMatrixLieAlgebra(MatrixLieAlgebra):
         basis = homogeneous_representation(
             self.skew.basis,
             gs.zeros((self.skew.dim, n)),
-            (self.skew.dim, n + 1, n + 1),
             0.0,
         )
 
@@ -1428,9 +1403,7 @@ class SpecialEuclideanMatrixLieAlgebra(MatrixLieAlgebra):
         """
         rotation = mat[..., : self.n, : self.n]
         skew = SkewSymmetricMatrices.projection(rotation)
-        return homogeneous_representation(
-            skew, mat[..., : self.n, self.n], mat.shape, 0.0
-        )
+        return homogeneous_representation(skew, mat[..., : self.n, self.n], 0.0)
 
     def basis_representation(self, matrix_representation):
         """Calculate the coefficients of given matrix in the basis.

--- a/geomstats/geometry/special_orthogonal.py
+++ b/geomstats/geometry/special_orthogonal.py
@@ -43,7 +43,7 @@ class _SpecialOrthogonalMatrices(MatrixLieGroup, LevelSet):
 
         super().__init__(
             dim=int((n * (n - 1)) / 2),
-            n=n,
+            n_lg=n,
             lie_algebra=SkewSymmetricMatrices(n=n),
             default_coords_type="extrinsic",
             **kwargs,
@@ -336,8 +336,9 @@ class _SpecialOrthogonalVectors(LieGroup):
         self.n = n
         self.epsilon = epsilon
 
-    def get_identity(self):
-        """Get the identity of the group.
+    @property
+    def identity(self):
+        """Identity of the group.
 
         Parameters
         ----------
@@ -350,8 +351,6 @@ class _SpecialOrthogonalVectors(LieGroup):
             Identity.
         """
         return gs.zeros(self.dim)
-
-    identity = property(get_identity)
 
     def belongs(self, point, atol=ATOL):
         """Evaluate if a point belongs to SO(3).
@@ -869,7 +868,7 @@ class _SpecialOrthogonal3Vectors(_SpecialOrthogonalVectors):
         base_point = self.regularize(base_point)
 
         tangent_vec_at_id = self.tangent_translation_map(
-            base_point, left_or_right=metric.left_or_right, inverse=True
+            base_point, left=metric.left, inverse=True
         )(tangent_vec)
 
         tangent_vec_at_id = self.regularize_tangent_vec_at_identity(
@@ -877,7 +876,7 @@ class _SpecialOrthogonal3Vectors(_SpecialOrthogonalVectors):
         )
 
         regularized_tangent_vec = self.tangent_translation_map(
-            base_point, left_or_right=metric.left_or_right
+            base_point, left=metric.left
         )(tangent_vec_at_id)
 
         return regularized_tangent_vec
@@ -1638,7 +1637,7 @@ class _SpecialOrthogonal3Vectors(_SpecialOrthogonalVectors):
 
         return point_prod
 
-    def jacobian_translation(self, point, left_or_right="left"):
+    def jacobian_translation(self, point, left=True):
         """Compute the jacobian matrix corresponding to translation.
 
         Compute the jacobian matrix of the differential
@@ -1648,19 +1647,15 @@ class _SpecialOrthogonal3Vectors(_SpecialOrthogonalVectors):
         ----------
         point : array-like, shape=[..., 3]
             Point.
-        left_or_right : str, {'left', 'right'}
+        left : bool
             Whether to use left or right invariant metric.
-            Optional, default: 'left'.
+            Optional, default: True.
 
         Returns
         -------
         jacobian : array-like, shape=[..., 3, 3]
             Jacobian.
         """
-        geomstats.errors.check_parameter_accepted_values(
-            left_or_right, "left_or_right", ["left", "right"]
-        )
-
         point = self.regularize(point)
         squared_angle = gs.sum(point**2, axis=-1)
 
@@ -1683,7 +1678,7 @@ class _SpecialOrthogonal3Vectors(_SpecialOrthogonalVectors):
         )
 
         outer_ = gs.outer(point, point)
-        sign = -1.0 if left_or_right == "right" else 1.0
+        sign = 1.0 if left else -1.0
 
         return (
             gs.einsum("...,...ij->...ij", coef_1, gs.eye(self.dim))

--- a/geomstats/geometry/special_orthogonal.py
+++ b/geomstats/geometry/special_orthogonal.py
@@ -43,7 +43,7 @@ class _SpecialOrthogonalMatrices(MatrixLieGroup, LevelSet):
 
         super().__init__(
             dim=int((n * (n - 1)) / 2),
-            n_lg=n,
+            representation_dim=n,
             lie_algebra=SkewSymmetricMatrices(n=n),
             default_coords_type="extrinsic",
             **kwargs,

--- a/geomstats/geometry/symmetric_matrices.py
+++ b/geomstats/geometry/symmetric_matrices.py
@@ -6,7 +6,6 @@ Lead author: Yann Thanwerdas.
 import logging
 
 import geomstats.backend as gs
-import geomstats.vectorization
 from geomstats import algebra_utils
 from geomstats.geometry.base import VectorSpace
 from geomstats.geometry.matrices import Matrices, MatricesMetric
@@ -114,13 +113,9 @@ class SymmetricMatrices(VectorSpace):
         vec : array-like, shape=[..., n(n+1)/2]
             Vector.
         """
-        if not gs.all(Matrices.is_symmetric(mat)):
-            logging.warning("non-symmetric matrix encountered.")
-        mat = Matrices.to_symmetric(mat)
         return gs.triu_to_vec(mat)
 
     @staticmethod
-    @geomstats.vectorization.decorator(["vector", "else"])
     def from_vector(vec):
         """Convert a vector into a symmetric matrix.
 
@@ -145,9 +140,13 @@ class SymmetricMatrices(VectorSpace):
         shape = (mat_dim, mat_dim)
         mask = 2 * gs.ones(shape) - gs.eye(mat_dim)
         indices = list(zip(*gs.triu_indices(mat_dim)))
-        upper_triangular = gs.stack(
-            [gs.array_from_sparse(indices, data, shape) for data in vec]
-        )
+        if gs.ndim(vec) == 1:
+            upper_triangular = gs.array_from_sparse(indices, vec, shape)
+        else:
+            upper_triangular = gs.stack(
+                [gs.array_from_sparse(indices, data, shape) for data in vec]
+            )
+
         mat = Matrices.to_symmetric(upper_triangular) * mask
         return mat
 

--- a/geomstats/learning/kalman_filter.py
+++ b/geomstats/learning/kalman_filter.py
@@ -449,7 +449,7 @@ class KalmanFilter:
 
     def __init__(self, model):
         self.model = model
-        self.state = model.group.get_identity()
+        self.state = model.group.identity
         self.covariance = gs.zeros((self.model.dim, self.model.dim))
         self.process_noise = gs.zeros((self.model.dim_noise, self.model.dim_noise))
         self.measurement_noise = gs.zeros((self.model.dim_obs, self.model.dim_obs))

--- a/tests/data/invariant_metric_data.py
+++ b/tests/data/invariant_metric_data.py
@@ -56,7 +56,7 @@ class InvariantMetricTestData(_RiemannianMetricTestData):
             dict(
                 group=group,
                 metric_mat_at_identity=sym_mat_at_identity,
-                left_or_right="left",
+                left=True,
             )
         ]
         return self.generate_tests(smoke_data)
@@ -68,13 +68,13 @@ class InvariantMetricTestData(_RiemannianMetricTestData):
             dict(
                 group=group,
                 metric_mat_at_identity=sym_mat_at_identity,
-                left_or_right="left",
+                left=True,
                 base_point=None,
             ),
             dict(
                 group=group,
                 metric_mat_at_identity=sym_mat_at_identity,
-                left_or_right="left",
+                left=True,
                 base_point=group.identity,
             ),
         ]
@@ -82,9 +82,7 @@ class InvariantMetricTestData(_RiemannianMetricTestData):
 
     def inner_product_matrix_and_its_inverse_test_data(self):
         group = SpecialEuclidean(n=3, point_type="vector")
-        smoke_data = [
-            dict(group=group, metric_mat_at_identity=None, left_or_right="left")
-        ]
+        smoke_data = [dict(group=group, metric_mat_at_identity=None, left=True)]
         return self.generate_tests(smoke_data)
 
     def inner_product_test_data(self):
@@ -99,7 +97,7 @@ class InvariantMetricTestData(_RiemannianMetricTestData):
             dict(
                 group=group,
                 metric_mat_at_identity=None,
-                left_or_right="left",
+                left=True,
                 tangent_vec_a=tangent_vec_a,
                 tangent_vec_b=tangent_vec_b,
                 base_point=None,
@@ -108,7 +106,7 @@ class InvariantMetricTestData(_RiemannianMetricTestData):
             dict(
                 group=group,
                 metric_mat_at_identity=None,
-                left_or_right="left",
+                left=True,
                 tangent_vec_a=batch_tangent_vec,
                 tangent_vec_b=tangent_vec_b,
                 base_point=None,
@@ -117,7 +115,7 @@ class InvariantMetricTestData(_RiemannianMetricTestData):
             dict(
                 group=group,
                 metric_mat_at_identity=None,
-                left_or_right="left",
+                left=True,
                 tangent_vec_a=group.compose(self.point_1_matrix, tangent_vec_a),
                 tangent_vec_b=group.compose(self.point_1_matrix, tangent_vec_b),
                 base_point=self.point_1_matrix,
@@ -126,7 +124,7 @@ class InvariantMetricTestData(_RiemannianMetricTestData):
             dict(
                 group=group,
                 metric_mat_at_identity=None,
-                left_or_right="left",
+                left=True,
                 tangent_vec_a=group.compose(self.point_1_matrix, batch_tangent_vec),
                 tangent_vec_b=group.compose(self.point_1_matrix, tangent_vec_b),
                 base_point=self.point_1_matrix,
@@ -135,7 +133,7 @@ class InvariantMetricTestData(_RiemannianMetricTestData):
             dict(
                 group=group,
                 metric_mat_at_identity=None,
-                left_or_right="right",
+                left=False,
                 tangent_vec_a=group.compose(tangent_vec_a, self.point_1_matrix),
                 tangent_vec_b=group.compose(tangent_vec_b, self.point_1_matrix),
                 base_point=self.point_1_matrix,
@@ -144,7 +142,7 @@ class InvariantMetricTestData(_RiemannianMetricTestData):
             dict(
                 group=group,
                 metric_mat_at_identity=None,
-                left_or_right="right",
+                left=False,
                 tangent_vec_a=group.compose(batch_tangent_vec, self.point_1_matrix),
                 tangent_vec_b=group.compose(tangent_vec_b, self.point_1_matrix),
                 base_point=self.point_1_matrix,

--- a/tests/data/special_euclidean_data.py
+++ b/tests/data/special_euclidean_data.py
@@ -411,12 +411,12 @@ class SpecialEuclidean3VectorsTestData(TestData):
     left_diag_metric = InvariantMetric(
         group=group,
         metric_mat_at_identity=diag_mat_at_identity,
-        left_or_right="left",
+        left=True,
     )
     right_diag_metric = InvariantMetric(
         group=group,
         metric_mat_at_identity=diag_mat_at_identity,
-        left_or_right="right",
+        left=False,
     )
 
     metrics_all = {

--- a/tests/data/special_orthogonal_data.py
+++ b/tests/data/special_orthogonal_data.py
@@ -840,14 +840,12 @@ class InvariantMetricTestData(TestData):
 
     def squared_dist_is_symmetric_test_data(self):
         smoke_data = []
-        for angle_type_1, angle_type_2, left_or_right in zip(
-            elements, elements, ["left", "right"]
-        ):
+        for angle_type_1, angle_type_2, left in zip(elements, elements, [True, False]):
             smoke_data += [
                 dict(
                     metric_mat_at_identity=9
                     * gs.eye(SpecialOrthogonal(3, "vector").dim),
-                    left_or_right=left_or_right,
+                    left=left,
                     point_1=elements[angle_type_1],
                     point_2=elements[angle_type_2],
                 )

--- a/tests/tests_geomstats/test_invariant_metric.py
+++ b/tests/tests_geomstats/test_invariant_metric.py
@@ -35,17 +35,17 @@ class TestInvariantMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
     testing_data = InvariantMetricTestData()
 
     def test_inner_product_mat_at_identity_shape(
-        self, group, metric_mat_at_identity, left_or_right
+        self, group, metric_mat_at_identity, left
     ):
-        metric = self.Metric(group, metric_mat_at_identity, left_or_right)
+        metric = self.Metric(group, metric_mat_at_identity, left)
         dim = metric.group.dim
         result = metric.metric_mat_at_identity
         self.assertAllClose(gs.shape(result), (dim, dim))
 
     def test_inner_product_matrix_shape(
-        self, group, metric_mat_at_identity, left_or_right, base_point
+        self, group, metric_mat_at_identity, left, base_point
     ):
-        metric = self.Metric(group, metric_mat_at_identity, left_or_right)
+        metric = self.Metric(group, metric_mat_at_identity, left)
         base_point = None
         dim = metric.group.dim
         result = metric.metric_matrix(base_point=base_point)
@@ -57,9 +57,9 @@ class TestInvariantMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
         self.assertAllClose(gs.shape(result), (dim, dim))
 
     def test_inner_product_matrix_and_its_inverse(
-        self, group, metric_mat_at_identity, left_or_right
+        self, group, metric_mat_at_identity, left
     ):
-        metric = self.Metric(group, metric_mat_at_identity, left_or_right)
+        metric = self.Metric(group, metric_mat_at_identity, left)
         inner_prod_mat = metric.metric_mat_at_identity
         inv_inner_prod_mat = gs.linalg.inv(inner_prod_mat)
         result = gs.matmul(inv_inner_prod_mat, inner_prod_mat)
@@ -71,13 +71,13 @@ class TestInvariantMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
         self,
         group,
         metric_mat_at_identity,
-        left_or_right,
+        left,
         tangent_vec_a,
         tangent_vec_b,
         base_point,
         expected,
     ):
-        metric = self.Metric(group, metric_mat_at_identity, left_or_right)
+        metric = self.Metric(group, metric_mat_at_identity, left)
         result = metric.inner_product(tangent_vec_a, tangent_vec_b, base_point)
         self.assertAllClose(result, expected)
 

--- a/tests/tests_geomstats/test_special_euclidean.py
+++ b/tests/tests_geomstats/test_special_euclidean.py
@@ -66,7 +66,7 @@ class TestSpecialEuclidean(LieGroupTestCase, metaclass=Parametrizer):
 
         self.assertAllClose(
             gs.shape(regularized_points),
-            (n_samples, *group.get_point_type_shape()),
+            (n_samples, *group.shape),
         )
 
     def test_compose(self, n, point_type, point_1, point_2, expected):

--- a/tests/tests_geomstats/test_special_orthogonal.py
+++ b/tests/tests_geomstats/test_special_orthogonal.py
@@ -265,7 +265,7 @@ class TestSpecialOrthogonal3Vectors(TestCase, metaclass=Parametrizer):
     def test_left_jacobian_vectorization(self, n_samples):
         group = self.Space(3, point_type="vector")
         points = group.random_uniform(n_samples=n_samples)
-        jacobians = group.jacobian_translation(point=points, left_or_right="left")
+        jacobians = group.jacobian_translation(point=points, left=True)
         self.assertAllClose(gs.shape(jacobians), (n_samples, group.dim, group.dim))
 
     def test_inverse(self, n_samples):
@@ -277,7 +277,7 @@ class TestSpecialOrthogonal3Vectors(TestCase, metaclass=Parametrizer):
 
     def test_left_jacobian_through_its_determinant(self, point, expected):
         group = self.Space(3, point_type="vector")
-        jacobian = group.jacobian_translation(point=point, left_or_right="left")
+        jacobian = group.jacobian_translation(point=point, left=True)
         result = gs.linalg.det(jacobian)
         self.assertAllClose(result, expected)
 
@@ -395,13 +395,13 @@ class TestInvariantMetricOnSO3(TestCase, metaclass=Parametrizer):
     Metric = testing_data.Metric
 
     def test_squared_dist_is_symmetric(
-        self, metric_mat_at_identity, left_or_right, point_1, point_2
+        self, metric_mat_at_identity, left, point_1, point_2
     ):
         group = SpecialOrthogonal(3, "vector")
         metric = self.Metric(
             SpecialOrthogonal(n=3, point_type="vector"),
             metric_mat_at_identity=metric_mat_at_identity,
-            left_or_right=left_or_right,
+            left=left,
         )
         point_1 = group.regularize(point_1)
         point_2 = group.regularize(point_2)


### PR DESCRIPTION
This PR brings some fixes and improvements developed while refactoring tests in #1767. Since #1767 is a long PR and will take a while to get finished, some fixes and improvements done there are merged separately here.

Changes include:

1. closes #1694 by using `n_la` and `n_lg` in `MatrixLieAlgebra` and `MatrixLieGroup`, respectively.
2. for consistency, `get_identity` is removed from several files and only `identity` is kept (as a property)
3. vectorization is fixed in `FullRankCorrelationMatrices.tangent_submersion`
4. `left_or_right="left"` is replaced by `left=True` in several places (bools are more robust than strings)
5. `from_vector` is added to `LowerTriangularMatrices` for consistency with other matrix vector spaces
6. special_euclidean `homogeneous_representation` is simplified and vectorization behavior fixed

@ninamiolane, can you please quickly check if you agree with the changes? 