### PR TITLE
Add SymmetricHollowMatrices and corresponding permutation-invariant metric

### DIFF
--- a/geomstats/geometry/symmetric_matrices.py
+++ b/geomstats/geometry/symmetric_matrices.py
@@ -138,7 +138,26 @@ class SymmetricMatrices(MatrixVectorSpace):
 
 
 class SymmetricHollowMatrices(LevelSet, MatrixVectorSpace):
-    """Space of symmetric hollow matrices."""
+    r"""Space of symmetric hollow matrices.
+
+    Set of symmetric matrices with null diagonal:
+
+    .. math::
+
+        \operatorname{Hol}(n) = \{X \in \operatorname{Sym}(n)
+        \mid \operatorname{Diag}(X)=0\}
+
+    Parameters
+    ----------
+    n : int
+        Integer representing the shapes of the matrices: n x n.
+
+    References
+    ----------
+    .. [T2022] Yann Thanwerdas. Riemannian and stratified
+    geometries on covariance and correlation matrices. Differential
+    Geometry [math.DG]. Université Côte d'Azur, 2022.
+    """
 
     def __init__(self, n, equip=True):
         self.n = n
@@ -225,10 +244,36 @@ class SymmetricHollowMatrices(LevelSet, MatrixVectorSpace):
 
 
 class HollowMatricesPermutationInvariantMetric(FlatRiemannianMetric):
-    """A permutation-invariant metric on the space of hollow matrices.
+    r"""A permutation-invariant metric on the space of hollow matrices.
 
-    It is flat Riemannian metric a priori invariant by the congruence action
+    It is flat Riemannian metric invariant by the congruence action
     of permutation matrices defined over a matrix vector space.
+
+    Its associated quadratic form is:
+
+    .. math::
+
+        (X)=\alpha \operatorname{tr}\left(X^2\right)
+        +\beta \operatorname{Sum}\left(X^2\right)
+        +\gamma \operatorname{Sum}(X)^2
+
+    Parameters
+    ----------
+    space : Manifold
+    alpha : float
+        Scalar multiplying first term of quadratic form.
+    beta : float
+        Scalar multiplying second term of quadratic form.
+    gamma : float
+        Scalar multiplying third term of quadratic form.
+
+    Check out chapter 8 of [T2022]_ for more details.
+
+    References
+    ----------
+    .. [T2022] Yann Thanwerdas. Riemannian and stratified
+    geometries on covariance and correlation matrices. Differential
+    Geometry [math.DG]. Université Côte d'Azur, 2022.
     """
 
     def __init__(self, space, alpha=1.0, beta=1.0, gamma=1.0):
@@ -240,6 +285,13 @@ class HollowMatricesPermutationInvariantMetric(FlatRiemannianMetric):
 
     @staticmethod
     def _check_params(space, alpha, beta, gamma):
+        r"""Check parameters of quadratic form.
+
+        The following conditions must verify:
+        - n > 3: :math:`\alpha>0,2 \alpha+(n-2) \beta>0, \alpha+(n-1)(\beta+n \gamma)>0`
+        - n = 3: :math:`\alpha=0, \beta > 0, \beta+3 \gamma>0`
+        - n = 2: :math:`\alpha=0, \beta=0, \gamma > 0`
+        """
         n = space.n
         if n == 2:
             if alpha > gs.atol or beta > gs.atol or gamma < gs.atol:
@@ -268,6 +320,13 @@ class HollowMatricesPermutationInvariantMetric(FlatRiemannianMetric):
             )
 
     def _quadratic_form(self, tangent_vec):
+        """Quadratic form associated to inner product.
+
+        Parameters
+        ----------
+        tangent_vec: array-like, shape=[..., dim]
+            Tangent vector at base point.
+        """
         comp = gs.matmul(tangent_vec, tangent_vec)
         out_alpha = self.alpha * gs.trace(comp) if self.alpha > gs.atol else 0.0
         out_beta = (
@@ -303,3 +362,24 @@ class HollowMatricesPermutationInvariantMetric(FlatRiemannianMetric):
         return repeat_out(
             self._space.point_ndim, inner_prod, tangent_vec_a, tangent_vec_b, base_point
         )
+
+    def squared_norm(self, vector, base_point=None):
+        """Compute the square of the norm of a vector.
+
+        Squared norm of a vector associated to the inner product
+        at the tangent space at a base point.
+
+        Parameters
+        ----------
+        vector : array-like, shape=[..., dim]
+            Vector.
+        base_point : array-like, shape=[..., dim]
+            Base point.
+            Optional, default: None.
+
+        Returns
+        -------
+        sq_norm : array-like, shape=[...,]
+            Squared norm.
+        """
+        return self._quadratic_form(vector)

--- a/geomstats/test_cases/geometry/base.py
+++ b/geomstats/test_cases/geometry/base.py
@@ -43,7 +43,7 @@ class _VectorSpaceTestCaseMixins(ProjectionTestCaseMixins):
         """
         points = self.data_generator.random_point(n_points)
 
