### PR TITLE
Fix and clean value_and_grad

### DIFF
--- a/geomstats/_backend/autograd/autodiff.py
+++ b/geomstats/_backend/autograd/autodiff.py
@@ -5,6 +5,56 @@ import autograd.numpy as _np
 from autograd import jacobian
 
 
+def _get_max_ndim_point(*points):
+    """Identify point with higher dimension.
+
+    Same as `geomstats.vectorization._get_max_ndim_point`.
+
+    Parameters
+    ----------
+    points : array-like
+
+    Returns
+    -------
+    max_ndim_point : array-like
+        Point with higher dimension.
+    """
+    max_ndim_point = points[0]
+    for point in points[1:]:
+        if point.ndim > max_ndim_point.ndim:
+            max_ndim_point = point
+
+    return max_ndim_point
+
+
+def _get_batch_shape(*points, point_ndims=1):
+    """Get batch shape.
+
+    Similar to `geomstats.vectorization.get_batch_shape`.
+
+    Parameters
+    ----------
+    points : array-like or None
+        Point belonging to the space.
+    point_ndims : int or tuple[int]
+        Point number of array dimensions.
+
+    Returns
+    -------
+    batch_shape : tuple
+        Returns the shape related with batch. () if only one point.
+    """
+    if isinstance(point_ndims, int):
+        point_max_ndim = _get_max_ndim_point(*points)
+        return point_max_ndim.shape[:-point_ndims]
+
+    for point, point_ndim in zip(points, point_ndims):
+        if point.ndim > point_ndim:
+            return point.shape[:-point_ndim]
+
+    return ()
+
+
 def custom_gradient(*grad_funcs):
     """Create a decorator that allows a function to define its custom gradient(s).
 
@@ -93,16 +143,20 @@ def _elementwise_value_and_grad(fun, x):
     return ans, vjp(_autograd.differential_operators.vspace(ans).ones())
 
 
-def value_and_grad(func, argnums=0, to_numpy=False):
+def value_and_grad(func, argnums=0, point_ndims=1):
     """Wrap autograd value_and_grad function.
+
+    Suitable for use in scipy.optimize.
 
     Parameters
     ----------
     func : callable
         Function whose value and gradient values
         will be computed.
-    to_numpy : bool
-        Unused. Here for API consistency.
+    argnums: int or tuple[int]
+        Specifies arguments to compute gradients with respect to.
+    point_ndims: int or tuple[int]
+        Specifies arguments ndim.
 
     Returns
     -------
@@ -111,10 +165,27 @@ def value_and_grad(func, argnums=0, to_numpy=False):
         func's gradients' values at its inputs args.
     """
 
-    def _value_and_grad(*x, **kwargs):
-        if not hasattr(x[0], "ndim") or x[0].ndim < 2:
-            return _autograd.value_and_grad(func, argnum=argnums)(*x, **kwargs)
-        return _elementwise_value_and_grad(func, argnum=argnums)(*x, **kwargs)
+    def _value_and_grad(*inputs, **kwargs):
+        batch_shape = _get_batch_shape(*inputs, point_ndims=point_ndims)
+        if len(batch_shape) == 0:
+            return _autograd.value_and_grad(func, argnum=argnums)(*inputs, **kwargs)
+
+        if len(inputs) > 1:
+            point_ndims_ = (
+                (point_ndims,) * len(inputs)
+                if isinstance(point_ndims, int)
+                else point_ndims
+            )
+            inputs_ = []
+            for point, point_ndim in zip(inputs, point_ndims_):
+                if point.shape[:-point_ndim] != batch_shape:
+                    point = _autograd.numpy.broadcast_to(
+                        point, batch_shape + point.shape
+                    )
+                inputs_.append(point)
+            inputs = inputs_
+
+        return _elementwise_value_and_grad(func, argnum=argnums)(*inputs, **kwargs)
 
     return _value_and_grad
 

--- a/geomstats/_backend/pytorch/autodiff.py
+++ b/geomstats/_backend/pytorch/autodiff.py
@@ -2,10 +2,59 @@
 
 import functools
 
-import numpy as _np
 import torch as _torch
 from torch.autograd.functional import hessian as _torch_hessian
 from torch.autograd.functional import jacobian as _torch_jacobian
+
+
+def _get_max_ndim_point(*points):
+    """Identify point with higher dimension.
+
+    Same as `geomstats.vectorization._get_max_ndim_point`.
+
+    Parameters
+    ----------
+    points : array-like
+
+    Returns
+    -------
+    max_ndim_point : array-like
+        Point with higher dimension.
+    """
+    max_ndim_point = points[0]
+    for point in points[1:]:
+        if point.ndim > max_ndim_point.ndim:
+            max_ndim_point = point
+
+    return max_ndim_point
+
+
+def _get_batch_shape(*points, point_ndims=1):
+    """Get batch shape.
+
+    Similar to `geomstats.vectorization.get_batch_shape`.
+
+    Parameters
+    ----------
+    points : array-like or None
+        Point belonging to the space.
+    point_ndims : int or tuple[int]
+        Point number of array dimensions.
+
+    Returns
+    -------
+    batch_shape : tuple
+        Returns the shape related with batch. () if only one point.
+    """
+    if isinstance(point_ndims, int):
+        point_max_ndim = _get_max_ndim_point(*points)
+        return point_max_ndim.shape[:-point_ndims]
+
+    for point, point_ndim in zip(points, point_ndims):
+        if point.ndim > point_ndim:
+            return point.shape[:-point_ndim]
+
+    return ()
 
 
 def custom_gradient(*grad_funcs):
@@ -37,29 +86,33 @@ def custom_gradient(*grad_funcs):
             Function func with gradients specified by grad_funcs.
         """
 
-        class func_with_grad(_torch.autograd.Function):
+        class FuncWithGrad(_torch.autograd.Function):
             """Wrapper class for a function with custom grad."""
 
             @staticmethod
-            def forward(ctx, *args):
+            def forward(ctx, *args, **kwargs):
                 ctx.save_for_backward(*args)
-                return func(*args)
+                return func(*args, **kwargs)
 
             @staticmethod
             def backward(ctx, grad_output):
                 inputs = ctx.saved_tensors
 
-                grads = ()
-                for custom_grad in grad_funcs:
-                    grads = (*grads, grad_output * custom_grad(*inputs))
+                if grad_output.ndim > 0:
+                    return tuple(
+                        _torch.einsum("n,n...->n...", grad_output, custom_grad(*inputs))
+                        if input_.requires_grad
+                        else None
+                        for input_, custom_grad in zip(inputs, grad_funcs)
+                    )
 
