### PR TITLE
Fix sqrm for pytorch due to changes in scipy

### DIFF
--- a/geomstats/_backend/autograd/__init__.py
+++ b/geomstats/_backend/autograd/__init__.py
@@ -433,14 +433,12 @@ def vec_to_diag(vec):
 
 
 def tril_to_vec(x, k=0):
-    """ """
     n = x.shape[-1]
     rows, cols = tril_indices(n, k=k)
     return x[..., rows, cols]
 
 
 def triu_to_vec(x, k=0):
-    """ """
     n = x.shape[-1]
     rows, cols = triu_indices(n, k=k)
     return x[..., rows, cols]

--- a/geomstats/_backend/pytorch/linalg.py
+++ b/geomstats/_backend/pytorch/linalg.py
@@ -60,7 +60,10 @@ logm = _Logm.apply
 
 def sqrtm(x):
     np_sqrtm = _np.vectorize(_scipy.linalg.sqrtm, signature="(n,m)->(n,m)")(x)
-    return _torch.as_tensor(np_sqrtm, dtype=x.dtype)
+    if np_sqrtm.dtype.kind == "c":
+        np_sqrtm = np_sqrtm.astype(f"complex{int(np_sqrtm.dtype.name[7:]) // 2}")
+
+    return _torch.from_numpy(np_sqrtm)
 
 
 def svd(x, full_matrices=True, compute_uv=True):

--- a/geomstats/geometry/positive_lower_triangular_matrices.py
+++ b/geomstats/geometry/positive_lower_triangular_matrices.py
@@ -186,7 +186,6 @@ class CholeskyMetric(RiemannianMetric):
     """
 
     def __init__(self, n):
-        """ """
         dim = int(n * (n + 1) / 2)
         super().__init__(dim=dim, signature=(dim, 0), shape=(n, n))
         self.n = n


### PR DESCRIPTION
In `scipy` 1.10, [`linalg.sqrtm`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.linalg.sqrtm.html) doubles the precision of the output if complex. This behavior breaks the conversion back to `torch` tensor.  This PR fixes it.