### PR TITLE
Make torch.linspace accept array-like inputs

### DIFF
--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -349,7 +349,20 @@ def trace(x):
 
 
 def linspace(start, stop, num=50, dtype=None):
-    return _torch.linspace(start=start, end=stop, steps=num, dtype=dtype)
+    try:
+        return _torch.linspace(start=start, end=stop, steps=num, dtype=dtype)
+    except TypeError:
+        if not _torch.is_tensor(start) or start.ndim == 0:
+            start = _torch.tensor([start])
+        if not _torch.is_tensor(stop) or stop.ndim == 0:
+            stop = _torch.tensor([stop])
+
+        if start.shape == stop.shape:
+            return _torch.vstack([_torch.linspace(start=start[i], end=stop[i], steps=num, dtype=dtype) for i in range(start.shape[0])]).T
+        if start.shape[0] > stop.shape[0]:
+            return _torch.vstack([_torch.linspace(start=start[i], end=stop[0], steps=num, dtype=dtype) for i in range(start.shape[0])]).T
+        if stop.shape[0] > start.shape[0]:
+            return _torch.vstack([_torch.linspace(start=start[0], end=stop[i], steps=num, dtype=dtype) for i in range(stop.shape[0])]).T
 
 
 def equal(a, b, **kwargs):

--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -352,32 +352,24 @@ def linspace(start, stop, num=50, dtype=None):
     try:
         return _torch.linspace(start=start, end=stop, steps=num, dtype=dtype)
     except TypeError:
-        if not _torch.is_tensor(start) or start.ndim == 0:
-            start = _torch.tensor([start])
-        if not _torch.is_tensor(stop) or stop.ndim == 0:
-            stop = _torch.tensor([stop])
+        if not _torch.is_tensor(start):
+            start = _torch.tensor(start)
+        if not _torch.is_tensor(stop):
+            stop = _torch.tensor(stop)
+        start, stop = _torch.broadcast_tensors(start, stop)
+        result_shape = (num, *start.shape)
+        start = _torch.flatten(start)
+        stop = _torch.flatten(stop)
 
-        if start.shape == stop.shape:
-            return _torch.vstack(
+        return _torch.reshape(
+            _torch.vstack(
                 [
                     _torch.linspace(start=start[i], end=stop[i], steps=num, dtype=dtype)
                     for i in range(start.shape[0])
                 ]
-            ).T
-        if start.shape[0] > stop.shape[0]:
-            return _torch.vstack(
-                [
-                    _torch.linspace(start=start[i], end=stop[0], steps=num, dtype=dtype)
-                    for i in range(start.shape[0])
-                ]
-            ).T
-        if stop.shape[0] > start.shape[0]:
-            return _torch.vstack(
-                [
-                    _torch.linspace(start=start[0], end=stop[i], steps=num, dtype=dtype)
-                    for i in range(stop.shape[0])
-                ]
-            ).T
+            ).T,
+            result_shape,
+        )
 
 
 def equal(a, b, **kwargs):

--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -349,27 +349,30 @@ def trace(x):
 
 
 def linspace(start, stop, num=50, dtype=None):
-    try:
-        return _torch.linspace(start=start, end=stop, steps=num, dtype=dtype)
-    except TypeError:
-        if not _torch.is_tensor(start):
-            start = _torch.tensor(start)
-        if not _torch.is_tensor(stop):
-            stop = _torch.tensor(stop)
-        start, stop = _torch.broadcast_tensors(start, stop)
-        result_shape = (num, *start.shape)
-        start = _torch.flatten(start)
-        stop = _torch.flatten(stop)
+    start_is_array = _torch.is_tensor(start)
+    stop_is_array = _torch.is_tensor(stop)
 
-        return _torch.reshape(
-            _torch.vstack(
-                [
-                    _torch.linspace(start=start[i], end=stop[i], steps=num, dtype=dtype)
-                    for i in range(start.shape[0])
-                ]
-            ).T,
-            result_shape,
-        )
+    if not (start_is_array or stop_is_array):
+        return _torch.linspace(start=start, end=stop, steps=num, dtype=dtype)
+
+    if not start_is_array:
+        start = _torch.tensor(start)
+    if not stop_is_array:
+        stop = _torch.tensor(stop)
+    start, stop = _torch.broadcast_tensors(start, stop)
+    result_shape = (num, *start.shape)
+    start = _torch.flatten(start)
+    stop = _torch.flatten(stop)
+
+    return _torch.reshape(
+        _torch.vstack(
+            [
+                _torch.linspace(start=start[i], end=stop[i], steps=num, dtype=dtype)
+                for i in range(start.shape[0])
+            ]
+        ).T,
+        result_shape,
+    )
 
 
 def equal(a, b, **kwargs):

