### PR TITLE
Update versions of github actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,13 +15,13 @@ jobs:
         python-version: [3.11]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build using Python ${{matrix.python-version}}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{matrix.python-version}}
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: docs-${{matrix.os}}-${{matrix.python-version}}-${{ hashFiles('pyproject.toml') }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,13 +16,13 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Linting
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{matrix.python-version}}
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: lint-${{matrix.os}}-${{matrix.python-version}}-${{ hashFiles('pyproject.toml') }}
@@ -33,11 +33,11 @@ jobs:
           pip install -e .[lint]
 
       - name: Setup flake8 annotations
-        uses: rbialon/flake8-annotations@v1
+        run: pip install flake8-github-annotations
 
       - name: linting [flake8]
         run: |
-          flake8 geomstats/ tests/
+          flake8 geomstats/ tests/ --format github
 
       - name: linting [black and isort]
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,13 +35,13 @@ jobs:
       GEOMSTATS_BACKEND: ${{matrix.geomstats-backend}}
 
     steps:         
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build using Python ${{matrix.python-version}} and Backend ${{matrix.geomstats-backend}}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{matrix.python-version}}
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{matrix.geomstats-backend}}-${{matrix.os}}-${{matrix.python-version}}-${{ hashFiles('pyproject.toml') }}


### PR DESCRIPTION
Due to deprecation of Node.js 16 (see https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/).

Stopped using `rbialon/flake8-annotations@v1` because does not have Node.js 20 version (and https://pypi.org/project/flake8-github-annotations/ looks like a good alternative).