### PR TITLE
Fix complex output types

### DIFF
--- a/geomstats/geometry/hpd_matrices.py
+++ b/geomstats/geometry/hpd_matrices.py
@@ -7,7 +7,7 @@ import math
 
 import geomstats.backend as gs
 import geomstats.vectorization
-from geomstats.geometry.base import OpenSet
+from geomstats.geometry.base import ComplexOpenSet
 from geomstats.geometry.complex_matrices import ComplexMatrices, ComplexMatricesMetric
 from geomstats.geometry.complex_riemannian_metric import ComplexRiemannianMetric
 from geomstats.geometry.general_linear import GeneralLinear
@@ -18,7 +18,7 @@ from geomstats.geometry.positive_lower_triangular_matrices import (
 from geomstats.integrator import integrate
 
 
-class HPDMatrices(OpenSet):
+class HPDMatrices(ComplexOpenSet):
     """Class for the manifold of Hermitian positive definite (HPD) matrices.
 
     Parameters
@@ -581,7 +581,7 @@ class HPDAffineMetric(ComplexRiemannianMetric):
 
             inner_product = inner_product / (power_affine**2)
 
-        return gs.real(inner_product)
+        return inner_product
 
     @staticmethod
     def _aux_exp(tangent_vec, sqrt_base_point, inv_sqrt_base_point):

--- a/geomstats/geometry/hpd_matrices.py
+++ b/geomstats/geometry/hpd_matrices.py
@@ -42,7 +42,8 @@ class HPDMatrices(ComplexOpenSet):
         super().__init__(dim=n**2, embedding_space=HermitianMatrices(n), **kwargs)
         self.n = n
 
-    def belongs(self, point, atol=gs.atol):
+    @staticmethod
+    def belongs(point, atol=gs.atol):
         """Check if a matrix is Hermitian with positive eigenvalues.
 
         Parameters

--- a/geomstats/geometry/siegel.py
+++ b/geomstats/geometry/siegel.py
@@ -276,10 +276,7 @@ class SiegelMetric(ComplexRiemannianMetric):
         aux_d = gs.matmul(inv_aux_4, tangent_vec_a_transconj)
         trace_2 = ComplexMatrices.trace_product(aux_c, aux_d)
 
-        inner_product = trace_1 + trace_2
-        inner_product *= 0.5
-
-        return gs.real(inner_product)
+        return (trace_1 + trace_2) * 0.5
 
     @staticmethod
     def tangent_vec_from_base_point_to_zero(tangent_vec, base_point):

--- a/tests/data_generation.py
+++ b/tests/data_generation.py
@@ -1395,6 +1395,90 @@ class _ComplexRiemannianMetricTestData(_RiemannianMetricTestData):
             )
         return self.generate_tests([], random_data)
 
