### PR TITLE
Freeze black version due to breaking updates

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -60,7 +60,7 @@ doc =
     sphinx_gallery
     pydata-sphinx-theme
 lint =
-    black
+    black < 23.0
     flake8
     flake8-docstrings
     isort


### PR DESCRIPTION
Version `23.1.0` of `black` behaves very differently than previous one (e.g. "would reformat" message).

For now it is better to keep using previous one.