### PR TITLE
Fix typos in docs, docstrings and tutorial notebooks

### DIFF
--- a/docs/contributing/index.rst
+++ b/docs/contributing/index.rst
@@ -355,7 +355,7 @@ should not break any test.
 Workflow of a contribution 
 ===========================
 
-The best way to start contributing is by finding a part of the project that is more familiar to you (e.g. a specific manifold or metric, a learning algoritgm, etc). Instead, if these concepts are new to you and you would like to contribute while learning, look at some of the existing issues.
+The best way to start contributing is by finding a part of the project that is more familiar to you (e.g. a specific manifold or metric, a learning algorithm, etc). Instead, if these concepts are new to you and you would like to contribute while learning, look at some of the existing issues.
 
 
 .. _new-contributors:
@@ -678,7 +678,7 @@ guidelines:
    objects living in several namespaces which creates confusion (see
    `Language Constructs You Should Not Use <https://docs.python.org/2/howto/doanddont.html#language-constructs-you-should-not-use>`_).
    Keeping the original namespace ensures naming consistency in the codebase
-   and speeds up the code reviews: co-developpers and maintainers do not have
+   and speeds up the code reviews: co-developers and maintainers do not have
    to check if you are using the original module's method or if you have
    overwritten it.
 
@@ -725,7 +725,7 @@ Building the documentation requires installing specific requirements::
 
    pip install -e .[doc]
 
-To build the documentation, follow the steps discussed in `build the docs`_ to install other dependecies 
+To build the documentation, follow the steps discussed in `build the docs`_ to install other dependencies 
 and build the documentation.
 
 Writing Docstrings
@@ -951,7 +951,7 @@ from high-level questions to a more detailed check-list.
 Reporting bugs and features 
 ===========================
 
-Sharing bugs and potential new features for the geomstats project is an equally significant conteibution.
+Sharing bugs and potential new features for the geomstats project is an equally significant contribution.
 We encourage reports for any module including documentation and missing tests.
 
 Issue tracker
@@ -975,15 +975,15 @@ Issue Triaging
 ==============
 
 Other than reporting bugs, another important aspect of contribution is `issue triaging`. This is
-about issue mamanagement and includes certain aspects that are described in the sequel.
+about issue management and includes certain aspects that are described in the sequel.
 
 Reproducing issues
 ------------------
 
-Sometimes reported issues need to be verified to acertain if they are actual issues or false alarms. Part of 
+Sometimes reported issues need to be verified to ascertain if they are actual issues or false alarms. Part of 
 triaging is trying to simulate the bugs in their reported environments and other relevant environments. 
 
-We encourage you to help with this and comment on the issue if you can or can not reproduce it as decribed.
+We encourage you to help with this and comment on the issue if you can or can not reproduce it as described.
 This allows core devs to close the issue if it does not require fixing.
 
 Commenting on alternative solutions

--- a/docs/getting_started/first-steps.rst
+++ b/docs/getting_started/first-steps.rst
@@ -47,7 +47,7 @@ If you use the flag ``-e``, geomstats will be installed in editable mode, i.e. l
 
 **CHOOSE THE BACKEND**
 
-Geomstats can run seemlessly with ``numpy`` or ``pytorch``. Note that ``pytorch`` requirement is optional, as geomstats can be used with ``numpy`` only. By default, the ``numpy`` backend is used. The visualizations are only available with this backend.
+Geomstats can run seamlessly with ``numpy`` or ``pytorch``. Note that ``pytorch`` requirement is optional, as geomstats can be used with ``numpy`` only. By default, the ``numpy`` backend is used. The visualizations are only available with this backend.
 
 To get the ``autograd`` and ``pytorch`` versions compatible with geomstats, install the optional requirements::
 

--- a/docs/hackathons.rst
+++ b/docs/hackathons.rst
@@ -7,7 +7,7 @@ Hackathons
 Geomstats core developers organize several hackathons a year, with the following goals:
   * Train new users, e.g. pairing a new user with an experienced Geomstats developer.
   * On-board new contributors, e.g. on collaborative coding practices.
-  * Foster new collaborations and strenghten existing ones
+  * Foster new collaborations and strengthen existing ones
   * Bring the community of geometric statistics and learning together.
 
 