+    def inner_product_is_complex_test_data(self):
+        """Generate data to check that the inner product is Hermitian."""
+        random_data = []
+        for metric_args, space, shape, n_tangent_vecs in zip(
+            self.metric_args_list,
+            self.space_list,
+            self.shape_list,
+            self.n_tangent_vecs_list,
+        ):
+            base_point = space.random_point()
+            base_point_type = base_point.dtype
+            random_vec_a = generate_random_vec(
+                (n_tangent_vecs,) + shape, base_point_type
+            )
+            random_vec_b = generate_random_vec(
+                (n_tangent_vecs,) + shape, base_point_type
+            )
+            tangent_vec_a = space.to_tangent(random_vec_a)
+            tangent_vec_b = space.to_tangent(random_vec_b)
+            random_data.append(
+                dict(
+                    metric_args=metric_args,
+                    tangent_vec_a=tangent_vec_a,
+                    tangent_vec_b=tangent_vec_b,
+                    base_point=base_point,
+                )
+            )
+        return self.generate_tests([], random_data)
+
+    def dist_is_real_test_data(self):
+        random_data = []
+        for metric_args, space, shape in zip(
+            self.metric_args_list,
+            self.space_list,
+            self.shape_list,
+        ):
+            point_a, point_b = space.random_point(2)
+            random_data.append(
+                dict(
+                    metric_args=metric_args,
+                    point_a=point_a,
+                    point_b=point_b,
+                )
+            )
+        return self.generate_tests([], random_data)
+
+    def log_is_complex_test_data(self):
+        random_data = []
+        for metric_args, space, shape in zip(
+            self.metric_args_list,
+            self.space_list,
+            self.shape_list,
+        ):
+            point, base_point = space.random_point(2)
+            random_data.append(
+                dict(
+                    metric_args=metric_args,
+                    point=point,
+                    base_point=base_point,
+                )
+            )
+        return self.generate_tests([], random_data)
+
+    def exp_is_complex_test_data(self):
+        random_data = []
+        for metric_args, space, shape, n_tangent_vecs in zip(
+            self.metric_args_list,
+            self.space_list,
+            self.shape_list,
+            self.n_tangent_vecs_list,
+        ):
+            base_point = space.random_point()
+            base_point_type = base_point.dtype
+            random_vec = generate_random_vec((n_tangent_vecs,) + shape, base_point_type)
+            tangent_vec = space.to_tangent(random_vec)
+            random_data.append(
+                dict(
+                    metric_args=metric_args,
+                    tangent_vec=tangent_vec,
+                    base_point=base_point,
+                )
+            )
+        return self.generate_tests([], random_data)
+
     def inner_product_is_symmetric_test_data(self):
         """Generate data to check that the inner product is symmetric."""
         random_data = []

--- a/tests/data_generation.py
+++ b/tests/data_generation.py
@@ -1426,10 +1426,9 @@ class _ComplexRiemannianMetricTestData(_RiemannianMetricTestData):
 
     def dist_is_real_test_data(self):
         random_data = []
-        for metric_args, space, shape in zip(
+        for metric_args, space in zip(
             self.metric_args_list,
             self.space_list,
-            self.shape_list,
         ):
             point_a, point_b = space.random_point(2)
             random_data.append(
@@ -1443,10 +1442,9 @@ class _ComplexRiemannianMetricTestData(_RiemannianMetricTestData):
 
     def log_is_complex_test_data(self):
         random_data = []
-        for metric_args, space, shape in zip(
+        for metric_args, space in zip(
             self.metric_args_list,
             self.space_list,
-            self.shape_list,
         ):
             point, base_point = space.random_point(2)
             random_data.append(

--- a/tests/geometry_test_cases.py
+++ b/tests/geometry_test_cases.py
@@ -1366,6 +1366,28 @@ class ComplexRiemannianMetricTestCase(RiemannianMetricTestCase):
         ip_b_a = metric.inner_product(tangent_vec_b, tangent_vec_a, base_point)
         self.assertAllClose(ip_a_b, gs.conj(ip_b_a), rtol, atol)
 
+    def test_inner_product_is_complex(
+        self, metric_args, tangent_vec_a, tangent_vec_b, base_point
+    ):
+        metric = self.Metric(*metric_args)
+        result = metric.inner_product(tangent_vec_a, tangent_vec_b, base_point)
+        self.assertTrue(gs.is_complex(result))
+
+    def test_dist_is_real(self, metric_args, point_a, point_b):
+        metric = self.Metric(*metric_args)
+        result = metric.dist(point_a, point_b)
+        self.assertTrue(not gs.is_complex(result))
+
+    def test_log_is_complex(self, metric_args, point, base_point):
+        metric = self.Metric(*metric_args)
+        result = metric.log(point, base_point)
+        self.assertTrue(gs.is_complex(result))
+
+    def test_exp_is_complex(self, metric_args, tangent_vec, base_point):
+        metric = self.Metric(*metric_args)
+        result = metric.exp(tangent_vec, base_point)
+        self.assertTrue(gs.is_complex(result))
+
 
 class ProductRiemannianMetricTestCase(RiemannianMetricTestCase):
     def test_innerproduct_is_sum_of_innerproducts(


### PR DESCRIPTION
This PR ensures consistency of output types in complex metrics. In particular, new tests are added for inner_product, dist, log, and exp.

It results from the discussion in #1764.