### PR TITLE
Refactor vectorized-related functions to receive `point_ndim`

### DIFF
--- a/geomstats/geometry/complex_matrices.py
+++ b/geomstats/geometry/complex_matrices.py
@@ -310,4 +310,4 @@ class ComplexMatricesMetric(HermitianMetric):
             Norm.
         """
         norm = gs.linalg.norm(vector, axis=(-2, -1))
-        return repeat_out(self._space, norm, vector, base_point)
+        return repeat_out(self._space.point_ndim, norm, vector, base_point)

--- a/geomstats/geometry/discrete_curves.py
+++ b/geomstats/geometry/discrete_curves.py
@@ -1273,7 +1273,7 @@ class SRVMetric(PullbackDiffeoMetric):
 
         velocity_norm = ambient_metric.norm(velocity, base_point_flat)
         srv = gs.einsum("...i,...->...i", velocity, 1.0 / gs.sqrt(velocity_norm))
-        batch_shape = get_batch_shape(self._space, point)
+        batch_shape = get_batch_shape(self._space.point_ndim, point)
         srv = gs.reshape(srv, batch_shape + self.embedding_space.shape)
         return srv
 
@@ -1423,7 +1423,7 @@ class SRVMetric(PullbackDiffeoMetric):
             curve evaluated at tangent_vec.
         """
         batch_shape = get_batch_shape(
-            self.embedding_space, image_tangent_vec, image_point
+            self.embedding_space.point_ndim, image_tangent_vec, image_point
         )
         point = self.inverse_diffeomorphism(image_point)
 

--- a/geomstats/geometry/euclidean.py
+++ b/geomstats/geometry/euclidean.py
@@ -88,7 +88,7 @@ class EuclideanMetric(RiemannianMetric):
         """
         dim = self._space.dim
         mat = gs.eye(dim)
-        return repeat_out(self._space, mat, base_point, out_shape=(dim, dim))
+        return repeat_out(self._space.point_ndim, mat, base_point, out_shape=(dim, dim))
 
     def inner_product(self, tangent_vec_a, tangent_vec_b, base_point=None):
         """Inner product between two tangent vectors at a base point.
@@ -110,7 +110,11 @@ class EuclideanMetric(RiemannianMetric):
         """
         inner_product = gs.dot(tangent_vec_a, tangent_vec_b)
         return repeat_out(
-            self._space, inner_product, tangent_vec_a, tangent_vec_b, base_point
+            self._space.point_ndim,
+            inner_product,
+            tangent_vec_a,
+            tangent_vec_b,
+            base_point,
         )
 
     def norm(self, vector, base_point=None):
@@ -136,7 +140,7 @@ class EuclideanMetric(RiemannianMetric):
             Norm.
         """
         norm = gs.linalg.norm(vector, axis=-1)
-        return repeat_out(self._space, norm, vector, base_point)
+        return repeat_out(self._space.point_ndim, norm, vector, base_point)
 
     def exp(self, tangent_vec, base_point, **kwargs):
         """Compute exp map of a base point in tangent vector direction.
@@ -206,7 +210,7 @@ class EuclideanMetric(RiemannianMetric):
         """
         transported_tangent_vec = gs.copy(tangent_vec)
         return repeat_out(
-            self._space,
+            self._space.point_ndim,
             transported_tangent_vec,
             tangent_vec,
             base_point,

--- a/geomstats/geometry/fiber_bundle.py
+++ b/geomstats/geometry/fiber_bundle.py
@@ -147,7 +147,7 @@ class FiberBundle(ABC):
         group = self.group
         group_action = self.group_action
 
-        batch_shape = get_batch_shape(self.total_space, point, base_point)
+        batch_shape = get_batch_shape(self.total_space.point_ndim, point, base_point)
         max_shape = batch_shape + (self.group_dim,)
 
         if group is not None:
@@ -221,7 +221,7 @@ class FiberBundle(ABC):
             fiber_point=base_point,
         )
 
-    def vertical_projection(self, tangent_vec, base_point, **kwargs):
+    def vertical_projection(self, tangent_vec, base_point):
         r"""Project to vertical subspace.
 
         Compute the vertical component of a tangent vector :math:`w` at a

--- a/geomstats/geometry/grassmannian.py
+++ b/geomstats/geometry/grassmannian.py
@@ -503,4 +503,4 @@ class GrassmannianCanonicalMetric(MatricesMetric):
             https://arxiv.org/abs/2011.13699.
         """
         radius = gs.array(gs.pi / 2)
-        return repeat_out(self._space, radius, base_point)
+        return repeat_out(self._space.point_ndim, radius, base_point)

