### PR TITLE
Add GroupAction abstraction

### DIFF
--- a/geomstats/geometry/group_action.py
+++ b/geomstats/geometry/group_action.py
@@ -1,0 +1,183 @@
+"""Group actions."""
+
+import math
+from abc import ABC, abstractmethod
+
+import geomstats.backend as gs
+from geomstats.geometry.matrices import Matrices
+from geomstats.vectorization import get_batch_shape
+
+
+class GroupAction(ABC):
+    """Base class for group action."""
+
+    @abstractmethod
+    def __call__(self, group_elem, point):
+        """Perform action of a group element on a manifold point.
+
+        Parameters
+        ----------
+        group_elem : array-like
+            The element of a group.
+        point : array-like
+            A point on a manifold.
+
+        Returns
+        -------
+        orbit_point : array-like
+            A point on the orbit of point.
+        """
+
+    @abstractmethod
+    def inverse_element(self, group_elem):
+        """Inverse element.
+
+        Parameters
+        ----------
+        group_elem: : array-like, shape=[..., dim]
+
+        Returns
+        -------
+        group_elem : array-like, shape=[..., dim]
+        """
+
+
+class CongruenceAction(GroupAction):
+    """Congruence action."""
+
+    def __call__(self, group_elem, point):
+        """Congruence action of a group element on a matrix.
+
+        Parameters
+        ----------
+        group_elem : array-like, shape=[..., n, n]
+            The element of a group.
+        point : array-like, shape=[..., n, n]
+            A point on a manifold.
+
+        Returns
+        -------
+        orbit_point : array-like, shape=[..., n, n]
+            A point on the orbit of point.
+        """
+        return Matrices.mul(group_elem, point, Matrices.transpose(group_elem))
+
+    def inverse_element(self, group_elem):
+        """Inverse element.
+
+        Parameters
+        ----------
+        group_elem : array-like, shape=[..., n, n]
+
+        Returns
+        -------
+        inverse_group_elem : array-like, shape=[..., n, n]
+        """
+        return gs.linalg.inv(group_elem)
+
+
+class _PermutationActionMixins:
+    """Methods shared by the permutation action classes."""
+
+    def _inverse_element_single(self, group_elem):
+        """Inverse element.
+
+        Parameters
+        ----------
+        group_elem : array-like, shape=[dim]
+
+        Returns
+        -------
+        inverse_group_elem : array-like, shape=[dim]
+        """
+        inverse_group_elem = gs.zeros_like(group_elem)
+        for val, index in enumerate(group_elem):
+            inverse_group_elem[index] = val
+        return inverse_group_elem
+
+    def inverse_element(self, group_elem):
+        """Inverse element.
+
+        Parameters
+        ----------
+        group_elem : array-like, shape=[..., dim]
+
+        Returns
+        -------
+        inverse_group_elem : array-like, shape=[..., dim]
+        """
+        if group_elem.ndim == 1:
+            return self._inverse_element_single(group_elem)
+
+        return gs.stack(
+            [self._inverse_element_single(group_elem_) for group_elem_ in group_elem]
+        )
+
+
+class PermutationAction(_PermutationActionMixins, CongruenceAction):
+    """Congruence action of the permutation group on matrices."""
+
+    def __call__(self, group_elem, point):
+        """Congruence action of a group element on a matrix.
+
+        Parameters
+        ----------
+        group_elem : array-like, shape=[..., n]
+            Permutations where in position i we have the value j meaning
+            the node i should be permuted with node j.
+        point : array-like, shape=[..., n, n]
+            A point on a manifold.
+
+        Returns
+        -------
+        orbit_point : array-like, shape=[..., n, n]
+            A point on the orbit of point.
+        """
+        perm_mat = permutation_matrix_from_vector(group_elem, dtype=point.dtype)
+        return super().__call__(perm_mat, point)
+
+
+class RowPermutationAction(_PermutationActionMixins, GroupAction):
+    """Action of the permutation group on matrices by multiplication."""
+
+    def __call__(self, group_elem, point):
+        """Permutation action applied to matrix.
+
+        Parameters
+        ----------
+        group_elem: array-like, shape=[..., n]
+            Permutations where in position i we have the value j meaning
+            the node i should be permuted with node j.
+        point : array-like, shape=[..., n, n]
+            Matrices to be permuted.
+
+        Returns
+        -------
+        permuted_point : array-like, shape=[..., n, n]
+            Permuted matrices.
+        """
+        perm_mat = permutation_matrix_from_vector(group_elem, dtype=point.dtype)
+        return gs.matmul(Matrices.transpose(perm_mat), point)
+
+
+def permutation_matrix_from_vector(group_elem, dtype=gs.int64):
+    """Transform a permutation vector into a matrix."""
+    batch_shape = get_batch_shape(1, group_elem)
+    n = group_elem.shape[-1]
+
+    if batch_shape:
+        indices = gs.array(
+            [
+                (k, i, j)
+                for (k, group_elem_) in enumerate(group_elem)
+                for (i, j) in zip(range(n), group_elem_)
+            ]
+        )
+    else:
+        indices = gs.array(list(zip(range(n), group_elem)))
+
+    return gs.array_from_sparse(
+        data=gs.ones(math.prod(batch_shape) * n, dtype=dtype),
+        indices=indices,
+        target_shape=batch_shape + (n, n),
+    )

