### PR TITLE
Use "remainder" instead of "fmod" for mod for pytorch backend

### DIFF
--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -107,7 +107,7 @@ tanh = _box_unary_scalar(target=_torch.tanh)
 
 
 arctan2 = _box_binary_scalar(target=_torch.atan2)
-mod = _box_binary_scalar(target=_torch.fmod, box_x2=False)
+mod = _box_binary_scalar(target=_torch.remainder, box_x2=False)
 power = _box_binary_scalar(target=_torch.pow, box_x2=False)
 
 


### PR DESCRIPTION
Hi, 

I didn't check all boxes, but this is just a minor change. I have created an extended version of the _backend of geomstats for my [pyRecEst](https://github.com/FlorianPfaff/pyRecEst) library and now I want to see if you are interested in "mainlining" some fixes.

This fix concerns backend.mod. Currently, mod uses pytorch's fmod. However torch.fmod behaves like np.fmod. np.fmod and np.mod do not behave identically. A key difference is the handling of negative values. Hence, I changed torch.mod to use torch.remainder instead, which behaves like np.mod.