-        res = self.space.is_tangent(points, atol=atol)
+        res = self.space.is_tangent(points, base_point=None, atol=atol)
         self.assertAllEqual(res, gs.ones(n_points, dtype=bool))
 
     @pytest.mark.random

--- a/tests/tests_geomstats/test_geometry/data/symmetric_matrices.py
+++ b/tests/tests_geomstats/test_geometry/data/symmetric_matrices.py
@@ -2,6 +2,7 @@ import geomstats.backend as gs
 from geomstats.test.data import TestData
 
 from .base import LevelSetTestData, MatrixVectorSpaceTestData
+from .riemannian_metric import RiemannianMetricTestData
 
 
 class SymmetricMatricesTestData(MatrixVectorSpaceTestData):
@@ -90,3 +91,8 @@ class SymmetricMatrices3TestData(TestData):
 
 class SymmetricHollowMatricesTestData(MatrixVectorSpaceTestData, LevelSetTestData):
     pass
+
+
+class HollowMatricesPermutationInvariantMetricTestData(RiemannianMetricTestData):
+    fail_for_not_implemented_errors = False
+    fail_for_autodiff_exceptions = False

--- a/tests/tests_geomstats/test_geometry/data/symmetric_matrices.py
+++ b/tests/tests_geomstats/test_geometry/data/symmetric_matrices.py
@@ -2,7 +2,7 @@ import geomstats.backend as gs
 from geomstats.test.data import TestData
 
 from .base import LevelSetTestData, MatrixVectorSpaceTestData
-from .riemannian_metric import RiemannianMetricTestData
+from .euclidean import FlatRiemannianMetricTestData
 
 
 class SymmetricMatricesTestData(MatrixVectorSpaceTestData):
@@ -93,6 +93,6 @@ class SymmetricHollowMatricesTestData(MatrixVectorSpaceTestData, LevelSetTestDat
     pass
 
 
-class HollowMatricesPermutationInvariantMetricTestData(RiemannianMetricTestData):
+class HollowMatricesPermutationInvariantMetricTestData(FlatRiemannianMetricTestData):
     fail_for_not_implemented_errors = False
     fail_for_autodiff_exceptions = False

--- a/tests/tests_geomstats/test_geometry/data/symmetric_matrices.py
+++ b/tests/tests_geomstats/test_geometry/data/symmetric_matrices.py
@@ -1,7 +1,7 @@
 import geomstats.backend as gs
 from geomstats.test.data import TestData
 
-from .base import MatrixVectorSpaceTestData
+from .base import LevelSetTestData, MatrixVectorSpaceTestData
 
 
 class SymmetricMatricesTestData(MatrixVectorSpaceTestData):
@@ -86,3 +86,7 @@ class SymmetricMatrices3TestData(TestData):
             ),
         ]
         return self.generate_tests(data)