--- a/geomstats/geometry/group_action.py
+++ b/geomstats/geometry/group_action.py
@@ -28,19 +28,6 @@ class GroupAction(ABC):
             A point on the orbit of point.
         """
 
-    @abstractmethod
-    def inverse_element(self, group_elem):
-        """Inverse element.
-
-        Parameters
-        ----------
-        group_elem: : array-like, shape=[..., dim]
-
-        Returns
-        -------
-        group_elem : array-like, shape=[..., dim]
-        """
-
 
 class CongruenceAction(GroupAction):
     """Congruence action."""
@@ -62,59 +49,8 @@ class CongruenceAction(GroupAction):
         """
         return Matrices.mul(group_elem, point, Matrices.transpose(group_elem))
 
-    def inverse_element(self, group_elem):
-        """Inverse element.
 
-        Parameters
-        ----------
-        group_elem : array-like, shape=[..., n, n]
-
-        Returns
-        -------
-        inverse_group_elem : array-like, shape=[..., n, n]
-        """
-        return gs.linalg.inv(group_elem)
-
-
-class _PermutationActionMixins:
-    """Methods shared by the permutation action classes."""
-
-    def _inverse_element_single(self, group_elem):
-        """Inverse element.
-
-        Parameters
-        ----------
-        group_elem : array-like, shape=[dim]
-
-        Returns
-        -------
-        inverse_group_elem : array-like, shape=[dim]
-        """
-        inverse_group_elem = gs.zeros_like(group_elem)
-        for val, index in enumerate(group_elem):
-            inverse_group_elem[index] = val
-        return inverse_group_elem
-
-    def inverse_element(self, group_elem):
-        """Inverse element.
-
-        Parameters
-        ----------
-        group_elem : array-like, shape=[..., dim]
-
-        Returns
-        -------
-        inverse_group_elem : array-like, shape=[..., dim]
-        """
-        if group_elem.ndim == 1:
-            return self._inverse_element_single(group_elem)
-
-        return gs.stack(
-            [self._inverse_element_single(group_elem_) for group_elem_ in group_elem]
-        )
-
-
-class PermutationAction(_PermutationActionMixins, CongruenceAction):
+class PermutationAction(CongruenceAction):
     """Congruence action of the permutation group on matrices."""
 
     def __call__(self, group_elem, point):
@@ -137,7 +73,7 @@ class PermutationAction(_PermutationActionMixins, CongruenceAction):
         return super().__call__(perm_mat, point)
 
 
-class RowPermutationAction(_PermutationActionMixins, GroupAction):
+class RowPermutationAction(GroupAction):
     """Action of the permutation group on matrices by multiplication."""
 
     def __call__(self, group_elem, point):

--- a/geomstats/geometry/group_action.py
+++ b/geomstats/geometry/group_action.py
@@ -17,9 +17,9 @@ class GroupAction(ABC):
 
         Parameters
         ----------
-        group_elem : array-like
+        group_elem : array-like, shape=[..., *group.shape]
             The element of a group.
-        point : array-like
+        point : array-like, shape=[..., *space.shape]
             A point on a manifold.
 
         Returns
