### PR TITLE
Fix and clean information geometry

### DIFF
--- a/geomstats/geometry/poincare_half_space.py
+++ b/geomstats/geometry/poincare_half_space.py
@@ -110,10 +110,9 @@ class PoincareHalfSpaceMetric(RiemannianMetric):
             Inner-product of the two tangent vectors.
         """
         inner_prod = gs.sum(tangent_vec_a * tangent_vec_b, axis=-1)
-        inner_prod = inner_prod / base_point[..., -1] ** 2
-        return inner_prod
+        return inner_prod / base_point[..., -1] ** 2
 
-    def exp(self, tangent_vec, base_point, **kwargs):
+    def exp(self, tangent_vec, base_point):
         """Compute the Riemannian exponential.
 
         Parameters
@@ -138,7 +137,7 @@ class PoincareHalfSpaceMetric(RiemannianMetric):
         )
         return self._poincare_ball.ball_to_half_space_coordinates(end_point_ball)
 
-    def log(self, point, base_point, **kwargs):
+    def log(self, point, base_point):
         """Compute Riemannian logarithm of a point wrt a base point.
 
         Parameters

--- a/geomstats/geometry/riemannian_metric.py
+++ b/geomstats/geometry/riemannian_metric.py
@@ -602,10 +602,7 @@ class RiemannianMetric(Connection, ABC):
         norm_b = self.squared_norm(tangent_vec_b, base_point)
         inner_ab = self.inner_product(tangent_vec_a, tangent_vec_b, base_point)
         normalization_factor = norm_a * norm_b - inner_ab**2
-
-        condition = gs.isclose(normalization_factor, 0.0)
-        normalization_factor = gs.where(condition, EPSILON, normalization_factor)
-        return gs.where(~condition, sectional / normalization_factor, 0.0)
+        return gs.divide(sectional, normalization_factor, ignore_div_zero=True)
 
     def scalar_curvature(self, base_point):
         r"""Compute scalar curvature at base_point.

--- a/geomstats/information_geometry/base.py
+++ b/geomstats/information_geometry/base.py
@@ -1,8 +1,17 @@
 """Mixin for manifolds of probability distributions."""
 
+import math
+
+import geomstats.backend as gs
+from geomstats.vectorization import get_batch_shape
+
 
 class InformationManifoldMixin:
     """Mixin for manifolds of probability distributions."""
+
+    def __init__(self, support_shape, **kwargs):
+        self.support_shape = support_shape
+        super().__init__(**kwargs)
 
     def sample(self, point, n_samples=1):
         """Sample from the probability distribution.
@@ -62,3 +71,135 @@ class InformationManifoldMixin:
             parameters provided by point.
         """
         raise NotImplementedError("`point_to_cdf` has not yet been implemented.")
+
+
+class ScipyRandomVariable:
+    """A random variable."""
+
+    def __init__(self, space, scp_rvs, scp_pdf=None):
+        self.space = space
+        self.scp_rvs = scp_rvs
+        self.scp_pdf = scp_pdf
+
+
+class ScipyUnivariateRandomVariable(ScipyRandomVariable):
+    """A univariate random variable."""
+
+    def _unflatten_res(self, flat_res, expected_shape):
+        return gs.reshape(flat_res, expected_shape)
+
+    def rvs(self, point, n_samples=1):
+        """Sample from a univariate distribution.
+
+        Parameters
+        ----------
+        point : array-like, shape=[..., *space.shape]
+            Point representing a univariate distribution.
+        n_samples : int
+            Number of points to sample with each pair of parameters in point.
+            Optional, default: 1.
+
+        Returns
+        -------
+        samples : array-like, shape=[..., n_samples, *support_shape]
+            Sample from distribution.
+        """
+        batch_shape = get_batch_shape(self.space, point)
+        n_points = math.prod(batch_shape)
+
+        pre_flat_shape = batch_shape + (n_samples,)
+        params = self._flatten_params(point, pre_flat_shape)
+
+        size = n_points * n_samples
+        flat_sample = gs.from_numpy(self.scp_rvs(**params, size=size))
+
+        expected_shape = batch_shape + (n_samples,) + self.space.support_shape
+        return self._unflatten_res(flat_sample, expected_shape)
+
+    def pdf(self, sample, point):
+        """Evaluate the probability density function at x.
+
+        Parameters
+        ----------
+        x : array-like, shape=[n_samples, *support_shape]
+            Sample points at which to compute the probability density function.
+        point : array-like, shape=[..., *space.shape]
+            Point representing a distribution.
+
+        Returns
+        -------
+        pdf_at_x : array-like, shape=[..., n_samples]
+            Values of pdf at x for each value of the parameters provided
+            by point.
+        """
+        batch_shape = get_batch_shape(self.space, point)
+        n_points = math.prod(batch_shape)
+        n_samples = sample.shape[0]
+
+        pre_flat_shape = batch_shape + (n_samples,)
+        params = self._flatten_params(point, pre_flat_shape)
+
+        sample_ = gs.reshape(gs.broadcast_to(sample, (n_points, n_samples)), (-1,))
+
+        pdf = gs.from_numpy(self.scp_pdf(sample_, **params))
+
+        expected_shape = batch_shape + (n_samples,) + self.space.support_shape
+        return self._unflatten_res(pdf, expected_shape)
+
+
+class ScipyMultivariateRandomVariable(ScipyRandomVariable):
+    """A multivariate random variable."""
+
+    def _rvs_single(self, point, n_samples):
+        return gs.to_ndarray(
+            gs.from_numpy(self.scp_rvs(point, size=n_samples)),
+            to_ndim=len(self.space.support_shape) + 1,
+        )
+
+    def rvs(self, point, n_samples=1):
+        """Sample from a multivariate distribution.
+
+        Parameters
+        ----------
+        point : array-like, shape=[..., *space.shape]
+            Point representing a distribution.
+        n_samples : int
+            Number of points to sample with each pair of parameters in point.
+            Optional, default: 1.
+
+        Returns
+        -------
+        samples : array-like, shape=[..., n_samples, *support_shape]
+            Sample from distribution.
+        """
+        if point.ndim > self.space.point_ndim:
+            return gs.stack([self._rvs_single(point_, n_samples) for point_ in point])
+
+        return self._rvs_single(point, n_samples)
+
+    def _pdf_single(self, x, point, n_samples=1):
+        out = self.scp_pdf(x, point)
+        if x.shape[0] == 1 and point.ndim == self.space.point_ndim:
+            return gs.array([out])
+        return gs.from_numpy(out)
+
+    def pdf(self, x, point):
+        """Evaluate the probability density function at x.
+
+        Parameters
+        ----------
+        x : array-like, shape=[n_samples, *support_shape]
+            Sample points at which to compute the probability density function.
+        point : array-like, shape=[..., *space.shape]
+            Point representing a distribution.
+
+        Returns
+        -------
+        pdf_at_x : array-like, shape=[..., n_samples, *support_shape]
+            Values of pdf at x for each value of the parameters provided
+            by point.
+        """
+        if point.ndim > self.space.point_ndim:
+            return gs.stack([self._pdf_single(x, point_) for point_ in point])
+
+        return self._pdf_single(x, point)

--- a/geomstats/information_geometry/base.py
+++ b/geomstats/information_geometry/base.py
@@ -85,7 +85,8 @@ class ScipyRandomVariable:
 class ScipyUnivariateRandomVariable(ScipyRandomVariable):
     """A univariate random variable."""
 
-    def _unflatten_res(self, flat_res, expected_shape):
+    @staticmethod
+    def _unflatten_res(flat_res, expected_shape):
         return gs.reshape(flat_res, expected_shape)
 
     def rvs(self, point, n_samples=1):
@@ -177,7 +178,7 @@ class ScipyMultivariateRandomVariable(ScipyRandomVariable):
 
         return self._rvs_single(point, n_samples)
 
