### PR TITLE
Fix in-place operation in SPDBuresWassersteinMetric parallel transport

### DIFF
--- a/geomstats/geometry/spd_matrices.py
+++ b/geomstats/geometry/spd_matrices.py
@@ -918,7 +918,9 @@ class SPDBuresWassersteinMetric(RiemannianMetric):
 
         horizontal_velocity = gs.matmul(inverse_square_root_bp, square_root_lift)
         partial_horizontal_velocity = Matrices.mul(horizontal_velocity, square_root_bp)
-        partial_horizontal_velocity += Matrices.transpose(partial_horizontal_velocity)
+        partial_horizontal_velocity = partial_horizontal_velocity + Matrices.transpose(
+            partial_horizontal_velocity
+        )
 
         def force(state, time):
             horizontal_geodesic_t = (

--- a/tests/tests_geomstats/test_spd_matrices.py
+++ b/tests/tests_geomstats/test_spd_matrices.py
@@ -140,7 +140,6 @@ class TestSPDBuresWassersteinMetric(RiemannianMetricTestCase, metaclass=Parametr
         result = space.metric.log(point, base_point)
         self.assertAllClose(result, expected)
 
-    @tests.conftest.np_and_autograd_only
     def test_parallel_transport(self, space):
         space.equip_with_metric(self.Metric)
         n = space.n


### PR DESCRIPTION
Fixes SPDBuresWassersteinMetric parallel transport following @GitZH-Chen suggestion in #1859.

closes #1859 