### PR TITLE
Unfreeze numpy and update code for scipy 1.11.0

### DIFF
--- a/geomstats/geometry/discrete_curves.py
+++ b/geomstats/geometry/discrete_curves.py
@@ -1213,7 +1213,6 @@ class SRVMetric(PullbackDiffeoMetric):
         embedding_space : Manifold object
             Embedding space.
         """
-        print("here")
         embedding_space = DiscreteCurves(
             ambient_manifold=self._space.ambient_manifold,
             k_sampling_points=self._space.k_sampling_points - 1,

--- a/geomstats/information_geometry/binomial.py
+++ b/geomstats/information_geometry/binomial.py
@@ -306,9 +306,7 @@ class BinomialMetric(RiemannianMetric):
 
         return path
 
-    def geodesic(
-        self, initial_point, end_point=None, initial_tangent_vec=None, **exp_kwargs
-    ):
+    def geodesic(self, initial_point, end_point=None, initial_tangent_vec=None):
         """Generate parameterized function for the geodesic curve.
 
         Geodesic curve defined by either:

--- a/geomstats/information_geometry/binomial.py
+++ b/geomstats/information_geometry/binomial.py
@@ -161,8 +161,11 @@ class BinomialDistributions(InformationManifoldMixin, OpenSet):
                 by point.
             """
             k = gs.reshape(gs.array(k), (-1,))
+            const = factorial(self.n_draws) / (
+                factorial(k) * factorial(self.n_draws - k)
+            )
             return (
-                (factorial(self.n_draws) / (factorial(k) * factorial(self.n_draws - k)))
+                gs.from_numpy(const)
                 * (point**k)
                 * ((1 - point) ** (self.n_draws - k))
             )

--- a/geomstats/information_geometry/exponential.py
+++ b/geomstats/information_geometry/exponential.py
@@ -288,9 +288,7 @@ class ExponentialMetric(RiemannianMetric):
 
         return path
 
-    def geodesic(
-        self, initial_point, end_point=None, initial_tangent_vec=None, **exp_kwargs
-    ):
+    def geodesic(self, initial_point, end_point=None, initial_tangent_vec=None):
         """Generate parameterized function for the geodesic curve.
 
         Geodesic curve defined by either:

--- a/geomstats/information_geometry/geometric.py
+++ b/geomstats/information_geometry/geometric.py
@@ -303,9 +303,7 @@ class GeometricMetric(RiemannianMetric):
 
         return path
 
-    def geodesic(
-        self, initial_point, end_point=None, initial_tangent_vec=None, **exp_kwargs
-    ):
+    def geodesic(self, initial_point, end_point=None, initial_tangent_vec=None):
         """Generate parameterized function for the geodesic curve.
 
         Geodesic curve defined by either:

--- a/geomstats/information_geometry/poisson.py
+++ b/geomstats/information_geometry/poisson.py
@@ -159,7 +159,7 @@ class PoissonDistributions(InformationManifoldMixin, OpenSet):
                 parameters provided by point.
             """
             k = gs.reshape(gs.array(k), (-1,))
-            return point**k * gs.exp(-point) / factorial(k)
+            return point**k * gs.exp(-point) / gs.from_numpy(factorial(k))
 
         return pmf
 

--- a/geomstats/information_geometry/poisson.py
+++ b/geomstats/information_geometry/poisson.py
@@ -289,9 +289,7 @@ class PoissonMetric(RiemannianMetric):
 
         return path
 
-    def geodesic(
-        self, initial_point, end_point=None, initial_tangent_vec=None, **exp_kwargs
-    ):
+    def geodesic(self, initial_point, end_point=None, initial_tangent_vec=None):
         """Generate parameterized function for the geodesic curve.
 
         Geodesic curve defined by either:

--- a/geomstats/learning/geodesic_regression.py
+++ b/geomstats/learning/geodesic_regression.py
@@ -245,7 +245,7 @@ class GeodesicRegression(BaseEstimator):
         intercept_init, coef_init = self.initialize_parameters(y)
         intercept_hat = self.space.projection(intercept_init)
         coef_hat = self.space.to_tangent(coef_init, intercept_hat)
-        initial_guess = gs.vstack([gs.flatten(intercept_hat), gs.flatten(coef_hat)])
+        initial_guess = gs.hstack([gs.flatten(intercept_hat), gs.flatten(coef_hat)])
 
         objective_with_grad = gs.autodiff.value_and_grad(
             lambda param: self._loss(X, y, param, shape, weights), to_numpy=True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ requires-python = ">= 3.8"
 dependencies=[
     "joblib >= 0.17.0",
     "matplotlib >= 3.3.4",
-    "numpy >= 1.18.1, < 1.25",
+    "numpy >= 1.18.1",
     "pandas >= 1.1.5",
     "scikit-learn >= 0.22.1",
     "scipy >= 1.9",

--- a/tests/geometry_test_cases.py
+++ b/tests/geometry_test_cases.py
@@ -639,8 +639,6 @@ class ConnectionTestCase(TestCase):
         """
         space.equip_with_metric(self.Metric, **connection_args)
 
-        print(point.shape, base_point.shape)
-
         log = space.metric.log(point, base_point)
         result = gs.shape(log)
         self.assertAllClose(result, expected)

--- a/tests/tests_geomstats/test_pre_shape.py
+++ b/tests/tests_geomstats/test_pre_shape.py
@@ -545,7 +545,6 @@ class TestKendallShapeMetric(RiemannianMetricTestCase, metaclass=Parametrizer):
             "...ij,...->...ij", tan_a, 1.0 / space.metric.norm(tan_a, base_point)
         )
 
-        print(space.metric)
         transported = space.metric.parallel_transport(
             tan_a, base_point, direction=tan_b, n_steps=400, step="rk4"
         )


### PR DESCRIPTION
`autograd==1.6.2.` (released last friday) seems to solve the issue created by `numpy==1.25` (see #1866). Therefore, I'm unfreezing it again.


It also updates the code to work properly with last release of `scipy` (last sunday). 