### PR TITLE
Add `MatrixVectorSpace`

### DIFF
--- a/geomstats/datasets/prepare_emg_data.py
+++ b/geomstats/datasets/prepare_emg_data.py
@@ -108,5 +108,7 @@ class TimeSeriesCovariance:
             covs.append(np.cov(x.transpose()))
         self.labels = gs.array(self.data["y"][self.batches])
         self.covs = gs.array(covs)
-        self.covecs = gs.array([SymmetricMatrices.to_vector(cov) for cov in self.covs])
+        self.covecs = gs.array(
+            [SymmetricMatrices.basis_representation(cov) for cov in self.covs]
+        )
         self.diags = self.covs.diagonal(0, 1, 2)

--- a/geomstats/geometry/base.py
+++ b/geomstats/geometry/base.py
@@ -226,7 +226,6 @@ class ComplexVectorSpace(ComplexManifold, abc.ABC):
         if dim is None:
             dim = math.prod(shape)
         super().__init__(shape=shape, dim=dim, **kwargs)
-        self._basis = None
 
     def belongs(self, point, atol=gs.atol):
         """Evaluate if the point belongs to the vector space.
@@ -343,62 +342,9 @@ class ComplexVectorSpace(ComplexManifold, abc.ABC):
         )
         return point
 
-    @property
-    def basis(self):
-        """Basis of the vector space."""
-        if self._basis is None:
-            self._basis = self._create_basis()
-        return self._basis
-
-    @basis.setter
-    def basis(self, basis):
-        if len(basis) < self.dim:
-            raise ValueError(
-                "The basis should have length equal to the dimension of the space."
-            )
-        self._basis = basis
-
-    @abc.abstractmethod
-    def _create_basis(self):
-        """Create a canonical basis."""
-
 
 class ComplexMatrixVectorSpace(ComplexVectorSpace):
     """A matrix vector space."""
-
-    @abc.abstractmethod
-    def basis_representation(self, matrix_representation):
-        """Compute the coefficients of matrices in the given basis.
-
-        Parameters
-        ----------
-        matrix_representation : array-like, shape=[..., *point_shape]
-            Matrix.
-
-        Returns
-        -------
-        basis_representation : array-like, shape=[..., dim]
-            Coefficients in the basis.
-        """
-        raise NotImplementedError("basis_representation not implemented.")
-
-    def matrix_representation(self, basis_representation):
-        """Compute the matrix representation for the given basis coefficients.
-
-        Sums the basis elements according to the coefficients given in
-        basis_representation.
-
-        Parameters
-        ----------
-        basis_representation : array-like, shape=[..., dim]
-            Coefficients in the basis.
-
-        Returns
-        -------
-        matrix_representation : array-like, shape=[..., *point_shape]
-            Matrix.
-        """
-        return gs.einsum("...i,ijk ->...jk", basis_representation, self.basis)
 
 
 class LevelSet(Manifold, abc.ABC):

--- a/geomstats/geometry/base.py
+++ b/geomstats/geometry/base.py
@@ -159,6 +159,14 @@ class MatrixVectorSpace(VectorSpace):
     def basis_representation(self, matrix_representation):
         """Compute the coefficients of matrices in the given basis.
 
+        This takes a matrix (the matrix representation of a point) and
+        transforms it into its corresponding vector representation
+        (the coefficients wrt a given basis).
+
+        Previously, this method was called `to_vector`. `basis_representation`
+        makes it more clear that the vector representation depends on the chosen
+        basis.
+
         Parameters
         ----------
         matrix_representation : array-like, shape=[..., *point_shape]
@@ -174,8 +182,8 @@ class MatrixVectorSpace(VectorSpace):
     def matrix_representation(self, basis_representation):
         """Compute the matrix representation for the given basis coefficients.
 
-        Sums the basis elements according to the coefficients given in
-        basis_representation.
+        This takes a vector representation of a point (the coefficients wrt
+        a given basis) and creates the corresponding matrix representation.
 
         Parameters
         ----------

--- a/geomstats/geometry/complex_matrices.py
+++ b/geomstats/geometry/complex_matrices.py
@@ -32,30 +32,6 @@ class ComplexMatrices(ComplexMatrixVectorSpace):
         """Metric to equip the space with if equip is True."""
         return ComplexMatricesMetric
 
-    def _create_basis(self):
-        """Create the canonical basis."""
-        cdtype = gs.get_default_cdtype()
-        m, n = self.m, self.n
-        real_part = gs.reshape(gs.eye(n * m), (n * m, m, n))
-        complex_part = gs.reshape(gs.eye(n * m, dtype=cdtype), (n * m, m, n))
-        return gs.vstack([real_part, complex_part])
-
-    def basis_representation(self, matrix_representation):
-        """Compute the coefficients of matrices in the given basis.
-
-        Parameters
-        ----------
-        matrix_representation : array-like, shape=[..., *point_shape]
-            Matrix.
-
-        Returns
-        -------
-        basis_representation : array-like, shape=[..., dim]
-            Coefficients in the basis.
-        """
-        # TODO: complete
-        raise NotImplementedError("basis_representation not implemented.")
-
     def belongs(self, point, atol=gs.atol):
         """Check if point belongs to the Matrices space.
 

--- a/geomstats/geometry/complex_matrices.py
+++ b/geomstats/geometry/complex_matrices.py
@@ -5,13 +5,13 @@ Lead author: Yann Cabanes.
 
 import geomstats.backend as gs
 import geomstats.errors
-from geomstats.geometry.base import ComplexVectorSpace
+from geomstats.geometry.base import ComplexMatrixVectorSpace
 from geomstats.geometry.hermitian import HermitianMetric
 from geomstats.geometry.matrices import Matrices
 from geomstats.vectorization import repeat_out
 
 
-class ComplexMatrices(ComplexVectorSpace):
+class ComplexMatrices(ComplexMatrixVectorSpace):
     """Class for the space of complex matrices (m, n).
 
     Parameters
@@ -39,6 +39,22 @@ class ComplexMatrices(ComplexVectorSpace):
         real_part = gs.reshape(gs.eye(n * m), (n * m, m, n))
         complex_part = gs.reshape(gs.eye(n * m, dtype=cdtype), (n * m, m, n))
         return gs.vstack([real_part, complex_part])
+
+    def basis_representation(self, matrix_representation):
+        """Compute the coefficients of matrices in the given basis.
+
+        Parameters
+        ----------
+        matrix_representation : array-like, shape=[..., *point_shape]
+            Matrix.
+
+        Returns
+        -------
+        basis_representation : array-like, shape=[..., dim]
+            Coefficients in the basis.
+        """
+        # TODO: complete
+        raise NotImplementedError("basis_representation not implemented.")
 
     def belongs(self, point, atol=gs.atol):
         """Check if point belongs to the Matrices space.

--- a/geomstats/geometry/heisenberg.py
+++ b/geomstats/geometry/heisenberg.py
@@ -191,7 +191,7 @@ class HeisenbergVectors(LieGroup, VectorSpace):
                 axis=-1,
             )
 
-        return gs.triu(SymmetricMatrices.from_vector(modified_point))
+        return gs.triu(SymmetricMatrices.matrix_representation(modified_point))
 
     @staticmethod
     def vector_from_upper_triangular_matrix(matrix):