-    def _pdf_single(self, x, point, n_samples=1):
+    def _pdf_single(self, x, point):
         out = self.scp_pdf(x, point)
         if x.shape[0] == 1 and point.ndim == self.space.point_ndim:
             return gs.array([out])

--- a/geomstats/information_geometry/beta.py
+++ b/geomstats/information_geometry/beta.py
@@ -168,7 +168,8 @@ class BetaDistributionsRandomVariable(ScipyUnivariateRandomVariable):
     def __init__(self, space):
         super().__init__(space, beta.rvs, beta.pdf)
 
-    def _flatten_params(self, point, pre_flat_shape):
+    @staticmethod
+    def _flatten_params(point, pre_flat_shape):
         param_a = gs.expand_dims(point[..., 0], axis=-1)
         param_b = gs.expand_dims(point[..., 1], axis=-1)
 

--- a/geomstats/information_geometry/binomial.py
+++ b/geomstats/information_geometry/binomial.py
@@ -218,7 +218,8 @@ class BinomialMetric(RiemannianMetric):
             self._space.n_draws / (base_point * (1 - base_point)), axis=-1
         )
 
-    def _geodesic_path(self, t, initial_phase, frequency):
+    @staticmethod
+    def _geodesic_path(t, initial_phase, frequency):
         """Generate parameterized function for geodesic curve.
 
         Parameters
@@ -337,7 +338,8 @@ class BinomialDistributionsRandomVariable(ScipyUnivariateRandomVariable):
         rvs = lambda *args, **kwargs: binom.rvs(space.n_draws, *args, **kwargs)
         super().__init__(space, rvs)
 
-    def _flatten_params(self, point, pre_flat_shape):
+    @staticmethod
+    def _flatten_params(point, pre_flat_shape):
         flat_point = gs.reshape(gs.broadcast_to(point, pre_flat_shape), (-1,))
         return {"p": flat_point}
 

--- a/geomstats/information_geometry/binomial.py
+++ b/geomstats/information_geometry/binomial.py
@@ -2,7 +2,6 @@
 
 Lead authors: Jules Deschamps, Tra My Nguyen.
 """
-
 from scipy.special import factorial
 from scipy.stats import binom
 
@@ -10,7 +9,10 @@ import geomstats.backend as gs
 from geomstats.geometry.base import OpenSet
 from geomstats.geometry.euclidean import Euclidean
 from geomstats.geometry.riemannian_metric import RiemannianMetric
-from geomstats.information_geometry.base import InformationManifoldMixin
+from geomstats.information_geometry.base import (
+    InformationManifoldMixin,
+    ScipyUnivariateRandomVariable,
+)
 
 
 class BinomialDistributions(InformationManifoldMixin, OpenSet):
@@ -23,10 +25,12 @@ class BinomialDistributions(InformationManifoldMixin, OpenSet):
     def __init__(self, n_draws, equip=True):
         super().__init__(
             dim=1,
+            support_shape=(),
             embedding_space=Euclidean(dim=1, equip=False),
             equip=equip,
         )
         self.n_draws = n_draws
+        self._scp_rv = BinomialDistributionsRandomVariable(self)
 
     @staticmethod
     def default_metric():
@@ -118,14 +122,7 @@ class BinomialDistributions(InformationManifoldMixin, OpenSet):
         samples : array-like, shape=[..., n_samples]
             Sample from binomial distributions.
         """
-
-        def _sample(param):
-            return binom.rvs(self.n_draws, param, size=n_samples)
-
-        if point.ndim > 1:
-            return gs.array([_sample(point_) for point_ in point])
-
-        return gs.array(_sample(point))
+        return self._scp_rv.rvs(point, n_samples)
 
     def point_to_pdf(self, point):
         """Compute pmf associated to point.
@@ -182,7 +179,7 @@ class BinomialMetric(RiemannianMetric):
         Sankhyā: The Indian Journal of Statistics, Series A, 345-365.
     """
 
-    def squared_dist(self, point_a, point_b, **kwargs):
+    def squared_dist(self, point_a, point_b):
         """Compute squared distance associated with the binomial Fisher Rao metric.
 
         Parameters
@@ -197,11 +194,11 @@ class BinomialMetric(RiemannianMetric):
         squared_dist : array-like, shape=[...,]
             Squared distance between points point_a and point_b.
         """
-        point_a, point_b = gs.broadcast_arrays(point_a, point_b)
         return gs.squeeze(
             4
             * self._space.n_draws
-            * (gs.arcsin(gs.sqrt(point_a)) - gs.arcsin(gs.sqrt(point_b))) ** 2
+            * (gs.arcsin(gs.sqrt(point_a)) - gs.arcsin(gs.sqrt(point_b))) ** 2,
+            axis=-1,
         )
 
     def metric_matrix(self, base_point):
@@ -220,6 +217,21 @@ class BinomialMetric(RiemannianMetric):
         return gs.expand_dims(
             self._space.n_draws / (base_point * (1 - base_point)), axis=-1
         )
+
+    def _geodesic_path(self, t, initial_phase, frequency):
+        """Generate parameterized function for geodesic curve.
+
+        Parameters
+        ----------
+        t : array-like, shape=[n_times,]
+            Times at which to compute points of the geodesics.
+
+        Returns
+        -------
+        geodesic : array-like, shape=[..., n_times, 1]
+            Values of the geodesic at times t.
+        """
+        return gs.expand_dims(gs.sin(frequency * t + initial_phase) ** 2, axis=-1)
 
     def _geodesic_ivp(self, initial_point, initial_tangent_vec):
         """Solve geodesic initial value problem.
@@ -241,29 +253,11 @@ class BinomialMetric(RiemannianMetric):
             Parameterized function for the geodesic curve starting at
             initial_point with velocity initial_tangent_vec.
         """
-        initial_point = gs.broadcast_to(initial_point, initial_tangent_vec.shape)
-
         initial_phase = gs.arcsin(gs.sqrt(initial_point))
         frequency = initial_tangent_vec / (
             2.0 * gs.sqrt(initial_point) * gs.sqrt(1 - initial_point)
         )
-
-        def path(t):
-            """Generate parameterized function for geodesic curve.
-
-            Parameters
-            ----------
-            t : array-like, shape=[n_times,]
-                Times at which to compute points of the geodesics.
-
-            Returns
-            -------
-            geodesic : array-like, shape=[..., n_times, 1]
-                Values of the geodesic at times t.
-            """
-            return gs.expand_dims(gs.sin(frequency * t + initial_phase) ** 2, axis=-1)
-
-        return path
+        return lambda t: self._geodesic_path(t, initial_phase, frequency)
 
     def _geodesic_bvp(self, initial_point, end_point):
         """Solve geodesic boundary problem.
