### PR TITLE
Fix minor error in variable name in method squared_dist of the class ComplexPoincareDiskMetric

### DIFF
--- a/geomstats/geometry/complex_poincare_disk.py
+++ b/geomstats/geometry/complex_poincare_disk.py
@@ -251,8 +251,8 @@ class ComplexPoincareDiskMetric(ComplexRiemannianMetric):
         squared_dist : array-like, shape=[...]
             Riemannian squared distance.
         """
-        sq_dist = self._tau(point_a, point_b, atol=atol)
-        return gs.power(sq_dist, 2)
+        dist = self._tau(point_a, point_b, atol=atol)
+        return gs.power(dist, 2)
 
     def dist(self, point_a, point_b, atol=gs.atol):
         """Compute the complex Poincaré disk distance.


### PR DESCRIPTION
Fix minor error in variable name in method `squared_dist` of the class `ComplexPoincareDiskMetric`: the variable name `sq_dist` is used instead of `dist`.
