### PR TITLE
Refactor Stiefel

### DIFF
--- a/geomstats/geometry/stiefel.py
+++ b/geomstats/geometry/stiefel.py
@@ -432,9 +432,10 @@ class StiefelCanonicalMetric(RiemannianMetric):
 
 
 class _StiefelLogSolver:
-    def __init__(self, max_iter=500, tol=1e-8):
+    def __init__(self, max_iter=500, tol=1e-8, imag_tol=1e-6):
         self.max_iter = max_iter
         self.tol = tol
+        self.imag_tol = imag_tol
 
     @staticmethod
     def _normal_component_qr(point, base_point, matrix_m):
@@ -586,5 +587,12 @@ class _StiefelLogSolver:
 
         else:
             warnings.warn("`log` hasn't converged.")
+
+        if gs.is_complex(matrix_lv):
+            imag_sum = gs.amax(gs.abs(gs.imag(matrix_lv)))
+            if imag_sum < self.imag_tol:
+                matrix_lv = gs.real(matrix_lv)
+            else:
+                raise ValueError(f"Non-neglible imaginary part. max is {imag_sum}")
 
         return matrix_lv

--- a/tests/data/stiefel_data.py
+++ b/tests/data/stiefel_data.py
@@ -35,6 +35,7 @@ class StiefelTestData(_LevelSetTestData):
     Space = Stiefel
 
     tolerances = {
+        "random_point_belongs": {"atol": 1e-8},
         "random_tangent_vec_is_tangent": {"atol": 1e-8},
     }
 

--- a/tests/tests_geomstats/test_frechet_mean.py
+++ b/tests/tests_geomstats/test_frechet_mean.py
@@ -563,7 +563,7 @@ class TestFrechetMean(tests.conftest.TestCase):
         point = space.random_point(2)
         mean = FrechetMean(metric, method="default", init_step_size=0.5, verbose=True)
         mean.fit(point)
-        result = space.belongs(mean.estimate_)
+        result = space.belongs(mean.estimate_, atol=1e-8)
         self.assertTrue(result)
 
     def test_circle_mean(self):


### PR DESCRIPTION
This PR refactors Stiefel by removing the `log`  computation to an external object (a solver). This way, numerical parameters are easy to control and we can implement new algorithms to compute the log. Additionally, `lifting` is fixed (it was not working) and a tolerance is added to a test that fails recurrently.


It should be said that the `log` has problems, as during the iterative process it starts getting complex numbers as result. This comes from `logm`. We should address this is a new PR.