@@ -284,69 +278,9 @@ class BinomialMetric(RiemannianMetric):
             Parameterized function for the geodesic curve starting at
             initial_point and ending at end_point.
         """
-        initial_point, end_point = gs.broadcast_arrays(initial_point, end_point)
-
         initial_phase = gs.arcsin(gs.sqrt(initial_point))
         frequency = gs.arcsin(gs.sqrt(end_point)) - initial_phase
-
-        def path(t):
-            """Generate parameterized function for geodesic curve.
-
-            Parameters
-            ----------
-            t : array-like, shape=[n_times,]
-                Times at which to compute points of the geodesics.
-
-            Returns
-            -------
-            geodesic : array-like, shape=[..., n_times, 1]
-                Values of the geodesic at times t.
-            """
-            return gs.expand_dims(gs.sin(frequency * t + initial_phase) ** 2, axis=-1)
-
-        return path
-
-    def geodesic(self, initial_point, end_point=None, initial_tangent_vec=None):
-        """Generate parameterized function for the geodesic curve.
-
-        Geodesic curve defined by either:
-
-        - an initial point and an initial tangent vector,
-        - an initial point and an end point.
-
-        Parameters
-        ----------
-        initial_point : array-like, shape=[..., 1]
-            Point on the manifold, initial point of the geodesic.
-        end_point : array-like, shape=[..., 1], optional
-            Point on the manifold, end point of the geodesic. If None,
-            an initial tangent vector must be given.
-        initial_tangent_vec : array-like, shape=[..., 1],
-            Tangent vector at base point, the initial speed of the geodesics.
-            Optional, default: None.
-            If None, an end point must be given and a logarithm is computed.
-
-        Returns
-        -------
-        path : callable
-            Time parameterized geodesic curve. If a batch of initial
-            conditions is passed, the output array's first dimension
-            represents time, and the second corresponds to the different
-            initial conditions.
-        """
-        if end_point is None and initial_tangent_vec is None:
-            raise ValueError(
-                "Specify an end point or an initial tangent "
-                "vector to define the geodesic."
-            )
-        if end_point is not None:
-            if initial_tangent_vec is not None:
-                raise ValueError(
-                    "Cannot specify both an end point " "and an initial tangent vector."
-                )
-            return self._geodesic_bvp(initial_point, end_point)
-
-        return self._geodesic_ivp(initial_point, initial_tangent_vec)
+        return lambda t: self._geodesic_path(t, initial_phase, frequency)
 
     def exp(self, tangent_vec, base_point):
         """Compute exp map of a base point in tangent vector direction.
@@ -372,12 +306,12 @@ class BinomialMetric(RiemannianMetric):
             ** 2
         )
 
-    def log(self, end_point, base_point):
+    def log(self, point, base_point):
         """Compute log map using a base point and an end point.
 
         Parameters
         ----------
-        end_point : array-like, shape=[..., 1]
+        point : array-like, shape=[..., 1]
             End point.
         base_point : array-like, shape=[..., 1]
             Base point.
@@ -386,11 +320,43 @@ class BinomialMetric(RiemannianMetric):
         -------
         tangent_vec : array-like, shape=[..., 1]
             Initial velocity of the geodesic starting at base_point and
-            reaching end_point at time 1.
+            reaching point at time 1.
         """
         return (
             2
             * gs.sqrt(base_point)
             * gs.sqrt(1 - base_point)
-            * (gs.arcsin(gs.sqrt(end_point)) - gs.arcsin(gs.sqrt(base_point)))
+            * (gs.arcsin(gs.sqrt(point)) - gs.arcsin(gs.sqrt(base_point)))
+        )
+
+
+class BinomialDistributionsRandomVariable(ScipyUnivariateRandomVariable):
+    """A binomial random variable."""
+
+    def __init__(self, space):
+        rvs = lambda *args, **kwargs: binom.rvs(space.n_draws, *args, **kwargs)
+        super().__init__(space, rvs)
+
+    def _flatten_params(self, point, pre_flat_shape):
+        flat_point = gs.reshape(gs.broadcast_to(point, pre_flat_shape), (-1,))
+        return {"p": flat_point}
+
+    def pdf(self, x, point):
+        """Evaluate the probability density function at x.
+
+        Parameters
+        ----------
+        x : array-like, shape=[n_samples, *support_shape]
+            Sample points at which to compute the probability density function.
+        point : array-like, shape=[..., *space.shape]
+            Point representing a distribution.
+
+        Returns
+        -------
+        pdf_at_x : array-like, shape=[..., n_samples, *support_shape]
+            Values of pdf at x for each value of the parameters provided
+            by point.
+        """
+        return gs.from_numpy(
+            binom.pmf(x, self.space.n_draws, point),
         )

--- a/geomstats/information_geometry/categorical.py
+++ b/geomstats/information_geometry/categorical.py
@@ -2,9 +2,7 @@
 
 Lead author: Alice Le Brigant.
 """
-from scipy.stats import multinomial
 
-import geomstats.backend as gs
 from geomstats.information_geometry.multinomial import (
     MultinomialDistributions,
     MultinomialMetric,
@@ -35,34 +33,6 @@ class CategoricalDistributions(MultinomialDistributions):
     def default_metric():
         """Metric to equip the space with if equip is True."""
         return CategoricalMetric
-
-    def sample(self, point, n_samples=1):
-        """Sample from the categorical distribution.
-
-        Sample from the multinomial distribution with parameters provided by
-        point. This gives samples in the simplex.
-        Then take the argmax to get the category associated to the sample drawn.
-
-        Parameters
-        ----------
-        point : array-like, shape=[..., dim + 1]
-            Parameters of a categorical distribution, i.e. probabilities
-            associated to dim + 1 outcomes.
-        n_samples : int
-            Number of points to sample with each set of parameters in point.
-            Optional, default: 1.
-
-        Returns
-        -------
-        samples : array-like, shape=[..., n_samples]
-            Samples from categorical distributions.
-        """
-        point = gs.to_ndarray(point, to_ndim=2)
-        samples = []
-        for param in point:
-            counts = gs.from_numpy(multinomial.rvs(self.n_draws, param, size=n_samples))
-            samples.append(gs.argmax(counts, axis=-1))
-        return samples[0] if len(point) == 1 else gs.stack(samples)
 
 
 class CategoricalMetric(MultinomialMetric):

--- a/geomstats/information_geometry/exponential.py
+++ b/geomstats/information_geometry/exponential.py
@@ -202,7 +202,8 @@ class ExponentialMetric(RiemannianMetric):
         """
         return gs.expand_dims(1 / base_point**2, axis=-1)
 
-    def _geodesic_path(self, t, initial_point, base):
+    @staticmethod
+    def _geodesic_path(t, initial_point, base):
         """Generate parameterized function for geodesic curve.
 
         Parameters
@@ -307,6 +308,7 @@ class ExponentialDistributionsRandomVariable(ScipyUnivariateRandomVariable):
     def __init__(self, space):
         super().__init__(space, expon.rvs, expon.pdf)
 
-    def _flatten_params(self, point, pre_flat_shape):
+    @staticmethod
+    def _flatten_params(point, pre_flat_shape):
         flat_scale_param = gs.reshape(gs.broadcast_to(1 / point, pre_flat_shape), (-1,))
         return {"scale": flat_scale_param}

--- a/geomstats/information_geometry/gamma.py
+++ b/geomstats/information_geometry/gamma.py
@@ -528,7 +528,8 @@ class GammaDistributionsRandomVariable(ScipyUnivariateRandomVariable):
     def __init__(self, space):
         super().__init__(space, gamma.rvs, gamma.pdf)
 
-    def _flatten_params(self, point, pre_flat_shape):
+    @staticmethod
+    def _flatten_params(point, pre_flat_shape):
         param_a = gs.expand_dims(point[..., 0], axis=-1)
         scale = gs.expand_dims(point[..., 1] / point[..., 0], axis=-1)
 

--- a/geomstats/information_geometry/gamma.py
+++ b/geomstats/information_geometry/gamma.py
@@ -18,12 +18,14 @@ Lead author: Jules Deschamps.
 from scipy.stats import gamma
 
 import geomstats.backend as gs
-import geomstats.errors
 from geomstats.algebra_utils import from_vector_to_diagonal_matrix
 from geomstats.geometry.base import OpenSet
 from geomstats.geometry.euclidean import Euclidean
 from geomstats.geometry.riemannian_metric import RiemannianMetric
-from geomstats.information_geometry.base import InformationManifoldMixin
+from geomstats.information_geometry.base import (
+    InformationManifoldMixin,
+    ScipyUnivariateRandomVariable,
+)
 from geomstats.numerics.bvp import ScipySolveBVP
 from geomstats.numerics.geodesic import ExpODESolver, LogODESolver
 from geomstats.numerics.ivp import ScipySolveIVP
@@ -38,7 +40,14 @@ class GammaDistributions(InformationManifoldMixin, OpenSet):
     """
 
     def __init__(self, equip=True):