-                if len(grads) == 1:
-                    return grads[0]
-                return grads
+                return tuple(
+                    grad_output * custom_grad(*inputs) if input_.requires_grad else None
+                    for input_, custom_grad in zip(inputs, grad_funcs)
+                )
 
         def wrapped_function(*args, **kwargs):
-            new_inputs = args + tuple(kwargs.values())
-            return func_with_grad.apply(*new_inputs)
+            return FuncWithGrad.apply(*args, **kwargs)
 
         return wrapped_function
 
@@ -243,20 +296,20 @@ def jacobian_and_hessian(func, func_out_ndim=0):
     return _jacobian_and_hessian
 
 
-def value_and_grad(func, argnums=0, to_numpy=False):
+def value_and_grad(func, argnums=0, point_ndims=1):
     """Return a function that returns func's value and gradients' values.
 
-    Suitable for use in scipy.optimize with to_numpy=True.
+    Suitable for use in scipy.optimize.
 
     Parameters
     ----------
     func : callable
         Function whose value and gradient values
         will be computed. It must be real-valued.
-    to_numpy : bool
-        Determines if the outputs value and grad will be cast
-        to numpy arrays. Set to "True" when using scipy.optimize.
-        Optional, default: False.
+    argnums: int or tuple[int]
+        Specifies arguments to compute gradients with respect to.
+    point_ndims: int or tuple[int]
+        Specifies arguments ndim.
 
     Returns
     -------
@@ -264,60 +317,61 @@ def value_and_grad(func, argnums=0, to_numpy=False):
         Function that returns func's value and
         func's gradients' values at its inputs args.
     """
-    if isinstance(argnums, int):
-        argnums = (argnums,)
+    argnums_ = (argnums,) if isinstance(argnums, int) else argnums
 
-    def func_with_grad(*args, **kwargs):
+    def func_with_grad(*inputs, **kwargs):
         """Return func's value and func's gradients' values at args.
 
         Parameters
         ----------
-        args : list
-            Argument to function func and its gradients.
+        inputs : array-like, shape=[..., *point_shape]
         kwargs : dict
             Keyword arguments to function func and its gradients.
 
         Returns
         -------
-        value : any
-            Value of func at input arguments args.
-        all_grads : list or any
-            Values of func's gradients at input arguments args.
+        value : array-like, shape=[...,]
+            Image of func at point.
+        grad : array-like or tuple[array-like], shape=[..., *point_shape]
+            Gradient of func at required points.
         """
-        new_args = []
-        for i_arg, one_arg in enumerate(args):
-            if isinstance(one_arg, float):
-                one_arg = _torch.from_numpy(_np.array(one_arg))
-            if isinstance(one_arg, _np.ndarray):
-                one_arg = _torch.from_numpy(one_arg)
+        batch_shape = _get_batch_shape(*inputs, point_ndims=point_ndims)
 
-            requires_grad = i_arg in argnums
-            one_arg = one_arg.detach().requires_grad_(requires_grad)
-            new_args.append(one_arg)
+        if len(inputs) > 1:
+            point_ndims_ = (
+                (point_ndims,) * len(inputs)
+                if isinstance(point_ndims, int)
+                else point_ndims
+            )
+            inputs_ = []
+            for point, point_ndim in zip(inputs, point_ndims_):
+                if point.shape[:-point_ndim] != batch_shape:
+                    point = _torch.broadcast_to(point, batch_shape + point.shape)
+                inputs_.append(point)
+            inputs = inputs_
 
-        value = func(*new_args, **kwargs)
-        value = value.requires_grad_(True)
+        inputs_ = []
+        for index, point in enumerate(inputs):
+            if index in argnums_ and not point.requires_grad:
+                point = point.detach().requires_grad_(True)
+            inputs_.append(point)
+        inputs = inputs_
+        value = func(*inputs, **kwargs).requires_grad_(True)
 
         if value.ndim > 0:
-            sum_value = value.sum()
+            sum_value = value.sum(axis=-1)
             sum_value.backward()
         else:
             value.backward()
 
-        all_grads = []
-        for i_arg, one_arg in enumerate(new_args):
-            if i_arg in argnums:
-                all_grads.append(
-                    one_arg.grad,
-                )
-
-        if to_numpy:
-            value = value.detach().numpy()
-            all_grads = [one_grad.detach().numpy() for one_grad in all_grads]
-
-        if len(new_args) == 1:
-            return value, all_grads[0]
-        return value, tuple(all_grads)
+        grads = tuple(
+            point.grad.detach()
+            for index, point in enumerate(inputs)
+            if point.requires_grad and index in argnums_
+        )
+        if isinstance(argnums, int):
+            grads = grads[0]
+        return value.detach(), grads
 
     return func_with_grad
 

--- a/geomstats/geometry/discrete_surfaces.py
+++ b/geomstats/geometry/discrete_surfaces.py
@@ -1150,12 +1150,16 @@ class _ExpSolver:
                 return space.metric.squared_norm(next_to_next_next, base_point)
 
             _, energy_1 = gs.autodiff.value_and_grad(
-                _inner_product_with_current_to_next
+                _inner_product_with_current_to_next,
+                point_ndims=2,
             )(zeros)
             _, energy_2 = gs.autodiff.value_and_grad(
-                _inner_product_with_next_to_next_next
+                _inner_product_with_next_to_next_next,
+                point_ndims=2,
             )(zeros)
-            _, energy_3 = gs.autodiff.value_and_grad(_norm)(next_point_clone)
+            _, energy_3 = gs.autodiff.value_and_grad(_norm, point_ndims=2)(
+                next_point_clone
+            )
 
             energy_tot = 2 * energy_1 - 2 * energy_2 + energy_3
             return gs.sum(energy_tot**2)

--- a/geomstats/geometry/fiber_bundle.py
+++ b/geomstats/geometry/fiber_bundle.py
@@ -175,12 +175,11 @@ class FiberBundle(ABC):
             lambda param: gs.sum(
                 self.total_space.metric.squared_dist(wrap(param), base_point)
             ),
