### PR TITLE
Add LieCholeskyMetric on SPDMatrices

### DIFF
--- a/geomstats/geometry/spd_matrices.py
+++ b/geomstats/geometry/spd_matrices.py
@@ -1,6 +1,6 @@
 """The manifold of symmetric positive definite (SPD) matrices.
 
-Lead author: Yann Thanwerdas.
+Lead authors: Yann Thanwerdas and Olivier Bisson.
 """
 
 import math
@@ -12,6 +12,10 @@ from geomstats.geometry.diffeo import Diffeo
 from geomstats.geometry.general_linear import GeneralLinear
 from geomstats.geometry.hermitian_matrices import apply_func_to_eigvalsh, expmh, powermh
 from geomstats.geometry.matrices import Matrices, MatricesMetric
+from geomstats.geometry.positive_lower_triangular_matrices import (
+    InvariantPositiveLowerTriangularMatricesMetric,
+    PositiveLowerTriangularMatrices,
+)
 from geomstats.geometry.pullback_metric import PullbackDiffeoMetric
 from geomstats.geometry.riemannian_metric import RiemannianMetric
 from geomstats.geometry.scalar_product_metric import ScalarProductMetric
@@ -1052,3 +1056,25 @@ class SPDPowerMetric(PullbackDiffeoMetric):
         diffeo = MatrixPower(power)
 
         super().__init__(space, diffeo, image_space)
+
+
+class LieCholeskyMetric(PullbackDiffeoMetric):
+    """Pullback metric via a diffeomorphism.
+
+    Diffeormorphism between SPD matrices and PLT matrices equipped with
+    left invariant metric (see chapter 7 [TP2022]_).
+
+    References
+    ----------
+    .. [T2022] Yann Thanwerdas. Riemannian and stratified
+    geometries on covariance and correlation matrices. Differential
+    Geometry [math.DG]. Université Côte d'Azur, 2022.
+    """
+
+    def __init__(self, space):
+        image_space = PositiveLowerTriangularMatrices(space.n, equip=False)
+        image_space.equip_with_metric(InvariantPositiveLowerTriangularMatricesMetric)
+
+        diffeo = CholeskyMap()
+
+        super().__init__(space=space, diffeo=diffeo, image_space=image_space)

--- a/tests/tests_geomstats/test_geometry/data/spd_matrices.py
+++ b/tests/tests_geomstats/test_geometry/data/spd_matrices.py
@@ -509,3 +509,9 @@ class SPD3LogEuclideanMetricTestData(TestData):
             )
         ]
         return self.generate_tests(data)
+
+
+class LieCholeskyMetricTestData(PullbackDiffeoMetricTestData):
+    fail_for_autodiff_exceptions = False
+    fail_for_not_implemented_errors = False
+    skip_vec = True

--- a/tests/tests_geomstats/test_geometry/test_spd_matrices.py
+++ b/tests/tests_geomstats/test_geometry/test_spd_matrices.py
@@ -9,6 +9,7 @@ from geomstats.geometry.positive_lower_triangular_matrices import (
 from geomstats.geometry.scalar_product_metric import ScalarProductMetric
 from geomstats.geometry.spd_matrices import (
     CholeskyMap,
+    LieCholeskyMetric,
     MatrixPower,
     SPDAffineMetric,
     SPDBuresWassersteinMetric,
@@ -32,6 +33,7 @@ from geomstats.test_cases.geometry.spd_matrices import (
 from .data.diffeo import DiffeoTestData
 from .data.spd_matrices import (
     CholeskyMapSmokeTestData,
+    LieCholeskyMetricTestData,
     MatrixPower05TestData,
     SPD2AffineMetricTestData,
     SPD2BuresWassersteinMetricTestData,
@@ -292,3 +294,13 @@ class TestSPD3LogEuclideanMetric(
     space = SPDMatrices(n=3, equip=False)
     space.equip_with_metric(SPDLogEuclideanMetric)
     testing_data = SPD3LogEuclideanMetricTestData()
+
+
+@pytest.mark.slow
+@pytest.mark.redundant
+class TestLieCholeskyMetric(
+    PullbackDiffeoMetricTestCase, metaclass=DataBasedParametrizer
+):
+    _n = random.randint(2, 5)
+    space = SPDMatrices(n=_n, equip=False).equip_with_metric(LieCholeskyMetric)
+    testing_data = LieCholeskyMetricTestData()


### PR DESCRIPTION
This PR builds on top of  https://github.com/geomstats/geomstats/pull/1872 to implement a `LieCholeskyMetric`, which is a `PullbackDiffeoMetric` by the Cholesky map, on the `SPDMatrices`. The diffeomorphism is between the `SPDMatrices` and the `PositiveLowerTriangularMatrices` equipped with an invariant metric.

(with @olivierbisson)