-        super().__init__(dim=2, embedding_space=Euclidean(2, equip=False), equip=equip)
+        super().__init__(
+            dim=2,
+            embedding_space=Euclidean(2, equip=False),
+            support_shape=(),
+            equip=equip,
+        )
+
+        self._scp_rv = GammaDistributionsRandomVariable(self)
 
     @staticmethod
     def default_metric():
@@ -67,8 +76,7 @@ class GammaDistributions(InformationManifoldMixin, OpenSet):
         """
         point_dim = point.shape[-1]
         belongs = point_dim == 2
-        belongs = gs.logical_and(belongs, gs.all(point >= atol, axis=-1))
-        return belongs
+        return gs.logical_and(belongs, gs.all(point >= atol, axis=-1))
 
     def random_point(self, n_samples=1, upper_bound=5.0, lower_bound=0.0):
         """Sample parameters of Gamma distributions.
@@ -137,15 +145,7 @@ class GammaDistributions(InformationManifoldMixin, OpenSet):
         samples : array-like, shape=[..., n_samples]
             Sample from the Gamma distributions.
         """
-        geomstats.errors.check_belongs(point, self)
-        point = gs.to_ndarray(point, to_ndim=2)
-        samples = []
-        for param in point:
-            sample = gs.array(
-                gamma.rvs(param[0], loc=0, scale=param[1] / param[0], size=n_samples)
-            )
-            samples.append(sample)
-        return gs.squeeze(samples[0]) if len(point) == 1 else gs.stack(samples)
+        return self._scp_rv.rvs(point, n_samples)
 
     def point_to_pdf(self, point):
         """Compute pdf associated to point.
@@ -520,3 +520,18 @@ class GammaMetric(RiemannianMetric):
             jac = gs.transpose(jac, [4, 0, 1, 2, 3])
 
         return gs.squeeze(jac)
+
+
+class GammaDistributionsRandomVariable(ScipyUnivariateRandomVariable):
+    """A gamma random variable."""
+
+    def __init__(self, space):
+        super().__init__(space, gamma.rvs, gamma.pdf)
+
+    def _flatten_params(self, point, pre_flat_shape):
+        param_a = gs.expand_dims(point[..., 0], axis=-1)
+        scale = gs.expand_dims(point[..., 1] / point[..., 0], axis=-1)
+
+        flat_param_a = gs.reshape(gs.broadcast_to(param_a, pre_flat_shape), (-1,))
+        flat_scale = gs.reshape(gs.broadcast_to(scale, pre_flat_shape), (-1,))
+        return {"a": flat_param_a, "scale": flat_scale}

--- a/geomstats/information_geometry/geometric.py
+++ b/geomstats/information_geometry/geometric.py
@@ -9,7 +9,10 @@ import geomstats.backend as gs
 from geomstats.geometry.base import OpenSet
 from geomstats.geometry.euclidean import Euclidean
 from geomstats.geometry.riemannian_metric import RiemannianMetric
-from geomstats.information_geometry.base import InformationManifoldMixin
+from geomstats.information_geometry.base import (
+    InformationManifoldMixin,
+    ScipyUnivariateRandomVariable,
+)
 
 
 class GeometricDistributions(InformationManifoldMixin, OpenSet):
@@ -23,8 +26,10 @@ class GeometricDistributions(InformationManifoldMixin, OpenSet):
         super().__init__(
             dim=1,
             embedding_space=Euclidean(dim=1),
+            support_shape=(),
             equip=equip,
         )
+        self._scp_rv = GeometricDistributionsRandomVariable(self)
 
     @staticmethod
     def default_metric():
@@ -119,14 +124,7 @@ class GeometricDistributions(InformationManifoldMixin, OpenSet):
         samples : array-like, shape=[..., n_samples]
             Sample from geometric distributions.
         """
-
-        def _sample(param):
-            return geom.rvs(param, size=n_samples)
-
-        if point.ndim > 1:
-            return gs.array([_sample(point_) for point_ in point])
-
-        return gs.array(_sample(point))
+        return self._scp_rv.rvs(point, n_samples)
 
     def point_to_pdf(self, point):
         """Compute pmf associated to point.
@@ -193,7 +191,6 @@ class GeometricMetric(RiemannianMetric):
         squared_dist : array-like, shape=[...,]
             Squared distance between points point_a and point_b.
         """
-        point_a, point_b = gs.broadcast_arrays(point_a, point_b)
         return gs.squeeze(
             4
             * (gs.arctanh(gs.sqrt(1 - point_a)) - gs.arctanh(gs.sqrt(1 - point_b))) ** 2
@@ -213,6 +210,21 @@ class GeometricMetric(RiemannianMetric):
             Metric matrix.
         """
         return gs.expand_dims(1 / (base_point**2 * (1 - base_point)), axis=-1)
+
+    def _geodesic_path(self, t, frequency, initial_phase):
+        """Generate parameterized function for geodesic curve.
+
+        Parameters
+        ----------
+        t : array-like, shape=[n_times,]
+            Times at which to compute points of the geodesics.
+
+        Returns
+        -------
+        geodesic : array-like, shape=[..., n_times, 1]
+            Values of the geodesic at times t.
+        """
+        return gs.expand_dims(1 - gs.tanh(frequency * t + initial_phase) ** 2, axis=-1)
 
     def _geodesic_ivp(self, initial_point, initial_tangent_vec):
         """Solve geodesic initial value problem.
@@ -234,31 +246,11 @@ class GeometricMetric(RiemannianMetric):
             Parameterized function for the geodesic curve starting at
             initial_point with velocity initial_tangent_vec.
         """
-        initial_point = gs.broadcast_to(initial_point, initial_tangent_vec.shape)
-
         initial_phase = gs.arctanh(gs.sqrt(1 - initial_point))
         frequency = -initial_tangent_vec / (
             2 * initial_point * gs.sqrt(1 - initial_point)
         )
-
-        def path(t):
-            """Generate parameterized function for geodesic curve.
-
-            Parameters
-            ----------
-            t : array-like, shape=[n_times,]
-                Times at which to compute points of the geodesics.
-
-            Returns
-            -------
-            geodesic : array-like, shape=[..., n_times, 1]
-                Values of the geodesic at times t.
-            """
-            return gs.expand_dims(
-                1 - gs.tanh(frequency * t + initial_phase) ** 2, axis=-1
-            )
-
-        return path
+        return lambda t: self._geodesic_path(t, frequency, initial_phase)
 
     def _geodesic_bvp(self, initial_point, end_point):
         """Solve geodesic boundary problem.
@@ -279,74 +271,9 @@ class GeometricMetric(RiemannianMetric):
             Parameterized function for the geodesic curve starting at
             initial_point and ending at end_point.
         """
-        initial_point, end_point = gs.broadcast_arrays(initial_point, end_point)
-
         initial_phase = gs.arctanh(gs.sqrt(1 - initial_point))
         frequency = gs.arctanh(gs.sqrt(1 - end_point)) - initial_phase
