### PR TITLE
Endow space with mathematical structure

### DIFF
--- a/geomstats/geometry/base.py
+++ b/geomstats/geometry/base.py
@@ -12,6 +12,24 @@ from geomstats.geometry.manifold import Manifold
 from geomstats.geometry.pullback_metric import PullbackMetric
 
 
+class MathStruct(abc.ABC):
+    """Abstract mathematical structure.
+
+    Implements methods required to handle method/attribute calling.
+    """
+
+    def __init__(self, space):
+        self._space = space
+
+    def __getattr__(self, name):
+        """Get attribute.
+
+        Uses space to get attribute, as it is aware of mathematical structures.
+        This way preserves overriding expected behavior.
+        """
+        return getattr(self._space, name)
+
+
 class VectorSpace(Manifold, abc.ABC):
     """Abstract class for vector spaces.
 

--- a/geomstats/geometry/general_linear.py
+++ b/geomstats/geometry/general_linear.py
@@ -187,7 +187,7 @@ class GeneralLinear(MatrixLieGroup, OpenSet):
         return path
 
 
-class SquareMatrices(MatrixLieAlgebra):
+class SquareMatrices(Matrices):
     """Lie algebra of the general linear group.
 
     This is the space of matrices.
@@ -200,17 +200,14 @@ class SquareMatrices(MatrixLieAlgebra):
 
     def __init__(self, n, equip=True):
         self.n = n
-        super().__init__(dim=n**2, representation_dim=n, equip=equip)
-        self._mat_space = Matrices(n, n, equip=False)
+        super().__init__(n=n, m=n, equip=equip)
 
-    @staticmethod
-    def default_metric():
-        """Metric to equip the space with if equip is True."""
-        return MatricesMetric
 
-    def _create_basis(self):
-        """Create the canonical basis of the space of matrices."""
-        return self._mat_space.basis
+class SquareMatricesLieAlgebraStruct(MatrixLieAlgebra):
+    """Lie algebra structure for square matrices."""
+
+    def __init__(self, space):
+        super().__init__(space=space, representation_dim=space.n)
 
     def basis_representation(self, matrix_representation):
         """Compute the coefficient in the usual matrix basis.
@@ -227,7 +224,7 @@ class SquareMatrices(MatrixLieAlgebra):
         basis_representation : array-like, shape=[..., dim]
             Representation in the basis.
         """
-        return self._mat_space.flatten(matrix_representation)
+        return self.flatten(matrix_representation)
 
     def matrix_representation(self, basis_representation):
         """Compute the matrix representation for the given basis coefficients.
@@ -244,4 +241,4 @@ class SquareMatrices(MatrixLieAlgebra):
         matrix_representation : array-like, shape=[..., n, n]
             Matrix.
         """
-        return self._mat_space.reshape(basis_representation)
+        return self.reshape(basis_representation)

--- a/geomstats/geometry/lie_algebra.py
+++ b/geomstats/geometry/lie_algebra.py
@@ -12,14 +12,14 @@ Lead author: Stefan Heyder.
 import abc
 
 import geomstats.backend as gs
-import geomstats.errors
-from geomstats.geometry.base import VectorSpace
+from geomstats.errors import check_integer
+from geomstats.geometry.base import MathStruct
 from geomstats.geometry.matrices import Matrices
 
 from ._bch_coefficients import BCH_COEFFICIENTS
 
 
-class MatrixLieAlgebra(VectorSpace, abc.ABC):
+class MatrixLieAlgebra(MathStruct, abc.ABC):
     """Class implementing matrix Lie algebra related functions.
 
     Parameters
@@ -29,10 +29,10 @@ class MatrixLieAlgebra(VectorSpace, abc.ABC):
         Lie algebra.
     """
 
-    def __init__(self, representation_dim, **kwargs):
-        geomstats.errors.check_integer(representation_dim, "representation_dim")
-        super().__init__(shape=(representation_dim, representation_dim), **kwargs)
+    def __init__(self, space, representation_dim):
+        check_integer(representation_dim, "representation_dim")
         self.representation_dim = representation_dim
+        super().__init__(space=space)
 
     bracket = Matrices.bracket
 
@@ -118,7 +118,4 @@ class MatrixLieAlgebra(VectorSpace, abc.ABC):
         matrix_representation : array-like, shape=[..., *point_shape]
             Matrix.
         """
-        if self.basis is None:
-            raise NotImplementedError("basis not implemented")
-
         return gs.einsum("...i,ijk ->...jk", basis_representation, self.basis)

--- a/geomstats/geometry/manifold.py
+++ b/geomstats/geometry/manifold.py
@@ -63,6 +63,24 @@ class Manifold(abc.ABC):
         if equip:
             self.equip_with_metric()
 
+        self._math_structs = []
+
+    def __getattr__(self, name):
+        """Get attribute.
+
+        Looks for the attribute in the space and in the endowed mathematical
+        structures.
+        """
+        try:
+            return self.__getattribute__(name)
+        except AttributeError as e:
+            for math_struct in self._math_structs:
+                try:
+                    return getattr(math_struct, name)
+                except AttributeError:
+                    pass
+            raise e
+
     def equip_with_metric(self, Metric=None, **metric_kwargs):
         """Equip manifold with a Riemannian metric.
 