--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -358,11 +358,26 @@ def linspace(start, stop, num=50, dtype=None):
             stop = _torch.tensor([stop])
 
         if start.shape == stop.shape:
-            return _torch.vstack([_torch.linspace(start=start[i], end=stop[i], steps=num, dtype=dtype) for i in range(start.shape[0])]).T
+            return _torch.vstack(
+                [
+                    _torch.linspace(start=start[i], end=stop[i], steps=num, dtype=dtype)
+                    for i in range(start.shape[0])
+                ]
+            ).T
         if start.shape[0] > stop.shape[0]:
-            return _torch.vstack([_torch.linspace(start=start[i], end=stop[0], steps=num, dtype=dtype) for i in range(start.shape[0])]).T
+            return _torch.vstack(
+                [
+                    _torch.linspace(start=start[i], end=stop[0], steps=num, dtype=dtype)
+                    for i in range(start.shape[0])
+                ]
+            ).T
         if stop.shape[0] > start.shape[0]:
-            return _torch.vstack([_torch.linspace(start=start[0], end=stop[i], steps=num, dtype=dtype) for i in range(stop.shape[0])]).T
+            return _torch.vstack(
+                [
+                    _torch.linspace(start=start[0], end=stop[i], steps=num, dtype=dtype)
+                    for i in range(stop.shape[0])
+                ]
+            ).T
 
 
 def equal(a, b, **kwargs):


### PR DESCRIPTION
<!--
Thank you for opening this pull request!
-->

## Checklist

- [x] My pull request has a clear and explanatory title.
- [x] If necessary, my code is [vectorized](https://www.geeksforgeeks.org/vectorization-in-python/).
- [ ] I added appropriate unit tests.
- [ ] I made sure the code passes all unit tests. (refer to comment below)
- [x] My PR follows [PEP8](https://peps.python.org/pep-0008/) guidelines. (refer to comment below)
- [x] My PR follows [geomstats coding style](https://github.com/geomstats/geomstats/blob/master/docs/contributing.rst#coding-style-guidelines) and API.
- [x] My code is properly documented and I made sure the documentation renders properly. ([Link](https://github.com/geomstats/geomstats/blob/master/docs/contributing.rst#documentation))
- [ ] I linked to issues and PRs that are relevant to this PR.


<!-- For checking consistency of entire codebase
First, run the tests related to your changes. For example, if you changed something in geomstats/spd_matrices_space.py:
$ pytest tests/tests_geomstats/test_spd_matrices.py

and then run the tests of the whole codebase to check that your feature is not breaking any of them:
$ pytest tests/

This way, further modifications on the code base are guaranteed to be consistent with the desired behavior. Merging your PR should not break any test in any backend (numpy, tensorflow or pytorch)."

For testing in alternative backends such as `numpy`, `pytorch`, `autograd`, `tensorflow` set the environment variable using:
$ export GEOMSTATS_BACKEND=<backend_name>

Next, import the `backend` module using:
import geomstats.backend as gs
-->


<!-- For flake8 tests
Install dependencies
$ pip3 install -r dev-requirements.txt

Then run the following commands:
$ flake8 --ignore=D,W503,W504 geomstats examples tests   #shadows .flake8
$ flake8 geomstats/geometry geomstats/learning           #passed two subfolders
-->

## Description

<!-- Include a description of your pull request. If relevant, feel free to use this space to talk about time and space complexity as well scalability of your code-->

Modify `torch.linspace` to get the same behaviours as `numpy.linspace` (accept array-like `start` or `stop`, even lists). Original `torch.linspace` only works with `start` and `stop` inputs of type `Number` or `0D-Tensor`.

## Issue

<!-- Tell us which issue does this PR fix . Why this feature implementation/fix is important in practice ?-->

## Additional context

<!-- Add any extra information -->
Use `torch.broadcast_arrays` to get final result shape, stack results after looping over flattened inputs and return results after reshaping.

```
import os
os.environ["GEOMSTATS_BACKEND"] = "pytorch"
# Some tests
print(gs.linspace(0, 1, 10))  # 1D
print(gs.linspace(gs.array(0), gs.array(1), 10))  # 1D

print(gs.linspace(gs.array([0]), gs.array([1]), 10))
print(gs.linspace(gs.array(0), gs.array([1]), 10))
print(gs.linspace(gs.array([0.9]), 0, 10))
print(gs.linspace(gs.array([0, 9]), gs.array([1, 10]), 10))
print(gs.linspace(gs.array([[[0, 9, 4]]]), gs.array([[1], [15], [5]]), 10))
```