-
-        def path(t):
-            """Generate parameterized function for geodesic curve.
-
-            Parameters
-            ----------
-            t : array-like, shape=[n_times,]
-                Times at which to compute points of the geodesics.
-
-            Returns
-            -------
-            geodesic : array-like, shape=[..., n_times, 1]
-                Values of the geodesic at times t.
-            """
-            return gs.expand_dims(
-                1 - gs.tanh(frequency * t + initial_phase) ** 2, axis=-1
-            )
-
-        return path
-
-    def geodesic(self, initial_point, end_point=None, initial_tangent_vec=None):
-        """Generate parameterized function for the geodesic curve.
-
-        Geodesic curve defined by either:
-
-        - an initial point and an initial tangent vector,
-        - an initial point and an end point.
-
-        Parameters
-        ----------
-        initial_point : array-like, shape=[..., 1]
-            Point on the manifold, initial point of the geodesic.
-        end_point : array-like, shape=[..., 1], optional
-            Point on the manifold, end point of the geodesic. If None,
-            an initial tangent vector must be given.
-        initial_tangent_vec : array-like, shape=[..., 1],
-            Tangent vector at base point, the initial speed of the geodesics.
-            Optional, default: None.
-            If None, an end point must be given and a logarithm is computed.
-
-        Returns
-        -------
-        path : callable
-            Time parameterized geodesic curve. If a batch of initial
-            conditions is passed, the output array's first dimension
-            corresponds to the different initial conditions, and the
-            second represents time.
-        """
-        if end_point is None and initial_tangent_vec is None:
-            raise ValueError(
-                "Specify an end point or an initial tangent "
-                "vector to define the geodesic."
-            )
-        if end_point is not None:
-            if initial_tangent_vec is not None:
-                raise ValueError(
-                    "Cannot specify both an end point " "and an initial tangent vector."
-                )
-            path = self._geodesic_bvp(initial_point, end_point)
-
-        if initial_tangent_vec is not None:
-            path = self._geodesic_ivp(initial_point, initial_tangent_vec)
-
-        return path
+        return lambda t: self._geodesic_path(t, frequency, initial_phase)
 
     def exp(self, tangent_vec, base_point):
         """Compute exp map of a base point in tangent vector direction.
@@ -373,12 +300,12 @@ class GeometricMetric(RiemannianMetric):
             ** 2
         )
 
-    def log(self, end_point, base_point):
+    def log(self, point, base_point):
         """Compute log map using a base point and an end point.
 
         Parameters
         ----------
-        end_point : array-like, shape=[..., 1]
+        point : array-like, shape=[..., 1]
             End point.
         base_point : array-like, shape=[..., 1]
             Base point.
@@ -387,11 +314,42 @@ class GeometricMetric(RiemannianMetric):
         -------
         tangent_vec : array-like, shape=[..., 1]
             Initial velocity of the geodesic starting at base_point and
-            reaching end_point at time 1.
+            reaching point at time 1.
         """
         return (
             -2
             * base_point
             * gs.sqrt(1 - base_point)
-            * (gs.arctanh(gs.sqrt(1 - end_point)) - gs.arctanh(gs.sqrt(1 - base_point)))
+            * (gs.arctanh(gs.sqrt(1 - point)) - gs.arctanh(gs.sqrt(1 - base_point)))
+        )
+
+
+class GeometricDistributionsRandomVariable(ScipyUnivariateRandomVariable):
+    """A geometric random variable."""
+
+    def __init__(self, space):
+        super().__init__(space, geom.rvs)
+
+    def _flatten_params(self, point, pre_flat_shape):
+        flat_point = gs.reshape(gs.broadcast_to(point, pre_flat_shape), (-1,))
+        return {"p": flat_point}
+
+    def pdf(self, x, point):
+        """Evaluate the probability density function at x.
+
+        Parameters
+        ----------
+        x : array-like, shape=[n_samples, *support_shape]
+            Sample points at which to compute the probability density function.
+        point : array-like, shape=[..., *space.shape]
+            Point representing a distribution.
+
+        Returns
+        -------
+        pdf_at_x : array-like, shape=[..., n_samples, *support_shape]
+            Values of pdf at x for each value of the parameters provided
+            by point.
+        """
+        return gs.from_numpy(
+            geom.pmf(x, point),
         )

--- a/geomstats/information_geometry/geometric.py
+++ b/geomstats/information_geometry/geometric.py
@@ -211,7 +211,8 @@ class GeometricMetric(RiemannianMetric):
         """
         return gs.expand_dims(1 / (base_point**2 * (1 - base_point)), axis=-1)
 
-    def _geodesic_path(self, t, frequency, initial_phase):
+    @staticmethod
+    def _geodesic_path(t, frequency, initial_phase):
         """Generate parameterized function for geodesic curve.
 
         Parameters
@@ -330,7 +331,8 @@ class GeometricDistributionsRandomVariable(ScipyUnivariateRandomVariable):
     def __init__(self, space):
         super().__init__(space, geom.rvs)
 
-    def _flatten_params(self, point, pre_flat_shape):
+    @staticmethod
+    def _flatten_params(point, pre_flat_shape):
         flat_point = gs.reshape(gs.broadcast_to(point, pre_flat_shape), (-1,))
         return {"p": flat_point}
 

--- a/geomstats/information_geometry/normal.py
+++ b/geomstats/information_geometry/normal.py
@@ -554,7 +554,7 @@ class GeneralNormalDistributions(InformationManifoldMixin, ProductManifold):
             x_, (mean_, inv_cov_) = broadcast_to_multibatch(
                 (x.shape[0],), batch_shape, x, mean, inv_cov
             )
-            aux_0 = x - mean_
+            aux_0 = x_ - mean_
             aux_1 = gs.exp(-0.5 * gs.dot(aux_0, gs.matvec(inv_cov_, aux_0)))
             return gs.einsum(
                 "...,...i->...i", pdf_normalization, gs.to_ndarray(aux_1, to_ndim=1)
@@ -878,7 +878,8 @@ class UnivariateNormalDistributionsRandomVariable(ScipyUnivariateRandomVariable)
     def __init__(self, space):
         super().__init__(space, norm.rvs, norm.pdf)
 
-    def _flatten_params(self, point, pre_flat_shape):
+    @staticmethod
+    def _flatten_params(point, pre_flat_shape):
         loc = gs.expand_dims(point[..., 0], axis=-1)
         scale = gs.expand_dims(point[..., 1], axis=-1)
 

--- a/geomstats/information_geometry/normal.py
+++ b/geomstats/information_geometry/normal.py
@@ -7,7 +7,6 @@ import math
 
 from scipy.stats import multivariate_normal, norm
 
-import geomstats
 import geomstats.backend as gs
 import geomstats.errors as errors
 from geomstats.geometry.base import OpenSet
@@ -21,8 +20,12 @@ from geomstats.geometry.pullback_metric import PullbackDiffeoMetric
 from geomstats.geometry.riemannian_metric import RiemannianMetric
 from geomstats.geometry.scalar_product_metric import ScalarProductMetric
 from geomstats.geometry.spd_matrices import SPDAffineMetric, SPDMatrices
-from geomstats.information_geometry.base import InformationManifoldMixin
-from geomstats.vectorization import repeat_out
+from geomstats.information_geometry.base import (
+    InformationManifoldMixin,
+    ScipyMultivariateRandomVariable,
+    ScipyUnivariateRandomVariable,
+)
+from geomstats.vectorization import broadcast_to_multibatch, get_batch_shape, repeat_out
 
 
 class NormalDistributions:
@@ -67,7 +70,8 @@ class UnivariateNormalDistributions(InformationManifoldMixin, PoincareHalfSpace)
     """
 
     def __init__(self, equip=True):
-        super().__init__(dim=2, equip=equip)
+        super().__init__(dim=2, support_shape=(), equip=equip)
+        self._scp_rv = UnivariateNormalDistributionsRandomVariable(self)
 
     @staticmethod
     def default_metric():
@@ -119,12 +123,7 @@ class UnivariateNormalDistributions(InformationManifoldMixin, PoincareHalfSpace)
         samples : array-like, shape=[..., n_samples]
             Sample from normal distributions.
         """
-        geomstats.errors.check_belongs(point, self)
-        point = gs.to_ndarray(point, to_ndim=2)
-        samples = []
-        for mean, scale in point:
-            samples.append(gs.array(norm.rvs(mean, scale, size=n_samples)))
-        return samples[0] if len(point) == 1 else gs.stack(samples)
+        return self._scp_rv.rvs(point, n_samples)
 
     def point_to_pdf(self, point):
         """Compute pdf associated to point.
@@ -145,6 +144,7 @@ class UnivariateNormalDistributions(InformationManifoldMixin, PoincareHalfSpace)
         """
         means = gs.expand_dims(point[..., 0], axis=-1)
         stds = gs.expand_dims(point[..., 1], axis=-1)
+        pdf_normalization = 1.0 / gs.sqrt(2 * gs.pi * stds**2)
 
         def pdf(x):
             """Generate parameterized function for normal pdf.