--- a/geomstats/information_geometry/multinomial.py
+++ b/geomstats/information_geometry/multinomial.py
@@ -310,7 +310,7 @@ class MultinomialMetric(RiemannianMetric):
     def exp(self, tangent_vec, base_point):
         """Compute the exponential map.
 
-        Comute the exponential map associated to the Fisher information
+        Compute the exponential map associated to the Fisher information
         metric by pulling back the exponential map on the sphere by the
         simplex_to_sphere map.
 

--- a/geomstats/information_geometry/poisson.py
+++ b/geomstats/information_geometry/poisson.py
@@ -61,7 +61,7 @@ class PoissonDistributions(InformationManifoldMixin, OpenSet):
         return gs.squeeze(point >= -atol)
 
     def random_point(self, n_samples=1, bound=1.0):
-        """Sample parameters of Possion distributions.
+        """Sample parameters of Poisson distributions.
 
         The uniform distribution on (0, bound) is used.
 

--- a/geomstats/visualization/pre_shape.py
+++ b/geomstats/visualization/pre_shape.py
@@ -37,9 +37,9 @@ class KendallSphere:
     pole : array-like, shape=[3,2]
         Equilateral triangle (north pole).
     ua : array-like, shape=[3,2]
-        Tangent vector toward isocele triangle at vertex A.
+        Tangent vector toward isosceles triangle at vertex A.
     ub : array-like, shape=[3,2]
-        Tangent vector toward isocele triangle at vertex B.
+        Tangent vector toward isosceles triangle at vertex B.
     na : array-like, shape=[3,2]
         Tangent vector such that (ua,na) is a positively oriented
         orthonormal basis of the horizontal space at north pole.
@@ -285,9 +285,9 @@ class KendallDisk:
     centre : array-like, shape=[3,3]
         Equilateral triangle in 3D (centre).
     ua : array-like, shape=[3,2]
-        Tangent vector at north pole toward isocele triangle at vertex A.
+        Tangent vector at north pole toward isosceles triangle at vertex A.
     ub : array-like, shape=[3,2]
-        Tangent vector at north pole toward isocele triangle at vertex B.
+        Tangent vector at north pole toward isosceles triangle at vertex B.
     na : array-like, shape=[3,2]
         Tangent vector such that (ua,na) is a positively oriented
         orthonormal basis of the horizontal space at north pole.

--- a/geomstats/visualization/spd_matrices.py
+++ b/geomstats/visualization/spd_matrices.py
@@ -57,7 +57,7 @@ class Ellipses:
             positive definite matrices.
             Optional, default: None.
         plot_kwargs : dict
-            Dictionnary of arguments related to plotting.
+            Dictionary of arguments related to plotting.
         """
         if ax is None:
             ax = self.set_ax()

