### PR TITLE
Simplify ExpODESolver

### DIFF
--- a/geomstats/geometry/invariant_metric.py
+++ b/geomstats/geometry/invariant_metric.py
@@ -127,7 +127,7 @@ class _InvariantMetricMatrix(RiemannianMetric):
             n_nodes=100, use_jac=False, integrator=ScipySolveBVP(tol=1e-8)
         )
         self.exp_solver = InvariantMetricMatrixExpODESolver(
-            integrator=ScipySolveIVP(atol=1e-8)
+            integrator=ScipySolveIVP(atol=1e-8, point_ndim=2)
         )
 
     @property

--- a/geomstats/numerics/geodesic.py
+++ b/geomstats/numerics/geodesic.py
@@ -1,13 +1,11 @@
 """Geodesic solvers implementation."""
 
-import math
 from abc import ABC, abstractmethod
 
 import geomstats.backend as gs
 from geomstats.numerics.bvp import ScipySolveBVP
 from geomstats.numerics.ivp import GSIVPIntegrator
 from geomstats.numerics.optimizers import ScipyMinimize
-from geomstats.vectorization import get_batch_shape
 
 
 class ExpSolver(ABC):
@@ -71,7 +69,7 @@ class ExpODESolver(ExpSolver):
     """
 
     def __init__(self, integrator=None):
-        super().__init__(solves_ivp=False)
+        super().__init__()
 
         if integrator is None:
             integrator = GSIVPIntegrator()
@@ -91,23 +89,17 @@ class ExpODESolver(ExpSolver):
         self._integrator = integrator
 
     def _solve(self, space, tangent_vec, base_point, t_eval=None):
-        batch_shape = get_batch_shape(space.point_ndim, base_point, tangent_vec)
-        base_point = gs.broadcast_to(base_point, tangent_vec.shape)
+        if base_point.ndim != tangent_vec.ndim:
+            base_point = gs.broadcast_to(base_point, tangent_vec.shape)
 
         state_axis = -(space.point_ndim + 1)
         initial_state = gs.stack([base_point, tangent_vec], axis=state_axis)
-        if self.integrator.state_is_raveled:
-            initial_state = gs.reshape(initial_state, batch_shape + (-1,))
 
-        force = self._get_force(space)
+        force = space.metric.geodesic_equation
         if t_eval is None:
-            result = self.integrator.integrate(force, initial_state)
-        else:
-            result = self.integrator.integrate_t(force, initial_state, t_eval)
+            return self.integrator.integrate(force, initial_state)
 
-        result.batch_shape = batch_shape
-
-        return result
+        return self.integrator.integrate_t(force, initial_state, t_eval)
 
     def exp(self, space, tangent_vec, base_point):
         """Exponential map.
@@ -176,50 +168,14 @@ class ExpODESolver(ExpSolver):
 
         return path
 
-    def _get_force(self, space):
-        if self.integrator.state_is_raveled:
-            force_ = lambda state, t: self._force_raveled_state(state, t, space=space)
-        else:
-            force_ = lambda state, t: self._force_unraveled_state(state, t, space=space)
-
-        if self.integrator.tfirst:
-            return lambda t, state: force_(state, t)
-
-        return force_
-
-    def _force_raveled_state(self, raveled_initial_state, _, space):
-        # input: (n,)
-
-        # assumes unvectorize
-        state = gs.reshape(raveled_initial_state, (2,) + space.shape)
-
-        eq = space.metric.geodesic_equation(state, _)
-
-        return gs.flatten(eq)
-
-    def _force_unraveled_state(self, initial_state, _, space):
-        return space.metric.geodesic_equation(initial_state, _)
-
     def _simplify_exp_result(self, result, space):
         y = result.get_last_y()
-        if self.integrator.state_is_raveled:
-            dim_vec = math.prod(space.shape)
-            exp = y[..., :dim_vec]
-
-            return gs.reshape(exp, exp.shape[:-1] + space.shape)
-
         slc = tuple([slice(None)] * space.point_ndim)
         return y[..., 0, *slc]
 
     def _simplify_result_t(self, result, space):
         # assumes several t
         y = result.y
-
-        if self.integrator.state_is_raveled:
-            dim_vec = math.prod(space.shape)
-            y = y[..., :dim_vec]
-            return gs.reshape(y, y.shape[:-1] + space.shape)
-
         slc = tuple([slice(None)] * space.point_ndim)
         return y[..., :, 0, *slc]
 