@@ -161,9 +161,7 @@ class UnivariateNormalDistributions(InformationManifoldMixin, PoincareHalfSpace)
                 by point.
             """
             x = gs.reshape(gs.array(x), (-1,))
-            return (1.0 / gs.sqrt(2 * gs.pi * stds**2)) * gs.exp(
-                -((x - means) ** 2) / (2 * stds**2)
-            )
+            return pdf_normalization * gs.exp(-((x - means) ** 2) / (2 * stds**2))
 
         return pdf
 
@@ -182,8 +180,9 @@ class CenteredNormalDistributions(InformationManifoldMixin, SPDMatrices):
     """
 
     def __init__(self, sample_dim, equip=True):
-        super().__init__(n=sample_dim, equip=equip)
+        super().__init__(n=sample_dim, support_shape=(sample_dim,), equip=equip)
         self.sample_dim = sample_dim
+        self._scp_rv = SharedMeanNormalDistributionsRandomVariable(self)
 
     @staticmethod
     def default_metric():
@@ -207,13 +206,7 @@ class CenteredNormalDistributions(InformationManifoldMixin, SPDMatrices):
         samples : array-like, shape=[..., n_samples, sample_dim]
             Sample from centered multivariate normal distributions.
         """
-        geomstats.errors.check_belongs(point, self)
-        point = gs.to_ndarray(point, to_ndim=3)
-        samples = []
-        mean = gs.zeros(self.sample_dim)
-        for cov in point:
-            samples.append(gs.array(multivariate_normal.rvs(mean, cov, size=n_samples)))
-        return samples[0] if point.shape[0] == 1 else gs.stack(samples)
+        return self._scp_rv.rvs(point, n_samples)
 
     def point_to_pdf(self, point):
         """Compute pdf associated to point.
@@ -230,12 +223,10 @@ class CenteredNormalDistributions(InformationManifoldMixin, SPDMatrices):
             Probability density function of the centered multivariate normal
             distributions with covariance matrices provided by point.
         """
-        geomstats.errors.check_belongs(point, self)
-        point = point[None, :, :] if point.ndim == 2 else point
-        n = self.sample_dim
+        batch_shape = get_batch_shape(self, point)
         det_cov = gs.linalg.det(point)
         inv_cov = gs.linalg.inv(point)
-        pdf_normalization = 1 / gs.sqrt(gs.power(2 * gs.pi, n) * det_cov)
+        pdf_normalization = 1 / gs.sqrt(gs.power(2 * gs.pi, self.sample_dim) * det_cov)
 
         def pdf(x):
             """Generate parameterized function for normal pdf.
@@ -251,14 +242,14 @@ class CenteredNormalDistributions(InformationManifoldMixin, SPDMatrices):
             pdf_at_x: array-like, shape=[..., n_samples]
                 Probability density function at x.
             """
-            x = gs.to_ndarray(x, to_ndim=2, axis=0)
+            x_, inv_cov_ = broadcast_to_multibatch(
+                (x.shape[0],), batch_shape, x, inv_cov
+            )
 
-            pdf = []
-            for xi in x:
-                pdf.append(gs.exp(-0.5 * gs.transpose(xi) @ inv_cov @ xi))
-            pdf = gs.stack(pdf)
-            pdf = pdf_normalization * pdf
-            return gs.squeeze(pdf)
+            aux = gs.exp(-0.5 * gs.dot(x_, gs.matvec(inv_cov_, x_)))
+            return gs.einsum(
+                "...,...i->...i", pdf_normalization, gs.to_ndarray(aux, to_ndim=1)
+            )
 
         return pdf
 
@@ -282,15 +273,20 @@ class DiagonalNormalDistributions(InformationManifoldMixin, OpenSet):
         self.sample_dim = sample_dim
         self.sample_space = Euclidean(dim=sample_dim, equip=False)
         dim = int(2 * sample_dim)
-        super().__init__(dim=dim, embedding_space=Euclidean(dim), equip=equip)
+        super().__init__(
+            dim=dim,
+            embedding_space=Euclidean(dim),
+            support_shape=(sample_dim,),
+            equip=equip,
+        )
+        self._scp_rv = DiagonalNormalDistributionsRandomVariable(self)
 
     @staticmethod
     def default_metric():
         """Metric to equip the space with if equip is True."""
         return DiagonalNormalMetric
 
-    @staticmethod
-    def _unstack_mean_diagonal(sample_dim, point):
+    def _unstack_mean_diagonal(self, point):
         """Extract mean and diagonal of the covariance matrix from a given point.
 
         Parameters
@@ -307,8 +303,8 @@ class DiagonalNormalDistributions(InformationManifoldMixin, OpenSet):
         diagonal : array-like, shape=[..., sample_dim]
             Diagonals of covariance matrices from the input point.
         """
-        mean = point[..., :sample_dim]
-        diagonal = point[..., sample_dim:]
+        mean = point[..., : self.sample_dim]
+        diagonal = point[..., self.sample_dim :]
         return mean, diagonal
 
     @staticmethod
@@ -327,8 +323,7 @@ class DiagonalNormalDistributions(InformationManifoldMixin, OpenSet):
         point : array-like, shape=[..., 2 * sample_dim]
             Point with means and diagonals covariance matrices.
         """
-        point = gs.concatenate([mean, diagonal], axis=-1)
-        return point
+        return gs.concatenate([mean, diagonal], axis=-1)
 
     def belongs(self, point, atol=gs.atol):
         """Evaluate if the point belongs to the manifold.
@@ -347,9 +342,8 @@ class DiagonalNormalDistributions(InformationManifoldMixin, OpenSet):
         """
         point_dim = point.shape[-1]
         belongs = point_dim == self.dim
-        _, diagonal = self._unstack_mean_diagonal(self.sample_dim, point)
-        belongs = gs.logical_and(belongs, gs.all(diagonal >= atol, axis=-1))
-        return belongs
+        _, diagonal = self._unstack_mean_diagonal(point)
+        return gs.logical_and(belongs, gs.all(diagonal >= atol, axis=-1))
 
     def random_point(self, n_samples=1):
         """Generate random parameters of multivariate diagonal normal distributions.
@@ -395,10 +389,9 @@ class DiagonalNormalDistributions(InformationManifoldMixin, OpenSet):
             Point containing means and diagonals
             of covariance matrices.
         """
-        mean, diagonal = self._unstack_mean_diagonal(self.sample_dim, point)
+        mean, diagonal = self._unstack_mean_diagonal(point)
         regularized = gs.where(diagonal < gs.atol, gs.atol, diagonal)
-        projected = self._stack_mean_diagonal(mean, regularized)
-        return projected
+        return self._stack_mean_diagonal(mean, regularized)
 
     def sample(self, point, n_samples=1):
         """Sample from the diagonal multivariate normal distribution.
@@ -418,16 +411,7 @@ class DiagonalNormalDistributions(InformationManifoldMixin, OpenSet):
         samples : array-like, shape=[..., n_samples, sample_dim]
             Sample from multivariate normal distributions.
         """
-        geomstats.errors.check_belongs(point, self)
-        if point.ndim > 2:
-            raise NotImplementedError
-        point = gs.to_ndarray(point, to_ndim=2)
-        samples = []
-        for p in point:
-            mean, diag = self._unstack_mean_diagonal(self.sample_dim, p)
-            cov = gs.vec_to_diag(diag)
-            samples.append(gs.array(multivariate_normal.rvs(mean, cov, size=n_samples)))
-        return samples[0] if point.shape[0] == 1 else gs.stack(samples)
+        return self._scp_rv.rvs(point, n_samples)
 
     def point_to_pdf(self, point):
         """Compute pdf associated to point.
@@ -445,14 +429,11 @@ class DiagonalNormalDistributions(InformationManifoldMixin, OpenSet):
             Probability density function of the normal distribution with
             parameters provided by point.
         """