--- a/notebooks/00_foundations__introduction_to_geomstats.ipynb
+++ b/notebooks/00_foundations__introduction_to_geomstats.ipynb
@@ -57,7 +57,7 @@
    "id": "5cdd76be",
    "metadata": {},
    "source": [
-    "Analyzing data that lie on manifolds is often possible without Riemannain Geometry, but choosing to analyze data on manifolds is advantageous for three reasons:\n",
+    "Analyzing data that lie on manifolds is often possible without Riemannian Geometry, but choosing to analyze data on manifolds is advantageous for three reasons:\n",
     "\n",
     "1. Analyzing data on the manifold it lies on allows you to reduce the degrees of freedom of the system, which makes  computations less complicated and more intuitive and interpretable.\n",
     "2. Knowing the manifold that a data set belongs to will give you a better understanding of the data's evolution.\n",
@@ -251,7 +251,7 @@
    "id": "5cd75c7e",
    "metadata": {},
    "source": [
-    "Geomstats is designed to be intuitive and user friendly, but having some knowledge about Riemannian Geometry will put you in a good position to understand how to use Geomstats most effectively. Therefore, in the next three notebooks, we will give you an overview of three of the most important parent classes in Geomstats, along with a description of the matematical concepts implemented in each class."
+    "Geomstats is designed to be intuitive and user friendly, but having some knowledge about Riemannian Geometry will put you in a good position to understand how to use Geomstats most effectively. Therefore, in the next three notebooks, we will give you an overview of three of the most important parent classes in Geomstats, along with a description of the mathematical concepts implemented in each class."
    ]
   },
   {

--- a/notebooks/01_foundations__manifolds.ipynb
+++ b/notebooks/01_foundations__manifolds.ipynb
@@ -228,7 +228,7 @@
    "id": "deb3926b",
    "metadata": {},
    "source": [
-    "A hyperphere is one type of manifold, but there are many other types of manifolds that are commonly used and seen in nature. We will show a few examples here to help you build intuition about what a manifold is and what a manifold can look like."
+    "A hypersphere is one type of manifold, but there are many other types of manifolds that are commonly used and seen in nature. We will show a few examples here to help you build intuition about what a manifold is and what a manifold can look like."
    ]
   },
   {
@@ -334,7 +334,7 @@
    "id": "cdce00c5",
    "metadata": {},
    "source": [
-    "The `Manifold` class describes different types of manifolds. The `Manifold` class and its subclasses implement methods that establish the properties of different types of manifolds, and the manifolds that exist under these subclasses inherit the properties implemented in their respective sublclasses.\n",
+    "The `Manifold` class describes different types of manifolds. The `Manifold` class and its subclasses implement methods that establish the properties of different types of manifolds, and the manifolds that exist under these subclasses inherit the properties implemented in their respective subclasses.\n",
     "\n",
     "Note: The words \"class\", \"subclass\", \"methods\" refer to [object oriented programming](https://www.educative.io/blog/object-oriented-programming)."
    ]
@@ -438,7 +438,7 @@
    "source": [
     "As discussed in the previous section, one of the primary purposes of the `Manifold` class is to hold information about various types of manifolds. Rules that are universally true for all manifolds are implemented in methods in the parent class `Manifold`. Rules that are true for some types of manifolds are implemented in the subclasses of `Manifold`: `LevelSet`, `OpenSet`, `FiberBundle`, `ProductManifold`, `VectorSpace`, `MatrixLieAlgebra`, and `MatrixLieGroup`. Specific types of manifolds are described in methods within these subclasses.\n",
     "\n",
-    "In this notebook, we will focus on describing the subclasses pertenant to the geometry module of geomstats: `LevelSet`, `OpenSet`, `ProductManifold` and `VectorSpace`.\n",
+    "In this notebook, we will focus on describing the subclasses pertinent to the geometry module of geomstats: `LevelSet`, `OpenSet`, `ProductManifold` and `VectorSpace`.\n",
     "\n",
     "In the following subsections, we will discuss the methods and ideas implemented in the parent class and its subclasses."
    ]
@@ -456,7 +456,7 @@
    "id": "578faea8",
    "metadata": {},
    "source": [
-    "The Manifold parent class is an abstract base class which provides the minimal skeleton of attributes and methods expected in its subclasses. Note that the methods of the abstract parent class are declared, but they contain no implementation, and they are overridden by the subclasses. The properties that are declared in the `Manifold` class are properties that all types of manifold must posess. For example, the following methods and attributes are implemented in `Manifold`:\n",
+    "The Manifold parent class is an abstract base class which provides the minimal skeleton of attributes and methods expected in its subclasses. Note that the methods of the abstract parent class are declared, but they contain no implementation, and they are overridden by the subclasses. The properties that are declared in the `Manifold` class are properties that all types of manifold must possess. For example, the following methods and attributes are implemented in `Manifold`:\n",
     "\n",
     "1. `dim`: $\\textit{attribute}$. the dimension of the manifold. \"How many coordinates are necessary to fully describe the manifold?\"\n",
     "2. `belongs()`: $\\textit{method}$. evaluates whether a given element belongs to that manifold\n",
@@ -855,7 +855,7 @@
    "id": "3bb824a3",
    "metadata": {},
    "source": [
-    "Earlier in the notebook, we were able to say that a set of points is a manifold if it satisfied one of three constraints. We also said that every manifold can be described by any three of these definitions, and the choice of defintion is merely a question of which definition is most convenient. `OpenSet` provides a way of describing manifolds with local parametrization, which was labeled (1) on our definition list.\n",
+    "Earlier in the notebook, we were able to say that a set of points is a manifold if it satisfied one of three constraints. We also said that every manifold can be described by any three of these definitions, and the choice of definition is merely a question of which definition is most convenient. `OpenSet` provides a way of describing manifolds with local parametrization, which was labeled (1) on our definition list.\n",
     "\n",
     "One such way to describe a manifold is with the concept of an $\\textbf{Open Set}$: a manifold is the open sets of a d-dimensional vector space, called $\\textbf{ambient space}$."
    ]
@@ -1077,7 +1077,7 @@
    "id": "f2b6b387",
    "metadata": {},
    "source": [
-    "Another elementary class of manifolds are $\\textbf{Level Sets}$. A level set is the set of values $x$ for which a function f(x) is equal to a given constant. In other words, a level set is a set of curves for which the fucntion describing a manifold is constant along that curve. \n",
+    "Another elementary class of manifolds are $\\textbf{Level Sets}$. A level set is the set of values $x$ for which a function f(x) is equal to a given constant. In other words, a level set is a set of curves for which the function describing a manifold is constant along that curve. \n",
     "\n",
     "In the same way that `OpenSet` is an implementation of the first definition of a manifold (Local Parametrization), `LevelSet` is an implementation of the second definition of a manifold (Local Implicit Function). a level set is a set of points for which the function $f$ takes the exact same value. This value is called the \"level\", and does not need to be a scalar, it could also be a vector.\n",
     "\n",

--- a/notebooks/02_foundations__connection_riemannian_metric.ipynb
+++ b/notebooks/02_foundations__connection_riemannian_metric.ipynb
@@ -115,7 +115,7 @@
    "id": "7432cd4a",
    "metadata": {},
    "source": [
-    "$\\textbf{2. Now, let's consider the conditions that the connection must satsify.}$ \n",
+    "$\\textbf{2. Now, let's consider the conditions that the connection must satisfy.}$ \n",
     "1. (linearity of the $1^{st}$ argument): $\\nabla_{f X} Y = f \\nabla_{X} Y$\n",
     "\n",
     "2. (Leibniz rule in $2^{nd}$ argument): $\\nabla_{X} (fY) = X(f)Y+ f\\nabla_{X} Y$\n",
@@ -340,7 +340,7 @@
    "id": "04c152fc",
    "metadata": {},
    "source": [
-    "# 3. Defining Geodesics with the Conneciton"
+    "# 3. Defining Geodesics with the Connection"
    ]
   },
   {


### PR DESCRIPTION
I've fixed a few typos in docs, docstrings and tutorial notebooks. 
