### PR TITLE
Fix KMeans error with Euclidean space

### DIFF
--- a/geomstats/learning/expectation_maximization.py
+++ b/geomstats/learning/expectation_maximization.py
@@ -314,14 +314,14 @@ class RiemannianEM(TransformerMixin, ClusterMixin, BaseEstimator):
         self.conv_rate = conv_rate
         self.minimum_epochs = minimum_epochs
 
-        self.mean_estimator = FrechetMean(
-            space,
-            method="batch",
-        ).set(
-            max_iter=100,
-            epsilon=1e-4,
-            init_step_size=1.0,
-        )
+        self.mean_estimator = FrechetMean(space)
+        if isinstance(self.mean_estimator, FrechetMean):
+            self.mean_estimator.method = "batch"
+            self.mean_estimator.set(
+                max_iter=100,
+                epsilon=1e-4,
+                init_step_size=1.0,
+            )
 
         self._model = GaussianMixtureModel(self.space)
 

--- a/geomstats/learning/kmeans.py
+++ b/geomstats/learning/kmeans.py
@@ -10,9 +10,8 @@ from scipy.stats import rv_discrete
 from sklearn.base import BaseEstimator, ClusterMixin
 
 import geomstats.backend as gs
-from geomstats.geometry.euclidean import Euclidean
 from geomstats.learning._template import TransformerMixin
-from geomstats.learning.frechet_mean import FrechetMean, LinearMean
+from geomstats.learning.frechet_mean import FrechetMean
 
 
 class RiemannianKMeans(TransformerMixin, ClusterMixin, BaseEstimator):
@@ -77,13 +76,9 @@ class RiemannianKMeans(TransformerMixin, ClusterMixin, BaseEstimator):
 
         self.init_cluster_centers_ = None
 
-        if isinstance(space, Euclidean):
-            self.mean_estimator = LinearMean(space=space)
-        else:
-            self.mean_estimator = FrechetMean(
-                space=space,
-                method="default",
-            ).set(max_iter=100, init_step_size=1.0)
+        self.mean_estimator = FrechetMean(space=space)
+        if isinstance(self.mean_estimator, FrechetMean):
+            self.mean_estimator.set(max_iter=100, init_step_size=1.0)
 
         self.cluster_centers_ = None
         self.labels_ = None

--- a/geomstats/learning/kmeans.py
+++ b/geomstats/learning/kmeans.py
@@ -10,8 +10,9 @@ from scipy.stats import rv_discrete
 from sklearn.base import BaseEstimator, ClusterMixin
 
 import geomstats.backend as gs
+from geomstats.geometry.euclidean import Euclidean
 from geomstats.learning._template import TransformerMixin
-from geomstats.learning.frechet_mean import FrechetMean
+from geomstats.learning.frechet_mean import FrechetMean, LinearMean
 
 
 class RiemannianKMeans(TransformerMixin, ClusterMixin, BaseEstimator):
@@ -76,10 +77,13 @@ class RiemannianKMeans(TransformerMixin, ClusterMixin, BaseEstimator):
 
         self.init_cluster_centers_ = None
 
-        self.mean_estimator = FrechetMean(
-            space=space,
-            method="default",
-        ).set(max_iter=100, init_step_size=1.0)
+        if isinstance(space, Euclidean):
+            self.mean_estimator = LinearMean(space=space)
+        else:
+            self.mean_estimator = FrechetMean(
+                space=space,
+                method="default",
+            ).set(max_iter=100, init_step_size=1.0)
 
         self.cluster_centers_ = None
         self.labels_ = None

--- a/tests/tests_geomstats/test_learning/test_kmeans.py
+++ b/tests/tests_geomstats/test_learning/test_kmeans.py
@@ -2,6 +2,7 @@ import random
 
 import pytest
 
+from geomstats.geometry.euclidean import Euclidean
 from geomstats.geometry.hypersphere import Hypersphere
 from geomstats.geometry.spd_matrices import SPDMatrices
 from geomstats.learning.frechet_mean import FrechetMean
@@ -70,6 +71,7 @@ class TestClusterInitialization(
 @pytest.fixture(
     scope="class",
     params=[
+        (Euclidean(dim=random.randint(3, 4)), random.randint(2, 4)),
         (Hypersphere(dim=random.randint(3, 4)), random.randint(2, 4)),
         (SPDMatrices(n=random.randint(2, 4)), random.randint(2, 4)),
     ],


### PR DESCRIPTION
## Description

This fixes an error generated by using `RiemannianKMeans` with `space=Euclidean()`.

## Issue

This code for example creates an error:
```
from geomstats.geometry.euclidean import Euclidean
from geomstats.learning.kmeans import RiemannianKMeans

r2 = Euclidean(2)
points = r2.random_point(10)
clustering = RiemannianKMeans(space=r2, n_clusters=2)
clustering.fit(points)
```

@luisfpereira this is probably not be the optimal way to fix the error, tell me what you think !
