### PR TITLE
Simplify creation of identity matrices in the Siegel manifold

### DIFF
--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -14,7 +14,6 @@ from torch import (
     empty,
     empty_like,
     erf,
-    eye,
     flatten,
     float32,
     float64,
@@ -814,3 +813,12 @@ def imag(a):
     if is_complex(a):
         return _torch.imag(a)
     return _torch.zeros(a.shape, dtype=a.dtype)
+
+
+def eye(N, M=None, dtype=float, like=None):
+    if M is None:
+        M = N
+    if like is not None:
+        if hasattr(like, "device"):
+            return _torch.eye(n=N, m=M, dtype=dtype, device=like.device)
+    return _torch.eye(n=N, m=M, dtype=dtype)

--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -815,9 +815,9 @@ def imag(a):
     return _torch.zeros(a.shape, dtype=a.dtype)
 
 
-def eye(N, M=None, dtype=float, like=None):
+def eye(N, M=None, dtype=None, like=None):
     if M is None:
         M = N
-    if like is not None and hasattr(like, "device"):
+    if hasattr(like, "device"):
         return _torch.eye(n=N, m=M, dtype=dtype, device=like.device)
     return _torch.eye(n=N, m=M, dtype=dtype)

--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -14,6 +14,7 @@ from torch import (
     empty,
     empty_like,
     erf,
+    eye,
     flatten,
     float32,
     float64,
@@ -813,11 +814,3 @@ def imag(a):
     if is_complex(a):
         return _torch.imag(a)
     return _torch.zeros(a.shape, dtype=a.dtype)
-
-
-def eye(N, M=None, dtype=None, like=None):
-    if M is None:
-        M = N
-    if hasattr(like, "device"):
-        return _torch.eye(n=N, m=M, dtype=dtype, device=like.device)
-    return _torch.eye(n=N, m=M, dtype=dtype)

--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -818,7 +818,6 @@ def imag(a):
 def eye(N, M=None, dtype=float, like=None):
     if M is None:
         M = N
-    if like is not None:
-        if hasattr(like, "device"):
-            return _torch.eye(n=N, m=M, dtype=dtype, device=like.device)
+    if like is not None and hasattr(like, "device"):
+        return _torch.eye(n=N, m=M, dtype=dtype, device=like.device)
     return _torch.eye(n=N, m=M, dtype=dtype)

--- a/geomstats/algebra_utils.py
+++ b/geomstats/algebra_utils.py
@@ -114,12 +114,7 @@ def from_vector_to_diagonal_matrix(vector, num_diag=0):
         is a diagonal matrix containing the `i`-th row of `vector`.
     """
     num_columns = gs.shape(vector)[-1]
-    identity = gs.repeat(
-        gs.zeros_like(gs.reshape(vector, (-1, num_columns))[:1, :]),
-        repeats=num_columns,
-        axis=0,
-    )
-    identity[..., range(num_columns), range(num_columns)] = 1
+    identity = gs.eye(num_columns, dtype=vector.dtype, like=vector)
     diagonals = gs.einsum("...i,ij->...ij", vector, identity)
     diagonals = gs.to_ndarray(diagonals, to_ndim=3)
     num_lines = diagonals.shape[0]

--- a/geomstats/algebra_utils.py
+++ b/geomstats/algebra_utils.py
@@ -114,7 +114,7 @@ def from_vector_to_diagonal_matrix(vector, num_diag=0):
         is a diagonal matrix containing the `i`-th row of `vector`.
     """
     num_columns = gs.shape(vector)[-1]
-    identity = gs.eye(num_columns, dtype=vector.dtype, like=vector)
+    identity = gs.eye(num_columns, dtype=vector.dtype, like=gs.array(vector))
     diagonals = gs.einsum("...i,ij->...ij", vector, identity)
     diagonals = gs.to_ndarray(diagonals, to_ndim=3)
     num_lines = diagonals.shape[0]

--- a/geomstats/algebra_utils.py
+++ b/geomstats/algebra_utils.py
@@ -114,8 +114,10 @@ def from_vector_to_diagonal_matrix(vector, num_diag=0):
         is a diagonal matrix containing the `i`-th row of `vector`.
     """
     num_columns = gs.shape(vector)[-1]
-    identity = gs.eye(num_columns)
-    identity = gs.cast(identity, vector.dtype)
+    identity = gs.repeat(
+        gs.zeros_like(gs.reshape(vector, (-1, num_columns))[:1, :]),
+        repeats=num_columns, axis=0)
+    identity[range(num_columns), range(num_columns)] = 1
     diagonals = gs.einsum("...i,ij->...ij", vector, identity)
     diagonals = gs.to_ndarray(diagonals, to_ndim=3)
     num_lines = diagonals.shape[0]

--- a/geomstats/algebra_utils.py
+++ b/geomstats/algebra_utils.py
@@ -116,7 +116,9 @@ def from_vector_to_diagonal_matrix(vector, num_diag=0):
     num_columns = gs.shape(vector)[-1]
     identity = gs.repeat(
         gs.zeros_like(gs.reshape(vector, (-1, num_columns))[:1, :]),
-        repeats=num_columns, axis=0)
+        repeats=num_columns,
+        axis=0,
+    )
     identity[range(num_columns), range(num_columns)] = 1
     diagonals = gs.einsum("...i,ij->...ij", vector, identity)
     diagonals = gs.to_ndarray(diagonals, to_ndim=3)

--- a/geomstats/algebra_utils.py
+++ b/geomstats/algebra_utils.py
@@ -119,7 +119,7 @@ def from_vector_to_diagonal_matrix(vector, num_diag=0):
         repeats=num_columns,
         axis=0,
     )
-    identity[range(num_columns), range(num_columns)] = 1
+    identity[..., range(num_columns), range(num_columns)] = 1
     diagonals = gs.einsum("...i,ij->...ij", vector, identity)
     diagonals = gs.to_ndarray(diagonals, to_ndim=3)
     num_lines = diagonals.shape[0]

--- a/geomstats/algebra_utils.py
+++ b/geomstats/algebra_utils.py
@@ -114,7 +114,7 @@ def from_vector_to_diagonal_matrix(vector, num_diag=0):
         is a diagonal matrix containing the `i`-th row of `vector`.
     """
     num_columns = gs.shape(vector)[-1]
-    identity = gs.eye(num_columns, dtype=vector.dtype, like=gs.array(vector))
+    identity = gs.eye(num_columns, dtype=vector.dtype)
     diagonals = gs.einsum("...i,ij->...ij", vector, identity)
     diagonals = gs.to_ndarray(diagonals, to_ndim=3)
     num_lines = diagonals.shape[0]

--- a/geomstats/geometry/siegel.py
+++ b/geomstats/geometry/siegel.py
@@ -51,7 +51,7 @@ def _eye_like(mat):
         Stacked identity matrices.
     """
     identity = gs.zeros_like(mat)
-    identity[..., range(mat.ndim), range(mat.ndim)] = 1
+    identity[..., range(mat.shape[-2]), range(mat.shape[-1])] = 1
     return identity
 
 

--- a/geomstats/geometry/siegel.py
+++ b/geomstats/geometry/siegel.py
@@ -276,7 +276,9 @@ class SiegelMetric(ComplexRiemannianMetric):
         exp : array-like, shape=[..., n, n]
             Point on the manifold.
         """
-        identity = gs.eye(tangent_vec.shape[-1], dtype=tangent_vec.dtype, like=tangent_vec)
+        identity = gs.eye(
+            tangent_vec.shape[-1], dtype=tangent_vec.dtype, like=tangent_vec
+        )
         tangent_vec_transconj = ComplexMatrices.transconjugate(tangent_vec)
         aux_1 = gs.matmul(tangent_vec, tangent_vec_transconj)
         aux_2 = powermh(aux_1, 1 / 2)

--- a/geomstats/geometry/siegel.py
+++ b/geomstats/geometry/siegel.py
@@ -37,24 +37,6 @@ from geomstats.geometry.hermitian_matrices import expmh, powermh
 from geomstats.geometry.matrices import Matrices
 
 
-def _eye_like(mat):
-    """Stack identity matrices.
-
-    Parameters
-    ----------
-    mat : array-like, shape=[..., n, n]
-        Matrix.
-
-    Returns
-    -------
-    identity : array-like, shape=[..., n, n]
-        Stacked identity matrices.
-    """
-    identity = gs.zeros_like(mat)
-    identity[..., range(mat.shape[-2]), range(mat.shape[-1])] = 1
-    return identity
-
-
 class Siegel(ComplexVectorSpaceOpenSet):
     """Class for the Siegel space.
 
@@ -228,7 +210,7 @@ class SiegelMetric(ComplexRiemannianMetric):
         inner_product : array-like, shape=[...,]
             Inner-product.
         """
-        identity = _eye_like(base_point)
+        identity = gs.eye(base_point.shape[-1], dtype=base_point.dtype, like=base_point)
 
         base_point_transconj = ComplexMatrices.transconjugate(base_point)
         tangent_vec_b_transconj = ComplexMatrices.transconjugate(tangent_vec_b)
@@ -267,7 +249,7 @@ class SiegelMetric(ComplexRiemannianMetric):
         tangent_vec_at_zero : array-like, shape=[..., n, n]
             Tangent vector at zero (null matrix).
         """
-        identity = _eye_like(base_point)
+        identity = gs.eye(base_point.shape[-1], dtype=base_point.dtype, like=base_point)
         base_point_transconj = ComplexMatrices.transconjugate(base_point)
         aux_1 = gs.matmul(base_point, base_point_transconj)
         aux_2 = gs.matmul(base_point_transconj, base_point)
@@ -294,7 +276,7 @@ class SiegelMetric(ComplexRiemannianMetric):
         exp : array-like, shape=[..., n, n]
             Point on the manifold.
         """
-        identity = _eye_like(tangent_vec)
+        identity = gs.eye(tangent_vec.shape[-1], dtype=tangent_vec.dtype, like=tangent_vec)
         tangent_vec_transconj = ComplexMatrices.transconjugate(tangent_vec)
         aux_1 = gs.matmul(tangent_vec, tangent_vec_transconj)
         aux_2 = powermh(aux_1, 1 / 2)
@@ -327,7 +309,7 @@ class SiegelMetric(ComplexRiemannianMetric):
         point_image : array-like, shape=[..., n, n]
             Image of point by the isometry.
         """
-        identity = _eye_like(point)
+        identity = gs.eye(point.shape[-1], dtype=point.dtype, like=point)
         point_to_zero_transconj = ComplexMatrices.transconjugate(point_to_zero)
         aux_1 = gs.matmul(point_to_zero, point_to_zero_transconj)
         aux_2 = gs.matmul(point_to_zero_transconj, point_to_zero)
@@ -384,7 +366,7 @@ class SiegelMetric(ComplexRiemannianMetric):
         log_at_zero : array-like, shape=[..., n, n]
             Riemannian logarithm at zero (null matrix).
         """
-        identity = _eye_like(point)
+        identity = gs.eye(point.shape[-1], dtype=point.dtype, like=point)
         point_transconj = ComplexMatrices.transconjugate(point)
         aux_1 = gs.matmul(point, point_transconj)
         aux_2 = powermh(aux_1, 1 / 2)
@@ -414,7 +396,7 @@ class SiegelMetric(ComplexRiemannianMetric):
         tangent_vec_at_base_point : array-like, shape=[..., n, n]
             Tangent vector at the base point.
         """
-        identity = _eye_like(tangent_vec)
+        identity = gs.eye(base_point.shape[-1], dtype=base_point.dtype, like=base_point)
         base_point_transconj = ComplexMatrices.transconjugate(base_point)
         aux_1 = gs.matmul(base_point, base_point_transconj)
         aux_2 = gs.matmul(base_point_transconj, base_point)
@@ -472,7 +454,7 @@ class SiegelMetric(ComplexRiemannianMetric):
         if gs.ndim(point_a) > gs.ndim(point_b):
             point_a, point_b = point_b, point_a
 
-        identity = _eye_like(point_a)
+        identity = gs.eye(point_a.shape[-1], dtype=point_a.dtype, like=point_a)
 
         point_a_transconj = ComplexMatrices.transconjugate(point_a)
         point_b_transconj = ComplexMatrices.transconjugate(point_b)

--- a/geomstats/geometry/siegel.py
+++ b/geomstats/geometry/siegel.py
@@ -456,7 +456,9 @@ class SiegelMetric(ComplexRiemannianMetric):
         if gs.ndim(point_a) > gs.ndim(point_b):
             point_a, point_b = point_b, point_a
 
-        identity = gs.eye(point_a.shape[-1], dtype=point_a.dtype, like=point_a)
+        identity = gs.eye(
+            point_a.shape[-1], dtype=point_a.dtype, like=gs.array(point_a)
+        )
 
         point_a_transconj = ComplexMatrices.transconjugate(point_a)
         point_b_transconj = ComplexMatrices.transconjugate(point_b)

--- a/geomstats/geometry/siegel.py
+++ b/geomstats/geometry/siegel.py
@@ -37,25 +37,22 @@ from geomstats.geometry.hermitian_matrices import expmh, powermh
 from geomstats.geometry.matrices import Matrices
 
 
-def _create_identity_mat(shape, dtype):
+def _eye_like(mat):
     """Stack identity matrices.
 
     Parameters
     ----------
-    shape : tuple
-        Desired identity matrix shape of form [..., n, n].
-    dtype : dtype
-        Desired dtype.
+    mat : array-like, shape=[..., n, n]
+        Matrix.
 
     Returns
     -------
     identity : array-like, shape=[..., n, n]
         Stacked identity matrices.
     """
-    ndim = len(shape)
-    if ndim == 2:
-        return gs.eye(shape[-1], dtype=dtype)
-    return gs.stack([gs.eye(shape[-1], dtype=dtype) for _ in range(shape[0])], axis=0)
+    identity = gs.zeros_like(mat)
+    identity[..., range(mat.ndim), range(mat.ndim)] = 1
+    return identity
 
 
 class Siegel(ComplexVectorSpaceOpenSet):
@@ -231,7 +228,7 @@ class SiegelMetric(ComplexRiemannianMetric):
         inner_product : array-like, shape=[...,]
             Inner-product.
         """
-        identity = _create_identity_mat(base_point.shape, dtype=base_point.dtype)
+        identity = _eye_like(base_point)
 
         base_point_transconj = ComplexMatrices.transconjugate(base_point)
         tangent_vec_b_transconj = ComplexMatrices.transconjugate(tangent_vec_b)
@@ -270,7 +267,7 @@ class SiegelMetric(ComplexRiemannianMetric):
         tangent_vec_at_zero : array-like, shape=[..., n, n]
             Tangent vector at zero (null matrix).
         """
-        identity = _create_identity_mat(base_point.shape, dtype=base_point.dtype)
+        identity = _eye_like(base_point)
         base_point_transconj = ComplexMatrices.transconjugate(base_point)
         aux_1 = gs.matmul(base_point, base_point_transconj)
         aux_2 = gs.matmul(base_point_transconj, base_point)
@@ -297,7 +294,7 @@ class SiegelMetric(ComplexRiemannianMetric):
         exp : array-like, shape=[..., n, n]
             Point on the manifold.
         """
-        identity = _create_identity_mat(tangent_vec.shape, dtype=tangent_vec.dtype)
+        identity = _eye_like(tangent_vec)
         tangent_vec_transconj = ComplexMatrices.transconjugate(tangent_vec)
         aux_1 = gs.matmul(tangent_vec, tangent_vec_transconj)
         aux_2 = powermh(aux_1, 1 / 2)
@@ -330,7 +327,7 @@ class SiegelMetric(ComplexRiemannianMetric):
         point_image : array-like, shape=[..., n, n]
             Image of point by the isometry.
         """
-        identity = _create_identity_mat(point.shape, dtype=point.dtype)
+        identity = _eye_like(point)
         point_to_zero_transconj = ComplexMatrices.transconjugate(point_to_zero)
         aux_1 = gs.matmul(point_to_zero, point_to_zero_transconj)
         aux_2 = gs.matmul(point_to_zero_transconj, point_to_zero)
@@ -387,7 +384,7 @@ class SiegelMetric(ComplexRiemannianMetric):
         log_at_zero : array-like, shape=[..., n, n]
             Riemannian logarithm at zero (null matrix).
         """
-        identity = _create_identity_mat(point.shape, dtype=point.dtype)
+        identity = _eye_like(point)
         point_transconj = ComplexMatrices.transconjugate(point)
         aux_1 = gs.matmul(point, point_transconj)
         aux_2 = powermh(aux_1, 1 / 2)
@@ -417,7 +414,7 @@ class SiegelMetric(ComplexRiemannianMetric):
         tangent_vec_at_base_point : array-like, shape=[..., n, n]
             Tangent vector at the base point.
         """
-        identity = _create_identity_mat(tangent_vec.shape, dtype=base_point.dtype)
+        identity = _eye_like(tangent_vec)
         base_point_transconj = ComplexMatrices.transconjugate(base_point)
         aux_1 = gs.matmul(base_point, base_point_transconj)
         aux_2 = gs.matmul(base_point_transconj, base_point)
@@ -475,7 +472,7 @@ class SiegelMetric(ComplexRiemannianMetric):
         if gs.ndim(point_a) > gs.ndim(point_b):
             point_a, point_b = point_b, point_a
 
-        identity = _create_identity_mat(point_b.shape, dtype=point_a.dtype)
+        identity = _eye_like(point_a)
 
         point_a_transconj = ComplexMatrices.transconjugate(point_a)
         point_b_transconj = ComplexMatrices.transconjugate(point_b)

--- a/geomstats/geometry/siegel.py
+++ b/geomstats/geometry/siegel.py
@@ -210,7 +210,7 @@ class SiegelMetric(ComplexRiemannianMetric):
         inner_product : array-like, shape=[...,]
             Inner-product.
         """
-        identity = gs.eye(base_point.shape[-1], dtype=base_point.dtype, like=base_point)
+        identity = gs.eye(base_point.shape[-1], dtype=base_point.dtype)
 
         base_point_transconj = ComplexMatrices.transconjugate(base_point)
         tangent_vec_b_transconj = ComplexMatrices.transconjugate(tangent_vec_b)
@@ -249,7 +249,7 @@ class SiegelMetric(ComplexRiemannianMetric):
         tangent_vec_at_zero : array-like, shape=[..., n, n]
             Tangent vector at zero (null matrix).
         """
-        identity = gs.eye(base_point.shape[-1], dtype=base_point.dtype, like=base_point)
+        identity = gs.eye(base_point.shape[-1], dtype=base_point.dtype)
         base_point_transconj = ComplexMatrices.transconjugate(base_point)
         aux_1 = gs.matmul(base_point, base_point_transconj)
         aux_2 = gs.matmul(base_point_transconj, base_point)
@@ -276,9 +276,7 @@ class SiegelMetric(ComplexRiemannianMetric):
         exp : array-like, shape=[..., n, n]
             Point on the manifold.
         """
-        identity = gs.eye(
-            tangent_vec.shape[-1], dtype=tangent_vec.dtype, like=tangent_vec
-        )
+        identity = gs.eye(tangent_vec.shape[-1], dtype=tangent_vec.dtype)
         tangent_vec_transconj = ComplexMatrices.transconjugate(tangent_vec)
         aux_1 = gs.matmul(tangent_vec, tangent_vec_transconj)
         aux_2 = powermh(aux_1, 1 / 2)
@@ -311,7 +309,7 @@ class SiegelMetric(ComplexRiemannianMetric):
         point_image : array-like, shape=[..., n, n]
             Image of point by the isometry.
         """
-        identity = gs.eye(point.shape[-1], dtype=point.dtype, like=point)
+        identity = gs.eye(point.shape[-1], dtype=point.dtype)
         point_to_zero_transconj = ComplexMatrices.transconjugate(point_to_zero)
         aux_1 = gs.matmul(point_to_zero, point_to_zero_transconj)
         aux_2 = gs.matmul(point_to_zero_transconj, point_to_zero)
@@ -368,7 +366,7 @@ class SiegelMetric(ComplexRiemannianMetric):
         log_at_zero : array-like, shape=[..., n, n]
             Riemannian logarithm at zero (null matrix).
         """
-        identity = gs.eye(point.shape[-1], dtype=point.dtype, like=point)
+        identity = gs.eye(point.shape[-1], dtype=point.dtype)
         point_transconj = ComplexMatrices.transconjugate(point)
         aux_1 = gs.matmul(point, point_transconj)
         aux_2 = powermh(aux_1, 1 / 2)

--- a/geomstats/geometry/siegel.py
+++ b/geomstats/geometry/siegel.py
@@ -456,9 +456,7 @@ class SiegelMetric(ComplexRiemannianMetric):
         if gs.ndim(point_a) > gs.ndim(point_b):
             point_a, point_b = point_b, point_a
 
-        identity = gs.eye(
-            point_a.shape[-1], dtype=point_a.dtype, like=gs.array(point_a)
-        )
+        identity = gs.eye(point_a.shape[-1], dtype=point_a.dtype)
 
         point_a_transconj = ComplexMatrices.transconjugate(point_a)
         point_b_transconj = ComplexMatrices.transconjugate(point_b)

--- a/geomstats/geometry/siegel.py
+++ b/geomstats/geometry/siegel.py
@@ -396,7 +396,7 @@ class SiegelMetric(ComplexRiemannianMetric):
         tangent_vec_at_base_point : array-like, shape=[..., n, n]
             Tangent vector at the base point.
         """
-        identity = gs.eye(base_point.shape[-1], dtype=base_point.dtype, like=base_point)
+        identity = gs.eye(base_point.shape[-1], dtype=base_point.dtype)
         base_point_transconj = ComplexMatrices.transconjugate(base_point)
         aux_1 = gs.matmul(base_point, base_point_transconj)
         aux_2 = gs.matmul(base_point_transconj, base_point)


### PR DESCRIPTION
The function `siegel.metric.isometry` returns an error when used on PyTorch GPU.

When I run the following code in a Google Colab environment with the execution type "T4 GPU":

```
%env GEOMSTATS_BACKEND=pytorch

try:
    import geomstats
except ImportError:
    !pip install geomstats["pytorch"]

import geomstats
import geomstats.backend as gs
import torch
import torch.cuda

from geomstats.geometry.siegel import Siegel, SiegelMetric

device = torch.device("cuda:0")

point = torch.tensor([[0.5 + 0.2j, 0], [0, 0.5]], requires_grad=True, device=device)
point_to_zero = torch.tensor([[-0.5, 0], [0.1j, 0]], requires_grad=True, device=device)

siegel = Siegel(n=2)
isometry = siegel.metric.isometry(point=point, point_to_zero=point_to_zero)
```

I obtain the following error message:

```
env: GEOMSTATS_BACKEND=pytorch

---------------------------------------------------------------------------

RuntimeError                              Traceback (most recent call last)

[<ipython-input-2-7790184e609e>](https://localhost:8080/#) in <cell line: 23>()
     21 
     22 siegel = Siegel(n=2)
---> 23 isometry = siegel.metric.isometry(point=point, point_to_zero=point_to_zero)

[/usr/local/lib/python3.10/dist-packages/geomstats/geometry/siegel.py](https://localhost:8080/#) in isometry(point, point_to_zero)
    340         aux_1 = gs.matmul(point_to_zero, point_to_zero_transconj)
    341         aux_2 = gs.matmul(point_to_zero_transconj, point_to_zero)
--> 342         aux_3 = identity - aux_1
    343         aux_4 = identity - aux_2
    344         factor_1 = HermitianMatrices.powerm(aux_3, -1 / 2)

RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!
```

Indeed, the identity matrix created with the function `_create_identity_mat` is always created on CPU.
To fix this error, this PR replaces the function `_create_identity_mat` by the function `_eye_like`.