### PR TITLE
Add off-log metrics on Cor+

### DIFF
--- a/geomstats/geometry/full_rank_correlation_matrices.py
+++ b/geomstats/geometry/full_rank_correlation_matrices.py
@@ -10,11 +10,14 @@ geometries on covariance and correlation matrices. Differential
 Geometry [math.DG]. Université Côte d'Azur, 2022.
 """
 
+import logging
+
 import geomstats.backend as gs
 from geomstats.geometry.base import LevelSet
-from geomstats.geometry.diffeo import ComposedDiffeo
+from geomstats.geometry.diffeo import ComposedDiffeo, Diffeo
 from geomstats.geometry.fiber_bundle import FiberBundle
 from geomstats.geometry.general_linear import GeneralLinear
+from geomstats.geometry.hermitian_matrices import expmh
 from geomstats.geometry.hyperboloid import Hyperboloid
 from geomstats.geometry.matrices import Matrices
 from geomstats.geometry.open_hemisphere import (
@@ -26,7 +29,17 @@ from geomstats.geometry.positive_lower_triangular_matrices import (
 )
 from geomstats.geometry.pullback_metric import PullbackDiffeoMetric
 from geomstats.geometry.quotient_metric import QuotientMetric
-from geomstats.geometry.spd_matrices import CholeskyMap, SPDAffineMetric, SPDMatrices
+from geomstats.geometry.spd_matrices import (
+    CholeskyMap,
+    SPDAffineMetric,
+    SPDMatrices,
+    SymMatrixLog,
+    logmh,
+)
+from geomstats.geometry.symmetric_matrices import (
+    HollowMatricesPermutationInvariantMetric,
+    SymmetricHollowMatrices,
+)
 
 
 class FullRankCorrelationMatrices(LevelSet):
@@ -335,5 +348,189 @@ class PolyHyperbolicCholeskyMetric(PullbackDiffeoMetric):
             image_space = OpenHemispheresProduct(n=n)
 
         diffeo = ComposedDiffeo(diffeos)
+
+        super().__init__(space=space, diffeo=diffeo, image_space=image_space)
+
+
+def off_map(matrix):
+    """Subtract diagonal to a matrix."""
+    return matrix - Matrices.to_diagonal(matrix)
+
+
+class OffLogDiffeo(Diffeo):
+    """Off-log diffeomorphism from Cor+ to Hol.
+
+    A diffeomorphism between full-rank correlation matrices Cor+ and
+    symmetric hollow matrices Hol.
+    """
+
+    def __init__(self, space, atol=gs.atol, max_iter=100):
+        self.space = space
+        self.atol = atol
+        self.max_iter = max_iter
+
+    def _unique_diag_mat_single(self, sym_mat):
+        """Find unique diagonal matrix corresponding to a Cor+ mat.
+
+        Converges in logarithmic time to the solution of the equation, no closed form.
+        """
+        diag_mat = gs.zeros_like(sym_mat)
+
+        approx_cor_mat = expmh(diag_mat + sym_mat)
+        if self.space.belongs(approx_cor_mat, atol=self.atol):
+            return diag_mat
+
+        for _ in range(self.max_iter):
+            diag_mat = diag_mat - logmh(Matrices.to_diagonal(approx_cor_mat))
+            approx_cor_mat = expmh(diag_mat + sym_mat)
+            if self.space.belongs(approx_cor_mat, atol=self.atol):
+                return diag_mat
+        else:
+            logging.warning(
+                "Maximum number of iterations %d reached. The mean may be inaccurate",
+                self.max_iter,
+            )
+
+        return diag_mat
+
+    def _unique_diag_mat(self, sym_mat):
+        """Find unique diagonal matrix corresponding to a Cor+ mat."""
+        if sym_mat.ndim == 2:
+            return self._unique_diag_mat_single(sym_mat)
+
+        batch_shape = sym_mat.shape[:-2]
+        if len(batch_shape) == 1:
+            return gs.stack(
+                [self._unique_diag_mat_single(sym_mat_) for sym_mat_ in sym_mat]
+            )
+
+        mat_shape = sym_mat.shape[-2:]
+        flat_sym_mat = gs.reshape(sym_mat, (-1,) + mat_shape)
+        out = gs.stack(
+            [self._unique_diag_mat_single(sym_mat_) for sym_mat_ in flat_sym_mat]
+        )
+        return gs.reshape(out, batch_shape + mat_shape)
+
+    def diffeomorphism(self, base_point):
+        """Diffeomorphism at base point."""
+        return off_map(matrix=logmh(mat=base_point))
+
+    def inverse_diffeomorphism(self, image_point):
+        """Inverse diffeomorphism at image point."""
+        return expmh(self._unique_diag_mat(image_point) + image_point)
+
+    def tangent_diffeomorphism(self, tangent_vec, base_point=None, image_point=None):
+        """Tangent diffeomorphism at base point."""
+        if base_point is None:
+            base_point = self.inverse_diffeomorphism(image_point)
+
+        return off_map(
+            SymMatrixLog.tangent_diffeomorphism(
+                tangent_vec=tangent_vec, base_point=base_point
+            )
+        )
+
+    def _divided_difference_exp(self, eigvals):
+        eigvals_ = gs.expand_dims(eigvals, axis=-2)
+        eigvals_t = gs.expand_dims(eigvals, axis=-1)
+
+        eigvals_diff = eigvals_ - eigvals_t
+
+        mask = gs.logical_and(-gs.atol < eigvals_diff, eigvals_diff < gs.atol)
+
+        exp_eigvals = gs.exp(eigvals)
+
+        exp_eigvals_ = gs.expand_dims(exp_eigvals, axis=-2)
+        exp_eigvals_t = gs.expand_dims(exp_eigvals, axis=-1)
+        default_vals = exp_eigvals_ - gs.zeros((eigvals.shape[-1], 1))
+
+        return gs.where(
+            mask,
+            default_vals,
+            gs.divide(exp_eigvals_ - exp_eigvals_t, eigvals_diff, ignore_div_zero=True),
+        )
+
+    def _build_H_0_matrix(self, image_base_point=None, base_point=None):
+        n = self.space.n
+        if base_point is None:
+            sym_mat = image_base_point
+            mat = sym_mat + self._unique_diag_mat(sym_mat)
+        else:
+            mat = logmh(base_point)
+
+        eigvals, eigvecs = gs.linalg.eigh(mat)
+
+        H_0 = gs.zeros(mat.shape[:-2] + (self.space.n, self.space.n))
+
+        divided_diffs = self._divided_difference_exp(eigvals)
+
+        for index_i in range(n):
+            for index_j in range(n):
+                val = 0
+                for index_k in range(n):
+                    for index_l in range(n):
+                        val += (
+                            eigvecs[..., index_i, index_k]
+                            * eigvecs[..., index_j, index_k]
+                            * eigvecs[..., index_i, index_l]
+                            * eigvecs[..., index_j, index_l]
+                            * divided_diffs[..., index_k, index_l]
+                        )
+                H_0[..., index_i, index_j] = val
+
+        return H_0, mat
+
+    def _tangent_diag_map(
+        self, image_tangent_vec, image_base_point=None, base_point=None
+    ):
+        H_0, mat = self._build_H_0_matrix(
+            image_base_point=image_base_point, base_point=base_point
+        )
+        e = gs.ones(self.space.n)
+        vec = gs.matvec(
+            gs.linalg.inv(H_0),
+            gs.matvec(
+                Matrices.to_diagonal(
+                    SymMatrixLog.inverse_tangent_diffeomorphism(
+                        image_point=mat, image_tangent_vec=image_tangent_vec
+                    )
+                ),
+                e,
+            ),
+        )
+        return gs.vec_to_diag(-vec), mat
+
+    def inverse_tangent_diffeomorphism(
+        self, image_tangent_vec, image_point=None, base_point=None
+    ):
+        """Inverse tangent diffeomorphism at image point."""
+        diff_D, sym_mat = self._tangent_diag_map(
+            image_base_point=image_point,
+            base_point=base_point,
+            image_tangent_vec=image_tangent_vec,
+        )
+        return SymMatrixLog.inverse_tangent_diffeomorphism(
+            image_point=sym_mat, image_tangent_vec=image_tangent_vec + diff_D
+        )
+
+
+class OffLogMetric(PullbackDiffeoMetric):
+    """Pullback metric via a diffeomorphism.
+
+    Diffeormorphism between full-rank correlation matrices and
+    hollow matrices endowed with a permutation-invariant metric.
+
+    For more details, check section 8.2.2 [T2022]_.
+    """
+
+    def __init__(self, space, alpha=1.0, beta=1.0, gamma=1.0):
+        diffeo = OffLogDiffeo(space)
+
+        image_space = SymmetricHollowMatrices(n=space.n, equip=False).equip_with_metric(
+            HollowMatricesPermutationInvariantMetric,
+            alpha=alpha,
+            beta=beta,
+            gamma=gamma,
+        )
 
         super().__init__(space=space, diffeo=diffeo, image_space=image_space)

--- a/geomstats/geometry/full_rank_correlation_matrices.py
+++ b/geomstats/geometry/full_rank_correlation_matrices.py
@@ -376,7 +376,11 @@ class OffLogDiffeo(Diffeo):
         self.max_iter = max_iter
 
     def _unique_diag_mat_single(self, sym_mat):
-        """Find unique diagonal matrix corresponding to a Cor+ mat.
+        r"""Find unique diagonal matrix corresponding to a Cor+ mat.
+
+        That is, for all symmetric matrix :math:`S`,
+        there exists a unique diagonal matrix :math:`D` such that
+        :math:`exp(D+S)` is a full-rank correlation matrix.
 
         Converges in logarithmic time to the solution of the equation, no closed form.
 
@@ -408,7 +412,13 @@ class OffLogDiffeo(Diffeo):
         return diag_mat
 
     def _unique_diag_mat(self, sym_mat):
-        """Find unique diagonal matrix corresponding to a Cor+ mat.
+        r"""Find unique diagonal matrix corresponding to a Cor+ mat.
+
+        That is, for all symmetric matrix :math:`S`,
+        there exists a unique diagonal matrix :math:`D` such that
+        :math:`exp(D+S)` is a full-rank correlation matrix.
+
+        Converges in logarithmic time to the solution of the equation, no closed form.
 
         Parameters
         ----------
@@ -495,6 +505,31 @@ class OffLogDiffeo(Diffeo):
         )
 
     def _divided_difference_exp(self, eigvals):
+        r"""First divided difference function of the exponential, :math:`exp^(1)`.
+
+        If :math:` x \neq y`,
+
+        .. math::
+
+            exp^(1) = (exp(x)-exp(y))/(x-y)
+
+        else:
+
+        .. math::
+
+            exp'(x)=exp(x)
+
+        Parameters
+        ----------
+        eigvals : array-like, shape=[n]
+            Typically eigenvalues of the matrix.
+
+        Returns
+        -------
+        divided_diffs : array-like, shape=[..., n, n]
+            First divided difference function of the exponential.
+
+        """
         eigvals_ = gs.expand_dims(eigvals, axis=-2)
         eigvals_t = gs.expand_dims(eigvals, axis=-1)
 
@@ -515,6 +550,33 @@ class OffLogDiffeo(Diffeo):
         )
 
     def _build_H_0_matrix(self, image_base_point=None, base_point=None):
+        r"""Build the H_0 matrix.
+
+        The :math:`H_0` matrix is a SPD matrix where each coefficient is
+
+        .. math::
+
+            (H_0)_il = \sum_{j,k} P_ij*P_ik*P_lj*P_lk*exp^(1)(d_j, d_k)
+
+        where :math:`PDP^t = D+S`, with :math:`D` being a diagonal matrix obtained
+        using `_unique_diag_mat` and :math:`S` is a hollow matrix.
+
+        It is used to compute the pushforward of the `_unique_diag_mat` application.
+
+        Parameters
+        ----------
+        image_base_point : array-like, shape=[..., n, n]
+            Image of base point by the diffeomorphism.
+        base_point : array-like, optional
+            Base point.
+
+        Returns
+        -------
+        H_0 : array-like, shape=[..., n, n]
+            matrix H_0.
+        mat : array-like, shape=[..., n, n]
+            Matrix such that its exponential is Cor^+.
+        """
         n = self.space.n
         if base_point is None:
             sym_mat = image_base_point
@@ -547,6 +609,24 @@ class OffLogDiffeo(Diffeo):
     def _tangent_diag_map(
         self, image_tangent_vec, image_base_point=None, base_point=None
     ):
+        r"""Tangent _unique_diag_mat at base point.
+
+        Parameters
+        ----------
+        tangent_vec : array-like, shape=[..., n, n]
+            Tangent vector at base point.
+        base_point : array-like, shape=[..., n, n]
+            Base point.
+        image_point : array-like, shape=[..., n, n]
+            Image point.
+
+        Returns
+        -------
+        image_tangent_vec : array-like, shape=[..., n, n]
+            Image tangent vector at image of the base point.
+        mat : array-like, shape=[..., n, n]
+            Matrix such that its exponential is Cor^+.
+        """
         H_0, mat = self._build_H_0_matrix(
             image_base_point=image_base_point, base_point=base_point
         )

--- a/tests/tests_geomstats/test_geometry/data/full_rank_correlation_matrices.py
+++ b/tests/tests_geomstats/test_geometry/data/full_rank_correlation_matrices.py
@@ -1,3 +1,5 @@
+from geomstats.test.data import TestData
+
 from .base import LevelSetTestData
 from .fiber_bundle import FiberBundleTestData
 from .pullback_metric import PullbackDiffeoMetricTestData
@@ -42,6 +44,11 @@ class FullRankCorrelationAffineQuotientMetricTestData(QuotientMetricTestData):
         "exp_after_log": {"atol": 1e-4},
         "log_vec": {"atol": 1e-4},
     }
+
+
+class UniqueDiagonalMatrixAlgorithmTestData(TestData):
+    def belongs_to_full_rank_cor_test_data(self):
+        return self.generate_random_data()
 
 
 class PolyHyperbolicCholeskyMetricTestData(PullbackDiffeoMetricTestData):

--- a/tests/tests_geomstats/test_geometry/data/full_rank_correlation_matrices.py
+++ b/tests/tests_geomstats/test_geometry/data/full_rank_correlation_matrices.py
@@ -47,3 +47,8 @@ class FullRankCorrelationAffineQuotientMetricTestData(QuotientMetricTestData):
 class PolyHyperbolicCholeskyMetricTestData(PullbackDiffeoMetricTestData):
     fail_for_autodiff_exceptions = False
     fail_for_not_implemented_errors = False
+
+
+class OffLogMetricTestData(PullbackDiffeoMetricTestData):
+    fail_for_autodiff_exceptions = False
+    fail_for_not_implemented_errors = False

--- a/tests/tests_geomstats/test_geometry/test_full_rank_correlation_matrices.py
+++ b/tests/tests_geomstats/test_geometry/test_full_rank_correlation_matrices.py
@@ -7,6 +7,8 @@ from geomstats.geometry.diffeo import ComposedDiffeo
 from geomstats.geometry.full_rank_correlation_matrices import (
     CorrelationMatricesBundle,
     FullRankCorrelationMatrices,
+    OffLogDiffeo,
+    OffLogMetric,
     PolyHyperbolicCholeskyMetric,
 )
 from geomstats.geometry.general_linear import GeneralLinear
@@ -21,6 +23,7 @@ from geomstats.geometry.positive_lower_triangular_matrices import (
     UnitNormedRowsPLTMatrices,
 )
 from geomstats.geometry.spd_matrices import CholeskyMap, SPDMatrices
+from geomstats.geometry.symmetric_matrices import SymmetricHollowMatrices
 from geomstats.test.parametrizers import DataBasedParametrizer
 from geomstats.test_cases.geometry.diffeo import DiffeoTestCase
 from geomstats.test_cases.geometry.fiber_bundle import FiberBundleTestCase
@@ -35,6 +38,7 @@ from .data.full_rank_correlation_matrices import (
     CorrelationMatricesBundleTestData,
     FullRankCorrelationAffineQuotientMetricTestData,
     FullRankCorrelationMatricesTestData,
+    OffLogMetricTestData,
     PolyHyperbolicCholeskyMetricTestData,
 )
 
@@ -163,3 +167,31 @@ class TestPolyHyperbolicCholeskyMetric(
     PullbackDiffeoMetricTestCase, metaclass=DataBasedParametrizer
 ):
     testing_data = PolyHyperbolicCholeskyMetricTestData()
+
+
+class TestOffLogDiffeo(DiffeoTestCase, metaclass=DataBasedParametrizer):
+    _n = random.randint(2, 5)
+    space = FullRankCorrelationMatrices(n=_n, equip=False)
+    image_space = SymmetricHollowMatrices(n=_n, equip=False)
+    diffeo = OffLogDiffeo(space)
+    testing_data = DiffeoTestData()
+
+
+@pytest.fixture(
+    scope="class",
+    params=[
+        (2, (0.0, 0.0, 1.0)),
+        (3, (0.0, 1.0, 1.0)),
+        (random.randint(4, 5), (1.0, 1.0, 1.0)),
+    ],
+)
+def equipped_cor_with_off_log_metric(request):
+    n, (alpha, beta, gamma) = request.param
+    request.cls.space = FullRankCorrelationMatrices(n, equip=False).equip_with_metric(
+        OffLogMetric, alpha=alpha, beta=beta, gamma=gamma
+    )
+
+
+@pytest.mark.usefixtures("equipped_cor_with_off_log_metric")
+class TestOffLogMetric(PullbackDiffeoMetricTestCase, metaclass=DataBasedParametrizer):
+    testing_data = OffLogMetricTestData()


### PR DESCRIPTION
This PR builds on top of #1949 to add off-log metrics on full-rank correlation matrices `Cor+`. The diffeomorphism `OffLogDiffeo` is also added, since `OffLogMetric` is implemented as a `PullbackDiffeoMetric`.

NB: merging this PR also merges #1949.