--- a/geomstats/geometry/hpd_matrices.py
+++ b/geomstats/geometry/hpd_matrices.py
@@ -744,7 +744,7 @@ class HPDAffineMetric(ComplexRiemannianMetric):
             Injectivity radius.
         """
         radius = gs.array(math.inf)
-        return repeat_out(self._space, radius, base_point)
+        return repeat_out(self._space.point_ndim, radius, base_point)
 
 
 class HPDBuresWassersteinMetric(ComplexRiemannianMetric):
@@ -1163,7 +1163,7 @@ class HPDEuclideanMetric(ComplexRiemannianMetric):
         """
         if self.power_euclidean == 1:
             return repeat_out(
-                self._space,
+                self._space.point_ndim,
                 gs.copy(tangent_vec),
                 tangent_vec,
                 base_point,
@@ -1266,7 +1266,7 @@ class HPDLogEuclideanMetric(ComplexRiemannianMetric):
             Injectivity radius.
         """
         radius = gs.array(math.inf)
-        return repeat_out(self._space, radius, base_point)
+        return repeat_out(self._space.point_ndim, radius, base_point)
 
     def dist(self, point_a, point_b):
         """Compute log euclidean distance.

--- a/geomstats/geometry/hyperboloid.py
+++ b/geomstats/geometry/hyperboloid.py
@@ -413,4 +413,4 @@ class HyperboloidMetric(HyperbolicMetric):
             Injectivity radius.
         """
         radius = gs.array(math.inf)
-        return repeat_out(self._space, radius, base_point)
+        return repeat_out(self._space.point_ndim, radius, base_point)

--- a/geomstats/geometry/hypersphere.py
+++ b/geomstats/geometry/hypersphere.py
@@ -890,7 +890,7 @@ class HypersphereMetric(RiemannianMetric):
                 "The Christoffel symbols are only implemented"
                 " for spherical coordinates in the 2-sphere"
             )
-        batch_shape = get_batch_shape(self._space, base_point)
+        batch_shape = get_batch_shape(self._space.point_ndim, base_point)
 
         theta = base_point[..., 0]
 
@@ -1091,7 +1091,7 @@ class HypersphereMetric(RiemannianMetric):
         """
         curvature_derivative = gs.zeros_like(tangent_vec_a)
         return repeat_out(
-            self._space,
+            self._space.point_ndim,
             curvature_derivative,
             tangent_vec_a,
             tangent_vec_b,
@@ -1121,7 +1121,7 @@ class HypersphereMetric(RiemannianMetric):
             Injectivity radius.
         """
         radius = gs.array(gs.pi)
-        return repeat_out(self._space, radius, base_point)
+        return repeat_out(self._space.point_ndim, radius, base_point)
 
 
 class Hypersphere(_Hypersphere):

--- a/geomstats/geometry/invariant_metric.py
+++ b/geomstats/geometry/invariant_metric.py
@@ -1265,7 +1265,11 @@ class BiInvariantMetric(RiemannianMetric):
             inner_prod = self.inner_product_at_identity(tangent_vec_a, tangent_vec_b)
             if base_point is not None:
                 return repeat_out(
-                    self._space, inner_prod, base_point, tangent_vec_a, tangent_vec_b
+                    self._space.point_ndim,
+                    inner_prod,
+                    base_point,
+                    tangent_vec_a,
+                    tangent_vec_b,
                 )
             return inner_prod
 
@@ -1341,4 +1345,4 @@ class BiInvariantMetric(RiemannianMetric):
             Injectivity radius.
         """
         radius = gs.array(gs.pi * self._space.dim**0.5)
-        return repeat_out(self._space, radius, base_point)
+        return repeat_out(self._space.point_ndim, radius, base_point)

--- a/geomstats/geometry/matrices.py
+++ b/geomstats/geometry/matrices.py
@@ -687,7 +687,7 @@ class MatricesMetric(EuclideanMetric):
         """
         inner_prod = Matrices.frobenius_product(tangent_vec_a, tangent_vec_b)
         return repeat_out(
-            self._space, inner_prod, tangent_vec_a, tangent_vec_b, base_point
+            self._space.point_ndim, inner_prod, tangent_vec_a, tangent_vec_b, base_point
         )
 
     def norm(self, vector, base_point=None):
@@ -709,4 +709,4 @@ class MatricesMetric(EuclideanMetric):
             Norm.
         """
         norm = gs.linalg.norm(vector, axis=(-2, -1))
-        return repeat_out(self._space, norm, vector, base_point)
+        return repeat_out(self._space.point_ndim, norm, vector, base_point)

--- a/geomstats/geometry/minkowski.py
+++ b/geomstats/geometry/minkowski.py
@@ -145,4 +145,4 @@ class MinkowskiMetric(RiemannianMetric):
             Injectivity radius.
         """
         radius = gs.array(math.inf)
-        return repeat_out(self._space, radius, base_point)
+        return repeat_out(self._space.point_ndim, radius, base_point)

--- a/geomstats/geometry/nfold_manifold.py
+++ b/geomstats/geometry/nfold_manifold.py
@@ -68,7 +68,7 @@ class NFoldManifold(Manifold):
         belongs : array-like, shape=[..., n_copies, *base_shape]
             Boolean evaluating if the point belongs to the manifold.
         """
-        batch_shape = get_batch_shape(self, point)
+        batch_shape = get_batch_shape(self.point_ndim, point)
         point_ = gs.reshape(point, (-1, *self.base_manifold.shape))
 
         each_belongs = self.base_manifold.belongs(point_, atol=atol)
@@ -98,7 +98,7 @@ class NFoldManifold(Manifold):
             Boolean denoting if vector is a tangent vector at the base point.
         """
         vector_, base_point_ = gs.broadcast_arrays(vector, base_point)
-        batch_shape = get_batch_shape(self, vector_)
+        batch_shape = get_batch_shape(self.point_ndim, vector_)
         base_point_ = gs.reshape(base_point_, (-1, *self.base_manifold.shape))
         vector_ = gs.reshape(vector_, (-1, *self.base_manifold.shape))
 
@@ -127,7 +127,7 @@ class NFoldManifold(Manifold):
         """
         vector_, base_point_ = gs.broadcast_arrays(vector, base_point)
         base_point_ = gs.reshape(base_point_, (-1, *self.base_manifold.shape))
-        batch_shape = get_batch_shape(self, vector_)
+        batch_shape = get_batch_shape(self.point_ndim, vector_)
         vector_ = gs.reshape(vector_, (-1, *self.base_manifold.shape))
 
         each_tangent = self.base_manifold.to_tangent(vector_, base_point_)
@@ -175,7 +175,7 @@ class NFoldManifold(Manifold):
             Projected point.
         """
         if hasattr(self.base_manifold, "projection"):
-            batch_shape = get_batch_shape(self, point)
+            batch_shape = get_batch_shape(self.point_ndim, point)
             point_ = gs.reshape(point, (-1, *self.base_manifold.shape))
             projected = self.base_manifold.projection(point_)
             return gs.reshape(projected, batch_shape + self.shape)
@@ -228,7 +228,7 @@ class NFoldMetric(RiemannianMetric):
             Matrix of the inner-product at the base point.
         """
         base_manifold = self._space.base_manifold
-        batch_shape = get_batch_shape(self._space, base_point)
+        batch_shape = get_batch_shape(self._space.point_ndim, base_point)
 
         point_ = gs.reshape(base_point, (-1, *base_manifold.shape))
         matrices = base_manifold.metric.metric_matrix(point_)
@@ -267,7 +267,7 @@ class NFoldMetric(RiemannianMetric):
         tangent_vec_a_, tangent_vec_b_, point_ = gs.broadcast_arrays(
             tangent_vec_a, tangent_vec_b, base_point
         )
-        batch_shape = get_batch_shape(self._space, tangent_vec_a_)
+        batch_shape = get_batch_shape(self._space.point_ndim, tangent_vec_a_)
 
         point_ = gs.reshape(point_, (-1, *base_manifold.shape))
         vector_a = gs.reshape(tangent_vec_a_, (-1, *base_manifold.shape))
@@ -299,7 +299,7 @@ class NFoldMetric(RiemannianMetric):
             of tangent_vec at the base point.
         """
         base_manifold = self._space.base_manifold
-        batch_shape = get_batch_shape(self._space, tangent_vec, base_point)
+        batch_shape = get_batch_shape(self._space.point_ndim, tangent_vec, base_point)
 
         tangent_vec, point_ = gs.broadcast_arrays(tangent_vec, base_point)
         point_ = gs.reshape(point_, (-1, *base_manifold.shape))
@@ -325,7 +325,7 @@ class NFoldMetric(RiemannianMetric):
             of point at the base point.
         """
         base_manifold = self._space.base_manifold
-        batch_shape = get_batch_shape(self._space, point, base_point)
+        batch_shape = get_batch_shape(self._space.point_ndim, point, base_point)
 
         point_, base_point_ = gs.broadcast_arrays(point, base_point)
         base_point_ = gs.reshape(base_point_, (-1, *base_manifold.shape))

--- a/geomstats/geometry/poincare_ball.py
+++ b/geomstats/geometry/poincare_ball.py
@@ -447,4 +447,4 @@ class PoincareBallMetric(RiemannianMetric):
             Injectivity radius.
         """
         radius = gs.array(math.inf)
-        return repeat_out(self._space, radius, base_point)
+        return repeat_out(self._space.point_ndim, radius, base_point)

--- a/geomstats/geometry/poincare_half_space.py
+++ b/geomstats/geometry/poincare_half_space.py
@@ -179,4 +179,4 @@ class PoincareHalfSpaceMetric(RiemannianMetric):
             Injectivity radius.
         """
         radius = gs.array(math.inf)
-        return repeat_out(self._space, radius, base_point)
+        return repeat_out(self._space.point_ndim, radius, base_point)

--- a/geomstats/geometry/pre_shape.py
+++ b/geomstats/geometry/pre_shape.py
@@ -756,7 +756,7 @@ class PreShapeMetric(RiemannianMetric):
             Tangent vector at the base point equal to the Riemannian logarithm
             of point at the base point.
         """
-        batch_shape = get_batch_shape(self._space, point, base_point)
+        batch_shape = get_batch_shape(self._space.point_ndim, point, base_point)
 
         flat_bp = self._flatten_point(base_point)
         flat_pt = self._flatten_point(point)
@@ -793,7 +793,11 @@ class PreShapeMetric(RiemannianMetric):
             Tangent vector at `base_point`.
         """
         batch_shape = get_batch_shape(
-            self._space, base_point, tangent_vec_a, tangent_vec_b, tangent_vec_c
+            self._space.point_ndim,
+            base_point,
+            tangent_vec_a,
+            tangent_vec_b,
+            tangent_vec_c,
         )
         flat_a = self._flatten_point(tangent_vec_a)
         flat_b = self._flatten_point(tangent_vec_b)
@@ -846,7 +850,7 @@ class PreShapeMetric(RiemannianMetric):
             Tangent vector at base point.
         """
         batch_shape = get_batch_shape(
-            self._space,
+            self._space.point_ndim,
             tangent_vec_a,
             tangent_vec_b,
             tangent_vec_c,
@@ -890,7 +894,7 @@ class PreShapeMetric(RiemannianMetric):
                 )
 
         batch_shape = get_batch_shape(
-            self._space, tangent_vec, base_point, direction, end_point
+            self._space.point_ndim, tangent_vec, base_point, direction, end_point
         )
 
         flat_bp = self._flatten_point(base_point)
@@ -922,7 +926,7 @@ class PreShapeMetric(RiemannianMetric):
             Injectivity radius.
         """
         radius = gs.array(gs.pi)
-        return repeat_out(self._space, radius, base_point)
+        return repeat_out(self._space.point_ndim, radius, base_point)
 
 
 class KendallShapeMetric(QuotientMetric):

--- a/geomstats/geometry/product_manifold.py
+++ b/geomstats/geometry/product_manifold.py
@@ -120,7 +120,7 @@ class _IterateOverFactorsMixins:
             points_ = []
             for point, factor in zip(points, self.factors):
                 if gs.ndim(point) > len(factor.shape):
-                    batch_shape = get_batch_shape(factor, point)
+                    batch_shape = get_batch_shape(factor.point_ndim, point)
                     point = gs.reshape(point, batch_shape + (-1,))
                 else:
                     point = gs.flatten(point)

--- a/geomstats/geometry/pullback_metric.py
+++ b/geomstats/geometry/pullback_metric.py
@@ -64,7 +64,7 @@ class PullbackMetric(RiemannianMetric):
             Inner-product matrix.
         """
         dim, dim_embedding = self._space.dim, self._space.embedding_space.dim
-        is_vec = check_is_batch(self._space, base_point)
+        is_vec = check_is_batch(self._space.point_ndim, base_point)
 
         immersed_base_point = self._space.immersion(base_point)
         jacobian_immersion = self._space.jacobian_immersion(base_point)
@@ -295,7 +295,7 @@ class PullbackDiffeoMetric(RiemannianMetric, abc.ABC):
         image_tangent_vec : array-like, shape=[..., *i_shape]
             Image tangent vector at image of the base point.
         """
-        batch_shape = get_batch_shape(self._space, tangent_vec, base_point)
+        batch_shape = get_batch_shape(self._space.point_ndim, tangent_vec, base_point)
         flat_batch_shape = (-1,) if batch_shape else ()
 
         J_flat = gs.reshape(
@@ -352,7 +352,7 @@ class PullbackDiffeoMetric(RiemannianMetric, abc.ABC):
             Image tangent vector at image of the base point.
         """
         batch_shape = get_batch_shape(
-            self.embedding_space, image_tangent_vec, image_point
+            self.embedding_space.point_ndim, image_tangent_vec, image_point
         )
         flat_batch_shape = (-1,) if batch_shape else ()
 

--- a/geomstats/geometry/riemannian_metric.py
+++ b/geomstats/geometry/riemannian_metric.py
@@ -320,7 +320,7 @@ class RiemannianMetric(Connection, ABC):
         normalized_vector : array-like, shape=[..., n_vectors, dim]
             Random unit tangent vector at base_point.
         """
-        is_batch = check_is_batch(self._space, base_point)
+        is_batch = check_is_batch(self._space.point_ndim, base_point)
         if is_batch and n_vectors > 1:
             raise ValueError(
                 "Several tangent vectors is only applicable to a single base point."

--- a/geomstats/geometry/sasaki_metric.py
+++ b/geomstats/geometry/sasaki_metric.py
@@ -361,7 +361,7 @@ class SasakiMetric(RiemannianMetric):
                 ]
             )
 
-        is_batch = check_is_batch(self._space, initial_point, end_point)
+        is_batch = check_is_batch(self._space.point_ndim, initial_point, end_point)
         if not is_batch:
             return _geodesic_discrete_single(initial_point, end_point)
 

--- a/geomstats/geometry/spd_matrices.py
+++ b/geomstats/geometry/spd_matrices.py
@@ -715,7 +715,7 @@ class SPDAffineMetric(RiemannianMetric):
             Injectivity radius.
         """
         radius = gs.array(math.inf)
-        return repeat_out(self._space, radius, base_point)
+        return repeat_out(self._space.point_ndim, radius, base_point)
 
 
 class SPDBuresWassersteinMetric(RiemannianMetric):
@@ -992,7 +992,11 @@ class SPDEuclideanMetric(RiemannianMetric):
         if power_euclidean == 1:
             inner_product = Matrices.frobenius_product(tangent_vec_a, tangent_vec_b)
             return repeat_out(
-                self._space, inner_product, tangent_vec_a, tangent_vec_b, base_point
+                self._space.point_ndim,
+                inner_product,
+                tangent_vec_a,
+                tangent_vec_b,
+                base_point,
             )
 
         modified_tangent_vec_a = spd_space.differential_power(
@@ -1150,7 +1154,7 @@ class SPDEuclideanMetric(RiemannianMetric):
         """
         if self.power_euclidean == 1:
             return repeat_out(
-                self._space,
+                self._space.point_ndim,
                 gs.copy(tangent_vec),
                 tangent_vec,
                 base_point,
@@ -1253,7 +1257,7 @@ class SPDLogEuclideanMetric(RiemannianMetric):
             Injectivity radius.
         """
         radius = gs.array(math.inf)
-        return repeat_out(self._space, radius, base_point)
+        return repeat_out(self._space.point_ndim, radius, base_point)
 
     def dist(self, point_a, point_b):
         """Compute log euclidean distance.

--- a/geomstats/geometry/special_euclidean.py
+++ b/geomstats/geometry/special_euclidean.py
@@ -1048,7 +1048,7 @@ class SpecialEuclideanMatricesCanonicalLeftMetric(_InvariantMetricMatrix):
         """
         inner_prod = Matrices.frobenius_product(tangent_vec_a, tangent_vec_b)
         return repeat_out(
-            self._space, inner_prod, base_point, tangent_vec_a, tangent_vec_b
+            self._space.point_ndim, inner_prod, base_point, tangent_vec_a, tangent_vec_b
         )
 
     def exp(self, tangent_vec, base_point=None):

--- a/geomstats/geometry/stiefel.py
+++ b/geomstats/geometry/stiefel.py
@@ -427,7 +427,7 @@ class StiefelCanonicalMetric(RiemannianMetric):
             https://dial.uclouvain.be/pr/boreal/object/boreal:132587.
         """
         radius = gs.array(0.89 * gs.pi)
-        return repeat_out(self._space, radius, base_point)
+        return repeat_out(self._space.point_ndim, radius, base_point)
 
 
 class _StiefelLogSolver:

--- a/geomstats/information_geometry/base.py
+++ b/geomstats/information_geometry/base.py
@@ -105,7 +105,7 @@ class ScipyUnivariateRandomVariable(ScipyRandomVariable):
         samples : array-like, shape=[..., n_samples, *support_shape]
             Sample from distribution.
         """
-        batch_shape = get_batch_shape(self.space, point)
+        batch_shape = get_batch_shape(self.space.point_ndim, point)
         n_points = math.prod(batch_shape)
 
         pre_flat_shape = batch_shape + (n_samples,)
@@ -133,7 +133,7 @@ class ScipyUnivariateRandomVariable(ScipyRandomVariable):
             Values of pdf at x for each value of the parameters provided
             by point.
         """
-        batch_shape = get_batch_shape(self.space, point)
+        batch_shape = get_batch_shape(self.space.point_ndim, point)
         n_points = math.prod(batch_shape)
         n_samples = sample.shape[0]
 

--- a/geomstats/information_geometry/dirichlet.py
+++ b/geomstats/information_geometry/dirichlet.py
@@ -374,7 +374,7 @@ class DirichletMetric(RiemannianMetric):
             Injectivity radius.
         """
         radius = gs.array(math.inf)
-        return repeat_out(self._space, radius, base_point)
+        return repeat_out(self._space.point_ndim, radius, base_point)
 
     def _approx_geodesic_bvp(
         self,

--- a/geomstats/information_geometry/gamma.py
+++ b/geomstats/information_geometry/gamma.py
@@ -287,7 +287,7 @@ class GammaDistributions(InformationManifoldMixin, OpenSet):
         jac_row_1 = gs.array([1, 0])
         jac_row_2 = gs.stack([1 / scale, -kappa / scale**2], axis=-1)
 
-        if check_is_batch(self, base_point):
+        if check_is_batch(self.point_ndim, base_point):
             jac_row_1 = gs.repeat(
                 gs.expand_dims(jac_row_1, axis=0), base_point.shape[0], axis=0
             )

--- a/geomstats/information_geometry/multinomial.py
+++ b/geomstats/information_geometry/multinomial.py
@@ -146,7 +146,9 @@ class MultinomialDistributions(InformationManifoldMixin, LevelSet):
         component_mean = gs.mean(vector, axis=-1)
         tangent_vec = gs.transpose(gs.transpose(vector) - component_mean)
 
-        return repeat_out(self, tangent_vec, vector, base_point, out_shape=self.shape)
+        return repeat_out(
+            self.point_ndim, tangent_vec, vector, base_point, out_shape=self.shape
+        )
 
     def sample(self, point, n_samples=1):
         """Sample from the multinomial distribution.

--- a/geomstats/information_geometry/normal.py
+++ b/geomstats/information_geometry/normal.py
@@ -223,7 +223,7 @@ class CenteredNormalDistributions(InformationManifoldMixin, SPDMatrices):
             Probability density function of the centered multivariate normal
             distributions with covariance matrices provided by point.
         """
-        batch_shape = get_batch_shape(self, point)
+        batch_shape = get_batch_shape(self.point_ndim, point)
         det_cov = gs.linalg.det(point)
         inv_cov = gs.linalg.inv(point)
         pdf_normalization = 1 / gs.sqrt(gs.power(2 * gs.pi, self.sample_dim) * det_cov)
@@ -429,7 +429,7 @@ class DiagonalNormalDistributions(InformationManifoldMixin, OpenSet):
             Probability density function of the normal distribution with
             parameters provided by point.
         """
-        batch_shape = get_batch_shape(self, point)
+        batch_shape = get_batch_shape(self.point_ndim, point)
         n = self.sample_dim
         mean, diagonal = self._unstack_mean_diagonal(point)
         det_cov = gs.prod(diagonal, axis=-1)
@@ -494,7 +494,7 @@ class GeneralNormalDistributions(InformationManifoldMixin, ProductManifold):
         diagonal : array-like, shape=[..., sample_dim, sample_dim]
             Covariance matrices from the input point.
         """
-        batch_shape = get_batch_shape(self, point)
+        batch_shape = get_batch_shape(self.point_ndim, point)
         mean = point[..., : self.sample_dim]
         cov = point[..., self.sample_dim :]
         cov = cov.reshape(batch_shape + (self.sample_dim, self.sample_dim))
@@ -536,7 +536,7 @@ class GeneralNormalDistributions(InformationManifoldMixin, ProductManifold):
             Probability density function of the multivariate normal
             distributions with parameters provided by point.
         """
-        batch_shape = get_batch_shape(self, point)
+        batch_shape = get_batch_shape(self.point_ndim, point)
         mean, cov = self._unstack_mean_covariance(point)
         det_cov = gs.linalg.det(cov)
         inv_cov = gs.linalg.inv(cov)
@@ -721,7 +721,11 @@ class UnivariateNormalMetric(PullbackDiffeoMetric):
         """
         sectional_curv = gs.array(-0.5)
         return repeat_out(
-            self._space, sectional_curv, tangent_vec_a, tangent_vec_b, base_point
+            self._space.point_ndim,
+            sectional_curv,
+            tangent_vec_a,
+            tangent_vec_b,
+            base_point,
         )
 
 
@@ -869,7 +873,7 @@ class DiagonalNormalMetric(RiemannianMetric):
             Injectivity radius.
         """
         radius = gs.array(math.inf)
-        return repeat_out(self._space, radius, base_point)
+        return repeat_out(self._space.point_ndim, radius, base_point)
 
 
 class UnivariateNormalDistributionsRandomVariable(ScipyUnivariateRandomVariable):

--- a/geomstats/numerics/geodesic.py
+++ b/geomstats/numerics/geodesic.py
@@ -68,7 +68,7 @@ class ExpODESolver(ExpSolver):
         self.integrator = integrator
 
     def _solve(self, space, tangent_vec, base_point, t_eval=None):
-        batch_shape = get_batch_shape(space, base_point, tangent_vec)
+        batch_shape = get_batch_shape(space.point_ndim, base_point, tangent_vec)
         base_point = gs.broadcast_to(base_point, tangent_vec.shape)
 
         if self.integrator.state_is_raveled:

--- a/geomstats/test/random.py
+++ b/geomstats/test/random.py
@@ -78,7 +78,7 @@ class DiscreteCurvesRandomDataGenerator(RandomDataGenerator):
 
 class HypersphereIntrinsicRandomDataGenerator(RandomDataGenerator):
     def random_tangent_vec(self, base_point):
-        n_points = get_n_points(self.space, base_point)
+        n_points = get_n_points(self.space.point_ndim, base_point)
         batch_shape = (n_points,) if n_points > 1 else ()
         return gs.random.uniform(size=batch_shape + (self.space.dim,)) / self.amplitude
 

--- a/geomstats/test_cases/geometry/base.py
+++ b/geomstats/test_cases/geometry/base.py
@@ -188,7 +188,7 @@ class LevelSetTestCase(ProjectionTestCaseMixins, ManifoldTestCase):
 
     def test_submersion_is_zero(self, point, submersion_shape, atol):
         # TODO: keep?
-        batch_shape = get_batch_shape(self.space, point)
+        batch_shape = get_batch_shape(self.space.point_ndim, point)
         expected = gs.zeros(batch_shape + submersion_shape)
 
         self.test_submersion(point, expected, atol)
@@ -215,7 +215,7 @@ class LevelSetTestCase(ProjectionTestCaseMixins, ManifoldTestCase):
         self, tangent_vector, point, tangent_submersion_shape, atol
     ):
         # TODO: keep?
-        batch_shape = get_batch_shape(self.space, tangent_vector, point)
+        batch_shape = get_batch_shape(self.space.point_ndim, tangent_vector, point)
         expected = gs.zeros(batch_shape + tangent_submersion_shape)
 
         self.test_tangent_submersion(tangent_vector, point, expected, atol)

--- a/geomstats/test_cases/geometry/connection.py
+++ b/geomstats/test_cases/geometry/connection.py
@@ -43,7 +43,7 @@ class ConnectionTestCase(TestCase):
         point = self.space.metric.exp(tangent_vec, base_point)
 
         res = self.space.belongs(point, atol=atol)
-        expected_shape = get_batch_shape(self.space, base_point)
+        expected_shape = get_batch_shape(self.space.point_ndim, base_point)
         expected = gs.ones(expected_shape, dtype=bool)
         self.assertAllEqual(res, expected)
 
@@ -68,7 +68,7 @@ class ConnectionTestCase(TestCase):
         tangent_vec = self.space.metric.log(point, base_point)
 
         res = self.space.is_tangent(tangent_vec, base_point, atol=atol)
-        expected_shape = get_batch_shape(self.space, base_point)
+        expected_shape = get_batch_shape(self.space.point_ndim, base_point)
         expected = gs.ones(expected_shape, dtype=bool)
         self.assertAllEqual(res, expected)
 
@@ -278,7 +278,7 @@ class ConnectionTestCase(TestCase):
         res = self.space.belongs(gs.reshape(points, (-1, *self.space.shape)), atol=atol)
 
         expected_shape = (
-            math.prod(get_batch_shape(self.space, initial_point)) * n_times,
+            math.prod(get_batch_shape(self.space.point_ndim, initial_point)) * n_times,
         )
         expected = gs.ones(expected_shape, dtype=bool)
         self.assertAllEqual(res, expected)
@@ -310,7 +310,7 @@ class ConnectionTestCase(TestCase):
         res = self.space.belongs(gs.reshape(points, (-1, *self.space.shape)), atol=atol)
 
         expected_shape = (
-            math.prod(get_batch_shape(self.space, initial_point)) * n_times,
+            math.prod(get_batch_shape(self.space.point_ndim, initial_point)) * n_times,
         )
 
         expected = gs.ones(expected_shape, dtype=bool)
@@ -415,7 +415,7 @@ class ConnectionTestCase(TestCase):
 
         res = self.space.is_tangent(transported, end_point, atol=atol)
 
-        expected_shape = get_batch_shape(self.space, base_point)
+        expected_shape = get_batch_shape(self.space.point_ndim, base_point)
         expected = gs.ones(expected_shape, dtype=bool)
 
         self.assertAllEqual(res, expected)
@@ -434,7 +434,7 @@ class ConnectionTestCase(TestCase):
 
         res = self.space.is_tangent(transported, end_point, atol=atol)
 
-        expected_shape = get_batch_shape(self.space, base_point)
+        expected_shape = get_batch_shape(self.space.point_ndim, base_point)
         expected = gs.ones(expected_shape, dtype=bool)
 
         self.assertAllEqual(res, expected)

--- a/geomstats/test_cases/geometry/discrete_curves.py
+++ b/geomstats/test_cases/geometry/discrete_curves.py
@@ -103,7 +103,7 @@ class SRVShapeBundleTestCase(FiberBundleTestCase):
         res = self.total_space.metric.inner_product(
             tangent_vec_hor, tangent_vec_ver, base_point
         )
-        expected_shape = get_batch_shape(self.total_space, base_point)
+        expected_shape = get_batch_shape(self.total_space.point_ndim, base_point)
         expected = gs.zeros(expected_shape)
         self.assertAllClose(res, expected, atol=atol)
 

--- a/geomstats/test_cases/geometry/discrete_surfaces.py
+++ b/geomstats/test_cases/geometry/discrete_surfaces.py
@@ -43,7 +43,7 @@ class DiscreteSurfacesTestCase(ManifoldTestCase):
 
         res = self.space.normals(point)
 
-        n_points = get_n_points(self.space, point)
+        n_points = get_n_points(self.space.point_ndim, point)
         if n_points == 1:
             res = gs.expand_dims(res, axis=0)
             expected = gs.expand_dims(expected, axis=0)

--- a/geomstats/test_cases/geometry/hypersphere.py
+++ b/geomstats/test_cases/geometry/hypersphere.py
@@ -47,7 +47,7 @@ def _belongs_intrinsic(space, point, atol=gs.atol):
 
 
 def _is_tangent_intrinsic(space, tangent_vec, point, atol=gs.atol):
-    shape = get_batch_shape(space, point, tangent_vec)
+    shape = get_batch_shape(space.point_ndim, point, tangent_vec)
     if tangent_vec.shape[-1] == space.dim:
         return gs.ones(shape, dtype=bool)
 

--- a/geomstats/test_cases/geometry/pre_shape.py
+++ b/geomstats/test_cases/geometry/pre_shape.py
@@ -214,7 +214,7 @@ class PreShapeSpaceBundleTestCase(FiberBundleTestCase):
         result = self.total_space.metric.inner_product(
             tangent_vec_b, result_ab, base_point
         )
-        expected_shape = get_batch_shape(self.total_space, base_point)
+        expected_shape = get_batch_shape(self.total_space.point_ndim, base_point)
         expected = gs.zeros(expected_shape)
         self.assertAllClose(result, expected, atol=atol)
 
@@ -401,7 +401,7 @@ class PreShapeSpaceBundleTestCase(FiberBundleTestCase):
             + inner(nabla_x_a_y_v, horizontal_vec_z)
             + inner(a_y_v, nabla_x_z)
         )
-        expected_shape = get_batch_shape(self.total_space, base_point)
+        expected_shape = get_batch_shape(self.total_space.point_ndim, base_point)
         expected = gs.zeros(expected_shape)
         self.assertAllClose(result, expected, atol=atol)
 
@@ -435,7 +435,7 @@ class PreShapeSpaceBundleTestCase(FiberBundleTestCase):
 
         inner = self.total_space.metric.inner_product
         result = inner(nabla_x_a_y_z, horizontal_vec_h) + inner(a_y_z, nabla_x_h)
-        expected_shape = get_batch_shape(self.total_space, base_point)
+        expected_shape = get_batch_shape(self.total_space.point_ndim, base_point)
         expected = gs.zeros(expected_shape)
         self.assertAllClose(result, expected, atol=atol)
 
@@ -473,7 +473,7 @@ class PreShapeSpaceBundleTestCase(FiberBundleTestCase):
 
         inner = self.total_space.metric.inner_product
         result = inner(nabla_x_a_y_z, vertical_vec_w) + inner(a_y_z, nabla_x_w)
-        expected_shape = get_batch_shape(self.total_space, base_point)
+        expected_shape = get_batch_shape(self.total_space.point_ndim, base_point)
         expected = gs.zeros(expected_shape)
         self.assertAllClose(result, expected, atol=atol)
 
@@ -695,7 +695,7 @@ class KendallShapeMetricTestCase(QuotientMetricTestCase):
 
     def _cmp_points(self, point, point_, atol):
         dists = self.space.metric.dist(point, point_)
-        batch_shape = get_batch_shape(self.space, point, point_)
+        batch_shape = get_batch_shape(self.space.point_ndim, point, point_)
 
         self.assertAllClose(dists, gs.zeros(batch_shape), atol=atol)
 
@@ -910,7 +910,7 @@ class KendallShapeMetricTestCase(QuotientMetricTestCase):
         fiber_bundle = self.space.metric.fiber_bundle
         res = fiber_bundle.is_horizontal(transported, end_point, atol=atol)
 
-        expected_shape = get_batch_shape(self.space, base_point)
+        expected_shape = get_batch_shape(self.space.point_ndim, base_point)
         expected = gs.ones(expected_shape, dtype=bool)
 
         self.assertAllEqual(res, expected)

--- a/geomstats/test_cases/geometry/riemannian_metric.py
+++ b/geomstats/test_cases/geometry/riemannian_metric.py
@@ -25,7 +25,7 @@ class RiemannianMetricTestCase(ConnectionTestCase):
         res = SPDMatrices(n=math.prod(self.space.shape)).belongs(
             metric_matrix, atol=atol
         )
-        expected_shape = get_batch_shape(self.space, base_point)
+        expected_shape = get_batch_shape(self.space.point_ndim, base_point)
         expected = gs.ones(expected_shape, dtype=bool)
 
         self.assertAllEqual(res, expected)
@@ -233,7 +233,7 @@ class RiemannianMetricTestCase(ConnectionTestCase):
 
         dist_ = self.space.metric.dist(point, point)
 
-        expected_shape = get_batch_shape(self.space, point)
+        expected_shape = get_batch_shape(self.space.point_ndim, point)
         expected = gs.zeros(expected_shape)
         self.assertAllClose(dist_, expected, atol=atol)
 

--- a/geomstats/test_cases/information_geometry/base.py
+++ b/geomstats/test_cases/information_geometry/base.py
@@ -14,7 +14,9 @@ class InformationManifoldMixinTestCase(TestCase):
         res = self.space.sample(point, n_samples=n_samples)
 
         expected_shape = (
-            get_batch_shape(self.space, point) + (n_samples,) + self.space.support_shape
+            get_batch_shape(self.space.point_ndim, point)
+            + (n_samples,)
+            + self.space.support_shape
         )
         self.assertEqual(res.shape, expected_shape)
 

--- a/geomstats/vectorization.py
+++ b/geomstats/vectorization.py
@@ -36,13 +36,13 @@ def _get_max_ndim_point(*point):
     return max_ndim_point
 
 
-def get_n_points(space, *point):
+def get_n_points(point_ndim, *point):
     """Compute the number of points.
 
     Parameters
     ----------
-    space : Manifold object
-        Space to which point belongs.
+    point_ndim : int
+        Point number of array dimensions.
     point : array-like
         Point belonging to the space.
 
@@ -52,16 +52,16 @@ def get_n_points(space, *point):
         Number of points.
     """
     point_max_ndim = _get_max_ndim_point(*point)
-    return math.prod(point_max_ndim.shape[: -space.point_ndim])
+    return math.prod(point_max_ndim.shape[:-point_ndim])
 
 
-def check_is_batch(space, *point):
+def check_is_batch(point_ndim, *point):
     """Check if inputs are batch.
 
     Parameters
     ----------
-    space : Manifold object
-        Space to which point belongs.
+    point_ndim : int
+        Point number of array dimensions.
     point : array-like
         Point belonging to the space.
 
@@ -70,16 +70,16 @@ def check_is_batch(space, *point):
     is_batch : bool
         Returns True if point contains several points.
     """
-    return any(point_.ndim > space.point_ndim for point_ in point)
+    return any(point_.ndim > point_ndim for point_ in point)
 
 
-def get_batch_shape(space, *point):
+def get_batch_shape(point_ndim, *point):
     """Get batch shape.
 
     Parameters
     ----------
-    space : Manifold
-        Space to which point belongs.
+    point_ndim : int
+        Point number of array dimensions.
     point : array-like or None
         Point belonging to the space.
 
@@ -92,7 +92,7 @@ def get_batch_shape(space, *point):
     if len(point) == 0:
         return ()
     point_max_ndim = _get_max_ndim_point(*point)
-    return point_max_ndim.shape[: -space.point_ndim]
+    return point_max_ndim.shape[:-point_ndim]
 
 
 def repeat_point(point, n_reps=2, expand=False):
@@ -123,13 +123,13 @@ def _is_not_none(value):
     return value is not None
 
 
-def repeat_out(space, out, *point, out_shape=()):
+def repeat_out(point_ndim, out, *point, out_shape=()):
     """Repeat out shape after finding batch shape.
 
     Parameters
     ----------
-    space : Manifold
-        Space to which point belongs.
+    point_ndim : int
+        Point number of array dimensions.
     out : array-like
         Output to be repeated
     point : array-like or None
@@ -143,7 +143,7 @@ def repeat_out(space, out, *point, out_shape=()):
         If no batch, then input is returned. Otherwise it is broadcasted.
     """
     point = filter(_is_not_none, point)
-    batch_shape = get_batch_shape(space, *point)
+    batch_shape = get_batch_shape(point_ndim, *point)
     if out.shape[: -len(out_shape)] != batch_shape:
         return gs.broadcast_to(out, batch_shape + out_shape)
     return out


### PR DESCRIPTION
This PR refactors vectorization-related functions (`geomstats/vectorization`; e.g. `get_batch_shape`) to receive `point_ndim` instead of `space` (the information is available in `space.point_ndim`).

The main goal is to make them more general and avoid passing unnecessary information to such simple functions (this need comes from the design of `Diffeo`, being developed in a different PR).

All the changes in the other files reflect the wide use of these functions within the package (expected as they provide easy ways to e.g. gather information about (batch) shapes).