### PR TITLE
Fix problem in selection of the principal directions in Tangent PCA.

### DIFF
--- a/tests/tests_geomstats/test_pca.py
+++ b/tests/tests_geomstats/test_pca.py
@@ -117,8 +117,9 @@ class TestTangentPCA(tests.conftest.TestCase):
         class AlmostEuclideanDimTwo(VectorSpace):
             """Class for the almost Euclidean space of dimension 2.
 
-            This manifold almost corresponds to the Euclidean space of dimension 2:
-            the Euclidean metric is modified to give more weight to the second axis.
+            This manifold almost corresponds to the Euclidean space
+            of dimension 2: the Euclidean metric is modified to give
+            more weight to the second axis.
 
             Parameters
             ----------
@@ -152,30 +153,13 @@ class TestTangentPCA(tests.conftest.TestCase):
                 """Create the canonical basis."""
                 return gs.eye(2)
 
-            def exp(self, tangent_vec, base_point):
-                """Compute the group exponential, which is simply the addition.
-
-                Parameters
-                ----------
-                tangent_vec : array-like, shape=[..., n]
-                    Tangent vector at base point.
-                base_point : array-like, shape=[..., n]
-                    Point from which the exponential is computed.
-
-                Returns
-                -------
-                point : array-like, shape=[..., n]
-                    Group exponential.
-                """
-                return tangent_vec + base_point
-
         class AlmostEuclideanDimTwoMetric(RiemannianMetric):
             """Class for the almost Euclidean metric in dimension 2.
 
             It almost corresponds to the Euclidean space of dimension 2:
-            the Euclidean metric is modified to give more weight to the second axis.
-            The infinitesimal metric element has the following expression:
-            ds^2 = dx1^2 + 10000 dx2^2
+            the Euclidean metric is modified to give more weight to the
+            second axis. The infinitesimal metric element has the
+            following expression: ds^2 = dx1^2 + 10000 dx2^2
             """
 
             def metric_matrix(self, base_point=None):
@@ -197,7 +181,8 @@ class TestTangentPCA(tests.conftest.TestCase):
                 mat[1, 1] = 10000
                 return repeat_out(self._space, mat, base_point, out_shape=(2, 2))
 
-            def exp(self, tangent_vec, base_point, **kwargs):
+            @staticmethod
+            def exp(tangent_vec, base_point, **kwargs):
                 """Compute exp map of a base point in tangent vector direction.
 
                 The Riemannian exponential is vector addition in the Euclidean space.
@@ -216,7 +201,8 @@ class TestTangentPCA(tests.conftest.TestCase):
                 """
                 return base_point + tangent_vec
 
-            def log(self, point, base_point, **kwargs):
+            @staticmethod
+            def log(point, base_point, **kwargs):
                 """Compute log map using a base point and other point.
 
                 The Riemannian logarithm is the subtraction in the Euclidean space.
@@ -246,7 +232,4 @@ class TestTangentPCA(tests.conftest.TestCase):
         variance_axis_2 = almost_euclidean_dim_two.metric.squared_dist(mean, point_b)
         assert variance_axis_2 >= variance_axis_1
         axis_1 = gs.array([1, 0])
-        axis_2 = gs.array([0, 1])
-        """The tangent PCA return axis_2 as the principal axis since it is the axis which 
-        corresponds to the larger variance. It is returning axis_1 instead."""
         assert gs.all(tpca.components_ == axis_1)

--- a/tests/tests_geomstats/test_pca.py
+++ b/tests/tests_geomstats/test_pca.py
@@ -231,5 +231,7 @@ class TestTangentPCA(tests.conftest.TestCase):
         variance_axis_1 = almost_euclidean_dim_two.metric.squared_dist(mean, point_a)
         variance_axis_2 = almost_euclidean_dim_two.metric.squared_dist(mean, point_b)
         assert variance_axis_2 >= variance_axis_1