@@ -97,7 +97,20 @@ class RowPermutationAction(GroupAction):
 
 
 def permutation_matrix_from_vector(group_elem, dtype=gs.int64):
-    """Transform a permutation vector into a matrix."""
+    """Transform a permutation vector into a matrix.
+
+    Parameters
+    ----------
+    group_elem : array-like, shape=[..., n]
+        The element of a group.
+    dtype: gs.dtype
+        Array dtype
+
+    Returns
+    -------
+    mat_group_element : array-like, shape=[..., n, n]
+        Matrix representation of group element.
+    """
     batch_shape = get_batch_shape(1, group_elem)
     n = group_elem.shape[-1]
 

--- a/geomstats/test_cases/geometry/group_action.py
+++ b/geomstats/test_cases/geometry/group_action.py
@@ -1,0 +1,91 @@
+import itertools
+import random
+
+import pytest
+
+import geomstats.backend as gs
+from geomstats.test.random import RandomDataGenerator
+from geomstats.test.test_case import TestCase
+from geomstats.test.vectorization import generate_vectorization_data
+
+
+class PermutationGroup:
+    """Permutation group.
+
+    A basic (non-optimized) implementation of the permutation group with points
+    represented as 1d arrays for testing purposes.
+    """
+
+    def __init__(self, dim):
+        self.dim = dim
+        self.shape = (dim,)
+        self.identity = gs.arange(dim)
+
+        self._all_perms = list(itertools.permutations(range(self.dim), self.dim))
+
+    def random_point(self, n_samples=1):
+        """Sample random point.
+
+        Parameters
+        ----------
+        n_samples : int
+
+        Returns
+        -------
+        random_point : array-like, shape=[..., dim]
+        """
+        random_point = gs.array(random.sample(self._all_perms, n_samples))
+        if n_samples == 1:
+            return random_point[0]
+
+        return random_point
+
+
+class GroupActionTestCase(TestCase):
+    """Group action test case.
+
+    Requires: `group_action`, `space`, `group`.
+    """
+
+    def setup_method(self):
+        if not hasattr(self, "data_generator"):
+            self.data_generator = RandomDataGenerator(self.space)
+            self.group_data_generator = RandomDataGenerator(self.group)
+
+    @pytest.mark.random
+    def test_identity_action(self, n_points, atol):
+        point = self.data_generator.random_point(n_points)
+        orbit_point = self.group_action(self.group.identity, point)
+        self.assertAllClose(point, orbit_point)
+
+    def test_action(self, group_elem, point, expected, atol):
+        orbit_point = self.group_action(group_elem, point)
+        self.assertAllClose(orbit_point, expected, atol=atol)
+
+    @pytest.mark.vec
+    def test_action_vec(self, n_reps, atol):
+        group_elem = self.group_data_generator.random_point()
+        point = self.data_generator.random_point()
+
+        expected = self.group_action(group_elem, point)
+
+        vec_data = generate_vectorization_data(
+            data=[
+                dict(group_elem=group_elem, point=point, expected=expected, atol=atol)
+            ],
+            arg_names=["group_elem", "point"],
+            expected_name="expected",
+            n_reps=n_reps,
+        )
+        self._test_vectorization(vec_data)
+
+    @pytest.mark.random
+    def test_inverse_element_action(self, n_points, atol):
+        group_elem = self.group_data_generator.random_point(n_points)
+        point = self.data_generator.random_point(n_points)
+
+        orbit_point = self.group_action(group_elem, point)
+        point_ = self.group_action(
+            self.group_action.inverse_element(group_elem), orbit_point
+        )
+        self.assertAllClose(point_, point, atol)

--- a/geomstats/test_cases/geometry/group_action.py
+++ b/geomstats/test_cases/geometry/group_action.py
@@ -40,6 +40,40 @@ class PermutationGroup:
 
         return random_point
 