-            to_numpy=True,
         )
 
         tangent_vec = gs.flatten(gs.random.rand(*max_shape))
         res = minimize(
-            objective_with_grad,
+            lambda x: objective_with_grad(gs.from_numpy(x)),
             tangent_vec,
             method="L-BFGS-B",
             jac=True,

--- a/geomstats/geometry/sub_riemannian_metric.py
+++ b/geomstats/geometry/sub_riemannian_metric.py
@@ -183,7 +183,7 @@ class SubRiemannianMetric:
             The symplectic gradient of the Hamiltonian.
         """
         value_and_grad = gs.autodiff.value_and_grad(
-            lambda state: hamiltonian(state),
+            hamiltonian,
             point_ndims=2,
         )
 

--- a/geomstats/geometry/sub_riemannian_metric.py
+++ b/geomstats/geometry/sub_riemannian_metric.py
@@ -182,21 +182,14 @@ class SubRiemannianMetric:
         vector : array-like, shape=[, 2*dim]
             The symplectic gradient of the Hamiltonian.
         """
-
-        def H_sum(state):
-            """Sum each value of the Hamiltonian (relevant for vectorized input)."""
-            # TODO: nice trick to vectorize the gradient
-            return gs.sum(hamiltonian(state))
-
-        # TODO: vectorized grad
-        value_and_grad = gs.autodiff.value_and_grad(H_sum)
+        value_and_grad = gs.autodiff.value_and_grad(
+            lambda state: hamiltonian(state),
+            point_ndims=2,
+        )
 
         def vector(x):
             """Compute symplectic gradient at x."""
-            # TODO: update after add vectorized grad to backend
-            _, grad = value_and_grad(x)
-            h_q = grad[0]
-            h_p = grad[1]
+            _, (h_q, h_p) = value_and_grad(x)
             return gs.array([h_p, -h_q])
 
         return vector

--- a/geomstats/information_geometry/fisher_rao_metric.py
+++ b/geomstats/information_geometry/fisher_rao_metric.py
@@ -88,7 +88,7 @@ class FisherRaoMetric(RiemannianMetric):
             (
                 pdf_x_at_base_point,
                 pdf_x_derivative_at_base_point,
-            ) = gs.autodiff.value_and_grad(pdf_x, to_numpy=True)(base_point)
+            ) = gs.autodiff.value_and_grad(pdf_x)(base_point)
 
             return gs.einsum(
                 "...ij,...->...ij",

--- a/geomstats/learning/geodesic_regression.py
+++ b/geomstats/learning/geodesic_regression.py
@@ -42,11 +42,11 @@ class RiemannianGradientDescent:
         self.tol = tol
         self.jac = "autodiff"
 
-    def _handle_jac(self, fun):
+    def _handle_jac(self, fun, point_ndim):
         if self.jac == "autodiff":
 
             def fun_(x):
-                value, grad = gs.autodiff.value_and_grad(fun, to_numpy=False)(x)
+                value, grad = gs.autodiff.value_and_grad(fun, point_ndims=point_ndim)(x)
                 return value, grad
 
         else:
@@ -69,7 +69,7 @@ class RiemannianGradientDescent:
 
     def minimize(self, space, fun, x0):
         """Perform gradient descent."""
-        fun = self._handle_jac(fun)
+        fun = self._handle_jac(fun, point_ndim=space.point_ndim)
         vector_transport = self._get_vector_transport(space)
 
         lr = self.init_step_size

--- a/geomstats/numerics/optimizers.py
+++ b/geomstats/numerics/optimizers.py
@@ -48,9 +48,7 @@ class ScipyMinimize:
             jac = True
 
             def fun_(x):
-                value, grad = gs.autodiff.value_and_grad(fun, to_numpy=True)(
-                    gs.from_numpy(x)
-                )
+                value, grad = gs.autodiff.value_and_grad(fun)(gs.from_numpy(x))
                 return value, grad
 
         else:

--- a/geomstats/test_cases/backend/autodiff.py
+++ b/geomstats/test_cases/backend/autodiff.py
@@ -1,0 +1,156 @@
+import pytest
+
+import geomstats.backend as gs
+from geomstats.exceptions import AutodiffNotImplementedError
+from geomstats.test.test_case import TestCase
+from geomstats.test.vectorization import generate_vectorization_data
+
+
+class NumpyRaisesTestCase(TestCase):
+    def test_raises(self, autodiff_func):
+        with pytest.raises(AutodiffNotImplementedError):
+            autodiff_func(self.dummy_func)
+
+
+class AutodiffTestCase(TestCase):
+    def test_value_and_grad(
+        self,
+        func,
+        inputs,
+        expected_value,
+        expected_grad,
+        atol,
+        argnums=0,
+        point_ndims=1,
+    ):
+        value_and_grad = gs.autodiff.value_and_grad(
+            func, argnums=argnums, point_ndims=point_ndims
+        )
+        value, grad = value_and_grad(*inputs)
+        self.assertAllClose(value, expected_value, atol=atol)
+
+        if isinstance(argnums, int):
+            self.assertAllClose(grad, expected_grad, atol=atol)
+        else:
+            self.assertEqual(len(expected_grad), len(argnums))
+            for grad_, expected_grad_ in zip(grad, expected_grad):
+                self.assertAllClose(grad_, expected_grad_, atol=atol)
+
+    def _test_value_and_grad(
+        self,
+        func,
+        x,
+        expected_value,
+        expected_grad_x,
+        atol,
+        argnums=0,
+        point_ndims=1,
+        y=None,
+        expected_grad_y=None,
+    ):
+        """Auxiliar func for vectorization test."""
+        inputs = (x,) if y is None else (x, y)
+        if isinstance(argnums, int):
+            expected_grad = expected_grad_x if argnums == 0 else expected_grad_y
+        elif len(argnums) == 1:
+            argnum = argnums[0]
+            expected_grad = (expected_grad_x if argnum == 0 else expected_grad_y,)
+        else:
+            expected_grad = (expected_grad_x, expected_grad_y)
+
+        return self.test_value_and_grad(
+            func,
+            inputs,
+            expected_value,
+            expected_grad,
+            atol,
+            argnums=argnums,
+            point_ndims=point_ndims,
+        )
+
+    @pytest.mark.vec
+    def test_value_and_grad_vec(
+        self,
+        n_reps,
+        func,
+        input_shape_x,
+        atol,
+        argnums=0,
+        point_ndims=1,
+        input_shape_y=None,
+    ):
+        has_y = input_shape_y is not None
+
+        inputs = [gs.random.rand(*input_shape_x)]
+        if has_y:
+            inputs.append(gs.random.rand(*input_shape_y))
+
+        expected_value, expected_grad = gs.autodiff.value_and_grad(
+            func,
+            argnums=argnums,
+            point_ndims=point_ndims,
+        )(*inputs)
+
+        argnums_ = (argnums,) if isinstance(argnums, int) else argnums
+        expected_grad = (
+            (expected_grad,) if not isinstance(expected_grad, tuple) else expected_grad
+        )
+
+        arg_names = ["x"]
+        if has_y:
+            arg_names.append("y")
+        expected_names = ["expected_value"]
+
+        expected_grad_ = []
+        k = 0
+        map_index_varname = {0: "x", 1: "y"}
+        for index in range(2):
+            if index not in argnums_:
+                expected_grad_.append(None)
+                continue
+
+            expected_names.append(f"expected_grad_{map_index_varname[index]}")
+            expected_grad_.append(expected_grad[k])
+            k += 1
+
+        vec_data = generate_vectorization_data(
+            data=[
+                dict(
+                    func=func,
+                    x=inputs[0],
+                    y=inputs[1] if input_shape_y is not None else None,
+                    expected_value=expected_value,
+                    expected_grad_x=expected_grad_[0],
+                    expected_grad_y=expected_grad_[1],
+                    argnums=argnums,
+                    point_ndims=point_ndims,
+                    atol=atol,
+                )
+            ],
+            arg_names=arg_names,
+            expected_name=expected_names,
+            n_reps=n_reps,
+        )
+
+        self._test_vectorization(vec_data, test_fnc_name="_test_value_and_grad")
+
+
+class MetricDistGradTestCase(TestCase):
+    @pytest.mark.random
+    def test_value_and_grad_sdist(self, n_points, atol):
+        point_a = self.space.random_point(n_points)
+        point_b = self.space.random_point(n_points)
+
+        value_and_grad = gs.autodiff.value_and_grad(
+            lambda v: self.space.metric.squared_dist(v, point_b),
+            point_ndims=(self.space.point_ndim,),
+        )
+        sdist, sdist_grad = value_and_grad(point_a)
+
+        expected_sdist = self.space.metric.squared_dist(point_a, point_b)
+
+        tangent_vec = self.space.metric.log(point_b, point_a)
+        expected_sdist_grad = -2 * tangent_vec
+
+        self.assertAllClose(sdist, expected_sdist, atol=atol)
+        self.assertAllClose(sdist_grad, expected_sdist_grad, atol=atol)

--- a/tests/tests_geomstats/test_backend/data/autodiff.py
+++ b/tests/tests_geomstats/test_backend/data/autodiff.py
@@ -1,0 +1,331 @@
+import pytest
+
+import geomstats.backend as gs
+from geomstats.test.data import TestData
+
+
+class NumpyRaisesTestData(TestData):
+    def raises_test_data(self):
+        data = [
+            dict(autodiff_func=gs.autodiff.value_and_grad),
+            dict(autodiff_func=gs.autodiff.jacobian),
+            dict(autodiff_func=gs.autodiff.jacobian_vec),
+            dict(autodiff_func=gs.autodiff.hessian),
+            dict(autodiff_func=gs.autodiff.hessian_vec),
+            dict(autodiff_func=gs.autodiff.jacobian_and_hessian),
+            dict(autodiff_func=gs.autodiff.value_jacobian_and_hessian),
+        ]
+        return self.generate_tests(data)
+
+
+class NewAutodiffTestData(TestData):
+    trials = 1
+
+    def value_and_grad_test_data(self):
+        data = [
+            dict(
+                func=lambda x: x**2,
+                inputs=(gs.array(3.0),),
+                point_ndims=0,
+                expected_value=9.0,
+                expected_grad=6.0,
+            ),
+            dict(
+                func=lambda x: x[..., 0] ** 2 + x[..., 1],
+                inputs=(gs.array([3.0, 2.0]),),
+                expected_value=11.0,
+                expected_grad=gs.array([6.0, 1.0]),
+            ),
+            dict(
+                func=lambda x: x[..., 0, 0] ** 2 + x[..., 0, 1] + 2 * x[..., 1, 0],
+                inputs=(gs.array([[4.0, 3.0], [2.0, 1.0]]),),
+                point_ndims=2,
+                expected_value=23.0,
+                expected_grad=gs.array([[8.0, 1.0], [2.0, 0.0]]),
+            ),
+            dict(
+                func=lambda x, y: gs.sum((x - y) ** 2, axis=-1),
+                inputs=(
+                    gs.array([1.0, 2.0]),
+                    gs.array([2.0, 3.0]),
+                ),
+                argnums=0,
+                expected_value=2.0,
+                expected_grad=gs.array([-2.0, -2.0]),
+            ),
+            dict(
+                func=lambda x, y: gs.sum((x - y) ** 2, axis=-1),
+                inputs=(gs.array([1.0, 2.0]), gs.array([2.0, 3.0])),
+                argnums=(0, 1),
+                expected_value=2.0,
+                expected_grad=(
+                    gs.array([-2.0, -2.0]),
+                    gs.array([2.0, 2.0]),
+                ),
+            ),
+            dict(
+                func=lambda x, y: gs.sum((x - y) ** 2, axis=(-2, -1)),
+                inputs=(
+                    gs.array([[1.0, 3.0], [2.0, 3.0]]),
+                    gs.array([[2.0, 5.0], [0.0, 4.0]]),
+                ),
+                argnums=1,
+                point_ndims=2,
+                expected_value=10.0,
+                expected_grad=gs.array([[2.0, 4.0], [-4.0, 2.0]]),
+            ),
+            dict(
+                func=lambda x, y: gs.sum((x - y) ** 2, axis=(-2, -1)),
+                inputs=(
+                    gs.array([[1.0, 3.0], [2.0, 3.0]]),
+                    gs.array([[2.0, 5.0], [0.0, 4.0]]),
+                ),
+                argnums=(0, 1),
+                point_ndims=2,
+                expected_value=10.0,
+                expected_grad=(
+                    gs.array([[-2.0, -4.0], [4.0, -2.0]]),
+                    gs.array([[2.0, 4.0], [-4.0, 2.0]]),
+                ),
+            ),
+            dict(
+                func=lambda X, y: gs.sum(gs.matvec(X, y), axis=-1),
+                inputs=(
+                    gs.array([[1.0, 2.0], [3.0, 4.0]]),
+                    gs.array(
+                        [5.0, 6.0],
+                    ),
+                ),
+                point_ndims=(2, 1),
+                argnums=(0, 1),
+                expected_value=56.0,
+                expected_grad=(
+                    gs.array([[5.0, 6.0], [5.0, 6.0]]),
+                    gs.array([4.0, 6.0]),
+                ),
+            ),
+            dict(
+                func=lambda X, y: gs.sum(gs.matvec(X, y), axis=-1),
+                inputs=(
+                    gs.array([[1.0, 2.0], [3.0, 4.0]]),
+                    gs.array(
+                        [5.0, 6.0],
+                    ),
+                ),
+                point_ndims=(2, 1),
+                argnums=0,
+                expected_value=56.0,
+                expected_grad=gs.array([[5.0, 6.0], [5.0, 6.0]]),
+            ),
+        ]
+
+        return self.generate_tests(data, marks=[pytest.mark.smoke])
+
+    def value_and_grad_vec_test_data(self):
+        data = [
+            dict(
+                func=lambda x: x[..., 0] ** 2 + x[..., 1],
+                input_shape_x=(2,),
+            ),
+            dict(
+                func=lambda x, y: gs.sum((x - y) ** 2, axis=-1),
+                input_shape_x=(2,),
+                input_shape_y=(2,),
+                argnums=1,
+            ),
+            dict(
+                func=lambda x, y: gs.sum((x - y) ** 2, axis=-1),
+                input_shape_x=(2,),
+                input_shape_y=(2,),
+                argnums=(0, 1),
+            ),
+            dict(
+                func=lambda x, y: gs.sum(x * y**2, axis=-1),
+                input_shape_x=(2,),
+                input_shape_y=(2,),
+                argnums=(0, 1),
+            ),
+            dict(
+                func=lambda x, y: gs.sum((x - y) ** 2, axis=(-2, -1)),
+                input_shape_x=(2, 2),
+                input_shape_y=(2, 2),
+                argnums=(0, 1),
+                point_ndims=2,
+            ),
+            dict(
+                func=lambda x, y: gs.sum((x - y) ** 2, axis=(-2, -1)),
+                input_shape_x=(2, 2),
+                input_shape_y=(2, 2),
+                argnums=0,
+                point_ndims=2,
+            ),
+            dict(
+                func=lambda X, y: gs.sum(gs.matvec(X, y), axis=-1),
+                input_shape_x=(2, 2),
+                input_shape_y=(2,),
+                point_ndims=(2, 1),
+                argnums=(0, 1),
+            ),
+            dict(
+                func=lambda X, y: gs.sum(gs.matvec(X, y), axis=-1),
+                input_shape_x=(2, 2),
+                input_shape_y=(2,),
+                point_ndims=(2, 1),
+                argnums=0,
+            ),
+        ]
+
+        data_with_reps = []
+        for datum in data:
+            for n_reps in self.N_VEC_REPS:
+                new_datum = datum.copy()
+                new_datum["n_reps"] = n_reps
+                data_with_reps.append(new_datum)
+
+        return self.generate_tests(data_with_reps)
+
+
+class MetricDistGradTestData(TestData):
+    trials = 1
+
+    def value_and_grad_sdist_test_data(self):
+        return self.generate_random_data()
+
+
+class CustomGradientTestData(TestData):
+    trials = 1
+
+    def _func_1(self):
+        def fake_grad_func(x):
+            return 6 * x
+
+        @gs.autodiff.custom_gradient(fake_grad_func)
+        def func(x):
+            return gs.sum(x**2, axis=-1)
+
+        return func
+
+    def _func_2(self, axis=-1):
+        def fake_grad_func_x(x, y):
+            return 6 * (x - y)
+
+        def fake_grad_func_y(x, y):
+            return 6 * (y - x)
+
+        @gs.autodiff.custom_gradient(fake_grad_func_x, fake_grad_func_y)
+        def func(x, y):
+            return gs.sum((x - y) ** 2, axis=axis)
+
+        return func
+
+    def _func_3(self, axis=-1):
+        def fake_grad_func_1(x):
+            return 6 * x
+
+        @gs.autodiff.custom_gradient(fake_grad_func_1)
+        def func_1(x):
+            return gs.sum(x, axis=axis) ** 2
+
+        def func_2(x):
+            return func_1(x) ** 3
+
+        return func_2
+
+    def value_and_grad_test_data(self):
+        """Test value_and_grad with custom gradient.
+
+        NB: fake gradients are used to ensure the code goes through
+        the expected path.
+        """
+        data = [
+            dict(
+                func=self._func_1(),
+                inputs=(gs.array([1.0, 3.0]),),
+                expected_value=10.0,
+                expected_grad=gs.array([6.0, 18.0]),
+            ),
+            dict(
+                func=self._func_2(),
+                inputs=(gs.array([1.0, 2.0]), gs.array([2.0, 3.0])),
+                argnums=(0, 1),
+                expected_value=2.0,
+                expected_grad=(
+                    gs.array([-6.0, -6.0]),
+                    gs.array([6.0, 6.0]),
+                ),
+            ),
+            dict(
+                func=self._func_2(axis=(-2, -1)),
+                inputs=(
+                    gs.array([[1.0, 3.0], [2.0, 3.0]]),
+                    gs.array([[2.0, 5.0], [0.0, 4.0]]),
+                ),
+                argnums=(0, 1),
+                point_ndims=2,
+                expected_value=10.0,
+                expected_grad=(
+                    gs.array([[-6.0, -12.0], [12.0, -6]]),
+                    gs.array([[6.0, 12.0], [-12.0, 6.0]]),
+                ),
+            ),
+            dict(
+                func=self._func_3(),
+                inputs=(gs.array([1.0, 2.0]),),
+                expected_value=729.0,
+                expected_grad=gs.array([1458.0, 2916.0]),
+            ),
+        ]
+
+        return self.generate_tests(data)
+
+    def value_and_grad_vec_test_data(self):
+        data = [
+            dict(
+                func=self._func_1(),
+                input_shape_x=(2,),
+            ),
+            dict(
+                func=self._func_2(),
+                input_shape_x=(2,),
+                input_shape_y=(2,),
+                argnums=(0, 1),
+            ),
+            dict(
+                func=self._func_2(),
+                input_shape_x=(2,),
+                input_shape_y=(2,),
+                argnums=0,
+            ),
+            dict(
+                func=self._func_2(axis=(-2, -1)),
+                input_shape_x=(2, 2),
+                input_shape_y=(2, 2),
+                argnums=0,
+                point_ndims=2,
+            ),
+            dict(
+                func=self._func_2(axis=(-2, -1)),
+                input_shape_x=(2, 2),
+                input_shape_y=(2, 2),
+                argnums=(0, 1),
+                point_ndims=2,
+            ),
+            dict(
+                func=self._func_3(),
+                input_shape_x=(2,),
+            ),
+            dict(
+                func=self._func_3(axis=(-2, -1)),
+                input_shape_x=(2, 2),
+                point_ndim=2,
+            ),
+        ]
+
+        data_with_reps = []
+        for datum in data:
+            for n_reps in self.N_VEC_REPS:
+                new_datum = datum.copy()
+                new_datum["n_reps"] = n_reps
+                data_with_reps.append(new_datum)
+
+        return self.generate_tests(data_with_reps)

--- a/tests/tests_geomstats/test_backend/data/autodiff.py
+++ b/tests/tests_geomstats/test_backend/data/autodiff.py
@@ -276,7 +276,7 @@ class CustomGradientTestData(TestData):
             ),
         ]
 