-        axis_1 = gs.array([1, 0])
-        assert gs.all(tpca.components_ == axis_1)
+        normed_riemannian_basis_vector_2 = gs.array([0, 0.01])
+        assert gs.all(
+            tpca.components_in_riemannian_basis == normed_riemannian_basis_vector_2
+        )

--- a/tests/tests_geomstats/test_pca.py
+++ b/tests/tests_geomstats/test_pca.py
@@ -4,11 +4,14 @@ import pytest
 
 import geomstats.backend as gs
 import tests.conftest
+from geomstats.geometry.base import VectorSpace
+from geomstats.geometry.riemannian_metric import RiemannianMetric
 from geomstats.geometry.spd_matrices import SPDMatrices
 from geomstats.geometry.special_euclidean import SpecialEuclidean
 from geomstats.geometry.special_orthogonal import SpecialOrthogonal
 from geomstats.learning.exponential_barycenter import ExponentialBarycenter
 from geomstats.learning.pca import TangentPCA
+from geomstats.vectorization import repeat_out
 
 
 @tests.conftest.np_and_autograd_only
@@ -109,3 +112,141 @@ class TestTangentPCA(tests.conftest.TestCase):
         result = tpca.inverse_transform(tangent_projected_data)
         expected = X
         self.assertAllClose(result, expected)
+
+    def test_principal_directions_selection(self):
+        class AlmostEuclideanDimTwo(VectorSpace):
+            """Class for the almost Euclidean space of dimension 2.
+
+            This manifold almost corresponds to the Euclidean space of dimension 2:
+            the Euclidean metric is modified to give more weight to the second axis.
+
+            Parameters
+            ----------
+            dim : int
+                Dimension of the Euclidean space.
+            """
+
+            def __init__(self, equip=True):
+                super().__init__(
+                    dim=2,
+                    shape=(2,),
+                    equip=equip,
+                )
+
+            @staticmethod
+            def default_metric():
+                """Metric to equip the space with if equip is True."""
+                return AlmostEuclideanDimTwoMetric
+
+            @property
+            def identity(self):
+                """Identity of the group.
+
+                Returns
+                -------
+                identity : array-like, shape=[n]
+                """
+                return gs.zeros(2)
+
+            def _create_basis(self):
+                """Create the canonical basis."""
+                return gs.eye(2)
+
+            def exp(self, tangent_vec, base_point):
+                """Compute the group exponential, which is simply the addition.
+
+                Parameters
+                ----------
+                tangent_vec : array-like, shape=[..., n]
+                    Tangent vector at base point.
+                base_point : array-like, shape=[..., n]
+                    Point from which the exponential is computed.
+
+                Returns
+                -------
+                point : array-like, shape=[..., n]
+                    Group exponential.
+                """
+                return tangent_vec + base_point
+
+        class AlmostEuclideanDimTwoMetric(RiemannianMetric):
+            """Class for the almost Euclidean metric in dimension 2.
+
+            It almost corresponds to the Euclidean space of dimension 2:
+            the Euclidean metric is modified to give more weight to the second axis.
+            The infinitesimal metric element has the following expression:
+            ds^2 = dx1^2 + 10000 dx2^2
+            """
+
+            def metric_matrix(self, base_point=None):
+                """Compute the inner-product matrix, independent of the base point.
+
+                Parameters
+                ----------
+                base_point : array-like, shape=[..., dim]
+                    Base point.
+                    Optional, default: None.
+
+                Returns
+                -------
+                inner_prod_mat : array-like, shape=[..., dim, dim]
+                    Inner-product matrix.
+                """
+                mat = gs.zeros((2, 2))
+                mat[0, 0] = 1
+                mat[1, 1] = 10000
+                return repeat_out(self._space, mat, base_point, out_shape=(2, 2))
+
+            def exp(self, tangent_vec, base_point, **kwargs):
+                """Compute exp map of a base point in tangent vector direction.
+
+                The Riemannian exponential is vector addition in the Euclidean space.
+
+                Parameters
+                ----------
+                tangent_vec : array-like, shape=[..., dim]
+                    Tangent vector at base point.
+                base_point : array-like, shape=[..., dim]
+                    Base point.
+
+                Returns
+                -------
+                exp : array-like, shape=[..., dim]
+                    Riemannian exponential.
+                """
+                return base_point + tangent_vec
+
+            def log(self, point, base_point, **kwargs):
+                """Compute log map using a base point and other point.
+
+                The Riemannian logarithm is the subtraction in the Euclidean space.
+
+                Parameters
+                ----------
+                point: array-like, shape=[..., dim]
+                    Point.
+                base_point: array-like, shape=[..., dim]
+                    Base point.
+
+                Returns
+                -------
+                log: array-like, shape=[..., dim]
+                    Riemannian logarithm.
+                """
+                return point - base_point
+
+        almost_euclidean_dim_two = AlmostEuclideanDimTwo()
+        tpca = TangentPCA(space=almost_euclidean_dim_two, n_components=1)
+        point_a = gs.array([10, 0], dtype=float)
+        point_b = gs.array([0, 1], dtype=float)
+        X = gs.stack([point_a, -point_a, point_b, -point_b], axis=0)
+        mean = gs.array([0, 0], dtype=float)
+        tpca.fit(X=X, base_point=mean)
+        variance_axis_1 = almost_euclidean_dim_two.metric.squared_dist(mean, point_a)
+        variance_axis_2 = almost_euclidean_dim_two.metric.squared_dist(mean, point_b)
+        assert variance_axis_2 >= variance_axis_1
+        axis_1 = gs.array([1, 0])
+        axis_2 = gs.array([0, 1])
+        """The tangent PCA return axis_2 as the principal axis since it is the axis which 
+        corresponds to the larger variance. It is returning axis_1 instead."""
+        assert gs.all(tpca.components_ == axis_1)


