### PR TITLE
Update setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ packages = find:
 python_requires = >= 3.7
 zip_safe = False
 install_requires =
-    joblib >= 0.14.1
+    joblib >= 0.17.0
     matplotlib >= 3.3.4
     numpy >= 1.18.1
     pandas >= 1.1.5
@@ -59,7 +59,7 @@ doc =
     sphinx <= 5.3.0
     sphinx_gallery
     pydata-sphinx-theme
-lint = 
+lint =
     black
     flake8
     flake8-docstrings


### PR DESCRIPTION
## Description

Require more recent version of joblib

## Issue

`test_sasaki_metric.py` failed for me on a fresh installation due to an error in `joblib`. This works fine with any version above 0.17.0. This PR updates `setup.cfg` with the required version.

Ironically, the linting tools picked up trailing whitespace in the line `lint = `.
