### PR TITLE
Add path-straightening algorithm

### DIFF
--- a/geomstats/geometry/pullback_metric.py
+++ b/geomstats/geometry/pullback_metric.py
@@ -34,7 +34,9 @@ class PullbackMetric(RiemannianMetric):
         self._instantiate_solvers()
 
     def _instantiate_solvers(self):
-        self.log_solver = LogShootingSolver()
+        if not gs.__name__.endswith("numpy"):
+            self.log_solver = LogShootingSolver()
+
         self.exp_solver = ExpODESolver(
             integrator=GSIVPIntegrator(n_steps=100, step_type="euler"),
         )

--- a/geomstats/numerics/interpolation.py
+++ b/geomstats/numerics/interpolation.py
@@ -3,10 +3,11 @@
 import geomstats.backend as gs
 
 
-class LinearInterpolator1D:
+class UniformUnitIntervalLinearInterpolator:
     """A 1D linear interpolator.
 
-    Assumes interpolation occurs in the unit interval.
+    Assumes interpolation occurs in the unit interval and
+    data is uniformly sampled.
 
     Parameters
     ----------

--- a/geomstats/numerics/interpolation.py
+++ b/geomstats/numerics/interpolation.py
@@ -1,0 +1,83 @@
+"""Interpolation machinery."""
+
+import geomstats.backend as gs
+
+
+class LinearInterpolator1D:
+    """A 1D linear interpolator.
+
+    Assumes interpolation occurs in the unit interval.
+
+    Parameters
+    ----------
+    data : array-like, [..., *point_shape]
+    point_ndim : int
+        Dimension of point.
+    """
+
+    def __init__(self, data, point_ndim=1):
+        self.data = data
+        self.point_ndim = point_ndim
+        self._time_axis = -(point_ndim + 1)
+        self._n_times = self.data.shape[self._time_axis]
+        self._delta = 1 / (self._n_times - 1)
+
+    def __call__(self, t):
+        """Interpolate data.
+
+        Parameters
+        ----------
+        t : array-like, shape=[n_time]
+            Interpolation time.
+
+        Returns
+        -------
+        point : array-like, shape=[..., n_time, *point_shape]
+        """
+        return self.interpolate(t)
+
+    def _from_t_to_interval(self, t):
+        """Get interval index from time.
+
+        Parameters
+        ----------
+        t : array-like, shape=[n_time]
+            Interpolation time.
+
+        Returns
+        -------
+        interval_index : array-like, shape=[n_times]
+        """
+        return gs.cast(
+            t // self._delta,
+            dtype=gs.int32,
+        )
+
+    def interpolate(self, t):
+        """Interpolate data.
+
+        Parameters
+        ----------
+        t : array-like, shape=[n_time]
+            Interpolation time.
+
+        Returns
+        -------
+        point : array-like, shape=[..., n_time, *point_shape]
+        """
+        interval_index = self._from_t_to_interval(t)
+
+        point_ndim_slc = (slice(None),) * self.point_ndim
+
+        max_bound_reached = interval_index == self._n_times - 1
+
+        end_index = gs.where(max_bound_reached, interval_index, interval_index + 1)
+
+        initial_point = self.data[..., interval_index, *point_ndim_slc]
+        end_point = self.data[..., end_index, *point_ndim_slc]
+
+        diff = end_point - initial_point
+        ratio = gs.mod(t, self._delta) / self._delta
+
+        ijk = "ijk"[self.point_ndim]
+        return initial_point + gs.einsum(f"t,...t{ijk}->...t{ijk}", ratio, diff)

--- a/geomstats/numerics/optimizers.py
+++ b/geomstats/numerics/optimizers.py
@@ -5,6 +5,7 @@ import logging
 import scipy
 
 import geomstats.backend as gs
+from geomstats.exceptions import AutodiffNotImplementedError
 from geomstats.numerics._common import result_to_backend_type
 
 
@@ -27,6 +28,13 @@ class ScipyMinimize:
         options=None,
         save_result=False,
     ):
+        if jac == "autodiff" and gs.__name__.endswith("numpy"):
+            raise AutodiffNotImplementedError(
+                "Minimization with 'autodiff' requires automatic differentiation."
+                "Change backend via the command "
+                "export GEOMSTATS_BACKEND=pytorch in a terminal"
+            )
+
         self.method = method
         self.jac = jac
         self.hess = hess

--- a/geomstats/numerics/path.py
+++ b/geomstats/numerics/path.py
@@ -1,0 +1,94 @@
+"""Discrete-path related machinery."""
+
+import geomstats.backend as gs
+from geomstats.numerics.finite_differences import forward_difference
+from geomstats.numerics.interpolation import LinearInterpolator1D
+
+
+class UniformlySampledPathEnergy:
+    """Riemannian path energy of a uniformly-sampled path."""
+
+    def __call__(self, space, path):
+        """Compute Riemannian path energy.
+
+        Parameters
+        ----------
+        space : Manifold
+        path : array-like, shape=[..., n_times, *point_shape]
+            Piecewise linear path.
+
+        Returns
+        -------
+        energy : array-like, shape=[...,]
+            Path energy.
+        """
+        return self.path_energy(space, path)
+
+    def path_energy_per_time(self, space, path):
+        """Compute Riemannian path enery per time.
+
+        Parameters
+        ----------
+        space : Manifold
+        path : array-like, shape=[..., n_times, *point_shape]
+            Piecewise linear path.
+
+        Returns
+        -------
+        energy : array-like, shape=[..., n_times - 1,]
+            Stepwise path energy.
+        """
+        time_axis = -(space.point_ndim + 1)
+        point_ndim_slc = tuple([slice(None)] * space.point_ndim)
+
+        n_time = path.shape[time_axis]
+        tangent_vecs = forward_difference(path, axis=time_axis)
+        return space.metric.squared_norm(
+            tangent_vecs,
+            path[..., :-1, *point_ndim_slc],
+        ) / (2 * n_time)
+
+    def path_energy(self, space, path):
+        """Compute Riemannian path energy.
+
+        Parameters
+        ----------
+        space : Manifold
+        path : array-like, shape=[..., n_times, *point_shape]
+            Piecewise linear path.
+
+        Returns
+        -------
+        energy : array-like, shape=[...,]
+            Path energy.
+        """
+        return gs.sum(self.path_energy_per_time(space, path), axis=-1)
+
+
+class UniformlySampledDiscretePath:
+    """A uniformly-sampled discrete path.
+
+    Parameters
+    ----------
+    path : array-like, [..., *point_shape]
+    interpolator : Interpolator1D
+    """
+
+    def __init__(self, path, interpolator=None, **interpolator_kwargs):
+        if interpolator is None:
+            interpolator = LinearInterpolator1D(path, **interpolator_kwargs)
+        self.interpolator = interpolator
+
+    def __call__(self, t):
+        """Interpolate path.
+
+        Parameters
+        ----------
+        t : array-like, shape=[n_time]
+            Interpolation time.
+
+        Returns
+        -------
+        point : array-like, shape=[..., n_time, *point_shape]
+        """
+        return self.interpolator(t)

--- a/geomstats/test/test_case.py
+++ b/geomstats/test/test_case.py
@@ -60,6 +60,8 @@ np_autograd_and_torch_only = pytest.mark.skipif(
     reason="Test for numpy, autograd and pytorch backends only.",
 )
 
+autodiff_only = autograd_and_torch_only
+
 
 def pytorch_error_msg(a, b, rtol, atol):
     msg = f"\ntensor 1\n{a}\ntensor 2\n{b}"

--- a/geomstats/test_cases/geometry/discrete_surfaces.py
+++ b/geomstats/test_cases/geometry/discrete_surfaces.py
@@ -1,7 +1,33 @@
 import geomstats.backend as gs
+from geomstats.test.random import RandomDataGenerator
 from geomstats.test_cases.geometry.manifold import ManifoldTestCase
-from geomstats.test_cases.geometry.riemannian_metric import RiemannianMetricTestCase
 from geomstats.vectorization import get_n_points
+
+
+class SurfacesLocalRandomDataGenerator(RandomDataGenerator):
+    def __init__(self, space, point, amplitude=2.0):
+        super().__init__(space, amplitude)
+        self.point = point
+
+    def _get_deformation(self, n_points):
+        dim = self.point.shape[-1]
+        dof = self.point.shape[0] - 1
+
+        batch_shape = () if n_points == 1 else (n_points,)
+
+        return (
+            gs.concatenate(
+                [
+                    gs.zeros(batch_shape + (1, dim)),
+                    gs.random.rand(batch_shape + (dof, dim)),
+                ],
+                axis=-2,
+            )
+            / self.amplitude
+        )
+
+    def random_point(self, n_points=1):
+        return self.point + self._get_deformation(n_points)
 
 
 class DiscreteSurfacesTestCase(ManifoldTestCase):
@@ -71,13 +97,3 @@ class DiscreteSurfacesTestCase(ManifoldTestCase):
         """Test faces area."""
         res = self.space.face_areas(point=point)
         self.assertAllClose(res, expected, atol=atol)
-
-
-class ElasticMetricTestCase(RiemannianMetricTestCase):
-    def test_path_energy_is_positive(self, path, atol):
-        energy = self.space.metric.path_energy(path)
-        self.assertTrue(gs.all(energy > -1 * atol))
-
-    def test_path_energy_per_time_is_positive(self, path, atol):
-        energy = self.space.metric.path_energy_per_time(path)
-        self.assertTrue(gs.all(energy > -1 * atol))

--- a/geomstats/test_cases/numerics/geodesic.py
+++ b/geomstats/test_cases/numerics/geodesic.py
@@ -257,7 +257,7 @@ class ExpSolverTypeCheck(_SolverTestCase):
 
 
 class LogSolverTypeCheckTestCase(_SolverTestCase):
-    @pytest.mark.random
+    @pytest.mark.type
     def test_log_type(self, n_points):
         base_point = self.data_generator.random_point(n_points)
         end_point = self.data_generator.random_point(n_points)
@@ -265,7 +265,7 @@ class LogSolverTypeCheckTestCase(_SolverTestCase):
         res = self.log_solver.log(self.space, end_point, base_point)
         self.assertTrue(gs.is_array(res), f"Wrong type: {type(res)}")
 
-    @pytest.mark.random
+    @pytest.mark.type
     def test_geodesic_bvp_type(self, n_points, n_times):
         base_point = self.data_generator.random_point(n_points)
         end_point = self.data_generator.random_point(n_points)

--- a/tests/tests_geomstats/test_geometry/data/discrete_surfaces.py
+++ b/tests/tests_geomstats/test_geometry/data/discrete_surfaces.py
@@ -1,10 +1,11 @@
+import pytest
+
 import geomstats.backend as gs
 import geomstats.datasets.utils as data_utils
 from geomstats.test.data import TestData
 from geomstats.vectorization import repeat_point
 
 from .manifold import ManifoldTestData
-from .riemannian_metric import RiemannianMetricTestData
 
 
 class DiscreteSurfacesTestData(ManifoldTestData):
@@ -91,22 +92,16 @@ class DiscreteSurfacesSmokeTestData(TestData):
         return self.generate_tests(data)
 
 
-class ElasticMetricTestData(RiemannianMetricTestData):
-    pass
+class ElasticMetricTestData(TestData):
+    N_RANDOM_POINTS = [1]
 
+    tolerances = {"exp_after_log": {"atol": 1e-1}}
 
-class ElasticMetricSmokeTestData(TestData):
-    vertices, _ = data_utils.load_cube()
-    vertices = gs.array(vertices, dtype=gs.float64)
+    def exp_after_log_test_data(self):
+        return self.generate_random_data(marks=(pytest.mark.slow, pytest.mark.xfail))
 
-    def path_energy_is_positive_test_data(self):
-        data = [
-            dict(path=gs.array([self.vertices, self.vertices, self.vertices])),
-        ]
-        return self.generate_tests(data)
+    def inner_product_vec_test_data(self):
+        return self.generate_vec_data()
 
-    def path_energy_per_time_is_positive_test_data(self):
-        data = [
-            dict(path=gs.array([self.vertices, self.vertices, self.vertices])),
-        ]
-        return self.generate_tests(data)
+    def inner_product_is_symmetric_test_data(self):
+        return self.generate_random_data()

--- a/tests/tests_geomstats/test_geometry/test_discrete_surfaces.py
+++ b/tests/tests_geomstats/test_geometry/test_discrete_surfaces.py
@@ -2,18 +2,18 @@ import pytest
 
 import geomstats.backend as gs
 import geomstats.datasets.utils as data_utils
-from geomstats.geometry.discrete_surfaces import DiscreteSurfaces, ElasticMetric
+from geomstats.geometry.discrete_surfaces import DiscreteSurfaces
 from geomstats.test.parametrizers import DataBasedParametrizer
-from geomstats.test.test_case import torch_only
+from geomstats.test.test_case import pytorch_backend, torch_only
 from geomstats.test_cases.geometry.discrete_surfaces import (
     DiscreteSurfacesTestCase,
-    ElasticMetricTestCase,
+    SurfacesLocalRandomDataGenerator,
 )
+from geomstats.test_cases.geometry.riemannian_metric import RiemannianMetricTestCase
 
 from .data.discrete_surfaces import (
     DiscreteSurfacesSmokeTestData,
     DiscreteSurfacesTestData,
-    ElasticMetricSmokeTestData,
     ElasticMetricTestData,
 )
 
@@ -54,23 +54,18 @@ class TestDiscreteSurfacesSmoke(
 
 
 @torch_only
-@pytest.mark.skip
-class TestElasticMetric(ElasticMetricTestCase, metaclass=DataBasedParametrizer):
-    vertices, faces = data_utils.load_cube()
-    vertices = gs.array(vertices, dtype=gs.float64)
-    faces = gs.array(faces)
-    space = DiscreteSurfaces(faces)
+class TestElasticMetric(RiemannianMetricTestCase, metaclass=DataBasedParametrizer):
+    _vertices, _faces = data_utils.load_cube()
+    _vertices = gs.array(_vertices, dtype=gs.float64)
+    _faces = gs.array(_faces)
 
+    if pytorch_backend():
+        space = DiscreteSurfaces(_faces)
+
+        space.metric.log_solver.n_nodes = 100
+        space.metric.exp_solver.n_steps = 100
+
+        data_generator = SurfacesLocalRandomDataGenerator(
+            space, _vertices, amplitude=10.0
+        )
     testing_data = ElasticMetricTestData()
-
-
-@torch_only
-@pytest.mark.smoke
-class TestElasticMetricSmoke(ElasticMetricTestCase, metaclass=DataBasedParametrizer):
-    vertices, faces = data_utils.load_cube()
-    vertices = gs.array(vertices, dtype=gs.float64)
-    faces = gs.array(faces)
-    space = DiscreteSurfaces(faces, equip=False)
-    space.equip_with_metric(ElasticMetric, a0=1, a1=1, b1=1, c1=1, d1=1, a2=1)
-
-    testing_data = ElasticMetricSmokeTestData()

--- a/tests/tests_geomstats/test_numerics/data/geodesic.py
+++ b/tests/tests_geomstats/test_numerics/data/geodesic.py
@@ -35,14 +35,6 @@ class ExpSolverTestData(TestData):
 
 
 class LogSolverAgainstMetricTestData(TestData):
-    fail_for_autodiff_exceptions = False
-    fail_for_not_implemented_errors = False
-
-    tolerances = {
-        "log": {"atol": 1e-3},
-        "geodesic_bvp": {"atol": 1e-4},
-    }
-
     def log_test_data(self):
         return self.generate_random_data()
 

--- a/tests/tests_geomstats/test_numerics/data/interpolation.py
+++ b/tests/tests_geomstats/test_numerics/data/interpolation.py
@@ -1,0 +1,6 @@
+from geomstats.test.data import TestData
+
+
+class UniformUnitIntervalLinearInterpolatorTestData(TestData):
+    def interpolate_uniformly_test_data(self):
+        return self.generate_tests([dict()])

--- a/tests/tests_geomstats/test_numerics/data/log.py
+++ b/tests/tests_geomstats/test_numerics/data/log.py
@@ -1,10 +1,23 @@
-from .geodesic import LogSolverTestData
+from .geodesic import LogSolverAgainstMetricTestData, LogSolverTestData
+
+
+class LogSolverAgainstClosedFormTestData(LogSolverAgainstMetricTestData):
+    fail_for_not_implemented_errors = False
+
+    tolerances = {
+        "log": {"atol": 1e-3},
+        "geodesic_bvp": {"atol": 1e-4},
+    }
+
+
+class PathStraighteningAgainstClosedFormTestData(LogSolverAgainstMetricTestData):
+    tolerances = {
+        "log": {"atol": 1e-2},
+        "geodesic_bvp": {"atol": 1e-2},
+    }
 
 
 class LogODESolverMatrixTestData(LogSolverTestData):
-    fail_for_autodiff_exceptions = True
-    fail_for_not_implemented_errors = True
-
     skip_vec = True
 
     tolerances = {

--- a/tests/tests_geomstats/test_numerics/data/path.py
+++ b/tests/tests_geomstats/test_numerics/data/path.py
@@ -1,0 +1,10 @@
+from geomstats.test.data import TestData
+
+
+class UniformlySampledPathEnergyTestData(TestData):
+    N_TIME_POINTS = [100]
+
+    tolerances = {"dist_from_path_energy_per_time": {"atol": 1e-2}}
+
+    def dist_from_path_energy_per_time_test_data(self):
+        return self.generate_random_data_with_time()

--- a/tests/tests_geomstats/test_numerics/test_exp.py
+++ b/tests/tests_geomstats/test_numerics/test_exp.py
@@ -15,14 +15,12 @@ from geomstats.test_cases.numerics.geodesic import (
     ExpSolverAgainstMetricTestCase,
     ExpSolverComparisonTestCase,
     ExpSolverTestCase,
-    ExpSolverTypeCheck,
 )
 
 from .data.geodesic import (
     ExpSolverAgainstMetricTestData,
     ExpSolverComparisonTestData,
     ExpSolverTestData,
-    ExpSolverTypeCheckTestData,
 )
 
 
@@ -106,30 +104,3 @@ class TestExpODESolverMatrix(ExpSolverTestCase, metaclass=DataBasedParametrizer)
     )
 
     testing_data = ExpSolverTestData()
-
-
-def _create_params_type_check():
-    params = []
-
-    space = PoincareBall(random.randint(2, 3))
-    for integrator in (
-        GSIVPIntegrator(n_steps=10, step_type="euler"),
-        ScipySolveIVP(),
-    ):
-        solver = ExpODESolver(integrator=integrator)
-        params.append((space, solver))
-
-    return params
-
-
-@pytest.fixture(
-    scope="class",
-    params=_create_params_type_check(),
-)
-def spaces_for_type_checking(request):
-    request.cls.space, request.cls.exp_solver = request.param
-
-
-@pytest.mark.usefixtures("spaces_for_type_checking")
-class TestExpSolverTypeCheck(ExpSolverTypeCheck, metaclass=DataBasedParametrizer):
-    testing_data = ExpSolverTypeCheckTestData()

--- a/tests/tests_geomstats/test_numerics/test_interpolation.py
+++ b/tests/tests_geomstats/test_numerics/test_interpolation.py
@@ -1,0 +1,43 @@
+import random
+
+import pytest
+
+import geomstats.backend as gs
+from geomstats.numerics.interpolation import UniformUnitIntervalLinearInterpolator
+from geomstats.test.parametrizers import DataBasedParametrizer
+from geomstats.test.test_case import TestCase
+
+from .data.interpolation import UniformUnitIntervalLinearInterpolatorTestData
+
+
+@pytest.fixture(
+    scope="class",
+    params=[(1,), (2,)],
+)
+def interpolators(request):
+    point_shape = request.param
+
+    num_points = random.randint(5, 12)
+    data = gs.random.uniform(size=(num_points,) + point_shape)
+
+    request.cls.interpolator = UniformUnitIntervalLinearInterpolator(
+        data, point_ndim=len(point_shape)
+    )
+
+
+@pytest.mark.usefixtures("interpolators")
+class TestUniformUnitIntervalLinearInterpolator(
+    TestCase, metaclass=DataBasedParametrizer
+):
+    testing_data = UniformUnitIntervalLinearInterpolatorTestData()
+
+    def test_interpolate(self, t, expected, atol):
+        res = self.interpolator(t)
+        self.assertAllClose(res, expected, atol=atol)
+
+    @pytest.mark.random
+    def test_interpolate_uniformly(self, atol):
+        times = gs.linspace(0.0, 1.0, num=self.interpolator._n_times)
+
+        res = self.interpolator(times)
+        self.assertAllClose(res, self.interpolator.data, atol=atol)

--- a/tests/tests_geomstats/test_numerics/test_path.py
+++ b/tests/tests_geomstats/test_numerics/test_path.py
@@ -1,0 +1,49 @@
+import random
+
+import pytest
+
+import geomstats.backend as gs
+from geomstats.geometry.poincare_ball import PoincareBall
+from geomstats.numerics.path import UniformlySampledPathEnergy
+from geomstats.test.parametrizers import DataBasedParametrizer
+from geomstats.test.random import RandomDataGenerator
+from geomstats.test.test_case import TestCase
+
+from .data.path import UniformlySampledPathEnergyTestData
+
+
+class TestUniformlySampledPathEnergy(TestCase, metaclass=DataBasedParametrizer):
+    _dim = random.randint(2, 3)
+    space = PoincareBall(_dim)
+    path_energy = UniformlySampledPathEnergy()
+
+    data_generator = RandomDataGenerator(space)
+    testing_data = UniformlySampledPathEnergyTestData()
+
+    def test_energy(self, path, expected, atol):
+        res = self.path_energy.energy(self.space, path)
+        self.assertAllClose(res, expected, atol=atol)
+
+    def test_energy_per_time(self, path, expected, atol):
+        res = self.path_energy.energy_per_time(self.space, path)
+        self.assertAllClose(res, expected, atol=atol)
+
+    @pytest.mark.random
+    def test_dist_from_path_energy_per_time(self, n_points, n_times, atol):
+        point = self.data_generator.random_point(n_points)
+        base_point = self.data_generator.random_point(n_points)
+
+        geod_func = self.space.metric.geodesic(base_point, end_point=point)
+        times = gs.linspace(0, 1.0, num=n_times)
+        geod_points = geod_func(times)
+
+        energy_per_time = self.path_energy.energy_per_time(self.space, geod_points)
+
+        delta = 1 / (n_times - 1)
+        dist_from_energy_per_time = gs.sum(
+            gs.sqrt(energy_per_time * 2 / delta) * delta,
+            axis=-1,
+        )
+
+        dist = self.space.metric.dist(point, base_point)
+        self.assertAllClose(dist_from_energy_per_time, dist, atol=atol)


### PR DESCRIPTION
This PR generalizes implementation of  path-straightening algorithm already available on `discrete_surfaces`.

The algorithm minimizes the Riemannian geometry of a path.

Given the discretized nature of the path, I've created `numerics.path` with utils to compute the path energy of a uniformly-sampled path. Notice that there's a numerical analysis choice here: what finite-difference scheme to use? This implementation uses forward differences, but can easily be extended (not the same as @emmanuel-hartman original code).

Given the discretized nature of the output (the geodesic path is a collection of points), I've created `UniformlySampledPath` to interpolate between these points, such that `geodesic` is now a callable (and not an array). This relies on a 1d interpolator.

I've added a simple 1d linear interpolator in `numerics.interpolation`. Main reason: speed. We may use scipy machinery for more complex interpolation schemes.


I think may interest you @alebrigant and @MMalikT.




closes #1926

P.S. only missing tests, but already checked locally against closed-form solutions (works beautifully! though accuracy is not fantastic)