+
+
+class SymmetricHollowMatricesTestData(MatrixVectorSpaceTestData, LevelSetTestData):
+    pass

--- a/tests/tests_geomstats/test_geometry/test_symmetric_matrices.py
+++ b/tests/tests_geomstats/test_geometry/test_symmetric_matrices.py
@@ -12,8 +12,8 @@ from geomstats.test_cases.geometry.base import (
     LevelSetTestCase,
     MatrixVectorSpaceTestCase,
 )
+from geomstats.test_cases.geometry.euclidean import FlatRiemannianMetricTestCase
 from geomstats.test_cases.geometry.matrices import MatricesMetricTestCase
-from geomstats.test_cases.geometry.riemannian_metric import RiemannianMetricTestCase
 
 from .data.matrices import MatricesMetricTestData
 from .data.symmetric_matrices import (
@@ -26,22 +26,12 @@ from .data.symmetric_matrices import (
 )
 
 
-@pytest.fixture(
-    scope="class",
-    params=[
-        2,
-        random.randint(3, 5),
-    ],
-)
-def spaces(request):
-    request.cls.space = SymmetricMatrices(n=request.param, equip=False)
-
-
-@pytest.mark.usefixtures("spaces")
 class TestSymmetricMatrices(
     MatrixVectorSpaceTestCase,
     metaclass=DataBasedParametrizer,
 ):
+    _n = random.randint(2, 5)
+    space = SymmetricMatrices(n=_n, equip=False)
     testing_data = SymmetricMatricesTestData()
 
 
@@ -71,38 +61,42 @@ class TestSymmetricMatrices3(
     testing_data = SymmetricMatrices3TestData()
 
 
-@pytest.mark.parametrize("n,expected", [(1, 1), (2, 3), (5, 15)])
-def test_dim(n, expected):
-    space = SymmetricMatrices(n, equip=False)
-    assert space.dim == expected
-
-
 @pytest.mark.redundant
 class TestMatricesMetric(MatricesMetricTestCase, metaclass=DataBasedParametrizer):
-    n = random.randint(3, 5)
-    space = SymmetricMatrices(n=n)
+    _n = random.randint(2, 5)
+    space = SymmetricMatrices(n=_n)
 
     testing_data = MatricesMetricTestData()
 
 
 class TestSymmetricHollowMatrices(
-    MatrixVectorSpaceTestCase,
     LevelSetTestCase,
+    MatrixVectorSpaceTestCase,
     metaclass=DataBasedParametrizer,
 ):
-    _n = random.randint(2, 5)
+    _n = random.randint(2, 6)
     space = SymmetricHollowMatrices(n=_n, equip=False)
 
     testing_data = SymmetricHollowMatricesTestData()
 
 
-class TestHollowMatricesPermutationInvariantMetric(
-    RiemannianMetricTestCase, metaclass=DataBasedParametrizer
-):
-    # _n = random.randint(2, 5)
-    _n = 3
-    space = SymmetricHollowMatrices(n=_n, equip=False).equip_with_metric(
-        HollowMatricesPermutationInvariantMetric
+@pytest.fixture(
+    scope="class",
+    params=[
+        (2, (0.0, 0.0, 1.0)),
+        (3, (0.0, 1.0, 1.0)),
+        (random.randint(4, 6), (1.0, 1.0, 1.0)),
+    ],
+)
+def equipped_hollow_matrices(request):
+    n, (alpha, beta, gamma) = request.param
+    request.cls.space = SymmetricHollowMatrices(n, equip=False).equip_with_metric(
+        HollowMatricesPermutationInvariantMetric, alpha=alpha, beta=beta, gamma=gamma
     )
 
+
+@pytest.mark.usefixtures("equipped_hollow_matrices")
+class TestHollowMatricesPermutationInvariantMetric(
+    FlatRiemannianMetricTestCase, metaclass=DataBasedParametrizer
+):
     testing_data = HollowMatricesPermutationInvariantMetricTestData()

--- a/tests/tests_geomstats/test_geometry/test_symmetric_matrices.py
+++ b/tests/tests_geomstats/test_geometry/test_symmetric_matrices.py
@@ -2,13 +2,20 @@ import random
 
 import pytest
 
-from geomstats.geometry.symmetric_matrices import SymmetricMatrices
+from geomstats.geometry.symmetric_matrices import (
+    SymmetricHollowMatrices,
+    SymmetricMatrices,
+)
 from geomstats.test.parametrizers import DataBasedParametrizer
-from geomstats.test_cases.geometry.base import MatrixVectorSpaceTestCase
+from geomstats.test_cases.geometry.base import (
+    LevelSetTestCase,
+    MatrixVectorSpaceTestCase,
+)
 from geomstats.test_cases.geometry.matrices import MatricesMetricTestCase
 
 from .data.matrices import MatricesMetricTestData
 from .data.symmetric_matrices import (
+    SymmetricHollowMatricesTestData,
     SymmetricMatrices1TestData,
     SymmetricMatrices2TestData,
     SymmetricMatrices3TestData,
@@ -73,3 +80,14 @@ class TestMatricesMetric(MatricesMetricTestCase, metaclass=DataBasedParametrizer
     space = SymmetricMatrices(n=n)
 
     testing_data = MatricesMetricTestData()
+
+
+class TestSymmetricHollowMatrices(
+    MatrixVectorSpaceTestCase,
+    LevelSetTestCase,
+    metaclass=DataBasedParametrizer,
+):
+    _n = random.randint(2, 5)
+    space = SymmetricHollowMatrices(n=_n, equip=False)
+
+    testing_data = SymmetricHollowMatricesTestData()

--- a/tests/tests_geomstats/test_geometry/test_symmetric_matrices.py
+++ b/tests/tests_geomstats/test_geometry/test_symmetric_matrices.py
@@ -3,6 +3,7 @@ import random
 import pytest
 
 from geomstats.geometry.symmetric_matrices import (
+    HollowMatricesPermutationInvariantMetric,
     SymmetricHollowMatrices,
     SymmetricMatrices,
 )
@@ -12,9 +13,11 @@ from geomstats.test_cases.geometry.base import (
     MatrixVectorSpaceTestCase,
 )
 from geomstats.test_cases.geometry.matrices import MatricesMetricTestCase
+from geomstats.test_cases.geometry.riemannian_metric import RiemannianMetricTestCase
 
 from .data.matrices import MatricesMetricTestData
 from .data.symmetric_matrices import (
+    HollowMatricesPermutationInvariantMetricTestData,
     SymmetricHollowMatricesTestData,
     SymmetricMatrices1TestData,
     SymmetricMatrices2TestData,
@@ -91,3 +94,15 @@ class TestSymmetricHollowMatrices(
     space = SymmetricHollowMatrices(n=_n, equip=False)
 
     testing_data = SymmetricHollowMatricesTestData()
+
+
+class TestHollowMatricesPermutationInvariantMetric(
+    RiemannianMetricTestCase, metaclass=DataBasedParametrizer
+):
+    # _n = random.randint(2, 5)
+    _n = 3
+    space = SymmetricHollowMatrices(n=_n, equip=False).equip_with_metric(
+        HollowMatricesPermutationInvariantMetric
+    )
+
+    testing_data = HollowMatricesPermutationInvariantMetricTestData()


### PR DESCRIPTION
This PR builds on top of #1946 to add the matrix vector space `SymmetricHollowMatrices` and a permutation-invariant metric on it `HollowMatricesPermutationInvariantMetric`.

It also fixes small inheritance issues in `geometry.base`. In particular, deletes an abstract method which is also defined at manifold level in order to allow proper multiple inheritance from `LevelSet` and `MatrixVectorSpace`.

This is a first step to bring in pullback metrics on `Cor+` via the off-log diffeomorphism.

NB: merging this PR before #1946 also merges it.