-        return self.generate_tests(data)
+        return self.generate_tests(data, marks=[pytest.mark.smoke])
 
     def value_and_grad_vec_test_data(self):
         data = [

--- a/tests/tests_geomstats/test_backend/test_autodiff.py
+++ b/tests/tests_geomstats/test_backend/test_autodiff.py
@@ -2,24 +2,40 @@
 
 import warnings
 
-import numpy as _np
 import pytest
 
 import geomstats.backend as gs
 from geomstats.geometry.grassmannian import Grassmannian
 from geomstats.geometry.special_euclidean import SpecialEuclidean
-from geomstats.test.test_case import (
-    TestCase,
-    autograd_and_torch_only,
-    autograd_only,
-    np_only,
+from geomstats.test.parametrizers import DataBasedParametrizer
+from geomstats.test.test_case import TestCase, autograd_and_torch_only, np_only
+from geomstats.test_cases.backend.autodiff import (
+    AutodiffTestCase,
+    MetricDistGradTestCase,
+    NumpyRaisesTestCase,
+)
+
+from .data.autodiff import (
+    CustomGradientTestData,
+    MetricDistGradTestData,
+    NewAutodiffTestData,
+    NumpyRaisesTestData,
 )
 
 
 def _sphere_immersion(point):
+    """Sphere immersion
+
+    Parameters
+    ----------
+    point : array-like, shape=[2]
+
+    Returns
+    -------
+    immersed_point : array-like, shape=[3]
+    """
     radius = 4.0
-    theta = point[0]
-    phi = point[1]
+    theta, phi = point
     x = gs.sin(theta) * gs.cos(phi)
     y = gs.sin(theta) * gs.sin(phi)
     z = gs.cos(theta)
@@ -30,10 +46,13 @@ def _first_component_of_sphere_immersion(point):
     """First component of the sphere immersion function.
 
     This returns a vector of dim 1.
+
+    Parameters
+    ----------
+    point : array-like, shape=[2]
     """
     radius = 4.0
-    theta = point[0]
-    phi = point[1]
+    theta, phi = point
     x = gs.sin(theta) * gs.cos(phi)
     return gs.array([radius * x])
 
@@ -44,368 +63,48 @@ def _first_component_of_sphere_immersion_scalar(point):
     This returns a scalar.
     """
     radius = 4.0
-    theta = point[0]
-    phi = point[1]
+    theta, phi = point
     x = gs.sin(theta) * gs.cos(phi)
     return radius * x
 
 
-class TestAutodiff(TestCase):
+@np_only
+class TestNumpyRaises(NumpyRaisesTestCase, metaclass=DataBasedParametrizer):
+    dummy_func = lambda v: gs.sum(v**2)
+    testing_data = NumpyRaisesTestData()
+
+
+@autograd_and_torch_only
+class TestAutodiff(AutodiffTestCase, metaclass=DataBasedParametrizer):
+    testing_data = NewAutodiffTestData()
+
+
+@pytest.fixture(
+    scope="class",
+    params=[
+        SpecialEuclidean(3),
+        Grassmannian(3, 2),
+    ],
+)
+def equipped_spaces(request):
+    request.cls.space = request.param
+
+
+@autograd_and_torch_only
+class TestCustomGradient(AutodiffTestCase, metaclass=DataBasedParametrizer):
+    testing_data = CustomGradientTestData()
+
+
+@autograd_and_torch_only
+@pytest.mark.usefixtures("equipped_spaces")
+class TestMetricDistGrad(MetricDistGradTestCase, metaclass=DataBasedParametrizer):
+    testing_data = MetricDistGradTestData()
+
+
+class TestAutodiffOld(TestCase):
     def setup_method(self):
         warnings.simplefilter("ignore", category=ImportWarning)
         self.n_samples = 2
-
-    @np_only
-    def test_value_and_grad_np_backend(self):
-        n = 10
-        vector = gs.ones(n)
-        with pytest.raises(RuntimeError):
-            gs.autodiff.value_and_grad(lambda v: gs.sum(v**2))(vector)
-
-    @autograd_and_torch_only
-    def test_value_and_grad_one_vector_var(self):
-        n = 10
-        vector = gs.ones(n)
-        result_loss, result_grad = gs.autodiff.value_and_grad(lambda v: gs.sum(v**2))(
-            vector
-        )
-        expected_loss = n
-        expected_grad = 2 * vector
-
-        self.assertAllClose(result_loss, expected_loss)
-        self.assertAllClose(result_grad, expected_grad)
-
-    @autograd_only
-    def test_value_and_grad_dist(self):
-        space = SpecialEuclidean(3)
-        metric = space.metric
-        point = space.random_point()
-        id = space.identity
-        result_loss, result_grad = gs.autodiff.value_and_grad(
-            lambda v: metric.squared_dist(v, id)
-        )(point)
-
-        expected_loss = metric.squared_dist(point, id)
-        expected_grad = -2 * metric.log(id, point)
-
-        self.assertAllClose(result_loss, expected_loss)
-        self.assertAllClose(result_grad, expected_grad)
-
-    @autograd_and_torch_only
-    def test_value_and_grad_dist_grassmann(self):
-        space = Grassmannian(3, 2)
-        metric = space.metric
-        point = space.random_point()
-        vector = space.to_tangent(space.random_point(), point)
-        result_loss, result_grad = gs.autodiff.value_and_grad(
-            lambda v: metric.squared_norm(v, point)
-        )(vector)
-
-        expected_loss = metric.squared_norm(vector, point)
-        expected_grad = 2 * vector
-
-        self.assertAllClose(result_loss, expected_loss)
-        self.assertAllClose(result_grad, expected_grad)
-
-    @autograd_and_torch_only
-    def test_value_and_grad_one_vector_var_np_input(self):
-        n = 10
-        vector = _np.ones(n)
-        result_loss, result_grad = gs.autodiff.value_and_grad(lambda v: gs.sum(v**2))(
-            vector
-        )
-        expected_loss = n
-        expected_grad = 2 * vector
-        self.assertAllClose(result_loss, expected_loss)
-        self.assertAllClose(result_grad, expected_grad)
-
-    @autograd_and_torch_only
-    def test_value_and_grad_two_scalars_vars(self):
-        def func(x, y):
-            return gs.sum((x - y) ** 2)
-
-        arg_x = 1.0
-        arg_y = 2.0
-        val, grad = gs.autodiff.value_and_grad(func, argnums=(0, 1))(arg_x, arg_y)
-
-        self.assertAllClose(val, 1.0)
-        self.assertTrue(isinstance(grad, tuple))
-        self.assertAllClose(grad[0], -2)
-        self.assertAllClose(grad[1], 2.0)
-
-    @autograd_and_torch_only
-    def test_value_and_grad_two_vectors_vars(self):
-        def func(x, y):
-            return gs.sum((x - y) ** 2)
-
-        arg_x = gs.array([1.0, 2.0])
-        arg_y = gs.array([2.0, 3.0])
-        val, grad = gs.autodiff.value_and_grad(func, argnums=(0, 1))(arg_x, arg_y)
-
-        self.assertAllClose(val, 2.0)
-        self.assertTrue(isinstance(grad, tuple))
-        self.assertAllClose(grad[0], gs.array([-2.0, -2.0]))
-        self.assertAllClose(grad[1], gs.array([2.0, 2.0]))
-
-    @autograd_and_torch_only
-    def test_value_and_grad_two_matrix_vars(self):
-        def func(x, y):
-            return gs.sum((x - y) ** 2)
-
-        arg_x = gs.array([[1.0, 3.0], [2.0, 3.0]])
-        arg_y = gs.array([[2.0, 5.0], [0.0, 4.0]])
-        val, grad = gs.autodiff.value_and_grad(func, argnums=(0, 1))(arg_x, arg_y)
-        self.assertAllClose(val, 10.0)
-        self.assertAllClose(grad[0], gs.array([[-2.0, -4.0], [4.0, -2.0]]))
-        self.assertAllClose(grad[1], gs.array([[2.0, 4.0], [-4.0, 2.0]]))
-
-    @autograd_and_torch_only
-    def test_custom_gradient_one_vector_var(self):
-        """Assign made-up gradient to test custom_gradient."""
-
-        def grad_x(x):
-            return 6 * x
-
-        @gs.autodiff.custom_gradient(grad_x)
-        def func(x):
-            return gs.sum(x**2)
-
-        arg_x = gs.array([1.0, 3.0])
-        result_value, result_grad = gs.autodiff.value_and_grad(func)(arg_x)
-
-        expected_value = 10.0
-        expected_grad = gs.array([6.0, 18.0])
-
-        self.assertAllClose(result_value, expected_value)
-        self.assertAllClose(result_grad, expected_grad)
-
-    @autograd_and_torch_only
-    def test_custom_gradient_two_vector_vars(self):
-        """Assign made-up gradient to test custom_gradient."""
-
-        def grad_x(x, y):
-            return 6 * (x - y)
-
-        def grad_y(x, y):
-            return 6 * (y - x)
-
-        @gs.autodiff.custom_gradient(grad_x, grad_y)
-        def func(x, y):
-            return gs.sum((x - y) ** 2)
-
-        arg_x = gs.array([1.0, 3.0])
-        arg_y = gs.array([2.0, 5.0])
-
-        result_val, result_grad = gs.autodiff.value_and_grad(func, argnums=(0, 1))(
-            arg_x, arg_y
-        )
-
-        self.assertTrue(isinstance(result_grad, tuple))
-        result_grad_x, result_grad_y = result_grad
-
-        expected_val = func(arg_x, arg_y)
-        expected_grad_x = grad_x(arg_x, arg_y)
-        expected_grad_y = grad_y(arg_x, arg_y)
-
-        self.assertAllClose(result_val, expected_val)
-        self.assertAllClose(result_grad_x, expected_grad_x)
-        self.assertAllClose(result_grad_y, expected_grad_y)
-
-    @autograd_and_torch_only
-    def test_custom_gradient_two_matrix_vars(self):
-        """Assign made-up gradient to test custom_gradient."""
-
-        def grad_x(x, y):
-            return 6 * (x - y)
-
-        def grad_y(x, y):
-            return 6 * (y - x)
-
-        @gs.autodiff.custom_gradient(grad_x, grad_y)
-        def func(x, y):
-            return gs.sum((x - y) ** 2)
-
-        arg_x = gs.array([[1.0, 3.0], [2.0, 3.0]])
-        arg_y = gs.array([[2.0, 5.0], [0.0, 4.0]])
-
-        result_val, result_grad = gs.autodiff.value_and_grad(func, argnums=(0, 1))(
-            arg_x, arg_y
-        )
-
-        self.assertTrue(isinstance(result_grad, tuple))
-        result_grad_x, result_grad_y = result_grad
-
-        expected_val = func(arg_x, arg_y)
-        expected_grad_x = grad_x(arg_x, arg_y)
-        expected_grad_y = grad_y(arg_x, arg_y)
-
-        self.assertAllClose(result_val, expected_val)
-        self.assertAllClose(result_grad_x, expected_grad_x)
-        self.assertAllClose(result_grad_y, expected_grad_y)
-
-    @autograd_and_torch_only
-    def test_custom_gradient_composed_two_matrix_vars(self):
-        """Assign made-up gradient to test custom_gradient."""
-
-        def grad_x(x, y):
-            return 6 * (x - y)
-
-        def grad_y(x, y):
-            return 6 * (y - x)
-
-        @gs.autodiff.custom_gradient(grad_x, grad_y)
-        def func(x, y):
-            return gs.sum((x - y) ** 2)
-
-        arg_x = gs.array([[1.0, 3.0], [2.0, 3.0]])
-        const_y = gs.array([[2.0, 5.0], [0.0, 4.0]])
-
-        def func_2(x):
-            return gs.exp(-0.5 * func(x, const_y))
-
-        result_value, result_grad = gs.autodiff.value_and_grad(func_2)(arg_x)
-        expected_value = func_2(arg_x)
-        expected_grad = 3 * (const_y - arg_x) * expected_value
-        self.assertAllClose(result_value, expected_value)
-        self.assertAllClose(result_grad, expected_grad)
-
-    @autograd_and_torch_only
-    def test_custom_gradient_composed_with_dummy_two_matrix_vars(self):
-        """Assign made-up gradient to test custom_gradient."""
-
-        def grad_dummy(dummy, x, y):
-            return dummy
-
-        def grad_x(dummy, x, y):
-            return 6 * dummy * (x - y)
-
-        def grad_y(dummy, x, y):
-            return 6 * dummy * (y - x)
-
-        @gs.autodiff.custom_gradient(grad_dummy, grad_x, grad_y)
-        def func(dummy, x, y):
-            return dummy * gs.sum((x - y) ** 2)
-
-        const_y = gs.array([[2.0, 5.0], [0.0, 4.0]])
-        const_dummy = gs.array(4.0)
-
-        def func_of_x(x):
-            return func(const_dummy, x, const_y)
-
-        arg_x = gs.array([[1.0, 3.0], [2.0, 3.0]])
-        result_value, result_grad = gs.autodiff.value_and_grad(func_of_x)(arg_x)
-        expected_value = func_of_x(arg_x)
-        expected_grad = grad_x(const_dummy, arg_x, const_y)
-
-        self.assertAllClose(result_value, expected_value)
-        self.assertAllClose(result_grad, expected_grad)
-
-    @autograd_and_torch_only
-    def test_custom_gradient_chain_rule_one_scalar_var(self):
-        """Assign made-up gradient to test custom_gradient."""
-
-        def fun1_grad(x):
-            return gs.array(3.0, dtype=x.dtype)
-
-        @gs.autodiff.custom_gradient(fun1_grad)
-        def fun1(x):
-            return x
-
-        def fun2(x):
-            out = fun1(x) ** 2
-            return out
-
-        def fun2_grad(x):
-            return 2 * x
-
-        arg = gs.array(10.0)
-
-        result_value, result_grad = gs.autodiff.value_and_grad(fun2)(arg)
-        expected_value = fun2(arg)
-        expected_grad_explicit = 60.0
-
-        expected_grad_chain_rule = fun2_grad(fun1(arg)) * fun1_grad(arg)
-
-        self.assertAllClose(result_value, expected_value)
-        self.assertAllClose(result_grad, expected_grad_explicit)
-        self.assertAllClose(result_grad, expected_grad_chain_rule)
-
-    @autograd_and_torch_only
-    def test_custom_gradient_chain_rule_one_vector_var(self):
-        def fun1_grad(x):
-            return 6 * x
-
-        @gs.autodiff.custom_gradient(fun1_grad)
-        def fun1(x):
-            return gs.sum(x) ** 2
-
-        def fun2(x):
-            out = fun1(x) ** 3
-            return out
-
-        def fun2_grad(x):
-            return 3 * x**2
-
-        arg = gs.array([1.0, 2.0])
-
-        result_value, result_grad = gs.autodiff.value_and_grad(fun2)(arg)
-
-        expected_value = fun2(arg)
-        expected_grad_explicit = 18 * fun1(arg) ** 2 * arg
-        expected_grad_chain_rule = fun2_grad(fun1(arg)) * fun1_grad(arg)
-
-        self.assertAllClose(result_value, expected_value)
-        self.assertAllClose(result_grad, expected_grad_explicit)
-        self.assertAllClose(result_grad, expected_grad_chain_rule)
-
-    @autograd_only
-    def test_custom_gradient_squared_dist(self):
-        def squared_dist_grad_a(point_a, point_b, metric):
-            return -2 * metric.log(point_b, point_a)
-
-        def squared_dist_grad_b(point_a, point_b, metric):
-            return -2 * metric.log(point_a, point_b)
-
-        @gs.autodiff.custom_gradient(squared_dist_grad_a, squared_dist_grad_b)
-        def squared_dist(point_a, point_b, metric):
-            dist = metric.squared_dist(point_a, point_b)
-            return dist
-
-        space = SpecialEuclidean(n=2)
-        const_metric = space.metric
-        const_point_b = space.random_point()
-
-        def func(x):
-            return squared_dist(x, const_point_b, metric=const_metric)
-
-        arg_point_a = space.random_point()
-        expected_value = func(arg_point_a)
-        expected_grad = -2 * const_metric.log(const_point_b, arg_point_a)
-        result_value, result_grad = gs.autodiff.value_and_grad(func)(arg_point_a)
-        self.assertAllClose(result_value, expected_value)
-        self.assertAllClose(result_grad, expected_grad)
-
-    @autograd_only
-    def test_custom_gradient_in_action(self):
-        space = SpecialEuclidean(n=2)
-        const_metric = space.metric
-        const_point_b = space.random_point()
-
-        def func(x):
-            return const_metric.squared_dist(x, const_point_b)
-
-        arg_point_a = space.random_point()
-        func_with_grad = gs.autodiff.value_and_grad(func)
-        result_value, result_grad = func_with_grad(arg_point_a)
-        expected_value = const_metric.squared_dist(arg_point_a, const_point_b)
-        expected_grad = -2 * const_metric.log(const_point_b, arg_point_a)
-
-        self.assertAllClose(result_value, expected_value)
-        self.assertAllClose(result_grad, expected_grad)
-
-        loss, grad = func_with_grad(const_point_b)
-        self.assertAllClose(loss, 0.0)
-        self.assertAllClose(grad, gs.zeros_like(grad))
 
     @autograd_and_torch_only
     def test_jacobian(self):


### PR DESCRIPTION
Inspired by #1929, this PR is the first of a series of PRs that intends to fix and clean the `autodiff` backend module.

In this PR, the focus is the `value_and_grad` function. The following is done:

* vectorization is fixed, i.e. `value_and_grad` is now able to handle (correctly) batches of points

* `point_ndims` variable is added, following a similar behavior as `argnums` (used both in `autograd` and `pytorch`). This variable is required to handle vectorization properly


* custom gradient is fixed for `pytorch` to allow a custom computation of the squared distance gradient (see `SpecialEuclidean` and `Grassmannian`). Before this was only working for `autograd`

* custom gradient is improved for `pytorch` backend with potential gains in performance for the cases where only the gradient wrt to some variables is required for a multivariable function

* `to_numpy` flag is removed, as it is useless (this behavior must be controlled from outside)

* the tests are updated to new style and several additional use cases are added (in particular regarding vectorization). Mostly all `value_and_grad` use cases should now be being tested.  There's still a small proportion of  tests in the old style, but they will be updated in the following up PRs

* all the uses of `value_and_grad` are updated to ensure correct use of the updated API