+    def _inverse_single(self, group_elem):
+        """Inverse element.
+
+        Parameters
+        ----------
+        group_elem : array-like, shape=[dim]
+
+        Returns
+        -------
+        inverse_group_elem : array-like, shape=[dim]
+        """
+        inverse_group_elem = gs.zeros_like(group_elem)
+        for val, index in enumerate(group_elem):
+            inverse_group_elem[index] = val
+        return inverse_group_elem
+
+    def inverse(self, group_elem):
+        """Inverse element.
+
+        Parameters
+        ----------
+        group_elem : array-like, shape=[..., dim]
+
+        Returns
+        -------
+        inverse_group_elem : array-like, shape=[..., dim]
+        """
+        if group_elem.ndim == 1:
+            return self._inverse_single(group_elem)
+
+        return gs.stack(
+            [self._inverse_single(group_elem_) for group_elem_ in group_elem]
+        )
+
 
 class GroupActionTestCase(TestCase):
     """Group action test case.
@@ -80,12 +114,10 @@ class GroupActionTestCase(TestCase):
         self._test_vectorization(vec_data)
 
     @pytest.mark.random
-    def test_inverse_element_action(self, n_points, atol):
+    def test_inverse_action(self, n_points, atol):
         group_elem = self.group_data_generator.random_point(n_points)
         point = self.data_generator.random_point(n_points)
 
         orbit_point = self.group_action(group_elem, point)
-        point_ = self.group_action(
-            self.group_action.inverse_element(group_elem), orbit_point
-        )
+        point_ = self.group_action(self.group.inverse(group_elem), orbit_point)
         self.assertAllClose(point_, point, atol)

--- a/tests/tests_geomstats/test_geometry/data/group_action.py
+++ b/tests/tests_geomstats/test_geometry/data/group_action.py
@@ -1,0 +1,76 @@
+import pytest
+
+import geomstats.backend as gs
+from geomstats.test.data import TestData
+
+
+class GroupActionTestData(TestData):
+    def identity_action_test_data(self):
+        return self.generate_random_data()
+
+    def action_vec_test_data(self):
+        return self.generate_vec_data()
+
+    def inverse_element_action_test_data(self):
+        return self.generate_random_data()
+
+
+class RowPermutationAction4TestData(TestData):
+    """Permutation action data
+
+    Smoke data from
+    https://www.sciencedirect.com/topics/engineering/permutation-matrix.
+    """
+
+    def action_test_data(self):
+        data = [
+            dict(
+                group_elem=gs.array([1, 2, 3, 0]),
+                point=gs.array(
+                    [
+                        [4, 6, 8, 1],
+                        [5, 3, 1, 0],
+                        [7, 21, 0, 9],
+                        [3, -4, 1, 3],
+                    ]
+                ),
+                expected=gs.array(
+                    [
+                        [3, -4, 1, 3],
+                        [4, 6, 8, 1],
+                        [5, 3, 1, 0],
+                        [7, 21, 0, 9],
+                    ]
+                ),
+            )
+        ]
+
+        return self.generate_tests(data, marks=[pytest.mark.smoke])
+
+
+class PermutationMatrixFromVectorTestData(TestData):
+    """Permutation matrix from vector data.
+
+    Smoke data from
+    https://www.sciencedirect.com/topics/engineering/permutation-matrix.
+    """
+
+    def permutation_matrix_from_vector_vec_test_data(self):
+        return self.generate_vec_data()
+
+    def permutation_matrix_from_vector_test_data(self):
+        data = [
+            dict(
+                group_elem=gs.array([1, 2, 3, 0]),
+                expected=gs.array(
+                    [
+                        [0, 1, 0, 0],
+                        [0, 0, 1, 0],
+                        [0, 0, 0, 1],
+                        [1, 0, 0, 0],
+                    ]
+                ),
+            )
+        ]
+
+        return self.generate_tests(data, marks=[pytest.mark.smoke])

--- a/tests/tests_geomstats/test_geometry/data/group_action.py
+++ b/tests/tests_geomstats/test_geometry/data/group_action.py
@@ -11,7 +11,7 @@ class GroupActionTestData(TestData):
     def action_vec_test_data(self):
         return self.generate_vec_data()
 
-    def inverse_element_action_test_data(self):
+    def inverse_action_test_data(self):
         return self.generate_random_data()
 
 

--- a/tests/tests_geomstats/test_geometry/test_group_action.py
+++ b/tests/tests_geomstats/test_geometry/test_group_action.py
@@ -1,0 +1,89 @@
+import random
+
+import pytest
+
+from geomstats.geometry.general_linear import GeneralLinear
+from geomstats.geometry.group_action import (
+    CongruenceAction,
+    PermutationAction,
+    RowPermutationAction,
+    permutation_matrix_from_vector,
+)
+from geomstats.geometry.matrices import Matrices
+from geomstats.geometry.spd_matrices import SPDMatrices
+from geomstats.test.parametrizers import DataBasedParametrizer
+from geomstats.test.random import RandomDataGenerator
+from geomstats.test.test_case import TestCase
+from geomstats.test.vectorization import generate_vectorization_data
+from geomstats.test_cases.geometry.group_action import (
+    GroupActionTestCase,
+    PermutationGroup,
+)
+
+from .data.group_action import (
+    GroupActionTestData,
+    PermutationMatrixFromVectorTestData,
+    RowPermutationAction4TestData,
+)
+
+
+class TestGLCongruenceActionOnSPD(GroupActionTestCase, metaclass=DataBasedParametrizer):
+    _n = random.randint(4, 6)
+    space = SPDMatrices(_n, equip=False)
+    group = GeneralLinear(_n, equip=False)
+    group_action = CongruenceAction()
+
+    testing_data = GroupActionTestData()
+
+
+class TestPermutationAction(GroupActionTestCase, metaclass=DataBasedParametrizer):
+    _n = random.randint(4, 6)
+    space = Matrices(_n, _n, equip=False)
+    group = PermutationGroup(_n)
+    group_action = PermutationAction()
+
+    testing_data = GroupActionTestData()
+
+
+class TestRowPermutationAction(GroupActionTestCase, metaclass=DataBasedParametrizer):
+    _n = random.randint(4, 6)
+    space = Matrices(_n, _n, equip=False)
+    group = PermutationGroup(_n)
+    group_action = RowPermutationAction()
+
+    testing_data = GroupActionTestData()
+
+
+@pytest.mark.smoke
+class TestRowPermutationAction4(GroupActionTestCase, metaclass=DataBasedParametrizer):
+    _n = 4
+    space = Matrices(_n, _n, equip=False)
+    group = PermutationGroup(_n)
+    group_action = RowPermutationAction()
+
+    testing_data = RowPermutationAction4TestData()
+
+
+class TestPermutationMatrixFromVector(TestCase, metaclass=DataBasedParametrizer):
+    _n = random.randint(4, 6)
+    _group = PermutationGroup(_n)
+    data_generator = RandomDataGenerator(_group)
+    testing_data = PermutationMatrixFromVectorTestData()
+
+    def test_permutation_matrix_from_vector(self, group_elem, expected, atol):
+        perm_mat = permutation_matrix_from_vector(group_elem, dtype=expected.dtype)
+        self.assertAllClose(perm_mat, expected, atol=atol)
+
+    @pytest.mark.vec
+    def test_permutation_matrix_from_vector_vec(self, n_reps, atol):
+        group_elem = self.data_generator.random_point()
+
+        expected = permutation_matrix_from_vector(group_elem)
+
+        vec_data = generate_vectorization_data(
+            data=[dict(group_elem=group_elem, expected=expected, atol=atol)],
+            arg_names=["group_elem"],
+            expected_name="expected",
+            n_reps=n_reps,
+        )
+        self._test_vectorization(vec_data)


### PR DESCRIPTION
This PR adds the `GroupAction` abstraction. Design of the class follows similar ideas as `Diffeo` (e.g. group and space are not explicitly provided to the action, as the same implementation can be used for several groups acting on several manifolds).

Class has a main method (`__call__`) which implements the action of the group element on a point of a manifold.  An example of use:

```python
space = SPDMatrices(n=3, equip=False)
group = GeneralLinear(n=3, equip=False)
group_action = CongruenceAction()

point = space.random_point()
group_elem = space.random_point()

orbit_point = group_action(group_elem, point)  # NB: it looks like a function
```

I've also added the method `inverse_element`, which should retrieve the inverse element of the group wrt the group action. I've implemented it mostly for testing purposes and it can arguably be removed or made optional (I tend more to the second).

The main use of this class is the quotient spaces framework: I want to use them with `equip_with_group_action`, so everything becomes very coherent.

Additionally to the abstractions, I've added some group actions required in different parts of the package: `CongruenceAction`, `PermutationAction`, `RowPermutationAction`.

Everything is fully tested.
