### PR TITLE
Improve FiberBundle/QuotientMetric API

### DIFF
--- a/geomstats/geometry/discrete_curves.py
+++ b/geomstats/geometry/discrete_curves.py
@@ -1175,7 +1175,7 @@ class IterativeHorizontalGeodesicAligner:
 
     def _iterate(
         self,
-        bundle,
+        total_space,
         times,
         t_space,
         initial_point,
@@ -1184,16 +1184,16 @@ class IterativeHorizontalGeodesicAligner:
         end_spline,
     ):
         """Perform one step of the alignment algorithm."""
-        ndim = bundle.total_space.point_ndim
+        ndim = total_space.point_ndim
 
-        total_space_geod_fun = bundle.total_space.metric.geodesic(
+        total_space_geod_fun = total_space.metric.geodesic(
             initial_point=initial_point, end_point=end_point
         )
         geod_points = total_space_geod_fun(times)
         geod_points_with_origin = insert_zeros(geod_points, axis=-ndim)
 
         time_deriv = forward_difference(geod_points, axis=-(ndim + 1))
-        _, vertical_norm = bundle.vertical_projection(
+        _, vertical_norm = total_space.fiber_bundle.vertical_projection(
             time_deriv, geod_points[:-1], return_norm=True
         )
         vertical_norm = insert_zeros(vertical_norm, axis=-1)
@@ -1202,7 +1202,7 @@ class IterativeHorizontalGeodesicAligner:
             geod_points_with_origin, axis=-ndim, endpoints=True
         )[:-1]
 
-        pointwise_space_deriv_norm = bundle.total_space.ambient_manifold.metric.norm(
+        pointwise_space_deriv_norm = total_space.ambient_manifold.metric.norm(
             space_deriv, geod_points_with_origin[:-1]
         )
 
@@ -1218,14 +1218,14 @@ class IterativeHorizontalGeodesicAligner:
         return horizontal_path
 
     def _discrete_horizontal_geodesic_single(
-        self, bundle, initial_point, end_point, end_spline
+        self, total_space, initial_point, end_point, end_spline
     ):
         """Compute discrete horizontal geodesic, non vectorized.
 
         Parameters
         ----------
-        bundle : SRVReparametrizationBundle
-            Fiber bundle of curves modulo reparametrizations.
+        total_space : Manifold
+            Total space with reparametrizations fiber bundle structure.
         initial_point : array-like, shape=[k_sampling_points, ambient_dim]
             Initial discrete curve.
         end_point : array-like, shape=[k_sampling_points, ambient_dim]
@@ -1240,14 +1240,14 @@ class IterativeHorizontalGeodesicAligner:
         """
         times = gs.linspace(0.0, 1.0, self.n_time_grid)
 
-        k_sampling_points = bundle.total_space.k_sampling_points
+        k_sampling_points = total_space.k_sampling_points
         t_space = gs.linspace(0.0, 1.0, k_sampling_points)
 
         current_end_point = end_point
         repar_inverse_end = []
         for index in range(self.max_iter):
             horizontal_path_with_origin = self._iterate(
-                bundle,
+                total_space,
                 times,
                 t_space,
                 initial_point,
@@ -1256,7 +1256,7 @@ class IterativeHorizontalGeodesicAligner:
                 end_spline,
             )
             new_end_point = horizontal_path_with_origin[-1][1:]
-            l2_metric = bundle.total_space.discrete_curves_with_l2.metric
+            l2_metric = total_space.discrete_curves_with_l2.metric
             gap = l2_metric.dist(new_end_point, current_end_point)
             current_end_point = new_end_point
 
@@ -1282,14 +1282,14 @@ class IterativeHorizontalGeodesicAligner:
         return horizontal_path_with_origin[..., 1:, :]
 
     def discrete_horizontal_geodesic(
-        self, bundle, initial_point, end_point, end_spline
+        self, total_space, initial_point, end_point, end_spline
     ):
         """Compute discrete horizontal geodesic.
 
         Parameters
         ----------
-        bundle : SRVReparametrizationBundle
-            Fiber bundle of curves modulo reparametrizations.
+        total_space : Manifold
+            Total space with reparametrizations fiber bundle structure.
         initial_point : array-like, shape=[..., k_sampling_points, ambient_dim]
             Initial discrete curve.
         end_point : array-like, shape=[..., k_sampling_points, ambient_dim]
@@ -1302,13 +1302,13 @@ class IterativeHorizontalGeodesicAligner:
         geod_points : array, shape=[..., n_time_grid, k - 1, ambient_dim]
         """
         is_batch = check_is_batch(
-            bundle.total_space.point_ndim,
+            total_space.point_ndim,
             initial_point,
             end_point,
         )
         if not is_batch:
             return self._discrete_horizontal_geodesic_single(
-                bundle, initial_point, end_point, end_spline
+                total_space, initial_point, end_point, end_spline
             )
 
         if initial_point.ndim != end_point.ndim:
@@ -1317,7 +1317,7 @@ class IterativeHorizontalGeodesicAligner:
         return gs.stack(
             [
                 self._discrete_horizontal_geodesic_single(
-                    bundle, initial_point_, end_point_, end_spline_
+                    total_space, initial_point_, end_point_, end_spline_
                 )
                 for initial_point_, end_point_, end_spline_ in zip(
                     initial_point, end_point, end_spline
@@ -1325,13 +1325,13 @@ class IterativeHorizontalGeodesicAligner:
             ]
         )
 
-    def align(self, bundle, point, base_point):
+    def align(self, total_space, point, base_point):
         """Align point to base point.
 
         Parameters
         ----------
-        bundle : SRVReparametrizationBundle
-            Fiber bundle of curves modulo reparametrizations.
+        total_space : Manifold
+            Total space with reparametrizations fiber bundle structure.
         point : array-like, shape=[..., k_sampling_points - 1, ambient_dim]
             Discrete curve to align.
         base_point : array-like, shape=[..., k_sampling_points - 1, ambient_dim]
@@ -1342,16 +1342,16 @@ class IterativeHorizontalGeodesicAligner:
         aligned : array-like, shape=[..., k_sampling_points - 1, ambient_dim
             Curve reparametrized in an optimal way with respect to reference curve.
         """
-        if point.ndim == bundle.total_space.point_ndim:
-            spline = bundle.total_space.interpolate(point)
-            if base_point.ndim > bundle.total_space.point_ndim:
+        if point.ndim == total_space.point_ndim:
+            spline = total_space.interpolate(point)
+            if base_point.ndim > total_space.point_ndim:
                 spline = [spline] * base_point.shape[0]
         else:
-            spline = [bundle.total_space.interpolate(point_) for point_ in point]
+            spline = [total_space.interpolate(point_) for point_ in point]
 
-        return self.discrete_horizontal_geodesic(bundle, base_point, point, spline)[
-            ..., -1, :, :
-        ]
+        return self.discrete_horizontal_geodesic(
+            total_space, base_point, point, spline
+        )[..., -1, :, :]
 
 
 class DynamicProgrammingAligner:
@@ -1548,13 +1548,13 @@ class DynamicProgrammingAligner:
             norm_squared_initial_srv + norm_squared_end_srv - 2 * maximum_scalar_product
         )
 
-    def _align_single(self, bundle, point, base_point, return_sdist=False):
+    def _align_single(self, total_space, point, base_point, return_sdist=False):
         r"""Align point to base point, non vectorized.
 
         Parameters
         ----------
-        bundle : SRVReparametrizationBundle
-            Fiber bundle of curves modulo reparametrizations.
+        total_space : Manifold
+            Total space with reparametrizations fiber bundle structure.
         point : array-like, shape=[k_sampling_points - 1, ambient_dim]
             Discrete curve to align.
         base_point : array-like, shape=[k_sampling_points - 1, ambient_dim]
@@ -1573,9 +1573,9 @@ class DynamicProgrammingAligner:
         n_space_grid = self.n_space_grid
         max_slope = self.max_slope
 
-        k_sampling_points = bundle.total_space.k_sampling_points
+        k_sampling_points = total_space.k_sampling_points
         srv_transform = SRVTransform(
-            bundle.total_space.ambient_manifold,
+            total_space.ambient_manifold,
             k_sampling_points,
         )
         initial_srv = srv_transform.diffeomorphism(base_point)
@@ -1633,13 +1633,13 @@ class DynamicProgrammingAligner:
             initial_srv_, end_srv_, tableau
         )
 
-    def align(self, bundle, point, base_point, return_sdist=False):
+    def align(self, total_space, point, base_point, return_sdist=False):
         """Align point to base point.
 
         Parameters
         ----------
-        bundle : SRVReparametrizationBundle
-            Fiber bundle of curves modulo reparametrizations.
+        total_space : Manifold
+            Total space with reparametrizations fiber bundle structure.
         point : array-like, shape=[..., k_sampling_points - 1, ambient_dim]
             Discrete curve to align.
         base_point : array-like, shape=[..., k_sampling_points - 1, ambient_dim]
@@ -1656,20 +1656,22 @@ class DynamicProgrammingAligner:
             If return_sdist is True.
         """
         is_batch = check_is_batch(
-            bundle.total_space.point_ndim,
+            total_space.point_ndim,
             point,
             base_point,
         )
         if not is_batch:
             return self._align_single(
-                bundle, point, base_point, return_sdist=return_sdist
+                total_space, point, base_point, return_sdist=return_sdist
             )
 
         if point.ndim != base_point.ndim:
             point, base_point = gs.broadcast_arrays(point, base_point)
 
         out = [
-            self._align_single(bundle, point_, base_point_, return_sdist=return_sdist)
+            self._align_single(
+                total_space, point_, base_point_, return_sdist=return_sdist
+            )
             for point_, base_point_ in zip(point, base_point)
         ]
         if not return_sdist:
@@ -1731,12 +1733,12 @@ class SRVReparametrizationBundle(FiberBundle):
             Pointwise norm of the vertical part of tangent_vec.
             Only returned when return_norm is True.
         """
-        ambient_manifold = self.total_space.ambient_manifold
+        ambient_manifold = self._total_space.ambient_manifold
 
         a_param, b_param = 1, 1 / 2
         squotient = (a_param / b_param) ** 2
 
-        ndim = self.total_space.point_ndim
+        ndim = self._total_space.point_ndim
         tangent_vec_with_zeros = insert_zeros(tangent_vec, axis=-ndim)
         base_point_with_origin = insert_zeros(base_point, axis=-ndim)
 
@@ -1843,7 +1845,7 @@ class SRVReparametrizationBundle(FiberBundle):
         aligned : array-like, shape=[..., k_sampling_points -1 , ambient_dim]
             Optimal reparametrization of the curve represented by point.
         """
-        return self.aligner.align(self, point, base_point)
+        return self.aligner.align(self._total_space, point, base_point)
 
 
 class SRVRotationBundle(FiberBundle):
@@ -1859,12 +1861,9 @@ class SRVRotationBundle(FiberBundle):
         Space of discrete curves starting at the origin
     """
 
-    def __init__(self, total_space):
-        super().__init__(total_space=total_space)
-
     def _transpose(self, point):
         """Transpose discrete curve starting at origin."""
-        dim = self.total_space.ambient_manifold.dim
+        dim = self._total_space.ambient_manifold.dim
         return Matrices(dim, dim).transpose(point)
 
     def _rotate(self, point, rotation):
@@ -1895,7 +1894,7 @@ class SRVRotationBundle(FiberBundle):
         aligned : array-like, shape=[..., k_sampling_points - 1, ambient_dim
             Curve optimally rotated with respect to reference curve.
         """
-        srv_transform = self.total_space.metric.diffeo
+        srv_transform = self._total_space.metric.diffeo
         initial_srv = srv_transform.diffeomorphism(base_point)
         end_srv = srv_transform.diffeomorphism(point)
 
@@ -1944,8 +1943,22 @@ class SRVRotationReparametrizationBundle(FiberBundle):
         self.threshold = threshold
         self.max_iter = max_iter
         self.verbose = verbose
-        self._rotations_bundle = SRVRotationBundle(total_space)
-        self._reparameterizations_bundle = SRVReparametrizationBundle(total_space)
+        self._total_space_with_rotations = self._init_space_with_rotations(total_space)
+        self._total_space_with_reparametrizations = (
+            self._init_space_with_reparametrizations(total_space)
+        )
+
+    def _init_space_with_rotations(self, total_space):
+        space = total_space.new(equip=True)
+        space.equip_with_group_action("rotations")
+        space.fiber_bundle = SRVRotationBundle(space)
+        return space
+
+    def _init_space_with_reparametrizations(self, total_space):
+        space = total_space.new(equip=True)
+        space.equip_with_group_action("reparametrizations")
+        space.fiber_bundle = SRVReparametrizationBundle(space)
+        return space
 
     def horizontal_projection(self, tangent_vec, base_point):
         """Project to horizontal subspace."""
@@ -1969,7 +1982,9 @@ class SRVRotationReparametrizationBundle(FiberBundle):
         aligned : array-like, shape=[..., k_sampling_points - 1, ambient_dim
             Curve optimally rotated with respect to reference curve.
         """
-        return self._rotations_bundle.align(point, base_point, return_rotation)
+        return self._total_space_with_rotations.fiber_bundle.align(
+            point, base_point, return_rotation
+        )
 
     def align_reparametrization(self, point, base_point, spline):
         """Find optimal parametrization of a curve with respect to a base curve.
@@ -1989,26 +2004,29 @@ class SRVRotationReparametrizationBundle(FiberBundle):
         aligned : array-like, shape=[..., k_sampling_points - 1, ambient_dim
             Curve optimally reparametrized with respect to reference curve.
         """
-        return self._reparameterizations_bundle.aligner.discrete_horizontal_geodesic(
-            self._reparameterizations_bundle, base_point, point, spline
+        bundle = self._total_space_with_reparametrizations.fiber_bundle
+        return bundle.aligner.discrete_horizontal_geodesic(
+            self._total_space_with_reparametrizations, base_point, point, spline
         )[..., -1, :, :]
 
     def _align_single(self, point, base_point):
         """Align point to base point, non vectorized."""
         aligned_point = gs.copy(point)
-        rotation = gs.eye(self.total_space.ambient_manifold.dim)
+        rotation = gs.eye(self._total_space.ambient_manifold.dim)
         for index in range(self.max_iter):
             new_aligned_point, new_rotation = self.align_rotation(
                 aligned_point, base_point, return_rotation=True
             )
             rotation = gs.matmul(new_rotation, rotation)
-            rotated_point = self._rotations_bundle._rotate(point, rotation)
-            rotated_spline = self.total_space.interpolate(rotated_point)
+            rotated_point = self._total_space_with_rotations.fiber_bundle._rotate(
+                point, rotation
+            )
+            rotated_spline = self._total_space.interpolate(rotated_point)
 
             new_aligned_point = self.align_reparametrization(
                 new_aligned_point, base_point, rotated_spline
             )
-            l2_metric = self.total_space.discrete_curves_with_l2.metric
+            l2_metric = self._total_space.discrete_curves_with_l2.metric
             gap = l2_metric.dist(aligned_point, new_aligned_point)
             aligned_point = gs.copy(new_aligned_point)
 
@@ -2051,7 +2069,7 @@ class SRVRotationReparametrizationBundle(FiberBundle):
              the reference curve.
         """
         is_batch = check_is_batch(
-            self.total_space.point_ndim,
+            self._total_space.point_ndim,
             point,
             base_point,
         )

--- a/geomstats/geometry/fiber_bundle.py
+++ b/geomstats/geometry/fiber_bundle.py
@@ -36,7 +36,7 @@ class FiberBundle(ABC):
         group_action=None,
         group_dim=None,
     ):
-        self.total_space = total_space
+        self._total_space = total_space
         self.group = group
 
         if group_action is None and group is not None:
@@ -147,7 +147,7 @@ class FiberBundle(ABC):
         group = self.group
         group_action = self.group_action
 
-        batch_shape = get_batch_shape(self.total_space.point_ndim, point, base_point)
+        batch_shape = get_batch_shape(self._total_space.point_ndim, point, base_point)
         max_shape = batch_shape + (self.group_dim,)
 
         if group is not None:
@@ -173,7 +173,7 @@ class FiberBundle(ABC):
 
         objective_with_grad = gs.autodiff.value_and_grad(
             lambda param: gs.sum(
-                self.total_space.metric.squared_dist(wrap(param), base_point)
+                self._total_space.metric.squared_dist(wrap(param), base_point)
             ),
         )
 

--- a/geomstats/geometry/full_rank_correlation_matrices.py
+++ b/geomstats/geometry/full_rank_correlation_matrices.py
@@ -255,7 +255,7 @@ class CorrelationMatricesBundle(FiberBundle):
         ver : array-like, shape=[..., n, n]
             Vertical projection.
         """
-        n = self.total_space.n
+        n = self._total_space.n
         inverse_base_point = GeneralLinear.inverse(base_point)
         operator = gs.eye(n) + base_point * inverse_base_point
         inverse_operator = GeneralLinear.inverse(operator)
@@ -300,9 +300,12 @@ class FullRankCorrelationAffineQuotientMetric(QuotientMetric):
             total_space = SPDMatrices(space.n, equip=False)
             total_space.equip_with_metric(SPDAffineMetric)
 
+        if not hasattr(total_space, "fiber_bundle"):
+            total_space.fiber_bundle = CorrelationMatricesBundle(total_space)
+
         super().__init__(
             space=space,
-            fiber_bundle=CorrelationMatricesBundle(total_space),
+            total_space=total_space,
         )
 
 

--- a/geomstats/geometry/manifold.py
+++ b/geomstats/geometry/manifold.py
@@ -119,7 +119,7 @@ class Manifold(abc.ABC):
         self.fiber_bundle = FiberBundle_(total_space=self)
 
         self.quotient = self.new(equip=False)
-        self.quotient.equip_with_metric(QuotientMetric_, fiber_bundle=self.fiber_bundle)
+        self.quotient.equip_with_metric(QuotientMetric_, total_space=self)
 
     @abc.abstractmethod
     def belongs(self, point, atol=gs.atol):

--- a/geomstats/geometry/quotient_metric.py
+++ b/geomstats/geometry/quotient_metric.py
@@ -20,13 +20,18 @@ class QuotientMetric(RiemannianMetric):
     ----------
     space : Manifold
         Base.
-    fiber_bundle : FiberBundle
-        Bundle structure to define the quotient.
+    total_space : Manifold
+        Total space equipped with a fiber bundle structure.
     """
 
-    def __init__(self, space, fiber_bundle, signature=None):
-        self.fiber_bundle = fiber_bundle
+    def __init__(self, space, total_space, signature=None):
+        self._total_space = total_space
         super().__init__(space=space, signature=signature)
+
+    @property
+    def _fiber_bundle(self):
+        """Fiber bundle associated to total space."""
+        return self._total_space.fiber_bundle
 
     def inner_product(
         self, tangent_vec_a, tangent_vec_b, base_point=None, fiber_point=None
@@ -60,15 +65,15 @@ class QuotientMetric(RiemannianMetric):
                 "given."
             )
         if fiber_point is None:
-            fiber_point = self.fiber_bundle.lift(base_point)
+            fiber_point = self._fiber_bundle.lift(base_point)
 
-        horizontal_a = self.fiber_bundle.horizontal_lift(
+        horizontal_a = self._fiber_bundle.horizontal_lift(
             tangent_vec_a, base_point=base_point, fiber_point=fiber_point
         )
-        horizontal_b = self.fiber_bundle.horizontal_lift(
+        horizontal_b = self._fiber_bundle.horizontal_lift(
             tangent_vec_b, base_point=base_point, fiber_point=fiber_point
         )
-        return self.fiber_bundle.total_space.metric.inner_product(
+        return self._total_space.metric.inner_product(
             horizontal_a, horizontal_b, fiber_point
         )
 
@@ -88,12 +93,12 @@ class QuotientMetric(RiemannianMetric):
         exp : array-like, shape=[..., {dim, [n, n]}]
             Point on the quotient manifold.
         """
-        fiber_point = self.fiber_bundle.lift(base_point)
-        horizontal_vec = self.fiber_bundle.horizontal_lift(
+        fiber_point = self._fiber_bundle.lift(base_point)
+        horizontal_vec = self._fiber_bundle.horizontal_lift(
             tangent_vec, fiber_point=fiber_point, base_point=base_point
         )
-        return self.fiber_bundle.riemannian_submersion(
-            self.fiber_bundle.total_space.metric.exp(horizontal_vec, fiber_point)
+        return self._fiber_bundle.riemannian_submersion(
+            self._total_space.metric.exp(horizontal_vec, fiber_point)
         )
 
     def _geodesic_from_exp(self, initial_point, initial_tangent_vec):
@@ -116,17 +121,17 @@ class QuotientMetric(RiemannianMetric):
             represents the different initial conditions, and the second
             corresponds to time.
         """
-        fiber_point = self.fiber_bundle.lift(initial_point)
-        horizontal_vec = self.fiber_bundle.horizontal_lift(
+        fiber_point = self._fiber_bundle.lift(initial_point)
+        horizontal_vec = self._fiber_bundle.horizontal_lift(
             initial_tangent_vec, fiber_point=fiber_point, base_point=initial_point
         )
-        total_path = self.fiber_bundle.total_space.metric._geodesic_from_exp(
+        total_path = self._total_space.metric._geodesic_from_exp(
             fiber_point, horizontal_vec
         )
 
         def path(t):
             total_geod_points = total_path(t)
-            out = self.fiber_bundle.riemannian_submersion(total_geod_points)
+            out = self._fiber_bundle.riemannian_submersion(total_geod_points)
             return out
 
         return path
@@ -147,11 +152,11 @@ class QuotientMetric(RiemannianMetric):
             Tangent vector at the base point equal to the Riemannian logarithm
             of point at the base point.
         """
-        fiber_point = self.fiber_bundle.lift(point)
-        fiber_base_point = self.fiber_bundle.lift(base_point)
-        aligned = self.fiber_bundle.align(fiber_point, fiber_base_point)
-        return self.fiber_bundle.tangent_riemannian_submersion(
-            self.fiber_bundle.total_space.metric.log(aligned, fiber_base_point),
+        fiber_point = self._fiber_bundle.lift(point)
+        fiber_base_point = self._fiber_bundle.lift(base_point)
+        aligned = self._fiber_bundle.align(fiber_point, fiber_base_point)
+        return self._fiber_bundle.tangent_riemannian_submersion(
+            self._total_space.metric.log(aligned, fiber_base_point),
             fiber_base_point,
         )
 
@@ -170,10 +175,10 @@ class QuotientMetric(RiemannianMetric):
         sq_dist : array-like, shape=[...,]
             Squared distance.
         """
-        fiber_point_a = self.fiber_bundle.lift(point_a)
-        fiber_point_b = self.fiber_bundle.lift(point_b)
-        aligned = self.fiber_bundle.align(fiber_point_b, fiber_point_a)
-        return self.fiber_bundle.total_space.metric.squared_dist(fiber_point_a, aligned)
+        fiber_point_a = self._fiber_bundle.lift(point_a)
+        fiber_point_b = self._fiber_bundle.lift(point_b)
+        aligned = self._fiber_bundle.align(fiber_point_b, fiber_point_a)
+        return self._total_space.metric.squared_dist(fiber_point_a, aligned)
 
     def curvature(self, tangent_vec_a, tangent_vec_b, tangent_vec_c, base_point):
         r"""Compute the curvature.
@@ -219,13 +224,13 @@ class QuotientMetric(RiemannianMetric):
             Submersion, Michigan Mathematical Journal 13, no. 4
             (December 1966): 459–69. https://doi.org/10.1307/mmj/1028999604.
         """
-        bundle = self.fiber_bundle
+        bundle = self._fiber_bundle
         fiber_point = bundle.lift(base_point)
         horizontal_a = bundle.horizontal_lift(tangent_vec_a, base_point)
         horizontal_b = bundle.horizontal_lift(tangent_vec_b, base_point)
         horizontal_c = bundle.horizontal_lift(tangent_vec_c, base_point)
 
-        top_curvature = bundle.total_space.metric.curvature(
+        top_curvature = self._total_space.metric.curvature(
             horizontal_a, horizontal_b, horizontal_c, fiber_point
         )
         projected_top_curvature = bundle.tangent_riemannian_submersion(
@@ -308,7 +313,7 @@ class QuotientMetric(RiemannianMetric):
         .. [Pennec] Pennec, Xavier. Computing the curvature and its gradient
             in Kendall shape spaces. Unpublished.
         """
-        bundle = self.fiber_bundle
+        bundle = self._fiber_bundle
         point_fiber = bundle.lift(base_point)
         hor_h = bundle.horizontal_lift(tangent_vec_a, point_fiber)
         hor_x = bundle.horizontal_lift(tangent_vec_b, point_fiber)
@@ -319,7 +324,7 @@ class QuotientMetric(RiemannianMetric):
         nabla_h_y = bundle.integrability_tensor(hor_h, hor_y, point_fiber)
         nabla_h_z = bundle.integrability_tensor(hor_h, hor_z, point_fiber)
 
-        nabla_curvature_top = bundle.total_space.metric.curvature_derivative(
+        nabla_curvature_top = self._total_space.metric.curvature_derivative(
             hor_h, hor_x, hor_y, hor_z, point_fiber
         )
 
@@ -423,7 +428,7 @@ class QuotientMetric(RiemannianMetric):
         .. [Pennec] Pennec, Xavier. Computing the curvature and its gradient
             in Kendall shape spaces. Unpublished.
         """
-        bundle = self.fiber_bundle
+        bundle = self._fiber_bundle
         point_fiber = bundle.lift(base_point)
         hor_x = bundle.horizontal_lift(tangent_vec_a, point_fiber)
         hor_y = bundle.horizontal_lift(tangent_vec_b, point_fiber)
@@ -431,7 +436,7 @@ class QuotientMetric(RiemannianMetric):
         nabla_x_x = gs.zeros_like(hor_x)
         nabla_x_y = bundle.integrability_tensor(hor_x, hor_y, point_fiber)
 
-        nabla_curvature_top = bundle.total_space.metric.curvature_derivative(
+        nabla_curvature_top = self._total_space.metric.curvature_derivative(
             hor_x, hor_x, hor_y, hor_y, point_fiber
         )
 
@@ -497,17 +502,17 @@ class QuotientMetric(RiemannianMetric):
                 raise ValueError(
                     "Cannot specify both an end point and an initial tangent vector."
                 )
-            initial_fiber_point = self.fiber_bundle.lift(initial_point)
-            end_fiber_point = self.fiber_bundle.lift(end_point)
-            aligned_end_fiber_point = self.fiber_bundle.align(
+            initial_fiber_point = self._fiber_bundle.lift(initial_point)
+            end_fiber_point = self._fiber_bundle.lift(end_point)
+            aligned_end_fiber_point = self._fiber_bundle.align(
                 end_fiber_point, initial_fiber_point
             )
-            geodesic = self.fiber_bundle.total_space.metric.geodesic(
+            geodesic = self._total_space.metric.geodesic(
                 initial_point=initial_fiber_point, end_point=aligned_end_fiber_point
             )
 
             def projected_geodesic(t):
-                return self.fiber_bundle.riemannian_submersion(geodesic(t))
+                return self._fiber_bundle.riemannian_submersion(geodesic(t))
 
             return projected_geodesic
 

--- a/geomstats/geometry/rank_k_psd_matrices.py
+++ b/geomstats/geometry/rank_k_psd_matrices.py
@@ -245,7 +245,7 @@ class BuresWassersteinBundle(FiberBundle):
 
     def lift(self, point):
         """Find a representer in top space."""
-        k = self.total_space.k
+        k = self._total_space.k
         eigvals, eigvecs = gs.linalg.eigh(point)
         return gs.einsum(
             "...ij,...j->...ij", eigvecs[..., -k:], eigvals[..., -k:] ** 0.5
@@ -253,7 +253,7 @@ class BuresWassersteinBundle(FiberBundle):
 
     def horizontal_lift(self, tangent_vec, base_point=None, fiber_point=None):
         """Horizontal lift of a tangent vector."""
-        n = self.total_space.n
+        n = self._total_space.n
         if fiber_point is None:
             fiber_point = self.lift(base_point)
         transposed_point = Matrices.transpose(fiber_point)
@@ -333,4 +333,7 @@ class PSDBuresWassersteinMetric(QuotientMetric):
             total_space = FullRankMatrices(space.n, k, equip=False)
             total_space.equip_with_metric(MatricesMetric)
 
-        super().__init__(space=space, fiber_bundle=BuresWassersteinBundle(total_space))
+        if not hasattr(total_space, "fiber_bundle"):
+            total_space.fiber_bundle = BuresWassersteinBundle(total_space)
+
+        super().__init__(space=space, total_space=total_space)

--- a/geomstats/test/random.py
+++ b/geomstats/test/random.py
@@ -115,7 +115,7 @@ class LieGroupVectorRandomDataGenerator(RandomDataGenerator):
 class KendalShapeRandomDataGenerator(EmbeddedSpaceRandomDataGenerator):
     def random_horizontal_vec(self, base_point):
         tangent_vec = self.random_tangent_vec(base_point)
-        fiber_bundle = self.space.metric.fiber_bundle
+        fiber_bundle = self.space.metric._total_space.fiber_bundle
         return (
             fiber_bundle.horizontal_projection(tangent_vec, base_point) / self.amplitude
         )

--- a/geomstats/test/random.py
+++ b/geomstats/test/random.py
@@ -115,9 +115,9 @@ class LieGroupVectorRandomDataGenerator(RandomDataGenerator):
 class KendalShapeRandomDataGenerator(EmbeddedSpaceRandomDataGenerator):
     def random_horizontal_vec(self, base_point):
         tangent_vec = self.random_tangent_vec(base_point)
-        fiber_bundle = self.space.metric._total_space.fiber_bundle
         return (
-            fiber_bundle.horizontal_projection(tangent_vec, base_point) / self.amplitude
+            self.space.fiber_bundle.horizontal_projection(tangent_vec, base_point)
+            / self.amplitude
         )
 
 

--- a/geomstats/test_cases/geometry/discrete_curves.py
+++ b/geomstats/test_cases/geometry/discrete_curves.py
@@ -64,8 +64,12 @@ class SRVReparametrizationBundleTestCase(FiberBundleTestCase):
         base_point = self.data_generator.random_point(n_points)
         tangent_vec = self.data_generator.random_tangent_vec(base_point)
 
-        tangent_vec_hor = self.bundle.horizontal_projection(tangent_vec, base_point)
-        tangent_vec_ver = self.bundle.vertical_projection(tangent_vec, base_point)
+        tangent_vec_hor = self.total_space.fiber_bundle.horizontal_projection(
+            tangent_vec, base_point
+        )
+        tangent_vec_ver = self.total_space.fiber_bundle.vertical_projection(
+            tangent_vec, base_point
+        )
 
         res = self.total_space.metric.inner_product(
             tangent_vec_hor, tangent_vec_ver, base_point

--- a/geomstats/test_cases/geometry/fiber_bundle.py
+++ b/geomstats/test_cases/geometry/fiber_bundle.py
@@ -28,13 +28,13 @@ class FiberBundleTestCase(TestCase):
         self.assertAllEqual(res, expected)
 
     def test_riemannian_submersion(self, point, expected, atol):
-        res = self.bundle.riemannian_submersion(point)
+        res = self.total_space.fiber_bundle.riemannian_submersion(point)
         self.assertAllClose(res, expected, atol=atol)
 
     @pytest.mark.vec
     def test_riemannian_submersion_vec(self, n_reps, atol):
         point = self.data_generator.random_point()
-        expected = self.bundle.riemannian_submersion(point)
+        expected = self.total_space.fiber_bundle.riemannian_submersion(point)
 
         vec_data = generate_vectorization_data(
             data=[dict(point=point, expected=expected, atol=atol)],
@@ -48,19 +48,19 @@ class FiberBundleTestCase(TestCase):
     def test_riemannian_submersion_belongs_to_base(self, n_points, atol):
         point = self.data_generator.random_point(n_points)
 
-        proj_point = self.bundle.riemannian_submersion(point)
+        proj_point = self.total_space.fiber_bundle.riemannian_submersion(point)
         expected = gs.ones(n_points, dtype=bool)
 
         self._test_belongs_to_base(proj_point, expected, atol)
 
     def test_lift(self, point, expected, atol):
-        res = self.bundle.lift(point)
+        res = self.total_space.fiber_bundle.lift(point)
         self.assertAllClose(res, expected, atol=atol)
 
     @pytest.mark.vec
     def test_lift_vec(self, n_reps, atol):
         point = self.base_data_generator.random_point()
-        expected = self.bundle.lift(point)
+        expected = self.total_space.fiber_bundle.lift(point)
 
         vec_data = generate_vectorization_data(
             data=[dict(point=point, expected=expected, atol=atol)],
@@ -73,7 +73,7 @@ class FiberBundleTestCase(TestCase):
     @pytest.mark.random
     def test_lift_belongs_to_total_space(self, n_points, atol):
         point = self.base_data_generator.random_point(n_points)
-        lifted_point = self.bundle.lift(point)
+        lifted_point = self.total_space.fiber_bundle.lift(point)
 
         expected = gs.ones(n_points, dtype=bool)
         self._test_belongs_to_total_space(lifted_point, expected, atol)
@@ -81,15 +81,17 @@ class FiberBundleTestCase(TestCase):
     @pytest.mark.random
     def test_riemannian_submersion_after_lift(self, n_points, atol):
         point = self.base_data_generator.random_point(n_points)
-        lifted_point = self.bundle.lift(point)
-        point_ = self.bundle.riemannian_submersion(lifted_point)
+        lifted_point = self.total_space.fiber_bundle.lift(point)
+        point_ = self.total_space.fiber_bundle.riemannian_submersion(lifted_point)
 
         self.assertAllClose(point_, point, atol=atol)
 
     def test_tangent_riemannian_submersion(
         self, tangent_vec, base_point, expected, atol
     ):
-        res = self.bundle.tangent_riemannian_submersion(tangent_vec, base_point)
+        res = self.total_space.fiber_bundle.tangent_riemannian_submersion(
+            tangent_vec, base_point
+        )
         self.assertAllClose(res, expected, atol=atol)
 
     @pytest.mark.vec
@@ -97,7 +99,9 @@ class FiberBundleTestCase(TestCase):
         base_point = self.data_generator.random_point()
         tangent_vec = self.data_generator.random_tangent_vec(base_point)
 
-        expected = self.bundle.tangent_riemannian_submersion(tangent_vec, base_point)
+        expected = self.total_space.fiber_bundle.tangent_riemannian_submersion(
+            tangent_vec, base_point
+        )
 
         vec_data = generate_vectorization_data(
             data=[
@@ -120,17 +124,19 @@ class FiberBundleTestCase(TestCase):
         base_point = self.data_generator.random_point(n_points)
         tangent_vec = self.data_generator.random_tangent_vec(base_point)
 
-        proj_tangent_vector = self.bundle.tangent_riemannian_submersion(
-            tangent_vec, base_point
+        proj_tangent_vector = (
+            self.total_space.fiber_bundle.tangent_riemannian_submersion(
+                tangent_vec, base_point
+            )
         )
-        proj_point = self.bundle.riemannian_submersion(base_point)
+        proj_point = self.total_space.fiber_bundle.riemannian_submersion(base_point)
 
         res = self.base.is_tangent(proj_tangent_vector, proj_point, atol=atol)
         expected = gs.ones(n_points, dtype=bool)
         self.assertAllEqual(res, expected)
 
     def test_align(self, point, base_point, expected, atol):
-        res = self.bundle.align(point, base_point)
+        res = self.total_space.fiber_bundle.align(point, base_point)
         self.assertAllClose(res, expected, atol=atol)
 
     @pytest.mark.vec
@@ -138,7 +144,7 @@ class FiberBundleTestCase(TestCase):
         point = self.data_generator.random_point()
         base_point = self.data_generator.random_point()
 
-        expected = self.bundle.align(point, base_point)
+        expected = self.total_space.fiber_bundle.align(point, base_point)
 
         vec_data = generate_vectorization_data(
             data=[
@@ -155,14 +161,16 @@ class FiberBundleTestCase(TestCase):
         point = self.data_generator.random_point(n_points)
         base_point = self.data_generator.random_point(n_points)
 
-        aligned_point = self.bundle.align(point, base_point)
+        aligned_point = self.total_space.fiber_bundle.align(point, base_point)
         log = self.total_space.metric.log(aligned_point, base_point)
 
         expected = gs.ones(n_points, dtype=bool)
         self.test_is_horizontal(log, base_point, expected, atol)
 
     def test_horizontal_projection(self, tangent_vec, base_point, expected, atol):
-        res = self.bundle.horizontal_projection(tangent_vec, base_point)
+        res = self.total_space.fiber_bundle.horizontal_projection(
+            tangent_vec, base_point
+        )
         self.assertAllClose(res, expected, atol=atol)
 
     @pytest.mark.vec
@@ -170,7 +178,9 @@ class FiberBundleTestCase(TestCase):
         base_point = self.data_generator.random_point()
         tangent_vec = self.data_generator.random_tangent_vec(base_point)
 
-        expected = self.bundle.horizontal_projection(tangent_vec, base_point)
+        expected = self.total_space.fiber_bundle.horizontal_projection(
+            tangent_vec, base_point
+        )
 
         vec_data = generate_vectorization_data(
             data=[
@@ -193,12 +203,14 @@ class FiberBundleTestCase(TestCase):
         base_point = self.data_generator.random_point(n_points)
         tangent_vec = self.data_generator.random_tangent_vec(base_point)
 
-        horizontal = self.bundle.horizontal_projection(tangent_vec, base_point)
+        horizontal = self.total_space.fiber_bundle.horizontal_projection(
+            tangent_vec, base_point
+        )
         expected = gs.ones(n_points, dtype=bool)
         self.test_is_horizontal(horizontal, base_point, expected, atol)
 
     def test_vertical_projection(self, tangent_vec, base_point, expected, atol):
-        res = self.bundle.vertical_projection(tangent_vec, base_point)
+        res = self.total_space.fiber_bundle.vertical_projection(tangent_vec, base_point)
         self.assertAllClose(res, expected, atol=atol)
 
     @pytest.mark.vec
@@ -206,7 +218,9 @@ class FiberBundleTestCase(TestCase):
         base_point = self.data_generator.random_point()
         tangent_vec = self.data_generator.random_tangent_vec(base_point)
 
-        expected = self.bundle.vertical_projection(tangent_vec, base_point)
+        expected = self.total_space.fiber_bundle.vertical_projection(
+            tangent_vec, base_point
+        )
 
         vec_data = generate_vectorization_data(
             data=[
@@ -229,7 +243,9 @@ class FiberBundleTestCase(TestCase):
         base_point = self.data_generator.random_point(n_points)
         tangent_vec = self.data_generator.random_tangent_vec(base_point)
 
-        vertical = self.bundle.vertical_projection(tangent_vec, base_point)
+        vertical = self.total_space.fiber_bundle.vertical_projection(
+            tangent_vec, base_point
+        )
         expected = gs.ones(n_points, dtype=bool)
         self.test_is_vertical(vertical, base_point, expected, atol)
 
@@ -240,14 +256,20 @@ class FiberBundleTestCase(TestCase):
         base_point = self.data_generator.random_point(n_points)
         tangent_vec = self.data_generator.random_tangent_vec(base_point)
 
-        vertical = self.bundle.vertical_projection(tangent_vec, base_point)
-        res = self.bundle.tangent_riemannian_submersion(vertical, base_point)
+        vertical = self.total_space.fiber_bundle.vertical_projection(
+            tangent_vec, base_point
+        )
+        res = self.total_space.fiber_bundle.tangent_riemannian_submersion(
+            vertical, base_point
+        )
         expected = gs.zeros_like(res)
 
         self.assertAllClose(res, expected, atol=atol)
 
     def test_is_horizontal(self, tangent_vec, base_point, expected, atol):
-        res = self.bundle.is_horizontal(tangent_vec, base_point, atol=atol)
+        res = self.total_space.fiber_bundle.is_horizontal(
+            tangent_vec, base_point, atol=atol
+        )
         self.assertAllEqual(res, expected)
 
     @pytest.mark.vec
@@ -255,7 +277,9 @@ class FiberBundleTestCase(TestCase):
         base_point = self.data_generator.random_point()
         tangent_vec = self.data_generator.random_tangent_vec(base_point)
 
-        expected = self.bundle.is_horizontal(tangent_vec, base_point, atol=atol)
+        expected = self.total_space.fiber_bundle.is_horizontal(
+            tangent_vec, base_point, atol=atol
+        )
 
         vec_data = generate_vectorization_data(
             data=[
@@ -274,7 +298,9 @@ class FiberBundleTestCase(TestCase):
         self._test_vectorization(vec_data)
 
     def test_is_vertical(self, tangent_vec, base_point, expected, atol):
-        res = self.bundle.is_vertical(tangent_vec, base_point, atol=atol)
+        res = self.total_space.fiber_bundle.is_vertical(
+            tangent_vec, base_point, atol=atol
+        )
         self.assertAllEqual(res, expected)
 
     @pytest.mark.vec
@@ -282,7 +308,9 @@ class FiberBundleTestCase(TestCase):
         base_point = self.data_generator.random_point()
         tangent_vec = self.data_generator.random_tangent_vec(base_point)
 
-        expected = self.bundle.is_vertical(tangent_vec, base_point, atol=atol)
+        expected = self.total_space.fiber_bundle.is_vertical(
+            tangent_vec, base_point, atol=atol
+        )
 
         vec_data = generate_vectorization_data(
             data=[
@@ -303,7 +331,7 @@ class FiberBundleTestCase(TestCase):
     def test_horizontal_lift(
         self, tangent_vec, expected, atol, base_point=None, fiber_point=None
     ):
-        res = self.bundle.horizontal_lift(
+        res = self.total_space.fiber_bundle.horizontal_lift(
             tangent_vec, base_point=base_point, fiber_point=fiber_point
         )
         self.assertAllClose(res, expected, atol=atol)
@@ -313,7 +341,9 @@ class FiberBundleTestCase(TestCase):
         base_point = self.base_data_generator.random_point()
         tangent_vec = self.base_data_generator.random_tangent_vec(base_point)
 
-        expected = self.bundle.horizontal_lift(tangent_vec, base_point=base_point)
+        expected = self.total_space.fiber_bundle.horizontal_lift(
+            tangent_vec, base_point=base_point
+        )
 
         vec_data = generate_vectorization_data(
             data=[
@@ -336,8 +366,8 @@ class FiberBundleTestCase(TestCase):
         base_point = self.base_data_generator.random_point(n_points)
         tangent_vec = self.base_data_generator.random_tangent_vec(base_point)
 
-        fiber_point = self.bundle.lift(base_point)
-        horizontal = self.bundle.horizontal_lift(
+        fiber_point = self.total_space.fiber_bundle.lift(base_point)
+        horizontal = self.total_space.fiber_bundle.horizontal_lift(
             tangent_vec, base_point=base_point, fiber_point=fiber_point
         )
 
@@ -348,10 +378,12 @@ class FiberBundleTestCase(TestCase):
     def test_tangent_riemannian_submersion_after_horizontal_lift(self, n_points, atol):
         base_point = self.base_data_generator.random_point(n_points)
         tangent_vec = self.base_data_generator.random_tangent_vec(base_point)
-        fiber_point = self.bundle.lift(base_point)
+        fiber_point = self.total_space.fiber_bundle.lift(base_point)
 
-        horizontal = self.bundle.horizontal_lift(tangent_vec, fiber_point=fiber_point)
-        tangent_vec_ = self.bundle.tangent_riemannian_submersion(
+        horizontal = self.total_space.fiber_bundle.horizontal_lift(
+            tangent_vec, fiber_point=fiber_point
+        )
+        tangent_vec_ = self.total_space.fiber_bundle.tangent_riemannian_submersion(
             horizontal, fiber_point
         )
 
@@ -360,7 +392,9 @@ class FiberBundleTestCase(TestCase):
     def test_integrability_tensor(
         self, tangent_vec_a, tangent_vec_b, base_point, expected, atol
     ):
-        res = self.bundle.integrability_tensor(tangent_vec_a, tangent_vec_b, base_point)
+        res = self.total_space.fiber_bundle.integrability_tensor(
+            tangent_vec_a, tangent_vec_b, base_point
+        )
         self.assertAllClose(res, expected, atol=atol)
 
     @pytest.mark.vec
@@ -369,7 +403,7 @@ class FiberBundleTestCase(TestCase):
         tangent_vec_a = self.data_generator.random_tangent_vec(base_point)
         tangent_vec_b = self.data_generator.random_tangent_vec(base_point)
 
-        expected = self.bundle.integrability_tensor(
+        expected = self.total_space.fiber_bundle.integrability_tensor(
             tangent_vec_a, tangent_vec_b, base_point
         )
 
@@ -402,7 +436,10 @@ class FiberBundleTestCase(TestCase):
         expected_a_y_e,
         atol,
     ):
-        nabla_x_a_y_e, a_y_e = self.bundle.integrability_tensor_derivative(
+        (
+            nabla_x_a_y_e,
+            a_y_e,
+        ) = self.total_space.fiber_bundle.integrability_tensor_derivative(
             horizontal_vec_x,
             horizontal_vec_y,
             nabla_x_y,
@@ -416,11 +453,11 @@ class FiberBundleTestCase(TestCase):
     @pytest.mark.vec
     def test_integrability_tensor_derivative_vec(self, n_reps, atol):
         base_point = self.data_generator.random_point()
-        horizontal_vec_x = self.bundle.horizontal_lift(
+        horizontal_vec_x = self.total_space.fiber_bundle.horizontal_lift(
             self.data_generator.random_tangent_vec(base_point),
             fiber_point=base_point,
         )
-        horizontal_vec_y = self.bundle.horizontal_lift(
+        horizontal_vec_y = self.total_space.fiber_bundle.horizontal_lift(
             self.data_generator.random_tangent_vec(base_point),
             fiber_point=base_point,
         )
@@ -428,7 +465,10 @@ class FiberBundleTestCase(TestCase):
         tangent_vec_e = self.data_generator.random_tangent_vec(base_point)
         nabla_x_e = self.data_generator.random_tangent_vec(base_point)
 
-        nabla_x_a_y_e, a_y_e = self.bundle.integrability_tensor_derivative(
+        (
+            nabla_x_a_y_e,
+            a_y_e,
+        ) = self.total_space.fiber_bundle.integrability_tensor_derivative(
             horizontal_vec_x,
             horizontal_vec_y,
             nabla_x_y,

--- a/geomstats/test_cases/geometry/pre_shape.py
+++ b/geomstats/test_cases/geometry/pre_shape.py
@@ -742,7 +742,7 @@ class PreShapeSpaceBundleTestCase(FiberBundleTestCase):
 class KendallShapeMetricTestCase(QuotientMetricTestCase):
     def setup_method(self):
         if not hasattr(self, "data_generator"):
-            self.data_generator = KendalShapeRandomDataGenerator(self.space)
+            self.data_generator = KendalShapeRandomDataGenerator(self.total_space)
         super().setup_method()
 
     def _cmp_points(self, point, point_, atol):
@@ -959,8 +959,9 @@ class KendallShapeMetricTestCase(QuotientMetricTestCase):
 
         end_point = self.space.metric.exp(direction, base_point)
 
-        fiber_bundle = self.space.metric._total_space.fiber_bundle
-        res = fiber_bundle.is_horizontal(transported, end_point, atol=atol)
+        res = self.total_space.fiber_bundle.is_horizontal(
+            transported, end_point, atol=atol
+        )
 
         expected_shape = get_batch_shape(self.space.point_ndim, base_point)
         expected = gs.ones(expected_shape, dtype=bool)

--- a/geomstats/test_cases/geometry/pre_shape.py
+++ b/geomstats/test_cases/geometry/pre_shape.py
@@ -10,7 +10,7 @@ from geomstats.test_cases.geometry.quotient_metric import QuotientMetricTestCase
 from geomstats.vectorization import get_batch_shape
 
 
-def integrability_tensor_alt(bundle, tangent_vec_a, tangent_vec_b, base_point):
+def integrability_tensor_alt(total_space, tangent_vec_a, tangent_vec_b, base_point):
     r"""Compute the fundamental tensor A of the submersion.
 
     The fundamental tensor A is defined for tangent vectors of the total
@@ -25,7 +25,8 @@ def integrability_tensor_alt(bundle, tangent_vec_a, tangent_vec_b, base_point):
 
     Parameters
     ----------
-    bundle : PreShapeSpaceBundle
+    total_space : Manifold
+        Total space with fiber bundle structure.
     tangent_vec_a : array-like, shape=[..., k_landmarks, m_ambient]
         Tangent vector at `base_point`.
     tangent_vec_b : array-like, shape=[..., k_landmarks, m_ambient]
@@ -46,8 +47,10 @@ def integrability_tensor_alt(bundle, tangent_vec_a, tangent_vec_b, base_point):
         (December 1966): 459–69. https://doi.org/10.1307/mmj/1028999604.
     """
     # Only the horizontal part of a counts
-    horizontal_a = bundle.horizontal_projection(tangent_vec_a, base_point)
-    vertical_b, skew = bundle.vertical_projection(
+    horizontal_a = total_space.fiber_bundle.horizontal_projection(
+        tangent_vec_a, base_point
+    )
+    vertical_b, skew = total_space.fiber_bundle.vertical_projection(
         tangent_vec_b, base_point, return_skew=True
     )
     horizontal_b = tangent_vec_b - vertical_b
@@ -62,8 +65,10 @@ def integrability_tensor_alt(bundle, tangent_vec_a, tangent_vec_b, base_point):
 
     # For the vertical part of b
     vert_part = -gs.matmul(horizontal_a, skew)
-    tangent_vert = bundle.total_space.to_tangent(vert_part, base_point)
-    horizontal_ = bundle.horizontal_projection(tangent_vert, base_point)
+    tangent_vert = total_space.to_tangent(vert_part, base_point)
+    horizontal_ = total_space.fiber_bundle.horizontal_projection(
+        tangent_vert, base_point
+    )
 
     return vertical + horizontal_
 
@@ -119,7 +124,7 @@ class PreShapeSpaceBundleTestCase(FiberBundleTestCase):
 
     def _get_horizontal_vec(self, base_point, return_tangent=False):
         tangent_vec = self.data_generator.random_tangent_vec(base_point)
-        horizontal = self.bundle.horizontal_projection(
+        horizontal = self.total_space.fiber_bundle.horizontal_projection(
             tangent_vec,
             base_point,
         )
@@ -130,7 +135,7 @@ class PreShapeSpaceBundleTestCase(FiberBundleTestCase):
 
     def _get_vertical_vec(self, base_point, return_tangent=False):
         tangent_vec = self.data_generator.random_tangent_vec(base_point)
-        vertical = self.bundle.vertical_projection(
+        vertical = self.total_space.fiber_bundle.vertical_projection(
             tangent_vec,
             base_point,
         )
@@ -140,7 +145,9 @@ class PreShapeSpaceBundleTestCase(FiberBundleTestCase):
         return vertical
 
     def _get_nabla_x_y(self, horizontal_vec_x, vec_y, base_point, horizontal=True):
-        a_x_y = self.bundle.integrability_tensor(horizontal_vec_x, vec_y, base_point)
+        a_x_y = self.total_space.fiber_bundle.integrability_tensor(
+            horizontal_vec_x, vec_y, base_point
+        )
 
         dy = (
             self._get_horizontal_vec(base_point)
@@ -159,7 +166,9 @@ class PreShapeSpaceBundleTestCase(FiberBundleTestCase):
         tmp_expected = gs.matmul(transposed_point, tangent_vec)
         expected = Matrices.transpose(tmp_expected) - tmp_expected
 
-        vertical = self.bundle.vertical_projection(tangent_vec, base_point)
+        vertical = self.total_space.fiber_bundle.vertical_projection(
+            tangent_vec, base_point
+        )
         tmp_result = gs.matmul(transposed_point, vertical)
         result = Matrices.transpose(tmp_result) - tmp_result
 
@@ -170,7 +179,9 @@ class PreShapeSpaceBundleTestCase(FiberBundleTestCase):
         base_point = self.data_generator.random_point(n_points)
         tangent_vec = self.data_generator.random_tangent_vec(base_point)
 
-        horizontal = self.bundle.horizontal_projection(tangent_vec, base_point)
+        horizontal = self.total_space.fiber_bundle.horizontal_projection(
+            tangent_vec, base_point
+        )
 
         result = gs.matmul(Matrices.transpose(base_point), horizontal)
         self.assertAllClose(result, Matrices.transpose(result), atol=atol)
@@ -180,7 +191,9 @@ class PreShapeSpaceBundleTestCase(FiberBundleTestCase):
         base_point = self.data_generator.random_point(n_points)
         tangent_vec = self.data_generator.random_tangent_vec(base_point)
 
-        horizontal = self.bundle.horizontal_projection(tangent_vec, base_point)
+        horizontal = self.total_space.fiber_bundle.horizontal_projection(
+            tangent_vec, base_point
+        )
 
         expected = gs.ones(n_points, dtype=bool)
         self._test_is_tangent(horizontal, base_point, expected, atol)
@@ -190,7 +203,7 @@ class PreShapeSpaceBundleTestCase(FiberBundleTestCase):
         point = self.data_generator.random_point(n_points)
         base_point = self.data_generator.random_point(n_points)
 
-        aligned_point = self.bundle.align(point, base_point)
+        aligned_point = self.total_space.fiber_bundle.align(point, base_point)
         alignment = Matrices.mul(Matrices.transpose(aligned_point), base_point)
         self.assertAllClose(alignment, Matrices.transpose(alignment), atol=atol)
 
@@ -207,7 +220,7 @@ class PreShapeSpaceBundleTestCase(FiberBundleTestCase):
 
         tangent_vec_b = self.data_generator.random_tangent_vec(base_point)
 
-        result_ab = self.bundle.integrability_tensor(
+        result_ab = self.total_space.fiber_bundle.integrability_tensor(
             tangent_vec_a, tangent_vec_b, base_point
         )
 
@@ -232,21 +245,27 @@ class PreShapeSpaceBundleTestCase(FiberBundleTestCase):
             base_point, return_tangent=True
         )
 
-        result = self.bundle.integrability_tensor(
+        result = self.total_space.fiber_bundle.integrability_tensor(
             horizontal_a, horizontal_b, base_point
         )
-        expected = -self.bundle.integrability_tensor(
+        expected = -self.total_space.fiber_bundle.integrability_tensor(
             horizontal_b, horizontal_a, base_point
         )
         self.assertAllClose(result, expected, atol=atol)
 
-        is_vertical = self.bundle.is_vertical(result, base_point, atol=atol)
+        is_vertical = self.total_space.fiber_bundle.is_vertical(
+            result, base_point, atol=atol
+        )
         expected = gs.ones(n_points, dtype=bool)
         self.assertAllEqual(is_vertical, expected)
 
         vertical_b = tangent_vec_b - horizontal_b
-        result = self.bundle.integrability_tensor(horizontal_a, vertical_b, base_point)
-        is_horizontal = self.bundle.is_horizontal(result, base_point, atol=atol)
+        result = self.total_space.fiber_bundle.integrability_tensor(
+            horizontal_a, vertical_b, base_point
+        )
+        is_horizontal = self.total_space.fiber_bundle.is_horizontal(
+            result, base_point, atol=atol
+        )
         expected = gs.ones(n_points, dtype=bool)
         self.assertAllEqual(is_horizontal, expected)
 
@@ -257,11 +276,11 @@ class PreShapeSpaceBundleTestCase(FiberBundleTestCase):
         tangent_vec_a = self.data_generator.random_tangent_vec(base_point)
         tangent_vec_b = self.data_generator.random_tangent_vec(base_point)
 
-        expected = self.bundle.integrability_tensor(
+        expected = self.total_space.fiber_bundle.integrability_tensor(
             tangent_vec_a, tangent_vec_b, base_point
         )
         alt_expected = integrability_tensor_alt(
-            self.bundle, tangent_vec_a, tangent_vec_b, base_point
+            self.total_space, tangent_vec_a, tangent_vec_b, base_point
         )
         self.assertAllClose(expected, alt_expected, atol=atol)
 
@@ -277,7 +296,10 @@ class PreShapeSpaceBundleTestCase(FiberBundleTestCase):
         tangent_vec_e = self.data_generator.random_tangent_vec(base_point)
         nabla_x_e = self.data_generator.random_tangent_vec(base_point)
 
-        nabla_x_a_y_e, a_y_e = self.bundle.integrability_tensor_derivative(
+        (
+            nabla_x_a_y_e,
+            a_y_e,
+        ) = self.total_space.fiber_bundle.integrability_tensor_derivative(
             horizontal_vec_x,
             horizontal_vec_y,
             nabla_x_y,
@@ -329,7 +351,10 @@ class PreShapeSpaceBundleTestCase(FiberBundleTestCase):
         nabla_x_y = self._get_nabla_x_y(horizontal_vec_x, horizontal_vec_y, base_point)
         nabla_x_z = self._get_nabla_x_y(horizontal_vec_x, horizontal_vec_z, base_point)
 
-        nabla_x_a_y_z, a_y_z = self.bundle.integrability_tensor_derivative(
+        (
+            nabla_x_a_y_z,
+            a_y_z,
+        ) = self.total_space.fiber_bundle.integrability_tensor_derivative(
             horizontal_vec_x,
             horizontal_vec_y,
             nabla_x_y,
@@ -337,7 +362,10 @@ class PreShapeSpaceBundleTestCase(FiberBundleTestCase):
             nabla_x_z,
             base_point,
         )
-        nabla_x_a_z_y, a_z_y = self.bundle.integrability_tensor_derivative(
+        (
+            nabla_x_a_z_y,
+            a_z_y,
+        ) = self.total_space.fiber_bundle.integrability_tensor_derivative(
             horizontal_vec_x,
             horizontal_vec_z,
             nabla_x_z,
@@ -376,7 +404,10 @@ class PreShapeSpaceBundleTestCase(FiberBundleTestCase):
         ver_v = self.data_generator.random_tangent_vec(base_point)
         nabla_x_v = self.data_generator.random_tangent_vec(base_point)
 
-        nabla_x_a_y_z, a_y_z = self.bundle.integrability_tensor_derivative(
+        (
+            nabla_x_a_y_z,
+            a_y_z,
+        ) = self.total_space.fiber_bundle.integrability_tensor_derivative(
             horizontal_vec_x,
             horizontal_vec_y,
             nabla_x_y,
@@ -385,7 +416,10 @@ class PreShapeSpaceBundleTestCase(FiberBundleTestCase):
             base_point,
         )
 
-        nabla_x_a_y_v, a_y_v = self.bundle.integrability_tensor_derivative(
+        (
+            nabla_x_a_y_v,
+            a_y_v,
+        ) = self.total_space.fiber_bundle.integrability_tensor_derivative(
             horizontal_vec_x,
             horizontal_vec_y,
             nabla_x_y,
@@ -421,7 +455,10 @@ class PreShapeSpaceBundleTestCase(FiberBundleTestCase):
         nabla_x_y = self._get_nabla_x_y(horizontal_vec_x, horizontal_vec_y, base_point)
         nabla_x_z = self._get_nabla_x_y(horizontal_vec_x, horizontal_vec_z, base_point)
 
-        nabla_x_a_y_z, a_y_z = self.bundle.integrability_tensor_derivative(
+        (
+            nabla_x_a_y_z,
+            a_y_z,
+        ) = self.total_space.fiber_bundle.integrability_tensor_derivative(
             horizontal_vec_x,
             horizontal_vec_y,
             nabla_x_y,
@@ -457,7 +494,10 @@ class PreShapeSpaceBundleTestCase(FiberBundleTestCase):
             horizontal_vec_x, vertical_vec_z, base_point, horizontal=False
         )
 
-        nabla_x_a_y_z, a_y_z = self.bundle.integrability_tensor_derivative(
+        (
+            nabla_x_a_y_z,
+            a_y_z,
+        ) = self.total_space.fiber_bundle.integrability_tensor_derivative(
             horizontal_vec_x,
             horizontal_vec_y,
             nabla_x_y,
@@ -487,7 +527,10 @@ class PreShapeSpaceBundleTestCase(FiberBundleTestCase):
         expected_a_y_z,
         atol,
     ):
-        nabla_x_a_y_z, a_y_z = self.bundle.integrability_tensor_derivative_parallel(
+        (
+            nabla_x_a_y_z,
+            a_y_z,
+        ) = self.total_space.fiber_bundle.integrability_tensor_derivative_parallel(
             horizontal_vec_x, horizontal_vec_y, horizontal_vec_z, base_point
         )
         self.assertAllClose(nabla_x_a_y_z, expected_nabla_x_a_y_z, atol=atol)
@@ -503,7 +546,7 @@ class PreShapeSpaceBundleTestCase(FiberBundleTestCase):
         (
             expected_nabla_x_a_y_z,
             expected_a_y_z,
-        ) = self.bundle.integrability_tensor_derivative_parallel(
+        ) = self.total_space.fiber_bundle.integrability_tensor_derivative_parallel(
             horizontal_vec_x, horizontal_vec_y, horizontal_vec_z, base_point
         )
 
@@ -540,20 +583,23 @@ class PreShapeSpaceBundleTestCase(FiberBundleTestCase):
         horizontal_vec_y = self._get_horizontal_vec(base_point)
         horizontal_vec_z = self._get_horizontal_vec(base_point)
 
-        nabla_x_a_y_z, a_y_z = self.bundle.integrability_tensor_derivative_parallel(
+        (
+            nabla_x_a_y_z,
+            a_y_z,
+        ) = self.total_space.fiber_bundle.integrability_tensor_derivative_parallel(
             horizontal_vec_x, horizontal_vec_y, horizontal_vec_z, base_point
         )
 
-        a_x_y = self.bundle.integrability_tensor(
+        a_x_y = self.total_space.fiber_bundle.integrability_tensor(
             horizontal_vec_x, horizontal_vec_y, base_point
         )
-        a_x_z = self.bundle.integrability_tensor(
+        a_x_z = self.total_space.fiber_bundle.integrability_tensor(
             horizontal_vec_x, horizontal_vec_z, base_point
         )
         (
             expected_nabla_x_a_y_z,
             expected_a_y_z,
-        ) = self.bundle.integrability_tensor_derivative(
+        ) = self.total_space.fiber_bundle.integrability_tensor_derivative(
             horizontal_vec_x,
             horizontal_vec_y,
             a_x_y,
@@ -583,7 +629,7 @@ class PreShapeSpaceBundleTestCase(FiberBundleTestCase):
             nabla_x_v,
             a_y_a_x_y,
             vertical_vec_v,
-        ) = self.bundle.iterated_integrability_tensor_derivative_parallel(
+        ) = self.total_space.fiber_bundle.iterated_integrability_tensor_derivative_parallel(
             horizontal_vec_x, horizontal_vec_y, base_point
         )
         self.assertAllClose(nabla_x_a_y_v, expected_nabla_x_a_y_v, atol=atol)
@@ -603,7 +649,7 @@ class PreShapeSpaceBundleTestCase(FiberBundleTestCase):
             expected_nabla_x_v,
             expected_a_y_a_x_y,
             expected_vertical_vec_v,
-        ) = self.bundle.iterated_integrability_tensor_derivative_parallel(
+        ) = self.total_space.fiber_bundle.iterated_integrability_tensor_derivative_parallel(
             horizontal_vec_x, horizontal_vec_y, base_point
         )
 
@@ -651,10 +697,13 @@ class PreShapeSpaceBundleTestCase(FiberBundleTestCase):
         horizontal_vec_x = self._get_horizontal_vec(base_point)
         horizontal_vec_y = self._get_horizontal_vec(base_point)
 
-        a_x_y = self.bundle.integrability_tensor(
+        a_x_y = self.total_space.fiber_bundle.integrability_tensor(
             horizontal_vec_x, horizontal_vec_y, base_point
         )
-        nabla_x_v, a_x_y = self.bundle.integrability_tensor_derivative(
+        (
+            nabla_x_v,
+            a_x_y,
+        ) = self.total_space.fiber_bundle.integrability_tensor_derivative(
             horizontal_vec_x,
             horizontal_vec_x,
             gs.zeros_like(horizontal_vec_x),
@@ -663,11 +712,14 @@ class PreShapeSpaceBundleTestCase(FiberBundleTestCase):
             base_point,
         )
 
-        nabla_x_a_y_a_x_y, a_y_a_x_y = self.bundle.integrability_tensor_derivative(
+        (
+            nabla_x_a_y_a_x_y,
+            a_y_a_x_y,
+        ) = self.total_space.fiber_bundle.integrability_tensor_derivative(
             horizontal_vec_x, horizontal_vec_y, a_x_y, a_x_y, nabla_x_v, base_point
         )
 
-        a_x_a_y_a_x_y = self.bundle.integrability_tensor(
+        a_x_a_y_a_x_y = self.total_space.fiber_bundle.integrability_tensor(
             horizontal_vec_x, a_y_a_x_y, base_point
         )
 
@@ -677,7 +729,7 @@ class PreShapeSpaceBundleTestCase(FiberBundleTestCase):
             nabla_x_v_qp,
             a_y_a_x_y_qp,
             ver_v_qp,
-        ) = self.bundle.iterated_integrability_tensor_derivative_parallel(
+        ) = self.total_space.fiber_bundle.iterated_integrability_tensor_derivative_parallel(
             horizontal_vec_x, horizontal_vec_y, base_point
         )
         self.assertAllClose(a_x_y, ver_v_qp, atol=atol)
@@ -907,7 +959,7 @@ class KendallShapeMetricTestCase(QuotientMetricTestCase):
 
         end_point = self.space.metric.exp(direction, base_point)
 
-        fiber_bundle = self.space.metric.fiber_bundle
+        fiber_bundle = self.space.metric._total_space.fiber_bundle
         res = fiber_bundle.is_horizontal(transported, end_point, atol=atol)
 
         expected_shape = get_batch_shape(self.space.point_ndim, base_point)

--- a/tests/tests_geomstats/test_geometry/test_fiber_bundle.py
+++ b/tests/tests_geomstats/test_geometry/test_fiber_bundle.py
@@ -26,10 +26,9 @@ def bundle_spaces(request):
 
     request.cls.total_space = total_space = GeneralLinear(n, equip=False)
     total_space.equip_with_metric(MatricesMetric)
+    total_space.fiber_bundle = GeneralLinearBuresWassersteinBundle(total_space)
 
     request.cls.base = SPDMatrices(n=n, equip=False)
-
-    request.cls.bundle = GeneralLinearBuresWassersteinBundle(total_space)
 
 
 @pytest.mark.usefixtures("bundle_spaces")

--- a/tests/tests_geomstats/test_geometry/test_full_rank_correlation_matrices.py
+++ b/tests/tests_geomstats/test_geometry/test_full_rank_correlation_matrices.py
@@ -67,7 +67,7 @@ class TestFullRankCorrelationMatrices(
 def bundles(request):
     n = request.param
     request.cls.total_space = total_space = SPDMatrices(n=n, equip=True)
-    request.cls.bundle = CorrelationMatricesBundle(total_space)
+    total_space.fiber_bundle = CorrelationMatricesBundle(total_space)
     request.cls.base = FullRankCorrelationMatrices(n=n, equip=False)
 
 
@@ -81,7 +81,9 @@ class TestCorrelationMatricesBundle(
         base_point = self.data_generator.random_point(n_points)
         tangent_vec = self.data_generator.random_tangent_vec(base_point)
 
-        horizontal_vec = self.bundle.horizontal_projection(tangent_vec, base_point)
+        horizontal_vec = self.total_space.fiber_bundle.horizontal_projection(
+            tangent_vec, base_point
+        )
 
         inverse = GeneralLinear.inverse(base_point)
         product_1 = Matrices.mul(horizontal_vec, inverse)

--- a/tests/tests_geomstats/test_geometry/test_pre_shape.py
+++ b/tests/tests_geomstats/test_geometry/test_pre_shape.py
@@ -2,7 +2,7 @@ import random
 
 import pytest
 
-from geomstats.geometry.pre_shape import PreShapeSpace, PreShapeSpaceBundle
+from geomstats.geometry.pre_shape import PreShapeSpace
 from geomstats.geometry.quotient_metric import QuotientMetric
 from geomstats.test.parametrizers import DataBasedParametrizer
 from geomstats.test_cases.geometry.pre_shape import (
@@ -51,10 +51,12 @@ class TestPreShapeSpace(PreShapeSpaceTestCase, metaclass=DataBasedParametrizer):
 def bundles(request):
     k_landmarks, m_ambient = request.param
 
-    space = PreShapeSpace(k_landmarks, m_ambient, equip=True)
-    request.cls.total_space = request.cls.base = space
+    request.cls.total_space = total_space = PreShapeSpace(k_landmarks, m_ambient)
 
-    request.cls.bundle = PreShapeSpaceBundle(space)
+    total_space.equip_with_group_action("rotations")
+    total_space.equip_with_quotient_structure()
+
+    request.cls.base = total_space.quotient
 
 
 @pytest.mark.usefixtures("bundles")
@@ -92,12 +94,12 @@ class TestPreShapeMetric(RiemannianMetricTestCase, metaclass=DataBasedParametriz
 def spaces_with_quotient(request):
     k_landmarks, m_ambient = request.param
 
-    space = PreShapeSpace(k_landmarks, m_ambient)
+    total_space = PreShapeSpace(k_landmarks, m_ambient)
 
-    space.equip_with_group_action("rotations")
-    space.equip_with_quotient_structure()
+    total_space.equip_with_group_action("rotations")
+    total_space.equip_with_quotient_structure()
 
-    request.cls.space = space.quotient
+    request.cls.space = total_space.quotient
 
 
 @pytest.mark.usefixtures("spaces_with_quotient")
@@ -110,16 +112,16 @@ class TestKendallShapeMetric(
 class TestKendallShapeMetricCmp(
     RiemannianMetricComparisonTestCase, metaclass=DataBasedParametrizer
 ):
-    k_landmarks = random.randint(4, 5)
-    m_ambient = 2
-    total_space = PreShapeSpace(k_landmarks, m_ambient)
+    _k_landmarks = random.randint(4, 5)
+    _m_ambient = 2
+    _total_space = PreShapeSpace(_k_landmarks, _m_ambient)
 
-    total_space.equip_with_group_action("rotations")
-    total_space.equip_with_quotient_structure()
+    _total_space.equip_with_group_action("rotations")
+    _total_space.equip_with_quotient_structure()
 
-    space = total_space.quotient
+    space = _total_space.quotient
 
-    other_total_space = PreShapeSpace(k_landmarks, m_ambient)
+    other_total_space = PreShapeSpace(_k_landmarks, _m_ambient)
 
     other_total_space.equip_with_group_action("rotations")
     other_total_space.equip_with_quotient_structure()
@@ -127,7 +129,7 @@ class TestKendallShapeMetricCmp(
     other_space = other_total_space.quotient
     other_space.equip_with_metric(
         QuotientMetric,
-        fiber_bundle=other_space.metric.fiber_bundle,
+        total_space=other_total_space,
     )
 
     testing_data = KendallShapeMetricCmpTestData()

--- a/tests/tests_geomstats/test_geometry/test_pre_shape.py
+++ b/tests/tests_geomstats/test_geometry/test_pre_shape.py
@@ -99,6 +99,7 @@ def spaces_with_quotient(request):
     total_space.equip_with_group_action("rotations")
     total_space.equip_with_quotient_structure()
 
+    request.cls.total_space = total_space
     request.cls.space = total_space.quotient
 
 

--- a/tests/tests_geomstats/test_geometry/test_quotient_metric.py
+++ b/tests/tests_geomstats/test_geometry/test_quotient_metric.py
@@ -34,9 +34,8 @@ def spd_with_quotient_metric(request):
 
     total_space = GeneralLinear(n=n, equip=False)
     total_space.equip_with_metric(MatricesMetric)
-
-    bundle = GeneralLinearBuresWassersteinBundle(total_space)
-    other_space.equip_with_metric(QuotientMetric, fiber_bundle=bundle)
+    total_space.fiber_bundle = GeneralLinearBuresWassersteinBundle(total_space)
+    other_space.equip_with_metric(QuotientMetric, total_space=total_space)
 
     request.cls.data_generator = RandomDataGenerator(space, amplitude=10.0)
 

--- a/tests/tests_geomstats/test_geometry/test_rank_k_psd_matrices.py
+++ b/tests/tests_geomstats/test_geometry/test_rank_k_psd_matrices.py
@@ -83,10 +83,12 @@ def bundle_spaces(request):
         n = k = request.param
     else:
         n, k = request.param
+
     request.cls.base = PSDMatrices(n=n, k=k, equip=False)
+
     request.cls.total_space = total_space = FullRankMatrices(n=n, k=k, equip=False)
     total_space.equip_with_metric(MatricesMetric)
-    request.cls.bundle = BuresWassersteinBundle(total_space)
+    total_space.fiber_bundle = BuresWassersteinBundle(total_space)
 
 
 @pytest.mark.usefixtures("bundle_spaces")


### PR DESCRIPTION
This PR improves `FiberBundle`/`QuotientMetric` API (builds on top of https://github.com/luisfpereira/geomstats/pull/8) by making `total_space` a private attribute of `FiberBundle` (cf. `space` is a private method of `Connection`), and `QuotientMetric` receive `total_space` (which is stored privately) instead of `fiber_bundle`.

This design avoids weird code as `total_space.quotient.metric.fiber_bundle.total_space`, which was possible before. (Now it is possible to do `total_space.quotient.metric._total_space`, but private attributes are not supposed to be accessed from outside.)

Another reason for this PR is to hide a bit more the notion of `FiberBundle` from the user API (only power users may need to instantiate fiber bundles), so the learning curve for working with quotient spaces in `geomstats` becomes less steep.

Finally, this makes more mathematical sense, since we are thinking of a fiber bundle as a structure on the total space (when doing `total_space.equip_with_quotient_metric`, `total_space` gets such a structure), and opens the door to also remove `group`/`group_action` from the bundle, as with the introduction of the group action object we'll be able to do `total_space.group_action(group_elem, point)` (so the code within the bundle will use this pattern).
