### PR TITLE
Rename OpenSet to VectorSpaceOpenSet and create new OpenSet

### DIFF
--- a/geomstats/geometry/complex_poincare_disk.py
+++ b/geomstats/geometry/complex_poincare_disk.py
@@ -21,12 +21,12 @@ References
 """
 
 import geomstats.backend as gs
-from geomstats.geometry.base import ComplexOpenSet
+from geomstats.geometry.base import ComplexVectorSpaceOpenSet
 from geomstats.geometry.complex_riemannian_metric import ComplexRiemannianMetric
 from geomstats.geometry.hermitian import Hermitian
 
 
-class ComplexPoincareDisk(ComplexOpenSet):
+class ComplexPoincareDisk(ComplexVectorSpaceOpenSet):
     """Class for the complex Poincaré disk.
 
     The Poincaré disk is a representation of the Hyperbolic

--- a/geomstats/geometry/full_rank_matrices.py
+++ b/geomstats/geometry/full_rank_matrices.py
@@ -4,11 +4,11 @@ Lead author: Anna Calissano.
 """
 
 import geomstats.backend as gs
-from geomstats.geometry.base import OpenSet
+from geomstats.geometry.base import VectorSpaceOpenSet
 from geomstats.geometry.matrices import Matrices, MatricesMetric
 
 
-class FullRankMatrices(OpenSet):
+class FullRankMatrices(VectorSpaceOpenSet):
     r"""Class for :math:`R_*^{n\times k}` matrices of dimension n x k and full rank.
 
     Parameters

--- a/geomstats/geometry/general_linear.py
+++ b/geomstats/geometry/general_linear.py
@@ -2,13 +2,13 @@
 
 import geomstats.algebra_utils as utils
 import geomstats.backend as gs
-from geomstats.geometry.base import OpenSet
+from geomstats.geometry.base import VectorSpaceOpenSet
 from geomstats.geometry.lie_algebra import MatrixLieAlgebra
 from geomstats.geometry.lie_group import MatrixLieGroup
 from geomstats.geometry.matrices import Matrices, MatricesMetric
 
 
-class GeneralLinear(MatrixLieGroup, OpenSet):
+class GeneralLinear(MatrixLieGroup, VectorSpaceOpenSet):
     """Class for the general linear group GL(n) and its identity component.
 
     If `positive_det=True`, this is the connected component of the identity,

--- a/geomstats/geometry/hpd_matrices.py
+++ b/geomstats/geometry/hpd_matrices.py
@@ -6,7 +6,7 @@ Lead author: Yann Cabanes.
 import math
 
 import geomstats.backend as gs
-from geomstats.geometry.base import ComplexOpenSet
+from geomstats.geometry.base import ComplexVectorSpaceOpenSet
 from geomstats.geometry.complex_matrices import ComplexMatrices
 from geomstats.geometry.complex_riemannian_metric import ComplexRiemannianMetric
 from geomstats.geometry.general_linear import GeneralLinear
@@ -19,7 +19,7 @@ from geomstats.integrator import integrate
 from geomstats.vectorization import repeat_out
 
 
-class HPDMatrices(ComplexOpenSet):
+class HPDMatrices(ComplexVectorSpaceOpenSet):
     """Class for the manifold of Hermitian positive definite (HPD) matrices.
 
     Parameters

--- a/geomstats/geometry/poincare_ball.py
+++ b/geomstats/geometry/poincare_ball.py
@@ -10,7 +10,7 @@ import math
 import geomstats.algebra_utils as utils
 import geomstats.backend as gs
 from geomstats.geometry._hyperbolic import _Hyperbolic
-from geomstats.geometry.base import OpenSet
+from geomstats.geometry.base import VectorSpaceOpenSet
 from geomstats.geometry.euclidean import Euclidean
 from geomstats.geometry.riemannian_metric import RiemannianMetric
 from geomstats.vectorization import repeat_out
@@ -23,7 +23,7 @@ SQRT_2 = gs.sqrt(2.0)
 _COORDS_TYPE = "ball"
 
 
-class PoincareBall(_Hyperbolic, OpenSet):
+class PoincareBall(_Hyperbolic, VectorSpaceOpenSet):
     """Class for the n-dimensional Poincare ball.
 
     Class for the n-dimensional Poincaré ball model. For other

--- a/geomstats/geometry/poincare_half_space.py
+++ b/geomstats/geometry/poincare_half_space.py
@@ -9,14 +9,14 @@ import math
 
 import geomstats.backend as gs
 from geomstats.geometry._hyperbolic import _Hyperbolic
-from geomstats.geometry.base import OpenSet
+from geomstats.geometry.base import VectorSpaceOpenSet
 from geomstats.geometry.euclidean import Euclidean
 from geomstats.geometry.poincare_ball import PoincareBall
 from geomstats.geometry.riemannian_metric import RiemannianMetric
 from geomstats.vectorization import repeat_out
 
 
-class PoincareHalfSpace(_Hyperbolic, OpenSet):
+class PoincareHalfSpace(_Hyperbolic, VectorSpaceOpenSet):
     """Class for the n-dimensional Poincare half-space.
 
     Class for the n-dimensional Poincaré half space model. For other

--- a/geomstats/geometry/positive_lower_triangular_matrices.py
+++ b/geomstats/geometry/positive_lower_triangular_matrices.py
@@ -4,13 +4,13 @@ Lead author: Saiteja Utpala.
 """
 
 import geomstats.backend as gs
-from geomstats.geometry.base import OpenSet
+from geomstats.geometry.base import VectorSpaceOpenSet
 from geomstats.geometry.lower_triangular_matrices import LowerTriangularMatrices
 from geomstats.geometry.matrices import Matrices
 from geomstats.geometry.riemannian_metric import RiemannianMetric
 
 
-class PositiveLowerTriangularMatrices(OpenSet):
+class PositiveLowerTriangularMatrices(VectorSpaceOpenSet):
     """Manifold of lower triangular matrices with >0 diagonal.
 
     This manifold is also called the cholesky space.

--- a/geomstats/geometry/positive_reals.py
+++ b/geomstats/geometry/positive_reals.py
@@ -42,12 +42,12 @@ References
 """
 
 import geomstats.backend as gs
-from geomstats.geometry.base import OpenSet
+from geomstats.geometry.base import VectorSpaceOpenSet
 from geomstats.geometry.euclidean import Euclidean
 from geomstats.geometry.riemannian_metric import RiemannianMetric
 
 
-class PositiveReals(OpenSet):
+class PositiveReals(VectorSpaceOpenSet):
     """Class for the manifold of positive reals.
 
     The real positive axis endowed with the Information geometry metric.