### PR DESCRIPTION
This PR is related to PR https://github.com/geomstats/geomstats/pull/1513/ in which a solution is proposed.

The current Tangent PCA algorithm does not necessarily select the axis which corresponds to the largest variance.
The problem is that the current Tangent PCA does not take into account the metric at the mean to sort the principal directions.

To show this problem, I have created an almost Euclidean manifold (e488adb8b6bd8e6c956337f657817ddb1b525fad).
This manifold is the Euclidean space of dimension 2 whose metric has been modified to give more weight to the second axis. It's infinitesimal metric element is defined by: `ds^2 = dx1^2 + 10000 dx2^2`
Then if we run the following codes (e488adb8b6bd8e6c956337f657817ddb1b525fad):

```
almost_euclidean_dim_two = AlmostEuclideanDimTwo()
tpca = TangentPCA(space=almost_euclidean_dim_two, n_components=1)
point_a = gs.array([10, 0], dtype=float)
point_b = gs.array([0, 1], dtype=float)
X = gs.stack([point_a, -point_a, point_b, -point_b], axis=0)
mean = gs.array([0, 0], dtype=float)
tpca.fit(X=X, base_point=mean)
variance_axis_1 = almost_euclidean_dim_two.metric.squared_dist(mean, point_a)  # variance_axis_1 = 100
variance_axis_2 = almost_euclidean_dim_two.metric.squared_dist(mean, point_b)  # variance_axis_1 = 10000
assert variance_axis_2 >= variance_axis_1 # True
axis_1 = gs.array([1, 0])
axis_2 = gs.array([0, 1])
assert gs.all(tpca.components_ == axis_1) # True
```

The tangent PCA returns `axis_2` as the principal axis since it is the axis which 
corresponds to the larger variance. It is returning `axis_1` instead.

To solve this problem, we can multiply the `log` vectors at the `mean` by square root of the `metric_matrix` to select the correct principal directions (see PR https://github.com/geomstats/geomstats/pull/1513/). 