-        geomstats.errors.check_belongs(point, self)
-        if point.ndim > 2:
-            raise NotImplementedError
-        point = gs.to_ndarray(point, to_ndim=2, axis=0)
-        point = point[:, None, :]
+        batch_shape = get_batch_shape(self, point)
         n = self.sample_dim
-        mean, diagonal = self._unstack_mean_diagonal(n, point)
-        det_cov = gs.squeeze(gs.prod(diagonal, axis=-1))
+        mean, diagonal = self._unstack_mean_diagonal(point)
+        det_cov = gs.prod(diagonal, axis=-1)
+        pdf_normalization = 1 / gs.sqrt(gs.power((2 * gs.pi), n) * det_cov)
 
         def pdf(x):
             """Generate parameterized function for normal pdf.
@@ -463,15 +444,14 @@ class DiagonalNormalDistributions(InformationManifoldMixin, OpenSet):
                 Points at which to compute the probability
                 density function.
             """
-            x = gs.to_ndarray(x, to_ndim=2, axis=0)
-            x = x[None, :, :]
-            pdf = gs.exp(-0.5 * gs.sum(((x - mean) ** 2) / diagonal, axis=-1))
-            pdf_normalization = 1 / gs.sqrt(gs.power((2 * gs.pi), n) * det_cov)
-            while pdf_normalization.ndim < pdf.ndim:
-                pdf_normalization = pdf_normalization[..., None]
-            pdf = pdf_normalization * pdf
-            pdf = gs.squeeze(pdf)
-            return pdf
+            x_, (mean_, diagonal_) = broadcast_to_multibatch(
+                (x.shape[0],), batch_shape, x, mean, diagonal
+            )
+
+            aux = gs.exp(-0.5 * gs.sum(((x_ - mean_) ** 2) / diagonal_, axis=-1))
+            return gs.einsum(
+                "...,...i->...i", pdf_normalization, gs.to_ndarray(aux, to_ndim=1)
+            )
 
         return pdf
 
@@ -493,9 +473,11 @@ class GeneralNormalDistributions(InformationManifoldMixin, ProductManifold):
         super().__init__(
             factors=(Euclidean(sample_dim), SPDMatrices(sample_dim)),
             default_point_type="vector",
+            support_shape=(sample_dim,),
             equip=equip,
         )
         self.sample_dim = sample_dim
+        self._scp_rv = MultivariateNormalDistributionsRandomVariable(self)
 
     def _unstack_mean_covariance(self, point):
         """Extract mean and covariance matrix from a given point.
@@ -512,12 +494,11 @@ class GeneralNormalDistributions(InformationManifoldMixin, ProductManifold):
         diagonal : array-like, shape=[..., sample_dim, sample_dim]
             Covariance matrices from the input point.
         """
-        point = gs.to_ndarray(point, to_ndim=2)
-        n_points = gs.shape(point)[0]
-        mean = point[:, : self.sample_dim]
-        cov = point[:, self.sample_dim :]
-        cov = cov.reshape((n_points, self.sample_dim, self.sample_dim))
-        return gs.squeeze(mean), gs.squeeze(cov)
+        batch_shape = get_batch_shape(self, point)
+        mean = point[..., : self.sample_dim]
+        cov = point[..., self.sample_dim :]
+        cov = cov.reshape(batch_shape + (self.sample_dim, self.sample_dim))
+        return mean, cov
 
     def sample(self, point, n_samples=1):
         """Sample from a multivariate normal distribution.
@@ -537,14 +518,7 @@ class GeneralNormalDistributions(InformationManifoldMixin, ProductManifold):
         samples : array-like, shape=[..., n_samples, sample_dim]
             Sample from multivariate normal distributions.
         """
-        means, covs = self._unstack_mean_covariance(point)
-        means = gs.to_ndarray(means, to_ndim=2)
-        covs = gs.to_ndarray(covs, to_ndim=3)
-        samples = []
-        for mean, cov in zip(means, covs):
-            samples.append(gs.array(multivariate_normal.rvs(mean, cov, size=n_samples)))
-        samples = samples[0] if point.shape[0] == 1 else gs.stack(samples)
-        return gs.squeeze(samples)
+        return self._scp_rv.rvs(point, n_samples)
 
     def point_to_pdf(self, point):
         """Compute pdf associated to point.
@@ -562,15 +536,11 @@ class GeneralNormalDistributions(InformationManifoldMixin, ProductManifold):
             Probability density function of the multivariate normal
             distributions with parameters provided by point.
         """
-        if point.ndim > 3:
-            raise NotImplementedError
-        n = self.sample_dim
+        batch_shape = get_batch_shape(self, point)
         mean, cov = self._unstack_mean_covariance(point)
-        mean = gs.to_ndarray(mean, to_ndim=2)
-        cov = gs.to_ndarray(cov, to_ndim=3)
         det_cov = gs.linalg.det(cov)
         inv_cov = gs.linalg.inv(cov)
-        pdf_normalization = 1 / gs.sqrt(gs.power(2 * gs.pi, n) * det_cov)
+        pdf_normalization = 1 / gs.sqrt(gs.power(2 * gs.pi, self.sample_dim) * det_cov)
 
         def pdf(x):
             """Generate parameterized function for normal pdf.
@@ -581,15 +551,14 @@ class GeneralNormalDistributions(InformationManifoldMixin, ProductManifold):
                 Points at which to compute the probability
                 density function.
             """
-            x = gs.to_ndarray(x, to_ndim=2, axis=0)
-            pdf = []
-            for xi in x:
-                xi0 = xi - mean
-                pdf_at_xi = gs.exp(-0.5 * xi0[:, None, :] @ inv_cov @ xi0[:, :, None])
-                pdf.append(gs.squeeze(pdf_at_xi))
-            pdf = gs.stack(pdf)
-            pdf = pdf_normalization * pdf
-            return gs.squeeze(pdf)
+            x_, (mean_, inv_cov_) = broadcast_to_multibatch(
+                (x.shape[0],), batch_shape, x, mean, inv_cov
+            )
+            aux_0 = x - mean_
+            aux_1 = gs.exp(-0.5 * gs.dot(aux_0, gs.matvec(inv_cov_, aux_0)))
+            return gs.einsum(
+                "...,...i->...i", pdf_normalization, gs.to_ndarray(aux_1, to_ndim=1)
+            )
 
         return pdf
 
@@ -786,9 +755,7 @@ class DiagonalNormalMetric(RiemannianMetric):
         pairs : array-like, shape=[..., sample_dim, 2]
             Pairs of parameters (e.g. means and variances).
         """
-        mean, diagonal = self._space._unstack_mean_diagonal(
-            self._space.sample_dim, point
-        )
+        mean, diagonal = self._space._unstack_mean_diagonal(point)
         if apply_sqrt:
             diagonal = gs.sqrt(diagonal)
         return gs.stack([mean, diagonal], axis=-1)
@@ -903,3 +870,56 @@ class DiagonalNormalMetric(RiemannianMetric):
         """
         radius = gs.array(math.inf)
         return repeat_out(self._space, radius, base_point)