--- a/geomstats/numerics/geodesic.py
+++ b/geomstats/numerics/geodesic.py
@@ -64,7 +64,7 @@ class ExpODESolver(ExpSolver):
 
     Parameters
     ----------
-    integrator : ODEIVPSolver
+    integrator : ODEIVPIntegrator
         Instance of ODEIVP integrator.
     """
 
@@ -79,7 +79,7 @@ class ExpODESolver(ExpSolver):
 
     @property
     def integrator(self):
-        """An instance of ODEIVPSolver."""
+        """An instance of ODEIVPIntegrator."""
         return self._integrator
 
     @integrator.setter

--- a/geomstats/numerics/ivp.py
+++ b/geomstats/numerics/ivp.py
@@ -45,7 +45,7 @@ class OdeResult(scipy.optimize.OptimizeResult):
         return self.y[-1]
 
 
-class ODEIVPSolver(ABC):
+class ODEIVPIntegrator(ABC):
     """Abstract class for ode ivp solvers.
 
     Parameters
@@ -100,7 +100,7 @@ class ODEIVPSolver(ABC):
         raise NotImplementedError("Can't solve for chosen evaluating points.")
 
 
-class GSIVPIntegrator(ODEIVPSolver):
+class GSIVPIntegrator(ODEIVPIntegrator):
     """In-house ODE integrator.
 
     Parameters
@@ -187,7 +187,7 @@ class GSIVPIntegrator(ODEIVPSolver):
         return result
 
 
-class ScipySolveIVP(ODEIVPSolver):
+class ScipySolveIVP(ODEIVPIntegrator):
     """Wrapper for scipy.integrate.solve_ivp.
 
     Check

--- a/geomstats/numerics/ivp.py
+++ b/geomstats/numerics/ivp.py
@@ -52,22 +52,12 @@ class ODEIVPSolver(ABC):
     ----------
     save_result : bool
         If True, result is stored after calling `integrate` or `integrate_t`.
-    state_is_raveled : bool
-        If True, state is represented by a 1d array.
-        Else, it is represented by `(n_vars, dim)`.
-    tfirst : bool
-        Declares function signature.
-        If True `f(t, y)`, else `f(y, t)`.
     tchosen : bool
         Informs about ability to solve at chosen times.
         If False, then does not implement `integrate_t`.
     """
 
-    def __init__(
-        self, save_result=False, state_is_raveled=False, tfirst=False, tchosen=False
-    ):
-        self.state_is_raveled = state_is_raveled
-        self.tfirst = tfirst
+    def __init__(self, save_result=False, tchosen=False):
         self.save_result = save_result
         self.tchosen = tchosen
 
@@ -80,8 +70,8 @@ class ODEIVPSolver(ABC):
         Parameters
         ----------
         force : callable
-            Function to integrate.
-        initial_state : array-like
+            Function to integrate: `f(state, t)`.
+        initial_state : array-like, shape=[..., n_vars, *point_shape]
             Initial state.
         end_time : float or None
             Integration end time.
@@ -97,8 +87,8 @@ class ODEIVPSolver(ABC):
         Parameters
         ----------
         force : callable
-            Function to integrate.
-        initial_state : array-like
+            Function to integrate: `f(state, t)`.
+        initial_state : array-like, shape=[..., n_vars, *point_shape]
             Initial state.
         t_eval : array-like
             Times at which to store the computed solution.
@@ -125,9 +115,7 @@ class GSIVPIntegrator(ODEIVPSolver):
     """
 
     def __init__(self, n_steps=10, step_type="euler", save_result=False):
-        super().__init__(
-            save_result=save_result, state_is_raveled=False, tfirst=False, tchosen=False
-        )
+        super().__init__(save_result=save_result, tchosen=False)
         self.step_type = step_type
         self.n_steps = n_steps
 
@@ -176,8 +164,8 @@ class GSIVPIntegrator(ODEIVPSolver):
         Parameters
         ----------
         force : callable
-            Function to integrate.
-        initial_state : array-like
+            Function to integrate: `f(state, t)`.
+        initial_state : array-like, shape=[..., n_vars, *point_shape]
             Initial state.
         end_time : float or None
             Integration end time.
