### PR TITLE
set create_graph to True in `pytorch` jacobian and hessian computations to align with behaviors in `autograd` backend

### DIFF
--- a/geomstats/_backend/pytorch/autodiff.py
+++ b/geomstats/_backend/pytorch/autodiff.py
@@ -82,7 +82,7 @@ def jacobian(func):
     """
 
     def _jacobian(point):
-        return _torch_jacobian(func=lambda x: func(x), inputs=point)
+        return _torch_jacobian(func=lambda x: func(x), inputs=point, create_graph=True)
 
     return _jacobian
 
@@ -121,10 +121,10 @@ def jacobian_vec(func, point_ndim=1):
 
     def _jacobian(point):
         if point.ndim == point_ndim:
-            return _torch_jacobian(func=lambda x: func(x), inputs=point)
+            return _torch_jacobian(func=lambda x: func(x), inputs=point, create_graph=True)
         return _torch.stack(
             [
-                _torch_jacobian(func=lambda x: func(x), inputs=one_point)
+                _torch_jacobian(func=lambda x: func(x), inputs=one_point, create_graph=True)
                 for one_point in point
             ],
             axis=0,
@@ -151,7 +151,7 @@ def hessian(func, func_out_ndim=0):
     """
 
     def _hessian(point):
-        return _torch_hessian(func=lambda x: func(x), inputs=point, strict=True)
+        return _torch_hessian(func=lambda x: func(x), inputs=point, strict=True, create_graph=True)
 
     def _hessian_vector_valued(point):
         def scalar_func(point, a):

--- a/geomstats/_backend/pytorch/autodiff.py
+++ b/geomstats/_backend/pytorch/autodiff.py
@@ -121,10 +121,14 @@ def jacobian_vec(func, point_ndim=1):
 
     def _jacobian(point):
         if point.ndim == point_ndim:
-            return _torch_jacobian(func=lambda x: func(x), inputs=point, create_graph=True)
+            return _torch_jacobian(
+                func=lambda x: func(x), inputs=point, create_graph=True
+            )
         return _torch.stack(
             [
-                _torch_jacobian(func=lambda x: func(x), inputs=one_point, create_graph=True)
+                _torch_jacobian(
+                    func=lambda x: func(x), inputs=one_point, create_graph=True
+                )
                 for one_point in point
             ],
             axis=0,
@@ -151,7 +155,9 @@ def hessian(func, func_out_ndim=0):
     """
 
     def _hessian(point):
-        return _torch_hessian(func=lambda x: func(x), inputs=point, strict=True, create_graph=True)
+        return _torch_hessian(
+            func=lambda x: func(x), inputs=point, strict=True, create_graph=True
+        )
 
     def _hessian_vector_valued(point):
         def scalar_func(point, a):


### PR DESCRIPTION
By default, pytorch turns off the `create_graph` flag for runtime and memory concerns in its jacobian and hessian computations. However, this means we are not able to continue differentiate through the jacobian (see [Bug: Jacobian of Jacobian in pytorch produces null matrices #1801](https://github.com/geomstats/geomstats/issues/1801)) and may incur incorrect computations in geometric quantities such as Riemann tensor (see [Bug: Incorrect (3, 1) Riemann Tensor computation in PyTorch backend due to PyTorch autodiff jacobian create_graph being turned off #1928](https://github.com/geomstats/geomstats/issues/1928))

This PR merely sets the `create_graph` to True by default for simplicifty, potentially at the cost of runtime and memory. But with this we are able to fully align with the behaviors in `autograd` backend. 

<!--
Thank you for opening this pull request!
-->