+
+
+class UnivariateNormalDistributionsRandomVariable(ScipyUnivariateRandomVariable):
+    """A univariate normal random variable."""
+
+    def __init__(self, space):
+        super().__init__(space, norm.rvs, norm.pdf)
+
+    def _flatten_params(self, point, pre_flat_shape):
+        loc = gs.expand_dims(point[..., 0], axis=-1)
+        scale = gs.expand_dims(point[..., 1], axis=-1)
+
+        flat_loc = gs.reshape(gs.broadcast_to(loc, pre_flat_shape), (-1,))
+        flat_scale = gs.reshape(gs.broadcast_to(scale, pre_flat_shape), (-1,))
+        return {"loc": flat_loc, "scale": flat_scale}
+
+
+class SharedMeanNormalDistributionsRandomVariable(ScipyMultivariateRandomVariable):
+    """A multivariate normal random variable with zero mean."""
+
+    def __init__(self, space):
+        rvs = lambda point, *args, **kwargs: multivariate_normal.rvs(
+            *args, cov=point, **kwargs
+        )
+        pdf = lambda x, point: multivariate_normal.pdf(x, cov=point)
+        super().__init__(space, rvs, pdf)
+
+
+class DiagonalNormalDistributionsRandomVariable(ScipyMultivariateRandomVariable):
+    """A diagonal multivariate normal random variable."""
+
+    # TODO: update other children
+    def __init__(self, space):
+        rvs = lambda point, size: multivariate_normal.rvs(
+            *space._unstack_mean_diagonal(point), size=size
+        )
+        pdf = lambda x, point: multivariate_normal.pdf(
+            x, *space._unstack_mean_diagonal(point)
+        )
+        super().__init__(space, rvs, pdf)
+
+
+class MultivariateNormalDistributionsRandomVariable(ScipyMultivariateRandomVariable):
+    """A multivariate normal random variable."""
+
+    def __init__(self, space):
+        rvs = lambda point, size: multivariate_normal.rvs(
+            *space._unstack_mean_covariance(point), size=size
+        )
+        pdf = lambda x, point: multivariate_normal.pdf(
+            x, *space._unstack_mean_covariance(point)
+        )
+        super().__init__(space, rvs, pdf)

--- a/geomstats/information_geometry/poisson.py
+++ b/geomstats/information_geometry/poisson.py
@@ -205,7 +205,8 @@ class PoissonMetric(RiemannianMetric):
         """
         return gs.expand_dims(1 / base_point, axis=-1)
 
-    def _geodesic_path(self, t, constant_a, constant_b):
+    @staticmethod
+    def _geodesic_path(t, constant_a, constant_b):
         """Generate parameterized function for geodesic curve.
 
         Parameters
@@ -310,7 +311,8 @@ class PoissonDistributionsRandomVariable(ScipyUnivariateRandomVariable):
     def __init__(self, space):
         super().__init__(space, poisson.rvs)
 
-    def _flatten_params(self, point, pre_flat_shape):
+    @staticmethod
+    def _flatten_params(point, pre_flat_shape):
         flat_point = gs.reshape(gs.broadcast_to(point, pre_flat_shape), (-1,))
         return {"mu": flat_point}
 

--- a/geomstats/numerics/bvp.py
+++ b/geomstats/numerics/bvp.py
@@ -26,11 +26,13 @@ class ScipySolveBVP:
         def bc_(state_0, state_1):
             return bc(gs.from_numpy(state_0), gs.from_numpy(state_1))
 
-        fun_jac_ = None
         if fun_jac is not None:
 
             def fun_jac_(t, state):
                 return fun_jac(t, gs.from_numpy(state))
+
+        else:
+            fun_jac_ = None
 
         result = scipy.integrate.solve_bvp(
             fun_,

--- a/geomstats/vectorization.py
+++ b/geomstats/vectorization.py
@@ -596,7 +596,7 @@ def broadcast_to_multibatch(batch_shape_a, batch_shape_b, array_a, *array_b):
     array_a_ = gs.broadcast_to(array_a, batch_shape_b + array_a.shape)
 
     n_batch_b = len(batch_shape_b)
-    indices_in = [i for i in range(len(batch_shape_a))]
+    indices_in = list(range(len(batch_shape_a)))
     indices_out = [index + n_batch_b for index in indices_in]
 
     array_b_ = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ max-line-length = 88
 extend-ignore = "E203"
 per-file-ignores = [
     "geomstats/learning/_sklearn_wrapper.py: D101, D102, D105",
-    "geomstats/learning/*: E731",
+    "geomstats/*: E731",
     "geomstats/_backend/*:F401, D103",
     "geomstats/numerics/*:D104,E731",
     "geomstats/visualization/*: D101, D102",

--- a/tests/data/binomial_data.py
+++ b/tests/data/binomial_data.py
@@ -145,26 +145,26 @@ class BinomialMetricTestData(_RiemannianMetricTestData):
         smoke_data = [
             dict(
                 space=space_5,
-                point_a=gs.array([0.2, 0.3]),
-                point_b=gs.array([0.3, 0.5]),
+                point_a=gs.array([[0.2], [0.3]]),
+                point_b=gs.array([[0.3], [0.5]]),
                 expected=gs.array([0.26908349, 0.84673057]),
             ),
             dict(
                 space=space_10,
-                point_a=gs.array(0.1),
-                point_b=gs.array(0.99),
+                point_a=gs.array([0.1]),
+                point_b=gs.array([0.99]),
                 expected=gs.array(52.79685863761384),
             ),
             dict(
                 space=space_5,
-                point_a=gs.array(0.3),
-                point_b=gs.array([0.2, 0.5]),
+                point_a=gs.array([0.3]),
+                point_b=gs.array([[0.2], [0.5]]),
                 expected=gs.array([0.26908349, 0.84673057]),
             ),
             dict(
                 space=space_5,
-                point_a=gs.array([0.2, 0.5]),
-                point_b=gs.array(0.3),
+                point_a=gs.array([[0.2], [0.5]]),
+                point_b=gs.array([0.3]),
                 expected=gs.array([0.26908349, 0.84673057]),
             ),
         ]

--- a/tests/data/multinomial_data.py
+++ b/tests/data/multinomial_data.py
@@ -41,7 +41,10 @@ class MultinomialTestData(_LevelSetTestData):
                 n_draws=4,
                 point=gs.array([0.2, 0.3, 0.5]),
                 n_samples=1,
-                expected=(1, 3,),
+                expected=(
+                    1,
+                    3,
+                ),
             ),
             dict(
                 dim=3,

--- a/tests/data/multinomial_data.py
+++ b/tests/data/multinomial_data.py
@@ -41,7 +41,7 @@ class MultinomialTestData(_LevelSetTestData):
                 n_draws=4,
                 point=gs.array([0.2, 0.3, 0.5]),
                 n_samples=1,
-                expected=(3,),
+                expected=(1, 3,),
             ),
             dict(
                 dim=3,

--- a/tests/tests_geomstats/test_categorical.py
+++ b/tests/tests_geomstats/test_categorical.py
@@ -62,7 +62,7 @@ class TestCategoricalDistributions(tests.conftest.TestCase):
         points = self.categorical.random_point(self.n_points)
         samples = self.categorical.sample(points, self.n_samples)
         result = samples.shape
-        expected = (self.n_points, self.n_samples)
+        expected = (self.n_points, self.n_samples, self.dim + 1)
         self.assertAllClose(expected, result)
 
     def test_simplex_to_sphere_and_back(self):

--- a/tests/tests_geomstats/test_dirichlet.py
+++ b/tests/tests_geomstats/test_dirichlet.py
@@ -40,7 +40,7 @@ class TestDirichlet(OpenSetTestCase, metaclass=Parametrizer):
         pdf = []
         for i in range(n_points):
             pdf.append(gs.array([dirichlet.pdf(x, point[i, :]) for x in samples]))
-        expected = gs.squeeze(gs.stack(pdf, axis=0))
+        expected = gs.stack(pdf, axis=0)
         self.assertAllClose(result, expected)
 
 


### PR DESCRIPTION
This PR fixes several issues in information geometry (most of them related with vectorization) and cleans several parts of the code by taking more advantage of inheritance and/or new vectorization functions.

The main addition is the notion of `RandomVariable`, in particular `ScipyRandomVariable`. This comes from the fact that the `InformationManifold` method `sample` uses `scipy.stats.<distribution>.rvs`. We just need to "translate" the inputs from geomstats to `scipy`, which can be done in a generic way (or at least in two: one for univariate distributions, and another for multivariate). We also take advantage of the `scipy.stats.<distribution>.pdf`: for some manifolds we directly use this method, for others we use it to validate our implementations (in new tests framework - coming very soon).