@@ -202,23 +190,28 @@ class GSIVPIntegrator(ODEIVPSolver):
 class ScipySolveIVP(ODEIVPSolver):
     """Wrapper for scipy.integrate.solve_ivp.
 
+    Check
+    https://docs.scipy.org/doc/scipy/reference/generated/scipy.integrate.solve_ivp.html
+    for additional options.
+
     Parameters
     ----------
     method : str
         Integration method.
     save_result : bool
         If True, result is stored after calling `integrate` or `integrate_t`.
+    point_ndim = int
+        Dimension of array representing a point in the space.
     """
 
-    def __init__(self, method="RK45", save_result=False, **options):
-        super().__init__(
-            save_result=save_result, state_is_raveled=True, tfirst=True, tchosen=True
-        )
+    def __init__(self, method="RK45", save_result=False, point_ndim=1, **options):
+        super().__init__(save_result=save_result, tchosen=True)
         self.method = method
+        self.point_ndim = point_ndim
         self.options = options
 
     def _integrate(self, force, initial_state, end_time=1.0, t_eval=None):
-        if initial_state.ndim > 1:
+        if initial_state.ndim > (self.point_ndim + 1):
             results = []
             for initial_state_ in initial_state:
                 results.append(
@@ -244,8 +237,8 @@ class ScipySolveIVP(ODEIVPSolver):
         Parameters
         ----------
         force : callable
-            Function to integrate.
-        initial_state : array-like
+            Function to integrate: `f(state, t)`.
+        initial_state : array-like, shape=[..., n_vars, *point_shape]
             Initial state.
         end_time : float or None
             Integration end time.
@@ -262,8 +255,8 @@ class ScipySolveIVP(ODEIVPSolver):
         Parameters
         ----------
         force : callable
-            Function to integrate.
-        initial_state : array-like
+            Function to integrate: `f(state, t)`.
+        initial_state : array-like, shape=[..., n_vars, *point_shape]
             Initial state.
         t_eval : array-like
             Times at which to store the computed solution.
@@ -277,17 +270,27 @@ class ScipySolveIVP(ODEIVPSolver):
     def _integrate_single(self, force, initial_state, end_time=1.0, t_eval=None):
         def force_(t, state):
             state = gs.from_numpy(state)
-            return force(t, state)
+            unraveled_state = gs.reshape(state, initial_state.shape)
+
+            return gs.reshape(
+                force(unraveled_state, t),
+                state.shape,
+            )
+
+        raveled_initial_state = gs.reshape(initial_state, (-1,))
 
         result = scipy.integrate.solve_ivp(
             force_,
             (0.0, end_time),
-            initial_state,
+            raveled_initial_state,
             method=self.method,
             t_eval=t_eval,
             **self.options,
         )
         result = result_to_backend_type(result)
-        result.y = gs.moveaxis(result.y, 0, -1)
+        result.y = gs.reshape(
+            gs.moveaxis(result.y, 0, -1),
+            (-1,) + initial_state.shape,
+        )
 
         return result

--- a/tests/tests_geomstats/test_numerics/test_exp.py
+++ b/tests/tests_geomstats/test_numerics/test_exp.py
@@ -79,7 +79,7 @@ class TestExpODESolverMatrixComparison(
         integrator=GSIVPIntegrator(n_steps=15, step_type="rk4"),
     )
     cmp_exp_solver = InvariantMetricMatrixExpODESolver(
-        integrator=ScipySolveIVP(rtol=1e-8)
+        integrator=ScipySolveIVP(rtol=1e-8, point_ndim=2)
     )
 
     testing_data = ExpSolverComparisonTestData()
@@ -98,7 +98,12 @@ class TestExpODESolverMatrix(ExpSolverTestCase, metaclass=DataBasedParametrizer)
     space.metric.log_solver = None
     space.metric.exp_solver = None
 
-    exp_solver = InvariantMetricMatrixExpODESolver(integrator=ScipySolveIVP(rtol=1e-8))
+    exp_solver = InvariantMetricMatrixExpODESolver(
+        integrator=ScipySolveIVP(
+            rtol=1e-8,
+            point_ndim=2,
+        )
+    )
 
     testing_data = ExpSolverTestData()
 


### PR DESCRIPTION
Following #1944, this PR simplifies `ExpODESolver` by designing a less flexible interface for `ODEIVPSolver` (consequently, `ScipySolveIVP` was updated and previously existing geomstats API kept).

Goal of this PR is to improve code readability. More to come on this.