### PR TITLE
Stop tf tests in CI

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -26,9 +26,6 @@ coverage:
       pytorch:
         flags:
           - pytorch
-      tensorflow:
-        flags:
-          - tensorflow
     patch:
       default:
         # basic
@@ -54,9 +51,6 @@ coverage:
       pytorch:
         flags:
           - pytorch
-      tensorflow:
-        flags:
-          - tensorflow
 
 
 # Files to ignore
@@ -83,9 +77,3 @@ flags:
       - geomstats/_backend/autograd
       - geomstats/_backend/numpy
       - geomstats/_backend/tensorflow
-
-  tensorflow:
-    ignore:
-      - geomstats/_backend/autograd
-      - geomstats/_backend/numpy
-      - geomstats/_backend/pytorch

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: [3.8]
-        geomstats-backend : ['autograd','numpy','pytorch','tensorflow']
+        geomstats-backend : ['autograd','numpy','pytorch']
         test-folder : ['tests/tests_geomstats/' , 'tests/tests_scripts']
       fail-fast: false
 


### PR DESCRIPTION
After some months deliberating, we finally decided to drop support to `tensorflow`. This PR turns the CI tests off for `tf`. Soon to come a PR fully removing it. (with @ninamiolane)