### PR TITLE
Fix bugs that arise for complex matrices

### DIFF
--- a/geomstats/_backend/numpy/linalg.py
+++ b/geomstats/_backend/numpy/linalg.py
@@ -38,13 +38,8 @@ def _is_hermitian(x, tol=atol):
 def logm(x):
     ndim = x.ndim
     new_x = _to_ndarray(x, to_ndim=3)
-    
-    if new_x.dtype in [_np.complex64, _np.complex128]:
-        herm_or_sym = _is_hermitian(new_x)
-    else:
-        herm_or_sym = _is_symmetric(new_x)
 
-    if herm_or_sym:
+    if _is_symmetric(new_x) and new_x.dtype not in [_np.complex64, _np.complex128]:
         eigvals, eigvecs = _np.linalg.eigh(new_x)
         if (eigvals > 0).all():
             eigvals = _np.log(eigvals)

--- a/geomstats/geometry/base.py
+++ b/geomstats/geometry/base.py
@@ -390,7 +390,11 @@ class LevelSet(Manifold, abc.ABC):
         n_batch = gs.ndim(point) - len(self.shape)
         axis = tuple(range(-len(submersed_point.shape) + n_batch, 0))
 
-        constraint = gs.isclose(submersed_point, 0.0, atol=atol)
+        if gs.is_complex(submersed_point):
+            constraint = gs.isclose(submersed_point, 0.0 + 0.0j, atol=atol)
+        else:
+            constraint = gs.isclose(submersed_point, 0.0, atol=atol)
+
         if axis:
             constraint = gs.all(constraint, axis=axis)
 


### PR DESCRIPTION
<!--
Thank you for opening this pull request!
-->

## Checklist

- [X] My pull request has a clear and explanatory title.
- [X] If necessary, my code is [vectorized](https://www.geeksforgeeks.org/vectorization-in-python/).
- [X] I added appropriate unit tests.
- [X] I made sure the code passes all unit tests. (refer to comment below)
- [X] My PR follows [PEP8](https://peps.python.org/pep-0008/) guidelines. (refer to comment below)
- [X] My PR follows [geomstats coding style](https://github.com/geomstats/geomstats/blob/master/docs/contributing.rst#coding-style-guidelines) and API.
- [X] My code is properly documented and I made sure the documentation renders properly. ([Link](https://github.com/geomstats/geomstats/blob/master/docs/contributing.rst#documentation))
- [X] I linked to issues and PRs that are relevant to this PR.


<!-- For checking consistency of entire codebase
First, run the tests related to your changes. For example, if you changed something in geomstats/spd_matrices_space.py:
$ pytest tests/tests_geomstats/test_spd_matrices.py

and then run the tests of the whole codebase to check that your feature is not breaking any of them:
$ pytest tests/

This way, further modifications on the code base are guaranteed to be consistent with the desired behavior. Merging your PR should not break any test in any backend (numpy, tensorflow or pytorch)."

For testing in alternative backends such as `numpy`, `pytorch`, `autograd`, `tensorflow` set the environment variable using:
$ export GEOMSTATS_BACKEND=<backend_name>

Next, import the `backend` module using:
import geomstats.backend as gs
-->


<!-- For flake8 tests
Install dependencies
$ pip3 install -r dev-requirements.txt

Then run the following commands:
$ flake8 --ignore=D,W503,W504 geomstats examples tests   #shadows .flake8
$ flake8 geomstats/geometry geomstats/learning           #passed two subfolders
-->

## Description

<!-- Include a description of your pull request. If relevant, feel free to use this space to talk about time and space complexity as well scalability of your code-->

Adds a check for complex matrices which ensures that the scipy.linalg.logm method is used. This avoids bugs that arise otherwise.

## Issue

<!-- Tell us which issue does this PR fix . Why this feature implementation/fix is important in practice ?-->

The logm method implemented here gives incorrect answers for matrices that are symmetric and complex, but works fine for real symmetric matrices. 

## Additional context

<!-- Add any extra information -->
