### PR TITLE
Add centre and scale to DiscreteCurves projection

### DIFF
--- a/geomstats/geometry/discrete_curves.py
+++ b/geomstats/geometry/discrete_curves.py
@@ -62,8 +62,15 @@ class DiscreteCurves(Manifold):
     """
 
     def __init__(
-        self, ambient_manifold, k_sampling_points=10, a=None, b=None, centre=False, scale=False,
-        **kwargs):
+        self,
+        ambient_manifold,
+        k_sampling_points=10,
+        a=None,
+        b=None,
+        centre=False,
+        scale=False,
+        **kwargs,
+    ):
         dim = ambient_manifold.dim * k_sampling_points
         kwargs.setdefault("metric", SRVMetric(ambient_manifold))
         super().__init__(
@@ -157,7 +164,7 @@ class DiscreteCurves(Manifold):
         """
         mean = gs.mean(point, axis=-2)
         return point - mean[..., None, :]
-    
+
     def is_tangent(self, vector, base_point, atol=gs.atol):
         """Check whether the vector is tangent at a curve.
 
@@ -238,9 +245,11 @@ class DiscreteCurves(Manifold):
             projected_point = self.center(projected_point)
         if self.scale:
             curve_length = 0
-            for i in range(0, shape[-2]-1):
-                curve_length += ambient_manifold.metric.norm(projected_point[i+1] - projected_point[i])
-            projected_point = projected_point/curve_length
+            for i in range(0, shape[-2] - 1):
+                curve_length += ambient_manifold.metric.norm(
+                    projected_point[i + 1] - projected_point[i]
+                )
+            projected_point = projected_point / curve_length
         return projected_point
 
     def random_point(self, n_samples=1, bound=1.0):


### PR DESCRIPTION
<!--
Thank you for opening this pull request!
-->

## Checklist

- [x] My pull request has a clear and explanatory title.
- [x] If necessary, my code is [vectorized](https://www.geeksforgeeks.org/vectorization-in-python/).
- [ ] I added appropriate unit tests.
- [ ] I made sure the code passes all unit tests. (refer to comment below)
- [x] My PR follows [PEP8](https://peps.python.org/pep-0008/) guidelines. (refer to comment below)
- [x] My PR follows [geomstats coding style](https://github.com/geomstats/geomstats/blob/master/docs/contributing.rst#coding-style-guidelines) and API.
- [x] My code is properly documented and I made sure the documentation renders properly. ([Link](https://github.com/geomstats/geomstats/blob/master/docs/contributing.rst#documentation))
- [ ] I linked to issues and PRs that are relevant to this PR.


<!-- For checking consistency of entire codebase
First, run the tests related to your changes. For example, if you changed something in geomstats/spd_matrices_space.py:
$ pytest tests/tests_geomstats/test_spd_matrices.py

and then run the tests of the whole codebase to check that your feature is not breaking any of them:
$ pytest tests/

This way, further modifications on the code base are guaranteed to be consistent with the desired behavior. Merging your PR should not break any test in any backend (numpy, tensorflow or pytorch)."

For testing in alternative backends such as `numpy`, `pytorch`, `autograd`, `tensorflow` set the environment variable using:
$ export GEOMSTATS_BACKEND=<backend_name>

Next, import the `backend` module using:
import geomstats.backend as gs
-->


<!-- For flake8 tests
Install dependencies
$ pip3 install -r dev-requirements.txt

Then run the following commands:
$ flake8 --ignore=D,W503,W504 geomstats examples tests   #shadows .flake8
$ flake8 geomstats/geometry geomstats/learning           #passed two subfolders
-->

## Description

Added centering and scaling capabilities to `DiscreteCurves`. The constructor accepts `centre=False` and `scale=False` so that we are able to distinguish between object and preshape space. 

## Issue

<!-- Tell us which issue does this PR fix . Why this feature implementation/fix is important in practice ?-->

## Additional context

<!-- Add any extra information -->