@@ -120,6 +138,25 @@ class Manifold(abc.ABC):
 
         self.quotient = self.new(equip=False)
         self.quotient.equip_with_metric(QuotientMetric_, fiber_bundle=self.fiber_bundle)
+
+    def endow_with_math_struct(self, MathStruct, **kwargs):
+        """Endow manifold with mathematic structure.
+
+        Methods available in `MathStruct` become directly available to
+        the manifold.
+
+        A space can be endowed with several math structures. In case of
+        name clashing, first endowed structure has priority.
+
+        User is responsible for compatibility between mathematical
+        structures.
+
+        Parameters
+        ----------
+        MathStruct : MathStruct object
+        """
+        self._math_structs.append(MathStruct(self, **kwargs))
+        return self
 
     @abc.abstractmethod
     def belongs(self, point, atol=gs.atol):


### PR DESCRIPTION
Following some discussions we've been having about successively endowing a space with mathematical structures (especially during last year's hackathon), I suggest in this PR a technical way of accomplishing it. It allows to have much more flexible code with minimal changes. I use the square matrices and the corresponding `MatrixLieAlgebra` structure as example.


**Square matrices and matrix Lie algebra**

Currently, `SquareMatrices` inherit from `MatrixLieAlgebra`, which in turn inherits from `VectorSpace`. In my view, `SquareMatrices` plain implementation should be unaware of its role as Lie algebra for the general linear group.

This can be accomplished by (obviously) noticing that square matrices is a Manifold not because it is a Lie algebra, but because it is a vector space (and, of course, the fact it is a vector space allows it to be the Lie algebra of some space). Therefore, the plain implementation of square matrices should be a vector space with the possibility of adding `LieAlgebra` structure (meaning in this case bringing in methods such as `baker_campbell_hausdorff`). That is, `LieAlgebra` should not inherit from `Manifold`, but be something we can add to the  manifold.

In terms of plain `SquareMatrices` implementation, it is even enough to see it is a very particular case of `Matrices`, so we can simply implement it as a child where we set `m = n`.

For the `LieAlgebra` structure, I suggest we implement it in a separated object, which I'm calling, for the lack of a better name,  `SquareMatricesLieAlgebraStruct`. Notice, that similarly to the metric, a `MathStruct` is aware of the space it is put on (reason to receive `space` as first input).

This way, if someone is working with `SquareMatrices` out of a Lie groups context, they can instantiate an object that is simply a vector space. Within the context of Lie groups, they can add the Lie algebra structure with the following code:

```python
space = SquareMatrices(n=3)

space.endow_with_math_struct(SquareMatricesLieAlgebraStruct)
```

**Method calling**

When we equip with a metric, we call one of its methods with `space.metric.<method_name>`. Moreover, one space can only be associated with one metric at time.

For mathematical structures, I suggest `space.<method_name>` is desired, as the space **becomes** e.g. a `LieAlgebra`. Moreover, one space can be endowed with multiple (**compatible**) math structures. This translates into code in the following way:

```python
space = SquareMatrices(n=3)
point_a, point_b = space.random_point(2)

space.baker_campbell_hausdorff(point_a, point_b)
# raises AttributeError

space.endow_with_math_struct(SquareMatricesLieAlgebraStruct)
space.baker_campbell_hausdorff(point_a, point_b)
# works properly
```

**Name clashing**

Compatible math structures mean that there should be no name clashing. In case it happens, the current implementation chooses the method that corresponds to the mathematical structure added firstly (can be easily changed in the other direction).


**Remarks**

In my view, this solution makes the code more clean, readable, and closer to the mathematical literature. For educational purposes, I believe it makes it even better, as it becomes very clear why some methods are required (e.g. `baker_campbell_hausdorff` is only useful in the context of Lie groups, so a student can safely ignore its implementation until they start being concerned with the topic).

In terms of code organization, it can also make things nicer. For example, I suggest in the case of square matrices, we create `geomstats/geometry/square_matrices.py`, move `SquareMatrices` there, but keep `SquareMatricesLieAlgebraStruct` in `general_linear.py`, as it has a meaning in that context.

On the other side, we will end up with more smaller objects. I usually see it as a positive thing, as it means they're very easy to mantain, but I agree there's a negative side, as the relationships between objects need to be taken care of more carefully.

**Next steps**

Once you've reviewed this and we reach a satisfying solution for everyone, I'll extend the implementation to the other `LieAlgebra`'s. This should be enough to merge as a first step. Later, we should start thinking about additional mathematical structures to bring in.