--- a/geomstats/geometry/hermitian.py
+++ b/geomstats/geometry/hermitian.py
@@ -38,10 +38,6 @@ class Hermitian(ComplexVectorSpace):
         """
         return gs.zeros(self.dim, dtype=gs.get_default_cdtype())
 
-    def _create_basis(self):
-        """Create the canonical basis."""
-        return gs.eye(self.dim, dtype=gs.get_default_cdtype())
-
     def exp(self, tangent_vec, base_point=None):
         """Compute the group exponential, which is simply the addition.
 

--- a/geomstats/geometry/hermitian_matrices.py
+++ b/geomstats/geometry/hermitian_matrices.py
@@ -6,7 +6,7 @@ import logging
 
 import geomstats.backend as gs
 from geomstats import algebra_utils as utils
-from geomstats.geometry.base import ComplexVectorSpace
+from geomstats.geometry.base import ComplexMatrixVectorSpace
 from geomstats.geometry.complex_matrices import ComplexMatrices, ComplexMatricesMetric
 from geomstats.geometry.matrices import Matrices
 
@@ -102,7 +102,7 @@ def apply_func_to_eigvalsh(mat, function, check_positive=False):
     return reconstruction if return_list else reconstruction[0]
 
 
-class HermitianMatrices(ComplexVectorSpace):
+class HermitianMatrices(ComplexMatrixVectorSpace):
     """Class for the vector space of Hermitian matrices of size n.
 
     Parameters
@@ -223,40 +223,25 @@ class HermitianMatrices(ComplexVectorSpace):
         return ComplexMatrices.to_hermitian(point)
 
     @staticmethod
-    def to_vector(point):
+    def basis_representation(matrix_representation):
         """Convert a Hermitian matrix into a vector.
 
         Parameters
         ----------
-        point : array-like, shape=[..., n, n]
+        matrix_representation : array-like, shape=[..., n, n]
             Matrix.
 
         Returns
         -------
-        vec : array-like, shape=[..., n(n+1)/2]
+        basis_representation : array-like, shape=[..., n(n+1)/2]
             Vector.
         """
-        diag = Matrices.diagonal(point)
+        diag = Matrices.diagonal(matrix_representation)
 
-        up_triang = gs.triu_to_vec(point, k=1)
+        up_triang = gs.triu_to_vec(matrix_representation, k=1)
         real_part = gs.real(up_triang)
         complex_part = gs.imag(up_triang)
 
         vec = gs.hstack([diag, real_part, complex_part])
 
         return vec
-
-    def from_vector(self, vec):
-        """Convert a vector into a Hermitian matrix.
-
-        Parameters
-        ----------
-        vec : array-like, shape=[..., dim]
-            Vector.
-
-        Returns
-        -------
-        mat : array-like, shape=[..., n, n]
-            Hermitian matrix.
-        """
-        return gs.einsum("...k,...kij->...ij", vec, self.basis)

--- a/geomstats/geometry/hpd_matrices.py
+++ b/geomstats/geometry/hpd_matrices.py
@@ -152,9 +152,6 @@ class HPDMatrices(ComplexVectorSpaceOpenSet):
 
         return Matrices.mul(sqrt_base_point, tangent_vec_at_id, sqrt_base_point)
 
-    from_vector = HermitianMatrices.__dict__["from_vector"]
-    to_vector = HermitianMatrices.__dict__["to_vector"]
-
 
 class HPDAffineMetric(ComplexRiemannianMetric):
     """Class for the affine-invariant metric on the HPD manifold."""

--- a/geomstats/geometry/lie_algebra.py
+++ b/geomstats/geometry/lie_algebra.py
@@ -13,13 +13,13 @@ import abc
 
 import geomstats.backend as gs
 import geomstats.errors
-from geomstats.geometry.base import VectorSpace
+from geomstats.geometry.base import MatrixVectorSpace
 from geomstats.geometry.matrices import Matrices
 
 from ._bch_coefficients import BCH_COEFFICIENTS
 
 
-class MatrixLieAlgebra(VectorSpace, abc.ABC):
+class MatrixLieAlgebra(MatrixVectorSpace, abc.ABC):
     """Class implementing matrix Lie algebra related functions.
 
     Parameters
@@ -28,6 +28,8 @@ class MatrixLieAlgebra(VectorSpace, abc.ABC):
         Amount of rows and columns in the matrix representation of the
         Lie algebra.
     """
+
+    # TODO: check again need for representation_dim
 
     def __init__(self, representation_dim, **kwargs):
         geomstats.errors.check_integer(representation_dim, "representation_dim")
@@ -85,40 +87,3 @@ class MatrixLieAlgebra(VectorSpace, abc.ABC):
                 float(BCH_COEFFICIENTS[i, 3]) / float(BCH_COEFFICIENTS[i, 4]) * el[i]
             )
         return result
-
-    @abc.abstractmethod
-    def basis_representation(self, matrix_representation):
-        """Compute the coefficients of matrices in the given basis.
-
-        Parameters
-        ----------
-        matrix_representation : array-like, shape=[..., *point_shape]
-            Matrix.
-
-        Returns
-        -------
-        basis_representation : array-like, shape=[..., dim]
-            Coefficients in the basis.
-        """
-        raise NotImplementedError("basis_representation not implemented.")
-
-    def matrix_representation(self, basis_representation):
-        """Compute the matrix representation for the given basis coefficients.
-
-        Sums the basis elements according to the coefficients given in
-        basis_representation.
-
-        Parameters
-        ----------
-        basis_representation : array-like, shape=[..., dim]
-            Coefficients in the basis.
-
-        Returns
-        -------
-        matrix_representation : array-like, shape=[..., *point_shape]
-            Matrix.
-        """
-        if self.basis is None:
-            raise NotImplementedError("basis not implemented")
-
-        return gs.einsum("...i,ijk ->...jk", basis_representation, self.basis)

--- a/geomstats/geometry/lower_triangular_matrices.py
+++ b/geomstats/geometry/lower_triangular_matrices.py
@@ -4,11 +4,11 @@ Lead author: Saiteja Utpala.
 """
 
 import geomstats.backend as gs
-from geomstats.geometry.base import VectorSpace
+from geomstats.geometry.base import MatrixVectorSpace
 from geomstats.geometry.matrices import Matrices, MatricesMetric
 
 
-class LowerTriangularMatrices(VectorSpace):
+class LowerTriangularMatrices(MatrixVectorSpace):
     """Class for the vector space of lower triangular matrices of size n.
 
     Parameters
@@ -63,38 +63,8 @@ class LowerTriangularMatrices(VectorSpace):
         return belongs
 
     @staticmethod
-    def to_vector(point):
+    def basis_representation(matrix_representation):
         """Convert a lower triangular matrix into a vector.
-
-        Parameters
-        ----------
-        point : array-like, shape=[..., n, n]
-            Matrix.
-
-        Returns
-        -------
-        vec : array-like, shape=[..., n(n+1)/2]
-            Vector.
-        """
-        return gs.tril_to_vec(point)
-
-    def from_vector(self, vec):
-        """Convert a vector into a lower triangular matrix.
-
-        Parameters
-        ----------
-        vec : array-like, shape=[..., n(n+1)/2]
-            Vector.
-
-        Returns
-        -------
-        mat : array-like, shape=[..., n, n]
-            Lower triangular matrix.
-        """
-        return gs.einsum("...i,...ijk->...jk", vec, self.basis)
-
-    def matrix_representation(self, vec):
-        """Compute the matrix representation for the given basis coefficients.
 
         Parameters
         ----------
@@ -103,10 +73,10 @@ class LowerTriangularMatrices(VectorSpace):
 
         Returns
         -------
