### PR TITLE
Fix discrete curves vectorization and remove empty quotient metrics

### DIFF
--- a/geomstats/geometry/discrete_curves.py
+++ b/geomstats/geometry/discrete_curves.py
@@ -1314,9 +1314,6 @@ class IterativeHorizontalGeodesicAligner:
         if initial_point.ndim != end_point.ndim:
             initial_point, end_point = gs.broadcast_arrays(initial_point, end_point)
 
-        if callable(end_spline):
-            end_spline = [end_spline] * end_point.shape[0]
-
         return gs.stack(
             [
                 self._discrete_horizontal_geodesic_single(
@@ -1345,12 +1342,13 @@ class IterativeHorizontalGeodesicAligner:
         aligned : array-like, shape=[..., k_sampling_points - 1, ambient_dim
             Curve reparametrized in an optimal way with respect to reference curve.
         """
-        is_batch = check_is_batch(bundle.total_space.point_ndim, point)
-
-        if not is_batch:
+        if point.ndim == bundle.total_space.point_ndim:
             spline = bundle.total_space.interpolate(point)
+            if base_point.ndim > bundle.total_space.point_ndim:
+                spline = [spline] * base_point.shape[0]
         else:
             spline = [bundle.total_space.interpolate(point_) for point_ in point]
+
         return self.discrete_horizontal_geodesic(bundle, base_point, point, spline)[
             ..., -1, :, :
         ]

--- a/geomstats/geometry/discrete_curves.py
+++ b/geomstats/geometry/discrete_curves.py
@@ -209,15 +209,15 @@ class DiscreteCurvesStartingAtOrigin(NFoldManifold):
         self._quotient_map = {
             (SRVMetric, "rotations"): (
                 SRVRotationBundle,
-                SRVRotationQuotientMetric,
+                QuotientMetric,
             ),
             (SRVMetric, "reparametrizations"): (
                 SRVReparametrizationBundle,
-                SRVReparametrizationQuotientMetric,
+                QuotientMetric,
             ),
             (SRVMetric, "rotations and reparametrizations"): (
                 SRVRotationReparametrizationBundle,
-                SRVRotationReparametrizationQuotientMetric,
+                QuotientMetric,
             ),
         }
         self._sphere = Hypersphere(dim=ambient_dim - 1)
@@ -1294,7 +1294,7 @@ class IterativeHorizontalGeodesicAligner:
             Initial discrete curve.
         end_point : array-like, shape=[..., k_sampling_points, ambient_dim]
             End discrete curve.
-        end_spline : function
+        end_spline : callable or list[callable]
             Spline interpolation of end point.
 
         Returns
@@ -1313,6 +1313,9 @@ class IterativeHorizontalGeodesicAligner:
 
         if initial_point.ndim != end_point.ndim:
             initial_point, end_point = gs.broadcast_arrays(initial_point, end_point)
+
+        if callable(end_spline):
+            end_spline = [end_spline] * end_point.shape[0]
 
         return gs.stack(
             [
@@ -1845,16 +1848,6 @@ class SRVReparametrizationBundle(FiberBundle):
         return self.aligner.align(self, point, base_point)
 
 
-class SRVReparametrizationQuotientMetric(QuotientMetric):
-    """SRV quotient metric on the space of unparametrized curves.
-
-    This is the class for the quotient metric induced by the SRV Metric
-    on the shape space of unparametrized curves, i.e. the space of parametrized
-    curves quotiented by the group of reparametrizations. In the discrete case,
-    reparametrization corresponds to resampling.
-    """
-
-
 class SRVRotationBundle(FiberBundle):
     """Principal bundle of curves modulo rotations with the SRV metric.
 
@@ -1879,6 +1872,10 @@ class SRVRotationBundle(FiberBundle):
     def _rotate(self, point, rotation):
         """Rotate discrete curve starting at origin."""
         return self._transpose(gs.matmul(rotation, self._transpose(point)))
+
+    def horizontal_projection(self, tangent_vec, base_point):
+        """Project to horizontal subspace."""
+        raise NotImplementedError("Horizontal projection is not implemented.")
 
     def align(self, point, base_point, return_rotation=False):
         """Align point to base point.
@@ -1917,14 +1914,6 @@ class SRVRotationBundle(FiberBundle):
         return point_aligned
 
 
-class SRVRotationQuotientMetric(QuotientMetric):
-    """SRV quotient metric on space of curves modulo rotations.
-
-    This is the class for the quotient metric induced by the SRV Metric on the
-    space of parametrized curves quotiented by the action of rotations.
-    """
-
-
 class SRVRotationReparametrizationBundle(FiberBundle):
     """SRV principal bundle of curves modulo rotations and reparametrizations.
 
@@ -1959,6 +1948,10 @@ class SRVRotationReparametrizationBundle(FiberBundle):
         self.verbose = verbose
         self._rotations_bundle = SRVRotationBundle(total_space)
         self._reparameterizations_bundle = SRVReparametrizationBundle(total_space)
+
+    def horizontal_projection(self, tangent_vec, base_point):
+        """Project to horizontal subspace."""
+        raise NotImplementedError("Horizontal projection is not implemented.")
 
     def align_rotation(self, point, base_point, return_rotation=False):
         """Find optimal rotation of curve with respect to base curve.
@@ -2084,13 +2077,3 @@ class SRVRotationReparametrizationBundle(FiberBundle):
             return aligned_points, rotations
 
         return aligned_points
-
-
-class SRVRotationReparametrizationQuotientMetric(QuotientMetric):
-    """SRV quotient metric on space of curves modulo rotations and reparametrizations.
-
-    This is the class for the quotient metric induced by the SRV Metric on the
-    space of parametrized curves quotiented by the action of rotations and
-    reparametrizations. In the discrete case, reparametrization corresponds to
-    resampling.
-    """

--- a/tests/tests_geomstats/test_geometry/data/discrete_curves.py
+++ b/tests/tests_geomstats/test_geometry/data/discrete_curves.py
@@ -4,6 +4,7 @@ from geomstats.test.data import TestData
 from .fiber_bundle import FiberBundleTestData
 from .nfold_manifold import NFoldManifoldTestData
 from .pullback_metric import PullbackDiffeoMetricTestData
+from .quotient_metric import QuotientMetricTestData
 from .riemannian_metric import RiemannianMetricTestData
 
 
@@ -47,20 +48,16 @@ class SRVMetricTestData(PullbackDiffeoMetricTestData):
 
 class SRVReparametrizationBundleTestData(FiberBundleTestData):
     fail_for_not_implemented_errors = False
-    # TODO: delete
-    trials = 1
-    N_RANDOM_POINTS = [1]
 
-    skips = (
-        "align_vec",
-        "log_after_align_is_horizontal",
-    )
     xfails = (
         "tangent_riemannian_submersion_after_horizontal_lift",
         "horizontal_lift_is_horizontal",
+        "log_after_align_is_horizontal",
     )
     tolerances = {
         "align": {"atol": 1e-2},
+        "align_in_same_fiber": {"atol": 1e-2},
+        "log_after_align_is_horizontal": {"atol": 1e-2},
         "tangent_vector_projections_orthogonality_with_metric": {"atol": 5e-1},
         "vertical_projection_is_vertical": {"atol": 1e-1},
         "horizontal_projection_is_horizontal": {"atol": 1e-1},
@@ -72,7 +69,7 @@ class SRVReparametrizationBundleTestData(FiberBundleTestData):
     def tangent_vector_projections_orthogonality_with_metric_test_data(self):
         return self.generate_random_data()
 
-    def align_test_data(self):
+    def align_in_same_fiber_test_data(self):
         return self.generate_random_data()
 
 
@@ -107,3 +104,38 @@ class SRVRotationReparametrizationBundleTestData(TestData):
 
     def align_test_data(self):
         return self.generate_random_data()
+
+
+class SRVReparametrizationsQuotientMetricTestData(QuotientMetricTestData):
+    trials = 1
+    fail_for_autodiff_exceptions = False
+    fail_for_not_implemented_errors = False
+
+
+class SRVRotationsQuotientMetricTestData(QuotientMetricTestData):
+    trials = 1
+    fail_for_autodiff_exceptions = False
+    fail_for_not_implemented_errors = False
+
+    xfails = (
+        # need to do a better check on the test
+        "geodesic_bvp_reverse",
+        "geodesic_boundary_points",
+    )
+
+
+class SRVRotationsAndReparametrizationsQuotientMetricTestData(QuotientMetricTestData):
+    trials = 1
+    fail_for_autodiff_exceptions = False
+    fail_for_not_implemented_errors = False
+
+    tolerances = {
+        "dist_is_symmetric": {"atol": 1e-2},
+        "squared_dist_is_symmetric": {"atol": 1e-2},
+    }
+
+    xfails = (
+        # need to do a better check on the test
+        "geodesic_bvp_reverse",
+        "geodesic_boundary_points",
+    )


### PR DESCRIPTION
This PR follows #1924 to:

* fix `IterativeHorizontalGeodesicAligner.discrete_horizontal_geodesic` vectorization

* raise `NotImplementedError` in new fiber bundles to avoid recursion errors when calling the log on the quotient metrics

* improve SRVReparametrizationBundle tests:

    * by removing skips
    *  testing for both even and odd `k_sampling_points` due to different behavior in Euler step (this should probably be done in a specific test for the aligner later)

* improve discrete curves tests by adding tests for all quotient metrics

* remove empty quotient metrics  (closes #1931)