### PR TITLE
feat(ci): add `pip` caching to CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,14 +2,12 @@ name: "Docs check and Deployment"
 
 on:
   push:
-    branches: [master,github-actions-test]
+    branches: [master, github-actions-test]
   pull_request:
     branches: [master]
 
-
 jobs:
   build:
-
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
@@ -22,9 +20,13 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{matrix.python-version}}
+          cache: "pip"
+          cache-dependency-path: |
+            setup.cfg
+            setup.py
 
       - name: Install dependencies [pip]
-        run:  |
+        run: |
           pip install --upgrade pip setuptools wheel
           pip install -e .[doc,opt,backends]
 
@@ -38,10 +40,10 @@ jobs:
 
       - name: Deployement of Docs
         uses: JamesIves/github-pages-deploy-action@v4.2.2
-        if : ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'geomstats/geomstats' }}
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'geomstats/geomstats' }}
         with:
-          branch : master
+          branch: master
           folder: docs/_build
-          token : ${{ secrets.DOCUMENTATION_KEY }}
-          repository-name : geomstats/geomstats.github.io
-          clean : true
+          token: ${{ secrets.DOCUMENTATION_KEY }}
+          repository-name: geomstats/geomstats.github.io
+          clean: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,13 +2,12 @@ name: "Linting"
 
 on:
   push:
-    branches: [master,github-actions-test]
+    branches: [master, github-actions-test]
   pull_request:
     branches: [master]
 
 jobs:
   lint:
-
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
@@ -22,9 +21,13 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{matrix.python-version}}
+          cache: "pip"
+          cache-dependency-path: |
+            setup.cfg
+            setup.py
 
       - name: install dependencies [pip]
-        run:  |
+        run: |
           pip install --upgrade pip setuptools wheel
           pip install -e .[lint]
 
@@ -35,7 +38,7 @@ jobs:
         run: |
           flake8 geomstats/ tests/
 
-      - name : linting [black and isort]
+      - name: linting [black and isort]
         run: |
           black . --check
           isort --profile black --check .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,36 +2,34 @@ name: "Testing"
 
 on:
   push:
-    branches: [master,github-actions-test]
+    branches: [master, github-actions-test]
     paths-ignore:
-    - 'docs/**'
-    - 'README.rst'
-    - 'LICENSE.md'
-    - '.github/workflows/docs.yml'
-    - '.deepsource.toml'
-    - '.gitignore'
+      - "docs/**"
+      - "README.rst"
+      - "LICENSE.md"
+      - ".github/workflows/docs.yml"
+      - ".deepsource.toml"
+      - ".gitignore"
 
   pull_request:
     branches: [master]
     paths-ignore:
-    - 'docs/**'
-    - 'README.rst'
-    - '.github/workflows/docs.yml'
-    - 'LICENSE.md'
-    - '.deepsource.toml'
-    - '.gitignore'
-
+      - "docs/**"
+      - "README.rst"
+      - ".github/workflows/docs.yml"
+      - "LICENSE.md"
+      - ".deepsource.toml"
+      - ".gitignore"
 
 jobs:
   build:
-
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
         os: [ubuntu-latest]
         python-version: [3.8]
-        geomstats-backend : ['autograd','numpy','pytorch']
-        test-folder : ['tests/tests_geomstats/' , 'tests/tests_scripts']
+        geomstats-backend: ["autograd", "numpy", "pytorch"]
+        test-folder: ["tests/tests_geomstats/", "tests/tests_scripts"]
       fail-fast: false
 
     steps:
@@ -40,9 +38,13 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{matrix.python-version}}
+          cache: "pip"
+          cache-dependency-path: |
+            setup.cfg
+            setup.py
 
       - name: install dependencies [pip]
-        run:  |
+        run: |
           pip install --upgrade pip setuptools wheel
           pip install -e .[opt,test,${{ matrix.geomstats-backend }}]
 
@@ -51,7 +53,7 @@ jobs:
 
       - name: unit testing [pytest]
         env:
-          GEOMSTATS_BACKEND : ${{matrix.geomstats-backend}}
+          GEOMSTATS_BACKEND: ${{matrix.geomstats-backend}}
         run: |
           pytest --cov-report term --cov=geomstats ${{matrix.test-folder}}
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,7 +68,6 @@ lint =
 test =
     pytest
     pytest-cov
-    codecov
     coverage
     jupyter
 graph =


### PR DESCRIPTION
Changes made by this PR can be summarized as follows:

- Set the `cache` and `cache-dependency-path` argument to enable caching to speed up CI times.