-        basis_representation : array-like, shape=[..., dim]
-            Representation in the basis.
+        vec : array-like, shape=[..., n(n+1)/2]
+            Vector.
         """
-        return self.from_vector(vec)
+        return gs.tril_to_vec(matrix_representation)
 
     def projection(self, point):
         """Make a square matrix lower triangular by zeroing out other elements.
@@ -122,23 +92,3 @@ class LowerTriangularMatrices(VectorSpace):
             Symmetric matrix.
         """
         return gs.tril(point)
-
-    def random_point(self, n_samples=1, bound=1.0):
-        """Sample a lower triangular matrix with a uniform distribution in a box.
-
-        Parameters
-        ----------
-        n_samples : int
-            Number of samples.
-            Optional, default: 1.
-        bound : float
-            Side of hypercube support of the uniform distribution.
-            Optional, default: 1.0.
-
-        Returns
-        -------
-        point : array-like, shape=[..., n, n]
-           Sample.
-        """
-        sample = super().random_point(n_samples, bound)
-        return gs.tril(sample)

--- a/geomstats/geometry/matrices.py
+++ b/geomstats/geometry/matrices.py
@@ -6,12 +6,12 @@ from functools import reduce
 import geomstats.backend as gs
 import geomstats.errors
 from geomstats.algebra_utils import flip_determinant, from_vector_to_diagonal_matrix
-from geomstats.geometry.base import VectorSpace
+from geomstats.geometry.base import MatrixVectorSpace
 from geomstats.geometry.euclidean import EuclideanMetric
 from geomstats.vectorization import repeat_out
 
 
-class Matrices(VectorSpace):
+class Matrices(MatrixVectorSpace):
     """Class for the space of matrices (m, n).
 
     Parameters
@@ -37,6 +37,23 @@ class Matrices(VectorSpace):
     def default_metric():
         """Metric to equip the space with if equip is True."""
         return MatricesMetric
+
+    def basis_representation(self, matrix_representation):
+        """Compute the coefficient in the usual matrix basis.
+
+        This simply flattens the input.
+
+        Parameters
+        ----------
+        matrix_representation : array-like, shape=[..., n, n]
+            Matrix.
+
+        Returns
+        -------
+        basis_representation : array-like, shape=[..., dim]
+            Representation in the basis.
+        """
+        return self.flatten(matrix_representation)
 
     @staticmethod
     def equal(mat_a, mat_b, atol=gs.atol):

--- a/geomstats/geometry/riemannian_metric.py
+++ b/geomstats/geometry/riemannian_metric.py
@@ -453,7 +453,9 @@ class RiemannianMetric(Connection, ABC):
         pool = joblib.Parallel(n_jobs=n_jobs, **joblib_kwargs)
         out = pool(pickable_dist(points[i], points[j]) for i, j in zip(rows, cols))
 
-        return geometry.symmetric_matrices.SymmetricMatrices.from_vector(gs.array(out))
+        return geometry.symmetric_matrices.SymmetricMatrices.matrix_representation(
+            gs.array(out)
+        )
 
     def diameter(self, points):
         """Give the distance between two farthest points.

--- a/geomstats/geometry/spd_matrices.py
+++ b/geomstats/geometry/spd_matrices.py
@@ -551,9 +551,6 @@ class SPDMatrices(VectorSpaceOpenSet):
 
         return Matrices.mul(sqrt_base_point, tangent_vec_at_id, sqrt_base_point)
 
-    from_vector = SymmetricMatrices.__dict__["from_vector"]
-    to_vector = SymmetricMatrices.__dict__["to_vector"]
-
 
 class SPDAffineMetric(RiemannianMetric):
     """Class for the affine-invariant metric on the SPD manifold.

--- a/geomstats/learning/pca.py
+++ b/geomstats/learning/pca.py
@@ -214,7 +214,7 @@ class TangentPCA(_BasePCA):
                 gs.all(Matrices.is_square(tangent_vecs))
                 and Matrices.is_symmetric(tangent_vecs).all()
             ):
-                X = SymmetricMatrices.to_vector(tangent_vecs)
+                X = SymmetricMatrices.basis_representation(tangent_vecs)
             else:
                 X = gs.reshape(tangent_vecs, (len(X), -1))
         else:
@@ -246,9 +246,9 @@ class TangentPCA(_BasePCA):
             if gs.all(Matrices.is_square(self.base_point_)) and gs.all(
                 Matrices.is_symmetric(self.base_point_)
             ):
-                scores = SymmetricMatrices(self.base_point_.shape[-1]).from_vector(
-                    scores
-                )
+                scores = SymmetricMatrices(
+                    self.base_point_.shape[-1]
+                ).matrix_representation(scores)
             else:
                 dim = self.base_point_.shape[-1]
                 scores = gs.reshape(scores, (len(scores), dim, dim))
@@ -281,7 +281,7 @@ class TangentPCA(_BasePCA):
             if gs.all(Matrices.is_square(tangent_vecs)) and gs.all(
                 Matrices.is_symmetric(tangent_vecs)
             ):
-                X = SymmetricMatrices.to_vector(tangent_vecs)
+                X = SymmetricMatrices.basis_representation(tangent_vecs)
             else:
                 X = gs.reshape(tangent_vecs, (len(X), -1))
         else:

--- a/geomstats/learning/preprocessing.py
+++ b/geomstats/learning/preprocessing.py
@@ -113,7 +113,7 @@ class ToTangentSpace(BaseEstimator, TransformerMixin):
             return tangent_vecs
 
         if gs.all(Matrices.is_symmetric(tangent_vecs)):
-            X = SymmetricMatrices.to_vector(tangent_vecs)
+            X = SymmetricMatrices.basis_representation(tangent_vecs)
 
         elif gs.all(Matrices.is_skew_symmetric(tangent_vecs)):
             X = SkewSymmetricMatrices(tangent_vecs.shape[-1]).basis_representation(
@@ -152,7 +152,7 @@ class ToTangentSpace(BaseEstimator, TransformerMixin):
             if gs.all(Matrices.is_symmetric(self.base_point_)) and dim_sym == n_vecs:
                 tangent_vecs = SymmetricMatrices(
                     self.base_point_.shape[-1]
-                ).from_vector(X)
+                ).matrix_representation(X)
             elif dim_skew == n_vecs:
                 tangent_vecs = SkewSymmetricMatrices(dim_skew).matrix_representation(X)
             else:

--- a/geomstats/test/random.py
+++ b/geomstats/test/random.py
@@ -1,4 +1,5 @@
 import geomstats.backend as gs
+from geomstats.geometry.base import ComplexMatrixVectorSpace
 from geomstats.geometry.euclidean import Euclidean
 from geomstats.geometry.general_linear import SquareMatrices
 from geomstats.vectorization import get_n_points
@@ -48,6 +49,24 @@ class RandomDataGenerator:
 class VectorSpaceRandomDataGenerator(RandomDataGenerator):
     def point_to_project(self, n_points=1):
         return self.random_point(n_points)
+
+
+class MatrixVectorSpaceRandomDataGenerator(VectorSpaceRandomDataGenerator):
+    def random_basis_representation(self, n_points=1):
+        dtype = (
+            gs.get_default_cdtype()
+            if isinstance(self, ComplexMatrixVectorSpace)
+            else None
+        )
+
+        if n_points == 1:
+            return gs.random.rand(self.space.dim, dtype=dtype)
+
+        return gs.reshape(
+            gs.random.rand(n_points * self.space.dim),
+            (n_points, -1),
+            dtype=dtype,
+        )
 
 
 class EmbeddedSpaceRandomDataGenerator(RandomDataGenerator):