--- a/geomstats/geometry/siegel.py
+++ b/geomstats/geometry/siegel.py
@@ -30,7 +30,7 @@ References
 """
 
 import geomstats.backend as gs
-from geomstats.geometry.base import ComplexOpenSet
+from geomstats.geometry.base import ComplexVectorSpaceOpenSet
 from geomstats.geometry.complex_matrices import ComplexMatrices
 from geomstats.geometry.complex_riemannian_metric import ComplexRiemannianMetric
 from geomstats.geometry.hermitian_matrices import HermitianMatrices
@@ -58,7 +58,7 @@ def _create_identity_mat(shape, dtype):
     return gs.stack([gs.eye(shape[-1], dtype=dtype) for _ in range(shape[0])], axis=0)
 
 
-class Siegel(ComplexOpenSet):
+class Siegel(ComplexVectorSpaceOpenSet):
     """Class for the Siegel space.
 
     Parameters

--- a/geomstats/geometry/spd_matrices.py
+++ b/geomstats/geometry/spd_matrices.py
@@ -6,7 +6,7 @@ Lead author: Yann Thanwerdas.
 import math
 
 import geomstats.backend as gs
-from geomstats.geometry.base import OpenSet
+from geomstats.geometry.base import VectorSpaceOpenSet
 from geomstats.geometry.general_linear import GeneralLinear
 from geomstats.geometry.matrices import Matrices
 from geomstats.geometry.positive_lower_triangular_matrices import (
@@ -18,7 +18,7 @@ from geomstats.integrator import integrate
 from geomstats.vectorization import repeat_out
 
 
-class SPDMatrices(OpenSet):
+class SPDMatrices(VectorSpaceOpenSet):
     """Class for the manifold of symmetric positive definite (SPD) matrices.
 
     Parameters

--- a/geomstats/information_geometry/binomial.py
+++ b/geomstats/information_geometry/binomial.py
@@ -6,7 +6,7 @@ from scipy.special import factorial
 from scipy.stats import binom
 
 import geomstats.backend as gs
-from geomstats.geometry.base import OpenSet
+from geomstats.geometry.base import VectorSpaceOpenSet
 from geomstats.geometry.euclidean import Euclidean
 from geomstats.geometry.riemannian_metric import RiemannianMetric
 from geomstats.information_geometry.base import (
@@ -15,7 +15,7 @@ from geomstats.information_geometry.base import (
 )
 
 
-class BinomialDistributions(InformationManifoldMixin, OpenSet):
+class BinomialDistributions(InformationManifoldMixin, VectorSpaceOpenSet):
     """Class for the manifold of binomial distributions.
 
     This is the parameter space of binomial distributions

--- a/geomstats/information_geometry/dirichlet.py
+++ b/geomstats/information_geometry/dirichlet.py
@@ -10,7 +10,7 @@ from scipy.stats import dirichlet
 
 import geomstats.backend as gs
 from geomstats.algebra_utils import from_vector_to_diagonal_matrix
-from geomstats.geometry.base import OpenSet
+from geomstats.geometry.base import VectorSpaceOpenSet
 from geomstats.geometry.euclidean import Euclidean
 from geomstats.geometry.riemannian_metric import RiemannianMetric
 from geomstats.information_geometry.base import (
@@ -23,7 +23,7 @@ from geomstats.numerics.ivp import ScipySolveIVP
 from geomstats.vectorization import repeat_out
 
 
-class DirichletDistributions(InformationManifoldMixin, OpenSet):
+class DirichletDistributions(InformationManifoldMixin, VectorSpaceOpenSet):
     """Class for the manifold of Dirichlet distributions.
 
     This is Dirichlet = :math:`(R_+^*)^dim`, the positive quadrant of the

--- a/geomstats/information_geometry/exponential.py
+++ b/geomstats/information_geometry/exponential.py
@@ -6,7 +6,7 @@ Lead authors: Jules Deschamps, Tra My Nguyen.
 from scipy.stats import expon
 
 import geomstats.backend as gs
-from geomstats.geometry.base import OpenSet
+from geomstats.geometry.base import VectorSpaceOpenSet
 from geomstats.geometry.euclidean import Euclidean
 from geomstats.geometry.riemannian_metric import RiemannianMetric
 from geomstats.information_geometry.base import (
@@ -15,7 +15,7 @@ from geomstats.information_geometry.base import (
 )
 
 
-class ExponentialDistributions(InformationManifoldMixin, OpenSet):
+class ExponentialDistributions(InformationManifoldMixin, VectorSpaceOpenSet):
     """Class for the manifold of exponential distributions.
 
     This is the parameter space of exponential distributions

--- a/geomstats/information_geometry/gamma.py
+++ b/geomstats/information_geometry/gamma.py
@@ -19,7 +19,7 @@ from scipy.stats import gamma
 
 import geomstats.backend as gs
 from geomstats.algebra_utils import from_vector_to_diagonal_matrix
-from geomstats.geometry.base import OpenSet
+from geomstats.geometry.base import VectorSpaceOpenSet
 from geomstats.geometry.euclidean import Euclidean
 from geomstats.geometry.riemannian_metric import RiemannianMetric
 from geomstats.information_geometry.base import (
@@ -32,7 +32,7 @@ from geomstats.numerics.ivp import ScipySolveIVP
 from geomstats.vectorization import check_is_batch
 
 
-class GammaDistributions(InformationManifoldMixin, OpenSet):
+class GammaDistributions(InformationManifoldMixin, VectorSpaceOpenSet):
     """Class for the manifold of Gamma distributions.
 
     This is :math: Gamma = `(R_+^*)^2`, the positive quadrant of the

--- a/geomstats/information_geometry/geometric.py
+++ b/geomstats/information_geometry/geometric.py
@@ -6,7 +6,7 @@ Lead author: Tra My Nguyen.
 from scipy.stats import geom
 
 import geomstats.backend as gs
-from geomstats.geometry.base import OpenSet
+from geomstats.geometry.base import VectorSpaceOpenSet
 from geomstats.geometry.euclidean import Euclidean
 from geomstats.geometry.riemannian_metric import RiemannianMetric
 from geomstats.information_geometry.base import (
@@ -15,7 +15,7 @@ from geomstats.information_geometry.base import (
 )
 
 
-class GeometricDistributions(InformationManifoldMixin, OpenSet):
+class GeometricDistributions(InformationManifoldMixin, VectorSpaceOpenSet):
     """Class for the manifold of geometric distributions.
 
     This is the parameter space of geometric distributions

--- a/geomstats/information_geometry/normal.py
+++ b/geomstats/information_geometry/normal.py
@@ -9,7 +9,7 @@ from scipy.stats import multivariate_normal, norm
 
 import geomstats.backend as gs
 import geomstats.errors as errors
-from geomstats.geometry.base import OpenSet
+from geomstats.geometry.base import VectorSpaceOpenSet
 from geomstats.geometry.euclidean import Euclidean
 from geomstats.geometry.poincare_half_space import (
     PoincareHalfSpace,
@@ -254,7 +254,7 @@ class CenteredNormalDistributions(InformationManifoldMixin, SPDMatrices):
         return pdf
 
 
-class DiagonalNormalDistributions(InformationManifoldMixin, OpenSet):
+class DiagonalNormalDistributions(InformationManifoldMixin, VectorSpaceOpenSet):
     """Class for the manifold of diagonal multivariate normal distributions.
 
     This is the class for multivariate normal distributions with diagonal

--- a/geomstats/information_geometry/poisson.py
+++ b/geomstats/information_geometry/poisson.py
@@ -7,7 +7,7 @@ from scipy.special import factorial
 from scipy.stats import poisson
 
 import geomstats.backend as gs
-from geomstats.geometry.base import OpenSet
+from geomstats.geometry.base import VectorSpaceOpenSet
 from geomstats.geometry.euclidean import Euclidean
 from geomstats.geometry.riemannian_metric import RiemannianMetric
 from geomstats.information_geometry.base import (
@@ -16,7 +16,7 @@ from geomstats.information_geometry.base import (
 )
 
 
-class PoissonDistributions(InformationManifoldMixin, OpenSet):
+class PoissonDistributions(InformationManifoldMixin, VectorSpaceOpenSet):
     """Class for the manifold of Poisson distributions.
 
     This is the parameter space of Poisson distributions

--- a/geomstats/test_cases/geometry/base.py
+++ b/geomstats/test_cases/geometry/base.py
@@ -263,7 +263,13 @@ class OpenSetTestCase(_OpenSetTestCaseMixins, ManifoldTestCase):
     pass
 
 
-class ComplexOpenSetTestCase(_OpenSetTestCaseMixins, ComplexManifoldTestCase):
+class VectorSpaceOpenSetTestCase(OpenSetTestCase):
+    pass
+
+
+class ComplexVectorSpaceOpenSetTestCase(
+    _OpenSetTestCaseMixins, ComplexManifoldTestCase
+):
     pass
 
 

--- a/geomstats/test_cases/geometry/general_linear.py
+++ b/geomstats/test_cases/geometry/general_linear.py
@@ -2,11 +2,11 @@ import pytest
 
 import geomstats.backend as gs
 from geomstats.test.vectorization import generate_vectorization_data
-from geomstats.test_cases.geometry.base import OpenSetTestCase
+from geomstats.test_cases.geometry.base import VectorSpaceOpenSetTestCase
 from geomstats.test_cases.geometry.lie_group import MatrixLieGroupTestCase
 
 
-class GeneralLinearTestCase(MatrixLieGroupTestCase, OpenSetTestCase):
+class GeneralLinearTestCase(MatrixLieGroupTestCase, VectorSpaceOpenSetTestCase):
     def test_orbit(self, point, base_point, time, expected, atol):
         path = self.space.orbit(point, base_point)
         res = path(time)

--- a/geomstats/test_cases/geometry/poincare_ball.py
+++ b/geomstats/test_cases/geometry/poincare_ball.py
@@ -2,11 +2,11 @@ import pytest
 
 import geomstats.backend as gs
 from geomstats.test.vectorization import generate_vectorization_data
-from geomstats.test_cases.geometry.base import OpenSetTestCase
+from geomstats.test_cases.geometry.base import VectorSpaceOpenSetTestCase
 from geomstats.test_cases.geometry.riemannian_metric import RiemannianMetricTestCase
 
 
-class PoincareBallTestCase(OpenSetTestCase):
+class PoincareBallTestCase(VectorSpaceOpenSetTestCase):
     def test_projection_norm_less_than_1(self, point, atol):
         projected_point = self.space.projection(point)
         result = gs.sum(projected_point * projected_point, axis=-1) < 1.0 + atol

--- a/geomstats/test_cases/geometry/poincare_half_space.py
+++ b/geomstats/test_cases/geometry/poincare_half_space.py
@@ -1,5 +1,5 @@
-from geomstats.test_cases.geometry.base import OpenSetTestCase
+from geomstats.test_cases.geometry.base import VectorSpaceOpenSetTestCase
 
 
-class PoincareHalfSpaceTestCase(OpenSetTestCase):
+class PoincareHalfSpaceTestCase(VectorSpaceOpenSetTestCase):
     pass

--- a/geomstats/test_cases/geometry/positive_lower_triangular_matrices.py
+++ b/geomstats/test_cases/geometry/positive_lower_triangular_matrices.py
@@ -3,11 +3,11 @@ import pytest
 import geomstats.backend as gs
 from geomstats.geometry.spd_matrices import SPDMatrices
 from geomstats.geometry.symmetric_matrices import SymmetricMatrices
-from geomstats.test_cases.geometry.base import OpenSetTestCase
+from geomstats.test_cases.geometry.base import VectorSpaceOpenSetTestCase
 from geomstats.test_cases.geometry.riemannian_metric import RiemannianMetricTestCase
 
 
-class PositiveLowerTriangularMatricesTestCase(OpenSetTestCase):
+class PositiveLowerTriangularMatricesTestCase(VectorSpaceOpenSetTestCase):
     def test_gram(self, point, expected, atol):
         res = self.space.gram(point)
         self.assertAllClose(res, expected, atol=atol)

--- a/geomstats/test_cases/geometry/spd_matrices.py
+++ b/geomstats/test_cases/geometry/spd_matrices.py
@@ -6,7 +6,7 @@ from geomstats.geometry.positive_lower_triangular_matrices import (
     PositiveLowerTriangularMatrices,
 )
 from geomstats.test.vectorization import generate_vectorization_data
-from geomstats.test_cases.geometry.base import OpenSetTestCase
+from geomstats.test_cases.geometry.base import VectorSpaceOpenSetTestCase
 from geomstats.test_cases.geometry.riemannian_metric import RiemannianMetricTestCase
 
 
@@ -143,7 +143,7 @@ class SPDMatricesTestCaseMixins:
         self.assertAllEqual(res, expected)
 
 
-class SPDMatricesTestCase(SPDMatricesTestCaseMixins, OpenSetTestCase):
+class SPDMatricesTestCase(SPDMatricesTestCaseMixins, VectorSpaceOpenSetTestCase):
     pass
 
 

--- a/geomstats/test_cases/information_geometry/binomial.py
+++ b/geomstats/test_cases/information_geometry/binomial.py
@@ -1,11 +1,13 @@
 import geomstats.backend as gs
-from geomstats.test_cases.geometry.base import OpenSetTestCase
+from geomstats.test_cases.geometry.base import VectorSpaceOpenSetTestCase
 from geomstats.test_cases.information_geometry.base import (
     InformationManifoldMixinTestCase,
 )
 
 
-class BinomialDistributionsTestCase(InformationManifoldMixinTestCase, OpenSetTestCase):
+class BinomialDistributionsTestCase(
+    InformationManifoldMixinTestCase, VectorSpaceOpenSetTestCase
+):
     def _check_sample_belongs_to_support(self, sample, _atol):
         support = set(range(self.space.n_draws + 1))
         empty_set = set({int(val) for val in gs.unique(sample)}).difference(support)

--- a/geomstats/test_cases/information_geometry/dirichlet.py
+++ b/geomstats/test_cases/information_geometry/dirichlet.py
@@ -1,14 +1,16 @@
 import pytest
 
 import geomstats.backend as gs
-from geomstats.test_cases.geometry.base import OpenSetTestCase
+from geomstats.test_cases.geometry.base import VectorSpaceOpenSetTestCase
 from geomstats.test_cases.geometry.riemannian_metric import RiemannianMetricTestCase
 from geomstats.test_cases.information_geometry.base import (
     InformationManifoldMixinTestCase,
 )
 
 
-class DirichletDistributionsTestCase(InformationManifoldMixinTestCase, OpenSetTestCase):
+class DirichletDistributionsTestCase(
+    InformationManifoldMixinTestCase, VectorSpaceOpenSetTestCase
+):
     def _check_sample_belongs_to_support(self, sample, atol):
         self.assertTrue(gs.all(sample >= 0.0))
         self.assertTrue(gs.all(gs.abs(gs.sum(sample, axis=-1) - 1.0) < atol))

--- a/geomstats/test_cases/information_geometry/exponential.py
+++ b/geomstats/test_cases/information_geometry/exponential.py
@@ -1,12 +1,12 @@
 import geomstats.backend as gs
-from geomstats.test_cases.geometry.base import OpenSetTestCase
+from geomstats.test_cases.geometry.base import VectorSpaceOpenSetTestCase
 from geomstats.test_cases.information_geometry.base import (
     InformationManifoldMixinTestCase,
 )
 
 
 class ExponentialDistributionsTestCase(
-    InformationManifoldMixinTestCase, OpenSetTestCase
+    InformationManifoldMixinTestCase, VectorSpaceOpenSetTestCase
 ):
     def _check_sample_belongs_to_support(self, sample, atol):
         self.assertTrue(gs.all(sample >= 0.0))

--- a/geomstats/test_cases/information_geometry/gamma.py
+++ b/geomstats/test_cases/information_geometry/gamma.py
@@ -2,7 +2,7 @@ import pytest
 
 import geomstats.backend as gs
 from geomstats.test.vectorization import generate_vectorization_data
-from geomstats.test_cases.geometry.base import OpenSetTestCase
+from geomstats.test_cases.geometry.base import VectorSpaceOpenSetTestCase
 from geomstats.test_cases.geometry.riemannian_metric import RiemannianMetricTestCase
 from geomstats.test_cases.information_geometry.base import (
     InformationManifoldMixinTestCase,
@@ -16,7 +16,9 @@ def scalar_curvature(base_point):
     )
 
 
-class GammaDistributionsTestCase(InformationManifoldMixinTestCase, OpenSetTestCase):
+class GammaDistributionsTestCase(
+    InformationManifoldMixinTestCase, VectorSpaceOpenSetTestCase
+):
     def _check_sample_belongs_to_support(self, sample, atol):
         self.assertTrue(gs.all(sample > 0.0))
 

--- a/geomstats/test_cases/information_geometry/geometric.py
+++ b/geomstats/test_cases/information_geometry/geometric.py
@@ -1,10 +1,12 @@
 import geomstats.backend as gs
-from geomstats.test_cases.geometry.base import OpenSetTestCase
+from geomstats.test_cases.geometry.base import VectorSpaceOpenSetTestCase
 from geomstats.test_cases.information_geometry.base import (
     InformationManifoldMixinTestCase,
 )
 
 
-class GeometricDistributionsTestCase(InformationManifoldMixinTestCase, OpenSetTestCase):
+class GeometricDistributionsTestCase(
+    InformationManifoldMixinTestCase, VectorSpaceOpenSetTestCase
+):
     def _check_sample_belongs_to_support(self, sample, atol):
         self.assertTrue(gs.all(sample >= 0.0))

--- a/geomstats/test_cases/information_geometry/poisson.py
+++ b/geomstats/test_cases/information_geometry/poisson.py
@@ -1,10 +1,12 @@
 import geomstats.backend as gs
-from geomstats.test_cases.geometry.base import OpenSetTestCase
+from geomstats.test_cases.geometry.base import VectorSpaceOpenSetTestCase
 from geomstats.test_cases.information_geometry.base import (
     InformationManifoldMixinTestCase,
 )
 
 
-class PoissonDistributionsTestCase(InformationManifoldMixinTestCase, OpenSetTestCase):
+class PoissonDistributionsTestCase(
+    InformationManifoldMixinTestCase, VectorSpaceOpenSetTestCase
+):
     def _check_sample_belongs_to_support(self, sample, atol):
         self.assertTrue(gs.all(sample >= 0.0))

--- a/notebooks/01_foundations__manifolds.ipynb
+++ b/notebooks/01_foundations__manifolds.ipynb
@@ -436,9 +436,9 @@
    "id": "815af4cb",
    "metadata": {},
    "source": [
-    "As discussed in the previous section, one of the primary purposes of the `Manifold` class is to hold information about various types of manifolds. Rules that are universally true for all manifolds are implemented in methods in the parent class `Manifold`. Rules that are true for some types of manifolds are implemented in the subclasses of `Manifold`: `LevelSet`, `OpenSet`, `FiberBundle`, `ProductManifold`, `VectorSpace`, `MatrixLieAlgebra`, and `MatrixLieGroup`. Specific types of manifolds are described in methods within these subclasses.\n",
+    "As discussed in the previous section, one of the primary purposes of the `Manifold` class is to hold information about various types of manifolds. Rules that are universally true for all manifolds are implemented in methods in the parent class `Manifold`. Rules that are true for some types of manifolds are implemented in the subclasses of `Manifold`: `LevelSet`, `VectorSpaceOpenSet`, `FiberBundle`, `ProductManifold`, `VectorSpace`, `MatrixLieAlgebra`, and `MatrixLieGroup`. Specific types of manifolds are described in methods within these subclasses.\n",
     "\n",
-    "In this notebook, we will focus on describing the subclasses pertinent to the geometry module of geomstats: `LevelSet`, `OpenSet`, `ProductManifold` and `VectorSpace`.\n",
+    "In this notebook, we will focus on describing the subclasses pertinent to the geometry module of geomstats: `LevelSet`, `VectorSpaceOpenSet`, `ProductManifold` and `VectorSpace`.\n",
     "\n",
     "In the following subsections, we will discuss the methods and ideas implemented in the parent class and its subclasses."
    ]
@@ -847,7 +847,7 @@
    "id": "7ce847b2",
    "metadata": {},
    "source": [
-    "## 5.2 `OpenSet`"
+    "## 5.2 `VectorSpaceOpenSet`"
    ]
   },
   {
@@ -855,7 +855,7 @@
    "id": "3bb824a3",
    "metadata": {},
    "source": [
-    "Earlier in the notebook, we were able to say that a set of points is a manifold if it satisfied one of three constraints. We also said that every manifold can be described by any three of these definitions, and the choice of definition is merely a question of which definition is most convenient. `OpenSet` provides a way of describing manifolds with local parametrization, which was labeled (1) on our definition list.\n",
+    "Earlier in the notebook, we were able to say that a set of points is a manifold if it satisfied one of three constraints. We also said that every manifold can be described by any three of these definitions, and the choice of definition is merely a question of which definition is most convenient. `VectorSpaceOpenSet` provides a way of describing manifolds with local parametrization, which was labeled (1) on our definition list.\n",
     "\n",
     "One such way to describe a manifold is with the concept of an $\\textbf{Open Set}$: a manifold is the open sets of a d-dimensional vector space, called $\\textbf{ambient space}$."
    ]
@@ -905,7 +905,7 @@
    "id": "8cde0af0",
    "metadata": {},
    "source": [
-    "### 5.2.2 What Methods are Implemented in `OpenSet`?"
+    "### 5.2.2 What Methods are Implemented in `VectorSpaceOpenSet`?"
    ]
   },
   {
@@ -913,7 +913,7 @@
    "id": "151d22b8",
    "metadata": {},
    "source": [
-    "If we know that a manifold is conveniently described as an open set, then some of the manifold's abstract methods can be rewritten in a specific form. For example, `OpenSet` implements the methods:\n",
+    "If we know that a manifold is conveniently described as an open set, then some of the manifold's abstract methods can be rewritten in a specific form. For example, `VectorSpaceOpenSet` implements the methods:\n",
     "\n",
     "1. `projection()`: a method to project any d-dimensional vector to the manifold.\n",
     "2. `is_tangent()`: checks whether the input vector is tangent at the input point.\n",
@@ -927,7 +927,7 @@
    "id": "40c86d59",
    "metadata": {},
    "source": [
-    "Run the code below to see the contents of the `OpenSet` class."
+    "Run the code below to see the contents of the `VectorSpaceOpenSet` class."
    ]
   },
   {
@@ -942,7 +942,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "class OpenSet(Manifold, abc.ABC):\n",
+      "class VectorSpaceOpenSet(Manifold, abc.ABC):\n",
       "    \"\"\"Class for manifolds that are open sets of a vector space.\n",
       "\n",
       "    In this case, tangent vectors are identified with vectors of the embedding\n",
@@ -1049,9 +1049,9 @@
    "source": [
     "import inspect\n",
     "\n",
-    "from geomstats.geometry.base import OpenSet\n",
+    "from geomstats.geometry.base import VectorSpaceOpenSet\n",
     "\n",
-    "for line in inspect.getsourcelines(OpenSet)[0]:\n",
+    "for line in inspect.getsourcelines(VectorSpaceOpenSet)[0]:\n",
     "    line = line.replace(\"\\n\", \"\")\n",
     "    print(line)"
    ]
@@ -1079,7 +1079,7 @@
    "source": [
     "Another elementary class of manifolds are $\\textbf{Level Sets}$. A level set is the set of values $x$ for which a function f(x) is equal to a given constant. In other words, a level set is a set of curves for which the function describing a manifold is constant along that curve. \n",
     "\n",
-    "In the same way that `OpenSet` is an implementation of the first definition of a manifold (Local Parametrization), `LevelSet` is an implementation of the second definition of a manifold (Local Implicit Function). a level set is a set of points for which the function $f$ takes the exact same value. This value is called the \"level\", and does not need to be a scalar, it could also be a vector.\n",
+    "In the same way that `VectorSpaceOpenSet` is an implementation of the first definition of a manifold (Local Parametrization), `LevelSet` is an implementation of the second definition of a manifold (Local Implicit Function). a level set is a set of points for which the function $f$ takes the exact same value. This value is called the \"level\", and does not need to be a scalar, it could also be a vector.\n",
     "\n",
     "For example, consider a hypersphere in three dimensional space. Each of the concentric spheres is a 2-dimensional manifold, each corresponding to a different level $(r1, r2,r3)$."
    ]
@@ -1113,11 +1113,11 @@
    "id": "b4c2afa0",
    "metadata": {},
    "source": [
-    "You can run the code below to see the contents of the `LevelSet` class. The methods of LevelSet are similar to the methods of OpenSet , but their implementation is different. Recall from the (Local Implicit Function) definition, which `LevelSet` is an implementation of, that a manifold of this type must satisfy:\n",
+    "You can run the code below to see the contents of the `LevelSet` class. The methods of LevelSet are similar to the methods of VectorSpaceOpenSet , but their implementation is different. Recall from the (Local Implicit Function) definition, which `LevelSet` is an implementation of, that a manifold of this type must satisfy:\n",
     "\n",
     "\"For every $p \\in M$, there exists an open set $U \\in \\mathbb{R}^{N}$ and a smooth map $f: U \\to \\mathbb{R}^{N-d}$ that is a submersion at p, such that $U \\cap M = f^{-1}$({0}).\"\n",
     "\n",
-    "`OpenSet` is an implementation of the first manifold definition (Local Parametrization), and therefore need not follow the (Local Implicit Function) rule above. This is the reason that, `OpenSet` methods and `LevelSet` methods are implemented differently. As an example of these different implementations: observe the implementation of the belongs methods in `LevelSet`. For a general level set, in order to verify if a point belongs to the level set, we should verify that the (Local Implicit Function) definition constraint is met, which is done with the line\n",
+    "`VectorSpaceOpenSet` is an implementation of the first manifold definition (Local Parametrization), and therefore need not follow the (Local Implicit Function) rule above. This is the reason that, `VectorSpaceOpenSet` methods and `LevelSet` methods are implemented differently. As an example of these different implementations: observe the implementation of the belongs methods in `LevelSet`. For a general level set, in order to verify if a point belongs to the level set, we should verify that the (Local Implicit Function) definition constraint is met, which is done with the line\n",
     "\n",
     "`constraint = gs.isclose(self.submersion(point), value, atol=atol)`"
    ]
@@ -1355,7 +1355,7 @@
    "id": "962d4ac2",
    "metadata": {},
    "source": [
-    "This class does not provide another way of describing a manifold. This class is an abstract class that makes sure that the ambient/embedding vector space is compatible with the methods that are called in `OpenSet` and `LevelSet`.\n",
+    "This class does not provide another way of describing a manifold. This class is an abstract class that makes sure that the ambient/embedding vector space is compatible with the methods that are called in `VectorSpaceOpenSet` and `LevelSet`.\n",
     "\n",
     "Actual manifolds are implemented as subclasses of this abstract method and must implement all the abstract methods defined in this class."
    ]

--- a/tests/tests_geomstats/test_geometry/data/base.py
+++ b/tests/tests_geomstats/test_geometry/data/base.py
@@ -67,7 +67,13 @@ class OpenSetTestData(_OpenSetMixinsTestData, ManifoldTestData):
     pass
 
 
-class ComplexOpenSetTestData(_OpenSetMixinsTestData, ComplexManifoldTestData):
+class VectorSpaceOpenSetTestData(OpenSetTestData):
+    pass
+
+
+class ComplexVectorSpaceOpenSetTestData(
+    _OpenSetMixinsTestData, ComplexManifoldTestData
+):
     pass
 
 

--- a/tests/tests_geomstats/test_geometry/data/complex_poincare_disk.py
+++ b/tests/tests_geomstats/test_geometry/data/complex_poincare_disk.py
@@ -4,7 +4,7 @@ import pytest
 
 import geomstats.backend as gs
 
-from .base import ComplexOpenSetTestData
+from .base import ComplexVectorSpaceOpenSetTestData
 from .complex_riemannian_metric import ComplexRiemannianMetricTestData
 
 LN_3 = math.log(3.0)
@@ -13,7 +13,7 @@ SQRT_2 = math.sqrt(2.0)
 SQRT_8 = math.sqrt(8.0)
 
 
-class ComplexPoincareDiskTestData(ComplexOpenSetTestData):
+class ComplexPoincareDiskTestData(ComplexVectorSpaceOpenSetTestData):
     def belongs_test_data(self):
         data = [
             dict(point=gs.array([0.2 + 0.2j]), expected=gs.array(True)),

--- a/tests/tests_geomstats/test_geometry/data/general_linear.py
+++ b/tests/tests_geomstats/test_geometry/data/general_linear.py
@@ -3,12 +3,12 @@ import random
 import geomstats.backend as gs
 from geomstats.test.data import TestData
 
-from .base import OpenSetTestData
+from .base import VectorSpaceOpenSetTestData
 from .lie_group import MatrixLieGroupTestData
 from .matrices import MatricesMetricTestData
 
 
-class GeneralLinearTestData(MatrixLieGroupTestData, OpenSetTestData):
+class GeneralLinearTestData(MatrixLieGroupTestData, VectorSpaceOpenSetTestData):
     trials = 3
     xfails = ("exp_after_log", "log_after_exp")
 

--- a/tests/tests_geomstats/test_geometry/data/hpd_matrices.py
+++ b/tests/tests_geomstats/test_geometry/data/hpd_matrices.py
@@ -1,12 +1,12 @@
 import geomstats.backend as gs
 from geomstats.test.data import TestData
 
-from .base import ComplexOpenSetTestData
+from .base import ComplexVectorSpaceOpenSetTestData
 from .complex_riemannian_metric import ComplexRiemannianMetricTestData
 from .spd_matrices import SPDMatricesMixinsTestData
 
 
-class HPDMatricesTestData(SPDMatricesMixinsTestData, ComplexOpenSetTestData):
+class HPDMatricesTestData(SPDMatricesMixinsTestData, ComplexVectorSpaceOpenSetTestData):
     skips = ("cholesky_factor_belongs_to_positive_lower_triangular_matrices",)
 
 

--- a/tests/tests_geomstats/test_geometry/data/poincare_ball.py
+++ b/tests/tests_geomstats/test_geometry/data/poincare_ball.py
@@ -1,11 +1,11 @@
 import geomstats.backend as gs
 from geomstats.test.data import TestData
 
-from .base import OpenSetTestData
+from .base import VectorSpaceOpenSetTestData
 from .riemannian_metric import RiemannianMetricTestData
 
 
-class PoincareBallTestData(OpenSetTestData):
+class PoincareBallTestData(VectorSpaceOpenSetTestData):
     xfails = ("projection_belongs",)
 
 

--- a/tests/tests_geomstats/test_geometry/data/poincare_half_space.py
+++ b/tests/tests_geomstats/test_geometry/data/poincare_half_space.py
@@ -1,11 +1,11 @@
 import geomstats.backend as gs
 from geomstats.test.data import TestData
 
-from .base import OpenSetTestData
+from .base import VectorSpaceOpenSetTestData
 from .riemannian_metric import RiemannianMetricTestData
 
 
-class PoincareHalfSpaceTestData(OpenSetTestData):
+class PoincareHalfSpaceTestData(VectorSpaceOpenSetTestData):
     pass
 
 

--- a/tests/tests_geomstats/test_geometry/data/positive_lower_triangular_matrices.py
+++ b/tests/tests_geomstats/test_geometry/data/positive_lower_triangular_matrices.py
@@ -3,14 +3,14 @@ import math
 import geomstats.backend as gs
 from geomstats.test.data import TestData
 
-from .base import OpenSetTestData
+from .base import VectorSpaceOpenSetTestData
 from .riemannian_metric import RiemannianMetricTestData
 
 EULER = gs.exp(1.0)
 SQRT_2 = math.sqrt(2)
 
 
-class PositiveLowerTriangularMatricesTestData(OpenSetTestData):
+class PositiveLowerTriangularMatricesTestData(VectorSpaceOpenSetTestData):
     def gram_vec_test_data(self):
         return self.generate_vec_data()
 

--- a/tests/tests_geomstats/test_geometry/data/positive_reals.py
+++ b/tests/tests_geomstats/test_geometry/data/positive_reals.py
@@ -4,7 +4,7 @@ import pytest
 
 import geomstats.backend as gs
 
-from .base import OpenSetTestData
+from .base import VectorSpaceOpenSetTestData
 from .riemannian_metric import RiemannianMetricTestData
 
 LN_2 = math.log(2.0)
@@ -12,7 +12,7 @@ EXP_1 = math.exp(1.0)
 EXP_2 = math.exp(2.0)
 
 
-class PositiveRealsTestData(OpenSetTestData):
+class PositiveRealsTestData(VectorSpaceOpenSetTestData):
     def belongs_test_data(self):
         data = [
             dict(point=gs.array([[10.0]]), expected=[True]),

--- a/tests/tests_geomstats/test_geometry/data/spd_matrices.py
+++ b/tests/tests_geomstats/test_geometry/data/spd_matrices.py
@@ -4,7 +4,7 @@ import random
 import geomstats.backend as gs
 from geomstats.test.data import TestData
 
-from .base import OpenSetTestData
+from .base import VectorSpaceOpenSetTestData
 from .riemannian_metric import RiemannianMetricTestData
 
 SQRT_2 = math.sqrt(2.0)
@@ -66,7 +66,7 @@ class SPDMatricesMixinsTestData:
         return self.generate_random_data()
 
 
-class SPDMatricesTestData(SPDMatricesMixinsTestData, OpenSetTestData):
+class SPDMatricesTestData(SPDMatricesMixinsTestData, VectorSpaceOpenSetTestData):
     pass
 
 

--- a/tests/tests_geomstats/test_geometry/test_complex_poincare_disk.py
+++ b/tests/tests_geomstats/test_geometry/test_complex_poincare_disk.py
@@ -1,7 +1,7 @@
 from geomstats.geometry.complex_poincare_disk import ComplexPoincareDisk
 from geomstats.test.parametrizers import DataBasedParametrizer
 from geomstats.test.test_case import np_only
-from geomstats.test_cases.geometry.base import ComplexOpenSetTestCase
+from geomstats.test_cases.geometry.base import ComplexVectorSpaceOpenSetTestCase
 from geomstats.test_cases.geometry.complex_riemannian_metric import (
     ComplexRiemannianMetricTestCase,
 )
@@ -12,7 +12,9 @@ from .data.complex_poincare_disk import (
 )
 
 
-class TestComplexPoincareDisk(ComplexOpenSetTestCase, metaclass=DataBasedParametrizer):
+class TestComplexPoincareDisk(
+    ComplexVectorSpaceOpenSetTestCase, metaclass=DataBasedParametrizer
+):
     space = ComplexPoincareDisk(equip=False)
     testing_data = ComplexPoincareDiskTestData()
 

--- a/tests/tests_geomstats/test_geometry/test_full_rank_matrices.py
+++ b/tests/tests_geomstats/test_geometry/test_full_rank_matrices.py
@@ -4,10 +4,10 @@ import pytest
 
 from geomstats.geometry.full_rank_matrices import FullRankMatrices
 from geomstats.test.parametrizers import DataBasedParametrizer
-from geomstats.test_cases.geometry.base import OpenSetTestCase
+from geomstats.test_cases.geometry.base import VectorSpaceOpenSetTestCase
 from geomstats.test_cases.geometry.matrices import MatricesMetricTestCase
 
-from .data.base import OpenSetTestData
+from .data.base import VectorSpaceOpenSetTestData
 from .data.full_rank_matrices import FullRankMatrices32TestData
 from .data.matrices import MatricesMetricTestData
 
@@ -25,12 +25,14 @@ def spaces(request):
 
 
 @pytest.mark.usefixtures("spaces")
-class TestFullRankMatrices(OpenSetTestCase, metaclass=DataBasedParametrizer):
-    testing_data = OpenSetTestData()
+class TestFullRankMatrices(VectorSpaceOpenSetTestCase, metaclass=DataBasedParametrizer):
+    testing_data = VectorSpaceOpenSetTestData()
 
 
 @pytest.mark.smoke
-class TestFullRankMatrices32(OpenSetTestCase, metaclass=DataBasedParametrizer):
+class TestFullRankMatrices32(
+    VectorSpaceOpenSetTestCase, metaclass=DataBasedParametrizer
+):
     space = FullRankMatrices(3, 2, equip=False)
     testing_data = FullRankMatrices32TestData()
 

--- a/tests/tests_geomstats/test_geometry/test_hpd_matrices.py
+++ b/tests/tests_geomstats/test_geometry/test_hpd_matrices.py
@@ -11,7 +11,7 @@ from geomstats.geometry.hpd_matrices import (
 )
 from geomstats.test.parametrizers import DataBasedParametrizer
 from geomstats.test.random import RandomDataGenerator
-from geomstats.test_cases.geometry.base import ComplexOpenSetTestCase
+from geomstats.test_cases.geometry.base import ComplexVectorSpaceOpenSetTestCase
 from geomstats.test_cases.geometry.complex_riemannian_metric import (
     ComplexRiemannianMetricTestCase,
 )
@@ -42,19 +42,25 @@ def spaces(request):
 
 @pytest.mark.usefixtures("spaces")
 class TestHPDMatrices(
-    SPDMatricesTestCaseMixins, ComplexOpenSetTestCase, metaclass=DataBasedParametrizer
+    SPDMatricesTestCaseMixins,
+    ComplexVectorSpaceOpenSetTestCase,
+    metaclass=DataBasedParametrizer,
 ):
     testing_data = HPDMatricesTestData()
 
 
 @pytest.mark.smoke
-class TestHPDMatrices2(ComplexOpenSetTestCase, metaclass=DataBasedParametrizer):
+class TestHPDMatrices2(
+    ComplexVectorSpaceOpenSetTestCase, metaclass=DataBasedParametrizer
+):
     space = HPDMatrices(n=2, equip=False)
     testing_data = HPDMatrices2TestData()
 
 
 @pytest.mark.smoke
-class TestHPDMatrices3(ComplexOpenSetTestCase, metaclass=DataBasedParametrizer):
+class TestHPDMatrices3(
+    ComplexVectorSpaceOpenSetTestCase, metaclass=DataBasedParametrizer
+):
     space = HPDMatrices(n=3, equip=False)
     testing_data = HPDMatrices3TestData()
 

--- a/tests/tests_geomstats/test_geometry/test_positive_reals.py
+++ b/tests/tests_geomstats/test_geometry/test_positive_reals.py
@@ -1,12 +1,12 @@
 from geomstats.geometry.positive_reals import PositiveReals
 from geomstats.test.parametrizers import DataBasedParametrizer
-from geomstats.test_cases.geometry.base import OpenSetTestCase
+from geomstats.test_cases.geometry.base import VectorSpaceOpenSetTestCase
 from geomstats.test_cases.geometry.riemannian_metric import RiemannianMetricTestCase
 
 from .data.positive_reals import PositiveRealsMetricTestData, PositiveRealsTestData
 
 
-class TestPositiveReals(OpenSetTestCase, metaclass=DataBasedParametrizer):
+class TestPositiveReals(VectorSpaceOpenSetTestCase, metaclass=DataBasedParametrizer):
     space = PositiveReals(equip=False)
     testing_data = PositiveRealsTestData()
 

--- a/tests/tests_geomstats/test_geometry/test_siegel.py
+++ b/tests/tests_geomstats/test_geometry/test_siegel.py
@@ -4,10 +4,10 @@ import pytest
 
 from geomstats.geometry.siegel import Siegel, SiegelMetric
 from geomstats.test.parametrizers import DataBasedParametrizer
-from geomstats.test_cases.geometry.base import ComplexOpenSetTestCase
+from geomstats.test_cases.geometry.base import ComplexVectorSpaceOpenSetTestCase
 from geomstats.test_cases.geometry.siegel import SiegelMetricTestCase
 
-from .data.base import ComplexOpenSetTestData
+from .data.base import ComplexVectorSpaceOpenSetTestData
 from .data.siegel import (
     Siegel2MetricTestData,
     Siegel2TestData,
@@ -28,12 +28,12 @@ def spaces(request):
 
 
 @pytest.mark.usefixtures("spaces")
-class TestSiegel(ComplexOpenSetTestCase, metaclass=DataBasedParametrizer):
-    testing_data = ComplexOpenSetTestData()
+class TestSiegel(ComplexVectorSpaceOpenSetTestCase, metaclass=DataBasedParametrizer):
+    testing_data = ComplexVectorSpaceOpenSetTestData()
 
 
 @pytest.mark.smoke
-class TestSiegel2(ComplexOpenSetTestCase, metaclass=DataBasedParametrizer):
+class TestSiegel2(ComplexVectorSpaceOpenSetTestCase, metaclass=DataBasedParametrizer):
     space = Siegel(2, equip=False)
     testing_data = Siegel2TestData()
 

--- a/tests/tests_geomstats/test_information_geometry/data/binomial.py
+++ b/tests/tests_geomstats/test_information_geometry/data/binomial.py
@@ -1,12 +1,14 @@
 import geomstats.backend as gs
 from geomstats.test.data import TestData
 
-from ...test_geometry.data.base import OpenSetTestData
+from ...test_geometry.data.base import VectorSpaceOpenSetTestData
 from ...test_geometry.data.riemannian_metric import RiemannianMetricTestData
 from .base import InformationManifoldMixinTestData
 
 
-class BinomialDistributionsTestData(InformationManifoldMixinTestData, OpenSetTestData):
+class BinomialDistributionsTestData(
+    InformationManifoldMixinTestData, VectorSpaceOpenSetTestData
+):
     fail_for_not_implemented_errors = False
 
     def point_to_pdf_against_scipy_test_data(self):

--- a/tests/tests_geomstats/test_information_geometry/data/dirichlet.py
+++ b/tests/tests_geomstats/test_information_geometry/data/dirichlet.py
@@ -1,12 +1,14 @@
 import geomstats.backend as gs
 from geomstats.test.data import TestData
 
-from ...test_geometry.data.base import OpenSetTestData
+from ...test_geometry.data.base import VectorSpaceOpenSetTestData
 from ...test_geometry.data.riemannian_metric import RiemannianMetricTestData
 from .base import InformationManifoldMixinTestData
 
 
-class DirichletDistributionsTestData(InformationManifoldMixinTestData, OpenSetTestData):
+class DirichletDistributionsTestData(
+    InformationManifoldMixinTestData, VectorSpaceOpenSetTestData
+):
     fail_for_not_implemented_errors = False
 
 

--- a/tests/tests_geomstats/test_information_geometry/data/exponential.py
+++ b/tests/tests_geomstats/test_information_geometry/data/exponential.py
@@ -1,13 +1,13 @@
 import geomstats.backend as gs
 from geomstats.test.data import TestData
 
-from ...test_geometry.data.base import OpenSetTestData
+from ...test_geometry.data.base import VectorSpaceOpenSetTestData
 from ...test_geometry.data.riemannian_metric import RiemannianMetricTestData
 from .base import InformationManifoldMixinTestData
 
 
 class ExponentialDistributionsTestData(
-    InformationManifoldMixinTestData, OpenSetTestData
+    InformationManifoldMixinTestData, VectorSpaceOpenSetTestData
 ):
     fail_for_not_implemented_errors = False
 

--- a/tests/tests_geomstats/test_information_geometry/data/gamma.py
+++ b/tests/tests_geomstats/test_information_geometry/data/gamma.py
@@ -1,12 +1,14 @@
 import geomstats.backend as gs
 from geomstats.test.data import TestData
 
-from ...test_geometry.data.base import OpenSetTestData
+from ...test_geometry.data.base import VectorSpaceOpenSetTestData
 from ...test_geometry.data.riemannian_metric import RiemannianMetricTestData
 from .base import InformationManifoldMixinTestData
 
 
-class GammaDistributionsTestData(InformationManifoldMixinTestData, OpenSetTestData):
+class GammaDistributionsTestData(
+    InformationManifoldMixinTestData, VectorSpaceOpenSetTestData
+):
     fail_for_not_implemented_errors = False
 
     def point_to_pdf_against_scipy_test_data(self):

--- a/tests/tests_geomstats/test_information_geometry/data/geometric.py
+++ b/tests/tests_geomstats/test_information_geometry/data/geometric.py
@@ -1,12 +1,14 @@
 import geomstats.backend as gs
 from geomstats.test.data import TestData
 
-from ...test_geometry.data.base import OpenSetTestData
+from ...test_geometry.data.base import VectorSpaceOpenSetTestData
 from ...test_geometry.data.riemannian_metric import RiemannianMetricTestData
 from .base import InformationManifoldMixinTestData
 
 
-class GeometricDistributionsTestData(InformationManifoldMixinTestData, OpenSetTestData):
+class GeometricDistributionsTestData(
+    InformationManifoldMixinTestData, VectorSpaceOpenSetTestData
+):
     fail_for_not_implemented_errors = False
 
     def point_to_pdf_against_scipy_test_data(self):

--- a/tests/tests_geomstats/test_information_geometry/data/normal.py
+++ b/tests/tests_geomstats/test_information_geometry/data/normal.py
@@ -1,4 +1,4 @@
-from ...test_geometry.data.base import OpenSetTestData
+from ...test_geometry.data.base import VectorSpaceOpenSetTestData
 from ...test_geometry.data.poincare_half_space import PoincareHalfSpaceTestData
 from ...test_geometry.data.product_manifold import (
     ProductManifoldTestData,
@@ -42,7 +42,7 @@ class CenteredNormalDistributionsTestData(
 
 
 class DiagonalNormalDistributionsTestData(
-    InformationManifoldMixinTestData, OpenSetTestData
+    InformationManifoldMixinTestData, VectorSpaceOpenSetTestData
 ):
     fail_for_not_implemented_errors = False
 

--- a/tests/tests_geomstats/test_information_geometry/data/poisson.py
+++ b/tests/tests_geomstats/test_information_geometry/data/poisson.py
@@ -1,12 +1,14 @@
 import geomstats.backend as gs
 from geomstats.test.data import TestData
 
-from ...test_geometry.data.base import OpenSetTestData
+from ...test_geometry.data.base import VectorSpaceOpenSetTestData
 from ...test_geometry.data.riemannian_metric import RiemannianMetricTestData
 from .base import InformationManifoldMixinTestData
 
 
-class PoissonDistributionsTestData(InformationManifoldMixinTestData, OpenSetTestData):
+class PoissonDistributionsTestData(
+    InformationManifoldMixinTestData, VectorSpaceOpenSetTestData
+):
     fail_for_not_implemented_errors = False
 
     def point_to_pdf_against_scipy_test_data(self):

--- a/tests/tests_geomstats/test_information_geometry/test_normal.py
+++ b/tests/tests_geomstats/test_information_geometry/test_normal.py
@@ -11,7 +11,7 @@ from geomstats.information_geometry.normal import (
 )
 from geomstats.test.parametrizers import DataBasedParametrizer
 from geomstats.test.random import RandomDataGenerator
-from geomstats.test_cases.geometry.base import OpenSetTestCase
+from geomstats.test_cases.geometry.base import VectorSpaceOpenSetTestCase
 from geomstats.test_cases.geometry.poincare_half_space import PoincareHalfSpaceTestCase
 from geomstats.test_cases.geometry.product_manifold import ProductManifoldTestCase
 from geomstats.test_cases.geometry.riemannian_metric import RiemannianMetricTestCase
@@ -114,7 +114,9 @@ def diagonal_spaces(request):
 
 @pytest.mark.usefixtures("diagonal_spaces")
 class TestDiagonalNormalDistributions(
-    InformationManifoldMixinTestCase, OpenSetTestCase, metaclass=DataBasedParametrizer
+    InformationManifoldMixinTestCase,
+    VectorSpaceOpenSetTestCase,
+    metaclass=DataBasedParametrizer,
 ):
     testing_data = DiagonalNormalDistributionsTestData()
 


### PR DESCRIPTION
This PR renames `OpenSet` to `VectorSpaceOpenSet` (i.e. an open set of a vector space) and adds a more general abstraction, `OpenSet`, that represents an `OpenSet` of any manifold.

NB: changes other than `geomstats.geometry.base` are renamings.

(Done in collboration with @olivierbisson).