### PR TITLE
Improve documentation rendering, 2nd part

### DIFF
--- a/geomstats/datasets/prepare_graph_data.py
+++ b/geomstats/datasets/prepare_graph_data.py
@@ -66,9 +66,8 @@ class Graph:
 
         Returns
         -------
-        self : array-like,
-            Shape=[n_walks_per_node*self.n_edges), walk_length]
-            array containing random walks.
+        self : array-like, shape=[n_walks_per_node*self.n_edges), walk_length]
+            Array containing random walks.
         """
         paths = [
             [0] * (walk_length + 1) for i in range(self.n_nodes * n_walks_per_node)

--- a/geomstats/datasets/prepare_graph_data.py
+++ b/geomstats/datasets/prepare_graph_data.py
@@ -66,7 +66,7 @@ class Graph:
 
         Returns
         -------
-        self : array-like, shape=[n_walks_per_node*self.n_edges), walk_length]
+        self : array-like, shape=[n_walks_per_node*self.n_edges, walk_length]
             Array containing random walks.
         """
         paths = [

--- a/geomstats/distributions/lognormal.py
+++ b/geomstats/distributions/lognormal.py
@@ -92,18 +92,18 @@ class LogNormal:
     """LogNormal Distribution on manifold of SPD Matrices and Euclidean Spaces.
 
     (1) For Euclidean Spaces, if X is distributed as Normal(mean, cov), then
-    exp(X) is distributed as LogNormal(mean, cov).
+      exp(X) is distributed as LogNormal(mean, cov).
 
     (2) For SPDMatrices, there are different distributions based on metric
 
-        a)LogEuclidean Metric : With this metric, LogNormal distribution
+        a) LogEuclidean Metric : With this metric, LogNormal distribution
         is defined by transforming the mean -- an SPD matrix -- into
         a symmetric matrix through the Matrix logarithm, which gives
         the element "log-mean" that now belongs to a vector space.
         This log-mean and given cov are used to parametrize a Normal
         Distribution.
 
-        b)AffineInvariant Metric : X is distributed as LogNormal(mean, cov)
+        b) AffineInvariant Metric : X is distributed as LogNormal(mean, cov)
         if exp(mean^{1/2}.X.mean^{1/2}) is distributed as Normal(0, cov)
 
     Parameters
@@ -112,11 +112,11 @@ class LogNormal:
         Manifold to sample over. Manifold should
         be instance of Euclidean or SPDMatrices.
     mean : array-like, \
-            shape=[dim] if space is Euclidean Space \
+            shape=[dim] if space is Euclidean Space, \
             shape=[n, n] if space is SPD Manifold
         Mean of the distribution.
     cov : array-like, \
-            shape=[dim, dim] if space is Euclidean Space \
+            shape=[dim, dim] if space is Euclidean Space, \
             shape=[n*(n+1)/2, n*(n+1)/2] if space is SPD Manifold
         Covariance of the distribution.
 

--- a/geomstats/geometry/discrete_curves.py
+++ b/geomstats/geometry/discrete_curves.py
@@ -707,10 +707,10 @@ class L2CurvesMetric(NFoldMetric):
         at regularly spaced times
 
         .. math::
-            t_i = i / (k\_landmarks), \\
-            i = 0, ..., k\_landmarks - 1
+            t_i = i / k, \\
+            i = 0, ..., k - 1
 
-        (last time is missing).
+        where :math:`k` is the number of landmarks (last time is missing).
 
         Parameters
         ----------
@@ -1172,13 +1172,13 @@ class DynamicProgrammingAligner:
 
     The objective can be expressed in terms of square root velocity (SRV)
     representations: it is equivalent to finding the gamma that maximizes
-    the L2 scalar product between :math:`initial\_srv` and :math:`end\_srv@\gamma`,
-    where :math:`initial\_srv` is the SRV representation of the initial curve and
-    :math:`end\_srv@\gamma` is the SRV representation of the end curve
-    reparametrized by gamma, i.e
+    the L2 scalar product between :math:`initial_{srv}` and :math:`end_{srv}@\gamma`,
+    where :math:`initial_{srv}` is the SRV representation of the initial curve
+    and :math:`end_{srv}@\gamma` is the SRV representation of the end curve
+    reparametrized by :math:`\gamma`, i.e
 
     .. math::
-        end\_srv@\gamma(t) = end\_srv(\gamma(t))\cdot|\gamma(t)|^\frac{1}{2}
+        end_{srv}@\gamma(t) = end_{srv}(\gamma(t))\cdot|\gamma(t)|^\frac{1}{2}
 
     The dynamic programming algorithm assumes that for every subinterval
     :math:`\left[\frac{i}{n},\frac{i+1}{n}\right]` of :math:`\left[0,1\right]`,

--- a/geomstats/geometry/discrete_curves.py
+++ b/geomstats/geometry/discrete_curves.py
@@ -700,7 +700,7 @@ class L2CurvesMetric(NFoldMetric):
 
     @staticmethod
     def riemann_sum(func):
-        """Compute the left Riemann sum approximation of the integral.
+        r"""Compute the left Riemann sum approximation of the integral.
 
         Compute the left Riemann sum approximation of the integral of a
         function func defined on the unit interval, given by sample points
@@ -1174,7 +1174,8 @@ class DynamicProgrammingAligner:
     representations: it is equivalent to finding the gamma that maximizes
     the L2 scalar product between :math:`initial\_srv` and :math:`end\_srv@\gamma`,
     where :math:`initial\_srv` is the SRV representation of the initial curve and
-    :math:`end\_srv@\gamma` is the SRV representation of the end curve reparametrized by gamma, i.e
+    :math:`end\_srv@\gamma` is the SRV representation of the end curve
+    reparametrized by gamma, i.e
 
     .. math::
         end\_srv@\gamma(t) = end\_srv(\gamma(t))\cdot|\gamma(t)|^\frac{1}{2}

--- a/geomstats/geometry/discrete_curves.py
+++ b/geomstats/geometry/discrete_curves.py
@@ -378,7 +378,7 @@ class SRVTransform(Diffeo):
         r"""Differential of the square root velocity transform.
 
         .. math::
-            (h, c) -> dQ_c(h) = |c'|^(-1/2} * (h' - 1/2 * <h',v>v)
+            (h, c) -> dQ_c(h) = |c'|^(-1/2) * (h' - 1/2 * <h',v>v)
             v = c'/|c'|
 
         Parameters
@@ -707,8 +707,8 @@ class L2CurvesMetric(NFoldMetric):
         at regularly spaced times
 
         .. math::
-            t_i = i / (k_landmarks),
-            i = 0, ..., k_landmarks - 1
+            t_i = i / (k\_landmarks), \\
+            i = 0, ..., k\_landmarks - 1
 
         (last time is missing).
 
@@ -979,7 +979,7 @@ class IterativeHorizontalGeodesicAligner:
 
         Returns
         -------
-        reparametrized_path : array-like,
+        reparametrized_path : array-like, \
             shape=[n_times, k_sampling_points, ambient_dim]
             Path of curves composed with the inverse of the path of
             reparametrizations.
@@ -1172,12 +1172,12 @@ class DynamicProgrammingAligner:
 
     The objective can be expressed in terms of square root velocity (SRV)
     representations: it is equivalent to finding the gamma that maximizes
-    the L2 scalar product between initial_srv and end_srv@gamma where initial_srv
-    is the SRV representation of the initial curve and end_srv@gamma is the SRV
-    representation of the end curve reparametrized by gamma, i.e
+    the L2 scalar product between :math:`initial\_srv` and :math:`end\_srv@\gamma`,
+    where :math:`initial\_srv` is the SRV representation of the initial curve and
+    :math:`end\_srv@\gamma` is the SRV representation of the end curve reparametrized by gamma, i.e
 
     .. math::
-        end_srv@\gamma(t) = end_srv(\gamma(t))\cdot|\gamma(t)|^\frac{1}{2}
+        end\_srv@\gamma(t) = end\_srv(\gamma(t))\cdot|\gamma(t)|^\frac{1}{2}
 
     The dynamic programming algorithm assumes that for every subinterval
     :math:`\left[\frac{i}{n},\frac{i+1}{n}\right]` of :math:`\left[0,1\right]`,

--- a/geomstats/geometry/invariant_metric.py
+++ b/geomstats/geometry/invariant_metric.py
@@ -661,7 +661,7 @@ class _InvariantMetricMatrix(RiemannianMetric):
         end_point : array-like, shape=[..., dim], optional
             Point on the manifold, end point of the geodesic. If None,
             an initial tangent vector must be given.
-        initial_tangent_vec : array-like, shape=[..., dim],
+        initial_tangent_vec : array-like, shape=[..., dim]
             Tangent vector at base point, the initial speed of the geodesics.
             Optional, default: None.
             If None, an end point must be given and a logarithm is computed.

--- a/geomstats/geometry/pre_shape.py
+++ b/geomstats/geometry/pre_shape.py
@@ -819,13 +819,13 @@ class PreShapeMetric(RiemannianMetric):
     ):
         r"""Compute the covariant derivative of the curvature.
 
-        For four vectors fields :math:`H|_P = tangent\_vec\_a, X|_P =
-        tangent\_vec\_b, Y|_P = tangent\_vec\_c, Z|_P = tangent\_vec\_d` with
-        tangent vector value specified in argument at the base point `P`,
+        For four vectors fields :math:`H|_P =` `tangent_vec_a`,
+        :math:`X|_P =` `tangent_vec_b`, :math:`Y|_P =` `tangent_vec_c`,
+        :math:`Z|_P =` `tangent_vec_d` with
+        tangent vector value specified in argument at the `base_point` :math:`P`,
         the covariant derivative of the curvature
-        :math:`(\nabla_H R)(X, Y) Z |_P` is computed at the base point P.
-        Since the sphere is a constant curvature space this
-        vanishes identically.
+        :math:`(\nabla_H R)(X, Y) Z |_P` is computed at the `base_point` :math:`P`.
+        Since the sphere is a constant curvature space this vanishes identically.
 
         Parameters
         ----------
@@ -847,7 +847,7 @@ class PreShapeMetric(RiemannianMetric):
         Returns
         -------
         curvature_derivative : array-like, shape=[..., k_landmarks, m_ambient]
-            Tangent vector at base point.
+            Tangent vector at `base_point`.
         """
         batch_shape = get_batch_shape(
             self._space.point_ndim,
@@ -941,20 +941,21 @@ class KendallShapeMetric(QuotientMetric):
     ):
         r"""Compute the covariant derivative of the directional curvature.
 
-        For two vectors fields :math:`X|_P = tangent\_vec\_a, Y|_P =
-        tangent\_vec\_b` with tangent vector value specified in argument at the
-        base point `P`, the covariant derivative (in the direction `X`)
+        For two vectors fields :math:`X|_P =` `tangent_vec_a`,
+        :math:`Y|_P =` `tangent_vec_b` with tangent vector value specified in argument
+        at the `base_point` :math:`P`,
+        the covariant derivative (in the direction :math:`X`)
         :math:`(\nabla_X R_Y)(X) |_P = (\nabla_X R)(Y, X) Y |_P` of the
-        directional curvature (in the direction `Y`)
-        :math:`R_Y(X) = R(Y, X) Y`  is a quadratic tensor in `X` and `Y` that
-        plays an important role in the computation of the moments of the
+        directional curvature (in the direction :math:`Y`)
+        :math:`R_Y(X) = R(Y, X) Y` is a quadratic tensor in :math:`X` and :math:`Y`
+        that plays an important role in the computation of the moments of the
         empirical Fréchet mean [Pennec]_.
 
         In more details, let :math:`X, Y` be the horizontal lift of parallel
         vector fields extending the tangent vectors given in argument by
-        parallel transport in a neighborhood of the base-point P in the
+        parallel transport in a neighborhood of the`base_point` :math:`P` in the
         base-space. Such vector fields verify :math:`\nabla^T_X X=0` and
-        :math:`\nabla^T_X^Y = A_X Y` using the connection :math:`\nabla^T`
+        :math:`\nabla^T_X Y = A_X Y` using the connection :math:`\nabla^T`
         of the total space. Then the covariant derivative of the
         directional curvature tensor is given by
         :math:`\nabla_X (R_Y(X)) = hor \nabla^T_X (R^T_Y(X)) - A_X( ver R^T_Y(X))
@@ -973,7 +974,7 @@ class KendallShapeMetric(QuotientMetric):
         Returns
         -------
         curvature_derivative : array-like, shape=[..., k_landmarks, m_ambient]
-            Tangent vector at base point.
+            Tangent vector at `base_point`.
         """
         horizontal_x = self.fiber_bundle.horizontal_projection(
             tangent_vec_a, base_point

--- a/geomstats/geometry/product_manifold.py
+++ b/geomstats/geometry/product_manifold.py
@@ -469,7 +469,7 @@ class ProductManifold(_IterateOverFactorsMixins, Manifold):
 
         Parameters
         ----------
-        point : array-like, shape=[..., {dim, embedding_space.dim,
+        point : array-like, shape=[..., {dim, embedding_space.dim, \
             [n_manifolds, dim_each]}]
             Point in product manifold.
 
@@ -719,7 +719,7 @@ class ProductRiemannianMetric(_IterateOverFactorsMixins, RiemannianMetric):
         end_point : array-like, shape=[..., dim], optional
             Point on the manifold, end point of the geodesic. If None,
             an initial tangent vector must be given.
-        initial_tangent_vec : array-like, shape=[..., dim],
+        initial_tangent_vec : array-like, shape=[..., dim]
             Tangent vector at base point, the initial speed of the geodesics.
             Optional, default: None.
             If None, an end point must be given and a logarithm is computed.

--- a/geomstats/geometry/quotient_metric.py
+++ b/geomstats/geometry/quotient_metric.py
@@ -103,7 +103,7 @@ class QuotientMetric(RiemannianMetric):
         ----------
         initial_point : array-like, shape=[..., dim]
             Point on the manifold, initial point of the geodesic.
-        initial_tangent_vec : array-like, shape=[..., dim],
+        initial_tangent_vec : array-like, shape=[..., dim]
             Tangent vector at base point, the initial speed of the geodesics.
             Optional, default: None.
             If None, an end point must be given and a logarithm is computed.
@@ -278,7 +278,7 @@ class QuotientMetric(RiemannianMetric):
 
         .. math::
             \nabla_H (R(X, Y) Z) =
-            \hor\nabla_H^T(R^T(X,Y)Z) - A_H(ver R^T(X,Y)Z )
+            hor\nabla_H^T(R^T(X,Y)Z) - A_H(ver R^T(X,Y)Z )
             + (2 A_H A_Z A_X Y - A_H A_X A_Y Z + A_H A_Y A_X Z)
             - (2 \nabla_H^T A_Z A_X Y - \nabla_H^T A_X A_Y Z + \nabla_H^T A_Y A_X Z)
 
@@ -305,7 +305,7 @@ class QuotientMetric(RiemannianMetric):
         References
         ----------
         .. [Pennec] Pennec, Xavier. Computing the curvature and its gradient
-        in Kendall shape spaces. Unpublished.
+            in Kendall shape spaces. Unpublished.
         """
         bundle = self.fiber_bundle
         point_fiber = bundle.lift(base_point)

--- a/geomstats/geometry/quotient_metric.py
+++ b/geomstats/geometry/quotient_metric.py
@@ -256,11 +256,12 @@ class QuotientMetric(RiemannianMetric):
     ):
         r"""Compute the covariant derivative of the curvature.
 
-        For four vectors fields :math:`H|_P = tangent\_vec\_a, X|_P =
-        tangent\_vec\_b, Y|_P = tangent\_vec\_c, Z|_P = tangent\_vec\_d` with
-        tangent vector value specified in argument at the base point `P`,
+        For four vectors fields :math:`H|_P =` `tangent_vec_a`,
+        :math:`X|_P =` `tangent_vec_b`, :math:`Y|_P =` `tangent_vec_c`,
+        :math:`Z|_P =` `tangent_vec_d` with
+        tangent vector value specified in argument at the `base_point` :math:`P`,
         the covariant derivative of the curvature
-        :math:`(\nabla_H R)(X, Y)Z |_P` is computed at the base point P.
+        :math:`(\nabla_H R)(X, Y)Z |_P` is computed at the `base_point` :math:`P`.
 
         In the case of quotient metrics, the fundamental equations of a
         Riemannian submersion allow to compute this tensor on the base manifold
@@ -270,9 +271,9 @@ class QuotientMetric(RiemannianMetric):
 
         In more details, let :math:`H, X, Y, Z` be the horizontal lift of
         parallel vector fields extending the tangent vectors given in argument
-        by parallel transport in a neighborhood of the base-point P in the
+        by parallel transport in a neighborhood of the `base_point` :math:`P` in the
         base-space. Such vector fields verify :math:`\nabla^T_H H=0`,
-        :math:`\nabla^T_H^X = A_H X` (and similarly for Y and Z) using the
+        :math:`\nabla^T_H X = A_H X` (and similarly for Y and Z) using the
         connection :math:`\nabla^T` of the total space. Then the covariant
         derivative of the curvature tensor is given by
 
@@ -287,7 +288,7 @@ class QuotientMetric(RiemannianMetric):
         Parameters
         ----------
         tangent_vec_a : array-like, shape=[..., n, n]
-            Tangent vector at `base_point` (derivative direction)).
+            Tangent vector at `base_point` (derivative direction).
         tangent_vec_b : array-like, shape=[..., n, n]
             Tangent vector at `base_point`.
         tangent_vec_c : array-like, shape=[..., n, n]
@@ -300,7 +301,7 @@ class QuotientMetric(RiemannianMetric):
         Returns
         -------
         curvature_derivative : array-like, shape=[..., n, n]
-            Tangent vector at base point.
+            Tangent vector at `base_point`.
 
         References
         ----------
@@ -371,13 +372,14 @@ class QuotientMetric(RiemannianMetric):
     ):
         r"""Compute the covariant derivative of the directional curvature.
 
-        For two vectors fields :math:`X|_P = tangent\_vec\_a, Y|_P =
-        tangent\_vec\_b` with tangent vector value specified in argument at the
-        base point `P`, the covariant derivative (in the direction `X`)
+        For two vectors fields :math:`X|_P =` `tangent_vec_a`,
+        :math:`Y|_P =` `tangent_vec_b` with tangent vector value specified in
+        argument at the `base_point` :math:`P`,
+        the covariant derivative (in the direction :math:`X`)
         :math:`(\nabla_X R_Y)(X) |_P = (\nabla_X R)(Y, X) Y |_P` of the
-        directional curvature (in the direction `Y`)
-        :math:`R_Y(X) = R(Y, X) Y`  is a quadratic tensor in `X` and `Y` that
-        plays an important role in the computation of the moments of the
+        directional curvature (in the direction :math:`Y`)
+        :math:`R_Y(X) = R(Y, X) Y` is a quadratic tensor in :math:`X` and :math:`Y`
+        that plays an important role in the computation of the moments of the
         empirical Fréchet mean.
 
         This tensor can be computed from the covariant derivative of the
@@ -390,7 +392,7 @@ class QuotientMetric(RiemannianMetric):
 
         In more details, let :math:`X, Y` be the horizontal lift of parallel
         vector fields extending the tangent vectors given in argument by
-        parallel transport in a neighborhood of the base-point P in the
+        parallel transport in a neighborhood of the `base_point` :math:`P` in the
         base-space. Such vector fields verify :math:`\nabla^T_X X=0` and
         :math:`\nabla^T_X^Y = A_X Y` using the connection :math:`\nabla^T`
         of the total space. Then the covariant derivative of the
@@ -414,7 +416,7 @@ class QuotientMetric(RiemannianMetric):
         Returns
         -------
         curvature_derivative : array-like, shape=[..., n, n]
-            Tangent vector at base point.
+            Tangent vector at `base_point`.
 
         References
         ----------

--- a/geomstats/geometry/sub_riemannian_metric.py
+++ b/geomstats/geometry/sub_riemannian_metric.py
@@ -336,7 +336,7 @@ class SubRiemannianMetric:
         ----------
         initial_point : array-like, shape=[..., dim]
             Point on the manifold, initial point of the geodesic.
-        initial_cotangent_vec : array-like, shape=[..., dim],
+        initial_cotangent_vec : array-like, shape=[..., dim]
             Cotangent vector at base point, the initial speed of the geodesics.
 
         Returns

--- a/geomstats/information_geometry/multinomial.py
+++ b/geomstats/information_geometry/multinomial.py
@@ -375,7 +375,7 @@ class MultinomialMetric(RiemannianMetric):
             Point on the manifold, end point of the geodesic.
             Optional, default: None.
             If None, an initial tangent vector must be given.
-        initial_tangent_vec : array-like, shape=[..., dim + 1],
+        initial_tangent_vec : array-like, shape=[..., dim + 1]
             Tangent vector at base point, the initial speed of the geodesics.
             Optional, default: None.
             If None, an end point must be given and a logarithm is computed.

--- a/geomstats/learning/agglomerative_hierarchical_clustering.py
+++ b/geomstats/learning/agglomerative_hierarchical_clustering.py
@@ -83,8 +83,8 @@ class AgglomerativeHierarchicalClustering(AgglomerativeClustering):
     References
     ----------
     This algorithm uses the scikit-learn library:
-    https://github.com/scikit-learn/scikit-learn/blob/95d4f0841/sklearn/
-    cluster/_agglomerative.py#L656
+    https://github.com/scikit-learn/scikit-learn/blob/95d4f0841/sklearn/cluster
+    /_agglomerative.py#L656
     """
 
     def __init__(

--- a/geomstats/learning/radial_kernel_functions.py
+++ b/geomstats/learning/radial_kernel_functions.py
@@ -429,7 +429,8 @@ def laplacian_radial_kernel(distance, bandwidth=1.0):
 
     References
     ----------
-    .. [1] http://crsouza.com/2010/03/17/kernel-functions-for-machine-learning-applications/
+    .. [1] http://crsouza.com/2010/03/17/
+        kernel-functions-for-machine-learning-applications/
     .. [2] https://data-flair.training/blogs/svm-kernel-functions/
     """
     distance = _check_distance(distance)

--- a/geomstats/learning/radial_kernel_functions.py
+++ b/geomstats/learning/radial_kernel_functions.py
@@ -235,8 +235,8 @@ def gaussian_radial_kernel(distance, bandwidth=1.0):
 
     References
     ----------
-    https://en.wikipedia.org/wiki/Kernel_(statistics)
-    https://en.wikipedia.org/wiki/Radial_basis_function
+    .. [1] https://en.wikipedia.org/wiki/Kernel_(statistics)
+    .. [2] https://en.wikipedia.org/wiki/Radial_basis_function
     """
     distance = _check_distance(distance)
     bandwidth = _check_bandwidth(bandwidth)
@@ -429,9 +429,8 @@ def laplacian_radial_kernel(distance, bandwidth=1.0):
 
     References
     ----------
-    http://crsouza.com/2010/03/17/
-    kernel-functions-for-machine-learning-applications/
-    https://data-flair.training/blogs/svm-kernel-functions/
+    .. [1] http://crsouza.com/2010/03/17/kernel-functions-for-machine-learning-applications/
+    .. [2] https://data-flair.training/blogs/svm-kernel-functions/
     """
     distance = _check_distance(distance)
     bandwidth = _check_bandwidth(bandwidth)

--- a/geomstats/learning/wrapped_gaussian_process.py
+++ b/geomstats/learning/wrapped_gaussian_process.py
@@ -34,7 +34,7 @@ class WrappedGaussianProcess(MultiOutputMixin, RegressorMixin, BaseEstimator):
 
     References
     ----------
-    [1] Mallasto, A. and Feragen, A. Wrapped gaussian process
+    .. [1] Mallasto, A. and Feragen, A. Wrapped gaussian process
         regression on riemannian manifolds. In 2018 IEEE/CVF
         Conference on Computer Vision and Pattern Recognition
     """


### PR DESCRIPTION
## Description

Correct equations, references, bullet points, etc rendering in documentation.
No code modification.


Can you also indicate how to correct these equations? @luisfpereira
(see error "Double exponents: use braces to clarify")
https://geomstats.github.io/api/geomstats.geometry.html#geomstats.geometry.quotient_metric.QuotientMetric.curvature_derivative

https://geomstats.github.io/api/geomstats.geometry.html#geomstats.geometry.pre_shape.KendallShapeMetric.directional_curvature_derivative

https://geomstats.github.io/api/geomstats.geometry.html#geomstats.geometry.quotient_metric.QuotientMetric.directional_curvature_derivative