### PR TITLE
Fix ProductRiemannianMetric

### DIFF
--- a/geomstats/geometry/product_manifold.py
+++ b/geomstats/geometry/product_manifold.py
@@ -7,9 +7,7 @@ import math
 import geomstats.backend as gs
 import geomstats.errors
 from geomstats.geometry.complex_manifold import ComplexManifold
-from geomstats.geometry.complex_riemannian_metric import (
-    ComplexRiemannianMetric,
-)
+from geomstats.geometry.complex_riemannian_metric import ComplexRiemannianMetric
 from geomstats.geometry.manifold import Manifold
 from geomstats.geometry.riemannian_metric import RiemannianMetric
 
@@ -74,8 +72,8 @@ def _find_product_shape(factors, default_point_type):
         return (sum(math.prod(factor_shape) for factor_shape in factor_shapes),)
     if not _all_equal(factor_shapes):
         raise ValueError(
-            "A default_point_type of 'matrix' or 'other' can only be used if "
-            "all manifolds have the same shape."
+            "A default_point_type of 'matrix' or 'other' can only be used if all "
+            "manifolds have the same shape."
         )
     if default_point_type == "matrix" and not len(factor_shapes[0]) == 1:
         raise ValueError(
@@ -87,13 +85,7 @@ def _find_product_shape(factors, default_point_type):
 
 class _IterateOverFactorsMixins:
     def __init__(
-        self,
-        factors,
-        cum_index,
-        pool_outputs,
-        has_mixed_fields,
-        *args,
-        **kwargs,
+        self, factors, cum_index, pool_outputs, has_mixed_fields, *args, **kwargs
     ):
         self.factors = factors
         self._cum_index = cum_index
@@ -117,8 +109,8 @@ class _IterateOverFactorsMixins:
         Raises
         ------
         ShapeError
-            If the points are not compatible with the shapes of the
-            corresponding factors.
+            If the points are not compatible with the shapes of the corresponding
+            factors.
         """
         for point, factor in zip(points, self.factors):
             geomstats.errors.check_point_shape(point, factor)
@@ -152,8 +144,7 @@ class _IterateOverFactorsMixins:
         Raises
         ------
         ShapeError
-            If the point does not have a shape compatible with the product
-            manifold.
+            If the point does not have a shape compatible with the product manifold.
         """
         geomstats.errors.check_point_shape(point, self)
 
@@ -183,12 +174,7 @@ class _IterateOverFactorsMixins:
 
     @staticmethod
     def _reshape_trailing(argument, factor):
-        """
-        Convert trailing dimensions.
-
-        Convert the trailing dimensions to match the shape of a factor
-        manifold.
-        """
+        """Convert the trailing dimensions to match the shape of a factor manifold."""
         space = factor._space if isinstance(factor, RiemannianMetric) else factor
 
         if space.default_coords_type == "vector":
@@ -203,15 +189,15 @@ class _IterateOverFactorsMixins:
 
         func is called on each factor of the product.
 
-        Array-type arguments are separated out to be passed to func for each
-        factor, but other arguments are passed unchanged.
+        Array-type arguments are separated out to be passed to func for each factor,
+        but other arguments are passed unchanged.
 
         Parameters
         ----------
         func : str
-            The name of a method which is defined for each factor of the
-            product. The method must return an array of shape
-            (..., factor.shape) or a boolean array of shape (...,).
+            The name of a method which is defined for each factor of the product
+            The method must return an array of shape (..., factor.shape) or a boolean
+            array of shape (...,).
         args : dict
             Dict of arguments.
             Array-type arguments must be of type (..., shape)
@@ -221,14 +207,10 @@ class _IterateOverFactorsMixins:
         -------
         out : array-like, shape = [..., {(), shape}]
         """
-        # TODO The user may prefer to provide the arguments as lists and
-        # TODO receive them as lists, as this may be the form in which they
-        # TODO are available. This should be allowed, rather than packing and
-        # TODO unpacking them repeatedly.
-        (
-            args_list,
-            numerical_args,
-        ) = self._validate_and_prepare_args_for_iteration(args)
+        # TODO The user may prefer to provide the arguments as lists and receive them as
+        # TODO lists, as this may be the form in which they are available. This should
+        # TODO be allowed, rather than packing and unpacking them repeatedly.
+        args_list, numerical_args = self._validate_and_prepare_args_for_iteration(args)
 
         out = [
             self._get_method(self.factors[i], func, args_list[i], numerical_args)
@@ -285,16 +267,14 @@ class ProductManifold(_IterateOverFactorsMixins, Manifold):
     factors : list
         List of manifolds in the product.
     default_point_type : {'auto', 'vector', 'matrix', 'other'}
-        Optional. Default value is 'auto', which will implement as 'vector'
-        unless all factors have the same shape. Vector representation gives
-        the point as a 1-d array. Matrix representation allows for a point to
-        be represented by an array of shape (n, dim), if each manifold has
-        default_point_type 'vector' with shape (dim,). 'other' will behave as
-        `matrix` but for higher dimensions.
+        Optional. Default value is 'auto', which will implement as 'vector' unless all
+        factors have the same shape. Vector representation gives the point as a 1-d
+        array. Matrix representation allows for a point to be represented by an array of
+        shape (n, dim), if each manifold has default_point_type 'vector' with shape
+        (dim,). 'other' will behave as `matrix` but for higher dimensions.
     """
 
     def __init__(self, factors, default_point_type="auto", equip=True):
-        """Initialize manifold."""
         geomstats.errors.check_parameter_accepted_values(
             default_point_type,
             "default_point_type",
@@ -353,13 +333,13 @@ class ProductManifold(_IterateOverFactorsMixins, Manifold):
     def _pool_outputs_from_function(self, outputs):
         """Collect outputs for each product to be returned.
 
-        If each element of the output is a boolean array of the same shape,
-        test along the list whether all elements are True and return a boolean
-        array of the same shape.
+        If each element of the output is a boolean array of the same shape, test along
+        the list whether all elements are True and return a boolean array of the same
+        shape.
 
-        Otherwise, if each element of the output has a shape compatible with
-        points of the corresponding factor, an attempt is made to map the list
-        of points to a point in the product by embed_to_product.
+        Otherwise, if each element of the output has a shape compatible with points of
+        the corresponding factor, an attempt is made to map the list of points to a
+        point in the product by embed_to_product.
 
         Parameters
         ----------
@@ -386,8 +366,8 @@ class ProductManifold(_IterateOverFactorsMixins, Manifold):
             return self.embed_to_product(outputs)
         except geomstats.errors.ShapeError:
             raise RuntimeError(
-                "Could not combine outputs - they are not points of the "
-                "individual factors."
+                "Could not combine outputs - they are not points of the individual"
+                " factors."
             )
         except ValueError:
             raise RuntimeError(
@@ -476,12 +456,10 @@ class ProductManifold(_IterateOverFactorsMixins, Manifold):
         -------
         samples : array-like, shape=[..., {dim, embedding_space.dim,
             [n_manifolds, dim_each]}]
-            Points sampled in the tangent space of the product manifold at
-            base_point.
+            Points sampled in the tangent space of the product manifold at base_point.
         """
         samples = self._iterate_over_factors(
-            "random_tangent_vec",
-            {"base_point": base_point, "n_samples": n_samples},
+            "random_tangent_vec", {"base_point": base_point, "n_samples": n_samples}
         )
         return samples
 
@@ -551,8 +529,7 @@ class ProductManifold(_IterateOverFactorsMixins, Manifold):
             Boolean denoting if vector is a tangent vector at the base point.
         """
         is_tangent = self._iterate_over_factors(
-            "is_tangent",
-            {"base_point": base_point, "vector": vector, "atol": atol},
+            "is_tangent", {"base_point": base_point, "vector": vector, "atol": atol}
         )
         return is_tangent
 
@@ -561,7 +538,6 @@ class ProductRiemannianMetric(_IterateOverFactorsMixins, RiemannianMetric):
     """Class for product of Riemannian metrics."""
 
     def __init__(self, space):
-        """Initialize metric."""
         factors = [factor.metric for factor in space.factors]
         factor_signatures = [metric.signature for metric in factors]
 
@@ -664,6 +640,7 @@ class ProductRiemannianMetric(_IterateOverFactorsMixins, RiemannianMetric):
         """
         args = {"tangent_vec": tangent_vec, "base_point": base_point}
         exp = self._iterate_over_factors("exp", args)
+
         return self._pool_outputs_from_function(exp)
 
     def log(self, point, base_point=None, **kwargs):

--- a/geomstats/geometry/product_manifold.py
+++ b/geomstats/geometry/product_manifold.py
@@ -322,13 +322,21 @@ class ProductManifold(_IterateOverFactorsMixins, Manifold):
             equip=equip,
         )
 
-        if hasattr(self, "metric"):
-            self.metric._pool_outputs_from_function = self._pool_outputs_from_function
-
     @staticmethod
     def default_metric():
         """Metric to equip the space with if equip is True."""
         return ProductRiemannianMetric
+
+    def equip_with_metric(self, Metric=None, **metric_kwargs):
+        """Equip manifold with a Riemannian metric.
+
+        Parameters
+        ----------
+        Metric : RiemannianMetric object
+            If None, default metric will be used.
+        """
+        super().equip_with_metric(Metric, **metric_kwargs)
+        self.metric._pool_outputs_from_function = self._pool_outputs_from_function
 
     def _pool_outputs_from_function(self, outputs):
         """Collect outputs for each product to be returned.


### PR DESCRIPTION
Add to `ProductRiemannianMetric` a method `_pool_outputs_from_functio…n` (which wraps the method from the `ProductManifold`) to correctly structure the output of `exp` and `log`.

## Issue

As previously implemented, this did not correctly concatenate the output of `exp` and `log` if they had different shapes. They need to be flattened first.