--- a/geomstats/test_cases/geometry/base.py
+++ b/geomstats/test_cases/geometry/base.py
@@ -3,6 +3,7 @@ import pytest
 import geomstats.backend as gs
 from geomstats.test.random import (
     EmbeddedSpaceRandomDataGenerator,
+    MatrixVectorSpaceRandomDataGenerator,
     VectorSpaceRandomDataGenerator,
 )
 from geomstats.test.vectorization import generate_vectorization_data
@@ -98,79 +99,98 @@ class ComplexVectorSpaceTestCase(_VectorSpaceTestCaseMixins, ComplexManifoldTest
     pass
 
 
-class MatrixVectorSpaceTestCaseMixins:
-    def _get_random_vector(self, n_points=1):
-        # TODO: from data generator?
-        if n_points == 1:
-            return gs.random.rand(self.space.dim)
+class _MatrixVectorSpaceTestCaseMixins:
+    def setup_method(self):
+        if not hasattr(self, "data_generator"):
+            self.data_generator = MatrixVectorSpaceRandomDataGenerator(self.space)
+        super().setup_method()
 
-        return gs.reshape(gs.random.rand(n_points * self.space.dim), (n_points, -1))
-
-    def test_to_vector(self, point, expected, atol):
-        vec = self.space.to_vector(point)
+    def test_basis_representation(self, matrix_representation, expected, atol):
+        vec = self.space.basis_representation(matrix_representation)
         self.assertAllClose(vec, expected, atol=atol)
 
-    @pytest.mark.random
-    def test_to_vector_and_basis(self, n_points, atol):
-        mat = self.data_generator.random_point(n_points)
-        vec = self.space.to_vector(mat)
-
-        res = gs.einsum("...i,...ijk->...jk", vec, self.space.basis)
-        self.assertAllClose(res, mat, atol=atol)
-
-    def test_from_vector(self, vec, expected, atol):
-        mat = self.space.from_vector(vec)
-        self.assertAllClose(mat, expected, atol=atol)
-
     @pytest.mark.vec
-    def test_from_vector_vec(self, n_reps, atol):
-        vec = self._get_random_vector()
-        expected = self.space.from_vector(vec)
+    def test_basis_representation_vec(self, n_reps, atol):
+        matrix_representation = self.data_generator.random_point()
+        expected = self.space.basis_representation(matrix_representation)
 
         vec_data = generate_vectorization_data(
-            data=[dict(vec=vec, expected=expected, atol=atol)],
-            arg_names=["vec"],
+            data=[
+                dict(
+                    matrix_representation=matrix_representation,
+                    expected=expected,
+                    atol=atol,
+                )
+            ],
+            arg_names=["matrix_representation"],
             expected_name="expected",
             n_reps=n_reps,
         )
         self._test_vectorization(vec_data)
 
     @pytest.mark.random
-    def test_from_vector_belongs(self, n_points, atol):
-        vec = self._get_random_vector(n_points)
-        point = self.space.from_vector(vec)
+    def test_basis_representation_and_basis(self, n_points, atol):
+        mat = self.data_generator.random_point(n_points)
+        vec = self.space.basis_representation(mat)
+
+        res = gs.einsum("...i,...ijk->...jk", vec, self.space.basis)
+        self.assertAllClose(res, mat, atol=atol)
+
+    def test_matrix_representation(self, basis_representation, expected, atol):
+        mat = self.space.matrix_representation(basis_representation)
+        self.assertAllClose(mat, expected, atol=atol)
+
+    @pytest.mark.vec
+    def test_matrix_representation_vec(self, n_reps, atol):
+        basis_representation = gs.random.rand(self.space.dim)
+        expected = self.space.matrix_representation(basis_representation)
+
+        vec_data = generate_vectorization_data(
+            data=[
+                dict(
+                    basis_representation=basis_representation,
+                    expected=expected,
+                    atol=atol,
+                )
+            ],
+            arg_names=["basis_representation"],
+            expected_name="expected",
+            n_reps=n_reps,
+        )
+        self._test_vectorization(vec_data)
+
+    @pytest.mark.random
+    def test_matrix_representation_belongs(self, n_points, atol):
+        vec = gs.reshape(gs.random.rand(n_points * self.space.dim), (n_points, -1))
+        point = self.space.matrix_representation(vec)
 
         self.test_belongs(point, gs.ones(n_points, dtype=bool), atol)
 
     @pytest.mark.random
-    def test_from_vector_after_to_vector(self, n_points, atol):
-        mat = self.data_generator.random_point(n_points)
+    def test_matrix_representation_after_basis_representation(self, n_points, atol):
+        point = self.data_generator.random_point(n_points)
+        vec = self.space.basis_representation(point)
+        point_ = self.space.matrix_representation(vec)
 
-        vec = self.space.to_vector(mat)
-
-        mat_ = self.space.from_vector(vec)
-        self.assertAllClose(mat_, mat, atol=atol)
+        self.assertAllClose(point_, point, atol=atol)
 
     @pytest.mark.random
-    def test_to_vector_after_from_vector(self, n_points, atol):
-        vec = self._get_random_vector(n_points)
+    def test_basis_representation_after_matrix_representation(self, n_points, atol):
+        vec = gs.reshape(gs.random.rand(n_points * self.space.dim), (n_points, -1))
+        point = self.space.matrix_representation(vec)
+        vec_ = self.space.basis_representation(point)
 
-        mat = self.space.from_vector(vec)
-
-        vec_ = self.space.to_vector(mat)
         self.assertAllClose(vec_, vec, atol=atol)
 
 
-class ComplexMatrixVectorSpaceTestCaseMixins(MatrixVectorSpaceTestCaseMixins):
-    def _get_random_vector(self, n_points=1):
-        if n_points == 1:
-            return gs.random.rand(self.space.dim, dtype=gs.get_default_cdtype())
+class MatrixVectorSpaceTestCase(_MatrixVectorSpaceTestCaseMixins, VectorSpaceTestCase):
+    pass
 
-        return gs.reshape(
-            gs.random.rand(n_points * self.space.dim),
-            (n_points, -1),
-            dtype=gs.get_default_cdtype(),
-        )
+
+class ComplexMatrixVectorSpaceTestCase(
+    _MatrixVectorSpaceTestCaseMixins, ComplexVectorSpaceTestCase
+):
+    pass
 
 
 class LevelSetTestCase(ProjectionTestCaseMixins, ManifoldTestCase):

--- a/geomstats/test_cases/geometry/base.py
+++ b/geomstats/test_cases/geometry/base.py
@@ -63,6 +63,8 @@ class _VectorSpaceTestCaseMixins(ProjectionTestCaseMixins):
 
         self.assertAllClose(result, expected, atol=atol)
 
+
+class VectorSpaceTestCase(_VectorSpaceTestCaseMixins, ManifoldTestCase):
     @pytest.mark.mathprop
     def test_basis_cardinality(self):
         """Check number of basis elements is the dimension.
@@ -91,15 +93,11 @@ class _VectorSpaceTestCaseMixins(ProjectionTestCaseMixins):
         self.assertAllClose(self.space.basis, expected, atol=atol)
 
 
-class VectorSpaceTestCase(_VectorSpaceTestCaseMixins, ManifoldTestCase):
-    pass
-
-
 class ComplexVectorSpaceTestCase(_VectorSpaceTestCaseMixins, ComplexManifoldTestCase):
     pass
 
 
-class _MatrixVectorSpaceTestCaseMixins:
+class MatrixVectorSpaceTestCase(VectorSpaceTestCase):
     def setup_method(self):
         if not hasattr(self, "data_generator"):
             self.data_generator = MatrixVectorSpaceRandomDataGenerator(self.space)
@@ -183,13 +181,7 @@ class _MatrixVectorSpaceTestCaseMixins:
         self.assertAllClose(vec_, vec, atol=atol)
 
 
-class MatrixVectorSpaceTestCase(_MatrixVectorSpaceTestCaseMixins, VectorSpaceTestCase):
-    pass
-
-
-class ComplexMatrixVectorSpaceTestCase(
-    _MatrixVectorSpaceTestCaseMixins, ComplexVectorSpaceTestCase
-):
+class ComplexMatrixVectorSpaceTestCase(ComplexVectorSpaceTestCase):
     pass
 
 

--- a/geomstats/test_cases/geometry/complex_matrices.py
+++ b/geomstats/test_cases/geometry/complex_matrices.py
@@ -1,9 +1,7 @@
-from geomstats.test_cases.geometry.base import ComplexVectorSpaceTestCase
+from geomstats.test_cases.geometry.base import ComplexMatrixVectorSpaceTestCase
 
 
-class ComplexMatricesTestCase(ComplexVectorSpaceTestCase):
-    # TODO: with mixins?
-
+class ComplexMatricesTestCase(ComplexMatrixVectorSpaceTestCase):
     def test_transconjugate(self, mat, expected, atol):
         res = self.space.transconjugate(mat)
         self.assertAllClose(res, expected, atol=atol)

--- a/geomstats/test_cases/geometry/lie_algebra.py
+++ b/geomstats/test_cases/geometry/lie_algebra.py
@@ -1,15 +1,10 @@
 import pytest
 
-import geomstats.backend as gs
 from geomstats.test.vectorization import generate_vectorization_data
-from geomstats.test_cases.geometry.base import VectorSpaceTestCase
+from geomstats.test_cases.geometry.base import MatrixVectorSpaceTestCase
 
 
-class MatrixLieAlgebraTestCase(VectorSpaceTestCase):
-    # most of tests are very similar to MatrixVectorSpaceTestCaseMixins
-
-    # TODO: any mathematical property for baker_campbell_hausdorff?
-
+class MatrixLieAlgebraTestCase(MatrixVectorSpaceTestCase):
     def test_baker_campbell_hausdorff(
         self, matrix_a, matrix_b, expected, atol, order=2
     ):
@@ -36,80 +31,3 @@ class MatrixLieAlgebraTestCase(VectorSpaceTestCase):
             n_reps=n_reps,
         )
         self._test_vectorization(vec_data)
-
-    def test_basis_representation(self, matrix_representation, expected, atol):
-        vec = self.space.basis_representation(matrix_representation)
-        self.assertAllClose(vec, expected, atol=atol)
-
-    @pytest.mark.vec
-    def test_basis_representation_vec(self, n_reps, atol):
-        matrix_representation = self.data_generator.random_point()
-        expected = self.space.basis_representation(matrix_representation)
-
-        vec_data = generate_vectorization_data(
-            data=[
-                dict(
-                    matrix_representation=matrix_representation,
-                    expected=expected,
-                    atol=atol,
-                )
-            ],
-            arg_names=["matrix_representation"],
-            expected_name="expected",
-            n_reps=n_reps,
-        )
-        self._test_vectorization(vec_data)
-
-    @pytest.mark.random
-    def test_basis_representation_and_basis(self, n_points, atol):
-        mat = self.data_generator.random_point(n_points)
-        vec = self.space.basis_representation(mat)
-
-        res = gs.einsum("...i,...ijk->...jk", vec, self.space.basis)
-        self.assertAllClose(res, mat, atol=atol)
-
-    def test_matrix_representation(self, basis_representation, expected, atol):
-        mat = self.space.matrix_representation(basis_representation)
-        self.assertAllClose(mat, expected, atol=atol)
-
-    @pytest.mark.vec
-    def test_matrix_representation_vec(self, n_reps, atol):
-        basis_representation = gs.random.rand(self.space.dim)
-        expected = self.space.matrix_representation(basis_representation)
-
-        vec_data = generate_vectorization_data(
-            data=[
-                dict(
-                    basis_representation=basis_representation,
-                    expected=expected,
-                    atol=atol,
-                )
-            ],
-            arg_names=["basis_representation"],
-            expected_name="expected",
-            n_reps=n_reps,
-        )
-        self._test_vectorization(vec_data)
-
-    @pytest.mark.random
-    def test_matrix_representation_belongs(self, n_points, atol):
-        vec = gs.reshape(gs.random.rand(n_points * self.space.dim), (n_points, -1))
-        point = self.space.matrix_representation(vec)
-
-        self.test_belongs(point, gs.ones(n_points, dtype=bool), atol)
-
-    @pytest.mark.random
-    def test_matrix_representation_after_basis_representation(self, n_points, atol):
-        point = self.data_generator.random_point(n_points)
-        vec = self.space.basis_representation(point)
-        point_ = self.space.matrix_representation(vec)
-
-        self.assertAllClose(point_, point, atol=atol)
-
-    @pytest.mark.random
-    def test_basis_representation_after_matrix_representation(self, n_points, atol):
-        vec = gs.reshape(gs.random.rand(n_points * self.space.dim), (n_points, -1))
-        point = self.space.matrix_representation(vec)
-        vec_ = self.space.basis_representation(point)
-
-        self.assertAllClose(vec_, vec, atol=atol)

--- a/geomstats/test_cases/geometry/matrices.py
+++ b/geomstats/test_cases/geometry/matrices.py
@@ -4,7 +4,7 @@ import geomstats.backend as gs
 from geomstats.geometry.matrices import Matrices
 from geomstats.test.test_case import TestCase
 from geomstats.test.vectorization import generate_vectorization_data
-from geomstats.test_cases.geometry.base import VectorSpaceTestCase
+from geomstats.test_cases.geometry.base import MatrixVectorSpaceTestCase
 from geomstats.test_cases.geometry.euclidean import EuclideanMetricTestCase
 
 
@@ -355,7 +355,7 @@ class MatrixOperationsTestCase(TestCase):
         self._test_vectorization(vec_data)
 
 
-class MatricesTestCase(VectorSpaceTestCase):
+class MatricesTestCase(MatrixVectorSpaceTestCase):
     @pytest.mark.random
     def test_reshape_after_flatten(self, n_points, atol):
         point = self.data_generator.random_point(n_points)

--- a/geomstats/test_cases/information_geometry/beta.py
+++ b/geomstats/test_cases/information_geometry/beta.py
@@ -39,7 +39,7 @@ def metric_matrix(base_point):
         ],
         axis=-1,
     )
-    return SymmetricMatrices.from_vector(vector)
+    return SymmetricMatrices.matrix_representation(vector)
 
 
 def christoffels(base_point):
@@ -63,8 +63,8 @@ def christoffels(base_point):
     c4, c5, c6 = coefficients(param_b, param_a)
     vector_0 = gs.stack([c1, c2, c3], axis=-1)
     vector_1 = gs.stack([c6, c5, c4], axis=-1)
-    gamma_0 = SymmetricMatrices.from_vector(vector_0)
-    gamma_1 = SymmetricMatrices.from_vector(vector_1)
+    gamma_0 = SymmetricMatrices.matrix_representation(vector_0)
+    gamma_1 = SymmetricMatrices.matrix_representation(vector_1)
 
     return gs.stack([gamma_0, gamma_1], axis=-3)
 

--- a/tests/tests_geomstats/test_geometry/data/base.py
+++ b/tests/tests_geomstats/test_geometry/data/base.py
@@ -4,12 +4,6 @@ from .mixins import ProjectionMixinsTestData
 
 
 class _VectorSpaceMixinsTestData(ProjectionMixinsTestData):
-    def basis_cardinality_test_data(self):
-        return None
-
-    def basis_belongs_test_data(self):
-        return self.generate_tests([dict()])
-
     def random_point_is_tangent_test_data(self):
         return self.generate_random_data()
 
@@ -18,14 +12,18 @@ class _VectorSpaceMixinsTestData(ProjectionMixinsTestData):
 
 
 class VectorSpaceTestData(_VectorSpaceMixinsTestData, ManifoldTestData):
-    pass
+    def basis_cardinality_test_data(self):
+        return None
+
+    def basis_belongs_test_data(self):
+        return self.generate_tests([dict()])
 
 
 class ComplexVectorSpaceTestData(_VectorSpaceMixinsTestData, ComplexManifoldTestData):
     pass
 
 
-class _MatrixVectorSpaceMixinsTestData:
+class MatrixVectorSpaceTestData(VectorSpaceTestData):
     def basis_representation_vec_test_data(self):
         return self.generate_vec_data()
 
@@ -45,13 +43,7 @@ class _MatrixVectorSpaceMixinsTestData:
         return self.generate_random_data()
 
 
-class MatrixVectorSpaceTestData(_MatrixVectorSpaceMixinsTestData, VectorSpaceTestData):
-    pass
-
-
-class ComplexMatrixVectorSpaceTestData(
-    _MatrixVectorSpaceMixinsTestData, ComplexVectorSpaceTestData
-):
+class ComplexMatrixVectorSpaceTestData(ComplexVectorSpaceTestData):
     pass
 
 

--- a/tests/tests_geomstats/test_geometry/data/base.py
+++ b/tests/tests_geomstats/test_geometry/data/base.py
@@ -1,5 +1,3 @@
-from geomstats.test.data import TestData
-
 from .complex_manifold import ComplexManifoldTestData
 from .manifold import ManifoldTestData
 from .mixins import ProjectionMixinsTestData
@@ -27,27 +25,34 @@ class ComplexVectorSpaceTestData(_VectorSpaceMixinsTestData, ComplexManifoldTest
     pass
 
 
-class MatrixVectorSpaceMixinsTestData(TestData):
-    def to_vector_vec_test_data(self):
+class _MatrixVectorSpaceMixinsTestData:
+    def basis_representation_vec_test_data(self):
         return self.generate_vec_data()
 
-    def to_vector_and_basis_test_data(self):
+    def basis_representation_and_basis_test_data(self):
         return self.generate_random_data()
 
-    def from_vector_vec_test_data(self):
+    def matrix_representation_vec_test_data(self):
         return self.generate_vec_data()
 
-    def from_vector_belongs_test_data(self):
+    def matrix_representation_belongs_test_data(self):
         return self.generate_random_data()
 
-    def from_vector_after_to_vector_test_data(self):
+    def matrix_representation_after_basis_representation_test_data(self):
         return self.generate_random_data()
 
-    def to_vector_after_from_vector_test_data(self):
+    def basis_representation_after_matrix_representation_test_data(self):
         return self.generate_random_data()
 
 
-ComplexMatrixVectorSpaceMixinsTestData = MatrixVectorSpaceMixinsTestData
+class MatrixVectorSpaceTestData(_MatrixVectorSpaceMixinsTestData, VectorSpaceTestData):
+    pass
+
+
+class ComplexMatrixVectorSpaceTestData(
+    _MatrixVectorSpaceMixinsTestData, ComplexVectorSpaceTestData
+):
+    pass
 
 
 class LevelSetTestData(ProjectionMixinsTestData, ManifoldTestData):

--- a/tests/tests_geomstats/test_geometry/data/hermitian_matrices.py
+++ b/tests/tests_geomstats/test_geometry/data/hermitian_matrices.py
@@ -1,12 +1,10 @@
 import geomstats.backend as gs
 from geomstats.test.data import TestData
 
-from .base import ComplexVectorSpaceTestData, MatrixVectorSpaceMixinsTestData
+from .base import ComplexMatrixVectorSpaceTestData
 
 
-class HermitianMatricesTestData(
-    MatrixVectorSpaceMixinsTestData, ComplexVectorSpaceTestData
-):
+class HermitianMatricesTestData(ComplexMatrixVectorSpaceTestData):
     pass
 
 
@@ -26,10 +24,10 @@ class HermitianMatrices2TestData(TestData):
 
 
 class HermitianMatrices3TestData(TestData):
-    def to_vector_test_data(self):
+    def basis_representation_test_data(self):
         data = [
             dict(
-                point=gs.array(
+                matrix_representation=gs.array(
                     [[1.0, 2.0, 3.0 + 1.0j], [2.0, 4.0, 5.0], [3.0 - 1.0j, 5.0, 6.0]]
                 ),
                 expected=gs.array([1.0, 4.0, 6.0, 2.0, 3.0, 5.0, 0.0, 1.0, 0.0]),
@@ -37,10 +35,12 @@ class HermitianMatrices3TestData(TestData):
         ]
         return self.generate_tests(data)
 
-    def from_vector_test_data(self):
+    def matrix_representation_test_data(self):
         data = [
             dict(
-                vec=gs.array([1.0, 4.0, 6.0, 2.0, 3.0, 5.0, 0.0, 1.0, 0.0]),
+                basis_representation=gs.array(
+                    [1.0, 4.0, 6.0, 2.0, 3.0, 5.0, 0.0, 1.0, 0.0]
+                ),
                 expected=gs.array(
                     [[1.0, 2.0, 3.0 + 1j], [2.0, 4.0, 5.0], [3.0 - 1j, 5.0, 6.0]]
                 ),

--- a/tests/tests_geomstats/test_geometry/data/hermitian_matrices.py
+++ b/tests/tests_geomstats/test_geometry/data/hermitian_matrices.py
@@ -21,29 +21,3 @@ class HermitianMatrices2TestData(TestData):
             ),
         ]
         return self.generate_tests(data)
-
-
-class HermitianMatrices3TestData(TestData):
-    def basis_representation_test_data(self):
-        data = [
-            dict(
-                matrix_representation=gs.array(
-                    [[1.0, 2.0, 3.0 + 1.0j], [2.0, 4.0, 5.0], [3.0 - 1.0j, 5.0, 6.0]]
-                ),
-                expected=gs.array([1.0, 4.0, 6.0, 2.0, 3.0, 5.0, 0.0, 1.0, 0.0]),
-            ),
-        ]
-        return self.generate_tests(data)
-
-    def matrix_representation_test_data(self):
-        data = [
-            dict(
-                basis_representation=gs.array(
-                    [1.0, 4.0, 6.0, 2.0, 3.0, 5.0, 0.0, 1.0, 0.0]
-                ),
-                expected=gs.array(
-                    [[1.0, 2.0, 3.0 + 1j], [2.0, 4.0, 5.0], [3.0 - 1j, 5.0, 6.0]]
-                ),
-            ),
-        ]
-        return self.generate_tests(data)

--- a/tests/tests_geomstats/test_geometry/data/lie_algebra.py
+++ b/tests/tests_geomstats/test_geometry/data/lie_algebra.py
@@ -1,9 +1,9 @@
 import random
 
-from .base import VectorSpaceTestData
+from .base import MatrixVectorSpaceTestData
 
 
-class MatrixLieAlgebraTestData(VectorSpaceTestData):
+class MatrixLieAlgebraTestData(MatrixVectorSpaceTestData):
     def baker_campbell_hausdorff_vec_test_data(self):
         order = [2] + random.sample(range(3, 10), 1)
         data = []
@@ -13,21 +13,3 @@ class MatrixLieAlgebraTestData(VectorSpaceTestData):
             )
 
         return self.generate_tests(data)
-
-    def basis_representation_vec_test_data(self):
-        return self.generate_vec_data()
-
-    def basis_representation_and_basis_test_data(self):
-        return self.generate_random_data()
-
-    def matrix_representation_vec_test_data(self):
-        return self.generate_vec_data()
-
-    def matrix_representation_belongs_test_data(self):
-        return self.generate_random_data()
-
-    def matrix_representation_after_basis_representation_test_data(self):
-        return self.generate_random_data()
-
-    def basis_representation_after_matrix_representation_test_data(self):
-        return self.generate_random_data()

--- a/tests/tests_geomstats/test_geometry/data/lower_triangular_matrices.py
+++ b/tests/tests_geomstats/test_geometry/data/lower_triangular_matrices.py
@@ -1,12 +1,10 @@
 import geomstats.backend as gs
 from geomstats.test.data import TestData
 
-from .base import MatrixVectorSpaceMixinsTestData, VectorSpaceTestData
+from .base import MatrixVectorSpaceTestData
 
 
-class LowerTriangularMatricesTestData(
-    MatrixVectorSpaceMixinsTestData, VectorSpaceTestData
-):
+class LowerTriangularMatricesTestData(MatrixVectorSpaceTestData):
     pass
 
 
@@ -76,10 +74,12 @@ class LowerTriangularMatrices3TestData(TestData):
         ]
         return self.generate_tests(data)
 
-    def to_vector_test_data(self):
+    def basis_representation_test_data(self):
         data = [
             dict(
-                point=gs.array([[1.0, 0.0, 0.0], [0.6, 7.0, 0.0], [-3.0, 0.0, 8.0]]),
+                matrix_representation=gs.array(
+                    [[1.0, 0.0, 0.0], [0.6, 7.0, 0.0], [-3.0, 0.0, 8.0]]
+                ),
                 expected=gs.array([1.0, 0.6, 7.0, -3.0, 0.0, 8.0]),
             ),
         ]

--- a/tests/tests_geomstats/test_geometry/data/matrices.py
+++ b/tests/tests_geomstats/test_geometry/data/matrices.py
@@ -3,7 +3,7 @@ import math
 import geomstats.backend as gs
 from geomstats.test.data import TestData
 
-from .base import VectorSpaceTestData
+from .base import MatrixVectorSpaceTestData
 from .riemannian_metric import RiemannianMetricTestData
 
 
@@ -224,7 +224,7 @@ class MatrixOperationsSmokeTestData(TestData):
         return self.generate_tests(smoke_data)
 
 
-class MatricesTestData(VectorSpaceTestData):
+class MatricesTestData(MatrixVectorSpaceTestData):
     def reshape_after_flatten_test_data(self):
         return self.generate_random_data()
 

--- a/tests/tests_geomstats/test_geometry/data/symmetric_matrices.py
+++ b/tests/tests_geomstats/test_geometry/data/symmetric_matrices.py
@@ -1,10 +1,10 @@
 import geomstats.backend as gs
 from geomstats.test.data import TestData
 
-from .base import MatrixVectorSpaceMixinsTestData, VectorSpaceTestData
+from .base import MatrixVectorSpaceTestData
 
 
-class SymmetricMatricesTestData(MatrixVectorSpaceMixinsTestData, VectorSpaceTestData):
+class SymmetricMatricesTestData(MatrixVectorSpaceTestData):
     pass
 
 
@@ -15,14 +15,14 @@ class SymmetricMatrices1TestData(TestData):
         ]
         return self.generate_tests(smoke_data)
 
-    def to_vector_test_data(self):
-        data = [dict(point=gs.array([[1.0]]), expected=gs.array([1.0]))]
+    def basis_representation_test_data(self):
+        data = [dict(matrix_representation=gs.array([[1.0]]), expected=gs.array([1.0]))]
 
         return self.generate_tests(data)
 
-    def from_vector_test_data(self):
+    def matrix_representation_test_data(self):
         data = [
-            dict(vec=gs.array([1.0]), expected=gs.array([[1.0]])),
+            dict(basis_representation=gs.array([1.0]), expected=gs.array([[1.0]])),
         ]
 
         return self.generate_tests(data)
@@ -67,19 +67,21 @@ class SymmetricMatrices3TestData(TestData):
 
         return self.generate_tests(data)
 
-    def to_vector_test_data(self):
+    def basis_representation_test_data(self):
         data = [
             dict(
-                point=gs.array([[1.0, 2.0, 3.0], [2.0, 4.0, 5.0], [3.0, 5.0, 6.0]]),
+                matrix_representation=gs.array(
+                    [[1.0, 2.0, 3.0], [2.0, 4.0, 5.0], [3.0, 5.0, 6.0]]
+                ),
                 expected=gs.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]),
             ),
         ]
         return self.generate_tests(data)
 
-    def from_vector_test_data(self):
+    def matrix_representation_test_data(self):
         data = [
             dict(
-                vec=gs.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]),
+                basis_representation=gs.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]),
                 expected=gs.array([[1.0, 2.0, 3.0], [2.0, 4.0, 5.0], [3.0, 5.0, 6.0]]),
             ),
         ]

--- a/tests/tests_geomstats/test_geometry/test_complex_matrices.py
+++ b/tests/tests_geomstats/test_geometry/test_complex_matrices.py
@@ -7,7 +7,7 @@ from geomstats.test.parametrizers import DataBasedParametrizer
 from geomstats.test_cases.geometry.complex_matrices import ComplexMatricesTestCase
 from geomstats.test_cases.geometry.hermitian import HermitianMetricTestCase
 
-from .data.base import ComplexVectorSpaceTestData
+from .data.base import ComplexMatrixVectorSpaceTestData
 from .data.complex_matrices import (
     ComplexMatrices33TestData,
     ComplexMatricesMetricTestData,
@@ -28,7 +28,7 @@ def spaces(request):
 
 @pytest.mark.usefixtures("spaces")
 class TestComplexMatrices(ComplexMatricesTestCase, metaclass=DataBasedParametrizer):
-    testing_data = ComplexVectorSpaceTestData()
+    testing_data = ComplexMatrixVectorSpaceTestData()
 
 
 @pytest.mark.smoke

--- a/tests/tests_geomstats/test_geometry/test_hermitian_matrices.py
+++ b/tests/tests_geomstats/test_geometry/test_hermitian_matrices.py
@@ -4,10 +4,7 @@ import pytest
 
 from geomstats.geometry.hermitian_matrices import HermitianMatrices
 from geomstats.test.parametrizers import DataBasedParametrizer
-from geomstats.test_cases.geometry.base import (
-    ComplexVectorSpaceTestCase,
-    MatrixVectorSpaceTestCaseMixins,
-)
+from geomstats.test_cases.geometry.base import ComplexMatrixVectorSpaceTestCase
 from geomstats.test_cases.geometry.hermitian import HermitianMetricTestCase
 
 from .data.complex_matrices import ComplexMatricesMetricTestData
@@ -31,8 +28,7 @@ def spaces(request):
 
 @pytest.mark.usefixtures("spaces")
 class TestHermitianMatrices(
-    MatrixVectorSpaceTestCaseMixins,
-    ComplexVectorSpaceTestCase,
+    ComplexMatrixVectorSpaceTestCase,
     metaclass=DataBasedParametrizer,
 ):
     testing_data = HermitianMatricesTestData()
@@ -40,7 +36,7 @@ class TestHermitianMatrices(
 
 @pytest.mark.smoke
 class TestHermitianMatrices2(
-    ComplexVectorSpaceTestCase, metaclass=DataBasedParametrizer
+    ComplexMatrixVectorSpaceTestCase, metaclass=DataBasedParametrizer
 ):
     space = HermitianMatrices(n=2, equip=False)
     testing_data = HermitianMatrices2TestData()
@@ -48,8 +44,7 @@ class TestHermitianMatrices2(
 
 @pytest.mark.smoke
 class TestHermitianMatrices3(
-    MatrixVectorSpaceTestCaseMixins,
-    ComplexVectorSpaceTestCase,
+    ComplexMatrixVectorSpaceTestCase,
     metaclass=DataBasedParametrizer,
 ):
     space = HermitianMatrices(n=3, equip=False)

--- a/tests/tests_geomstats/test_geometry/test_hermitian_matrices.py
+++ b/tests/tests_geomstats/test_geometry/test_hermitian_matrices.py
@@ -10,7 +10,6 @@ from geomstats.test_cases.geometry.hermitian import HermitianMetricTestCase
 from .data.complex_matrices import ComplexMatricesMetricTestData
 from .data.hermitian_matrices import (
     HermitianMatrices2TestData,
-    HermitianMatrices3TestData,
     HermitianMatricesTestData,
 )
 
@@ -40,15 +39,6 @@ class TestHermitianMatrices2(
 ):
     space = HermitianMatrices(n=2, equip=False)
     testing_data = HermitianMatrices2TestData()
-
-
-@pytest.mark.smoke
-class TestHermitianMatrices3(
-    ComplexMatrixVectorSpaceTestCase,
-    metaclass=DataBasedParametrizer,
-):
-    space = HermitianMatrices(n=3, equip=False)
-    testing_data = HermitianMatrices3TestData()
 
 
 @pytest.mark.redundant

--- a/tests/tests_geomstats/test_geometry/test_lower_triangular_matrices.py
+++ b/tests/tests_geomstats/test_geometry/test_lower_triangular_matrices.py
@@ -4,10 +4,7 @@ import pytest
 
 from geomstats.geometry.lower_triangular_matrices import LowerTriangularMatrices
 from geomstats.test.parametrizers import DataBasedParametrizer
-from geomstats.test_cases.geometry.base import (
-    MatrixVectorSpaceTestCaseMixins,
-    VectorSpaceTestCase,
-)
+from geomstats.test_cases.geometry.base import MatrixVectorSpaceTestCase
 from geomstats.test_cases.geometry.matrices import MatricesMetricTestCase
 
 from .data.lower_triangular_matrices import (
@@ -31,8 +28,7 @@ def spaces(request):
 
 @pytest.mark.usefixtures("spaces")
 class TestLowerTriangularMatrices(
-    MatrixVectorSpaceTestCaseMixins,
-    VectorSpaceTestCase,
+    MatrixVectorSpaceTestCase,
     metaclass=DataBasedParametrizer,
 ):
     testing_data = LowerTriangularMatricesTestData()
@@ -40,8 +36,7 @@ class TestLowerTriangularMatrices(
 
 @pytest.mark.smoke
 class TestLowerTriangularMatrices2(
-    MatrixVectorSpaceTestCaseMixins,
-    VectorSpaceTestCase,
+    MatrixVectorSpaceTestCase,
     metaclass=DataBasedParametrizer,
 ):
     space = LowerTriangularMatrices(n=2)
@@ -50,8 +45,7 @@ class TestLowerTriangularMatrices2(
 
 @pytest.mark.smoke
 class TestLowerTriangularMatrices3(
-    MatrixVectorSpaceTestCaseMixins,
-    VectorSpaceTestCase,
+    MatrixVectorSpaceTestCase,
     metaclass=DataBasedParametrizer,
 ):
     space = LowerTriangularMatrices(n=3)

--- a/tests/tests_geomstats/test_geometry/test_symmetric_matrices.py
+++ b/tests/tests_geomstats/test_geometry/test_symmetric_matrices.py
@@ -4,10 +4,7 @@ import pytest
 
 from geomstats.geometry.symmetric_matrices import SymmetricMatrices
 from geomstats.test.parametrizers import DataBasedParametrizer
-from geomstats.test_cases.geometry.base import (
-    MatrixVectorSpaceTestCaseMixins,
-    VectorSpaceTestCase,
-)
+from geomstats.test_cases.geometry.base import MatrixVectorSpaceTestCase
 from geomstats.test_cases.geometry.matrices import MatricesMetricTestCase
 
 from .data.matrices import MatricesMetricTestData
@@ -32,8 +29,7 @@ def spaces(request):
 
 @pytest.mark.usefixtures("spaces")
 class TestSymmetricMatrices(
-    MatrixVectorSpaceTestCaseMixins,
-    VectorSpaceTestCase,
+    MatrixVectorSpaceTestCase,
     metaclass=DataBasedParametrizer,
 ):
     testing_data = SymmetricMatricesTestData()
@@ -41,8 +37,7 @@ class TestSymmetricMatrices(
 
 @pytest.mark.smoke
 class TestSymmetricMatrices1(
-    MatrixVectorSpaceTestCaseMixins,
-    VectorSpaceTestCase,
+    MatrixVectorSpaceTestCase,
     metaclass=DataBasedParametrizer,
 ):
     space = SymmetricMatrices(n=1, equip=False)
@@ -50,15 +45,16 @@ class TestSymmetricMatrices1(
 
 
 @pytest.mark.smoke
-class TestSymmetricMatrices2(VectorSpaceTestCase, metaclass=DataBasedParametrizer):
+class TestSymmetricMatrices2(
+    MatrixVectorSpaceTestCase, metaclass=DataBasedParametrizer
+):
     space = SymmetricMatrices(n=2, equip=False)
     testing_data = SymmetricMatrices2TestData()
 
 
 @pytest.mark.smoke
 class TestSymmetricMatrices3(
-    MatrixVectorSpaceTestCaseMixins,
-    VectorSpaceTestCase,
+    MatrixVectorSpaceTestCase,
     metaclass=DataBasedParametrizer,
 ):
     space = SymmetricMatrices(n=3, equip=False)


### PR DESCRIPTION
Following discussions in #1907, this PR add the `MatrixVectorSpace` abstraction. This abstraction inherits from `VectorSpace` and requires the definition of `basis_representation` and `matrix_representation`, previously defined in `MatrixLieAlgebra`.

With this abstraction, `MatrixLieAlgebra` only implements the bracket and BCH formula. On the other hand, `from_vector` and `to_vector` in several children of `MatrixVectorSpace` were renamed to `matrix_representation` and `basis_representation`, respectively.

A similar change in structure was done for `ComplexManifold`. Additionaly, I've decided to remove `basis` from `ComplexVectorSpace` and `ComplexMatrixVectorSpace` because it is ambiguous and is not used anywhere (we clearly need to define how to get the basis for these spaces in case of need; I suggest to wait for a use case).