### PR TITLE
Add method to change the lists in `scalar_product_metric.py`

### DIFF
--- a/geomstats/geometry/scalar_product_metric.py
+++ b/geomstats/geometry/scalar_product_metric.py
@@ -10,25 +10,6 @@ from functools import wraps
 import geomstats.backend as gs
 import geomstats.errors
 
-SQRT_LIST = ["norm", "dist", "dist_broadcast", "dist_pairwise", "diameter"]
-LINEAR_LIST = [
-    "metric_matrix",
-    "inner_product",
-    "inner_product_derivative_matrix",
-    "squared_norm",
-    "squared_dist",
-    "covariant_riemann_tensor",
-]
-QUADRATIC_LIST = []
-INVERSE_LIST = [
-    "cometric_matrix",
-    "inner_coproduct",
-    "hamiltonian",
-    "sectional_curvature",
-    "scalar_curvature",
-]
-INVERSE_SQRT_LIST = ["normalize", "random_unit_tangent_vec", "normal_basis"]
-
 
 def _wrap_attr(scaling_factor, func):
     @wraps(func)
@@ -39,52 +20,56 @@ def _wrap_attr(scaling_factor, func):
     return response
 
 
-def _get_scaling_factor(func_name, scale):
-    if func_name in SQRT_LIST:
-        return gs.sqrt(scale)
-
-    if func_name in LINEAR_LIST:
-        return scale
-
-    if func_name in QUADRATIC_LIST:
-        return gs.power(scale, 2)
-
-    if func_name in INVERSE_LIST:
-        return 1.0 / scale
-
-    if func_name in INVERSE_SQRT_LIST:
-        return 1.0 / gs.sqrt(scale)
-    return None
-
-
 class ScalarProductMetric:
     """Class for scalar products of Riemannian and pseudo-Riemannian metrics.
 
-    This class multiplies the (0,2) metric tensor 'underlying_metric' by a scalar
-    'scaling_factor'. Note that this does not scale distances by 'scaling_factor'. That
-    would require multiplication by the square of the scalar.
+    This class multiplies the (0,2) metric tensor 'underlying_metric' by a
+    scalar 'scaling_factor'. Note that this does not scale distances by
+    'scaling_factor'. That would require multiplication by the square of the
+    scalar.
 
     An object of this type can also be instantiated by the expression
     scaling_factor * underlying_metric.
 
-    This class acts as a wrapper for the underlying Riemannian metric. All public
-    attributes apart from 'underlying_metric' and 'scaling_factor' are loaded from the
-    underlying metric at initialization and rescaled by the appropriate factor. Changes
-    to the underlying metric at runtime will not affect the attributes of this object.
+    This class acts as a wrapper for the underlying Riemannian metric. All
+    public attributes apart from 'underlying_metric' and 'scaling_factor' are
+    loaded from the underlying metric at initialization and rescaled by the
+    appropriate factor. Changes to the underlying metric at runtime will not
+    affect the attributes of this object.
 
     One exception to this is when the 'underlying_metric' is itself of type
     ScalarProductMetric. In this case, rather than wrapping the wrapper, the
-    'underlying_metric' of the first ScalarProductMetric object is wrapped a second
-    time with a new 'scaling_factor'.
+    'underlying_metric' of the first ScalarProductMetric object is wrapped a
+    second time with a new 'scaling_factor'.
 
     Parameters
     ----------
     underlying_metric : RiemannianMetric
         The original metric of the manifold which is being scaled.
     scale : float
-        The value by which to scale the metric. Note that this rescales the (0,2)
-        metric tensor, so distances are rescaled by the square root of this.
+        The value by which to scale the metric. Note that this rescales the
+        (0,2) metric tensor, so distances are rescaled by the square root of
+        this.
     """
+
+    SQRT_LIST = ["norm", "dist", "dist_broadcast", "dist_pairwise", "diameter"]
+    LINEAR_LIST = [
+        "metric_matrix",
+        "inner_product",
+        "inner_product_derivative_matrix",
+        "squared_norm",
+        "squared_dist",
+        "covariant_riemann_tensor",
+    ]
+    QUADRATIC_LIST = []
+    INVERSE_LIST = [
+        "cometric_matrix",
+        "inner_coproduct",
+        "hamiltonian",
+        "sectional_curvature",
+        "scalar_curvature",
+    ]
+    INVERSE_SQRT_LIST = ["normalize", "random_unit_tangent_vec", "normal_basis"]
 
     def __init__(self, underlying_metric, scale):
         """Load all attributes from the underlying metric."""
@@ -113,16 +98,16 @@ class ScalarProductMetric:
                     ):
                         raise ex
             else:
-                scale = _get_scaling_factor(attr_name, self.scale)
+                scale = type(self)._get_scaling_factor(attr_name, self.scale)
                 method = attr if scale is None else _wrap_attr(scale, attr)
                 setattr(self, attr_name, method)
 
     def __mul__(self, scalar):
         """Multiply the metric by a scalar.
 
-        This method multiplies the (0,2) metric tensor by a scalar. Note that this does
-        not scale distances by the scalar. That would require multiplication by the
-        square of the scalar.
+        This method multiplies the (0,2) metric tensor by a scalar. Note that
+        this does not scale distances by the scalar. That would require
+        multiplication by the square of the scalar.
 
         Parameters
         ----------
@@ -141,9 +126,9 @@ class ScalarProductMetric:
     def __rmul__(self, scalar):
         """Multiply the metric by a scalar.
 
-        This method multiplies the (0,2) metric tensor by a scalar. Note that this does
-        not scale distances by the scalar. That would require multiplication by the
-        square of the scalar.
+        This method multiplies the (0,2) metric tensor by a scalar. Note that
+        this does not scale distances by the scalar. That would require
+        multiplication by the square of the scalar.
 
         Parameters
         ----------
@@ -156,3 +141,21 @@ class ScalarProductMetric:
             The metric multiplied by the scalar.
         """
         return self * scalar
+
+    @classmethod
+    def _get_scaling_factor(cls, func_name, scale):
+        if func_name in cls.SQRT_LIST:
+            return gs.sqrt(scale)
+
+        if func_name in cls.LINEAR_LIST:
+            return scale
+
+        if func_name in cls.QUADRATIC_LIST:
+            return gs.power(scale, 2)
+
+        if func_name in cls.INVERSE_LIST:
+            return 1.0 / scale
+
+        if func_name in cls.INVERSE_SQRT_LIST:
+            return 1.0 / gs.sqrt(scale)
+        return None

--- a/geomstats/geometry/scalar_product_metric.py
+++ b/geomstats/geometry/scalar_product_metric.py
@@ -195,8 +195,16 @@ class ScalarProductMetric:
         scaling_types = ["sqrt", "linear", "quadratic", "inverse", "inverse_sqrt"]
         scaling_dict = dict(zip(scaling_types, scaling_lists))
 
+        for list_of_methods in scaling_lists:
+            if func_name in list_of_methods:
+                msg = (
+                    f"'{func_name}' already has an assigned scaling rule "
+                    "which cannot be changed."
+                )
+                raise ValueError(msg)
         if func_name in cls.RESERVED_NAMES:
             raise ValueError(f"'{func_name}' is reserved for internal use.")
+
         try:
             scaling_dict[scaling_type].append(func_name)
         except KeyError:

--- a/geomstats/geometry/scalar_product_metric.py
+++ b/geomstats/geometry/scalar_product_metric.py
@@ -162,7 +162,7 @@ class ScalarProductMetric:
 
     @classmethod
     def add_scaled_method(cls, func_name, scaling_type):
-        """Configure ScalarProductMetric to scale an attribute
+        """Configure ScalarProductMetric to scale an attribute.
 
         The ScalarProductMetric class rescales various methods of a
         RiemannianMetric by the correct factor. The default behaviour is to

--- a/geomstats/test_cases/geometry/scalar_product_metric.py
+++ b/geomstats/test_cases/geometry/scalar_product_metric.py
@@ -1,6 +1,5 @@
 from geomstats.geometry.scalar_product_metric import (
     ScalarProductMetric,
-    _get_scaling_factor,
     _wrap_attr,
 )
 from geomstats.test.test_case import TestCase
@@ -16,11 +15,11 @@ class WrapperTestCase(TestCase):
         self.assertAllClose(res, scaled_res / scale)
 
     def test_scaling_factor(self, func_name, scale, expected):
-        scaling_factor = _get_scaling_factor(func_name, scale)
+        scaling_factor = ScalarProductMetric._get_scaling_factor(func_name, scale)
         self.assertAllClose(scaling_factor, expected)
 
     def test_non_scaled(self, func_name, scale):
-        scaling_factor = _get_scaling_factor(func_name, scale)
+        scaling_factor = ScalarProductMetric._get_scaling_factor(func_name, scale)
         assert scaling_factor is None
 
 

--- a/geomstats/test_cases/geometry/scalar_product_metric.py
+++ b/geomstats/test_cases/geometry/scalar_product_metric.py
@@ -1,5 +1,6 @@
 from geomstats.geometry.scalar_product_metric import (
     ScalarProductMetric,
+    _ScaledMethodsRegistry,
     _wrap_attr,
 )
 from geomstats.test.test_case import TestCase
@@ -15,11 +16,11 @@ class WrapperTestCase(TestCase):
         self.assertAllClose(res, scaled_res / scale)
 
     def test_scaling_factor(self, func_name, scale, expected):
-        scaling_factor = ScalarProductMetric._get_scaling_factor(func_name, scale)
+        scaling_factor = _ScaledMethodsRegistry._get_scaling_factor(func_name, scale)
         self.assertAllClose(scaling_factor, expected)
 
     def test_non_scaled(self, func_name, scale):
-        scaling_factor = ScalarProductMetric._get_scaling_factor(func_name, scale)
+        scaling_factor = _ScaledMethodsRegistry._get_scaling_factor(func_name, scale)
         assert scaling_factor is None
 
 


### PR DESCRIPTION
A new class method is added to `ScalarProductMetric` called `add_scaled_method` which allows the user to configure how a method from RiemannianMetric should be scaled.  The lists become class variables to allow them to be edited.

This fixes #1760.

###Tests

The added feature does not seem amenable to unit testing, but the following code does demonstrate that it works:

```
from geomstats import geomstats
from geomstats.geometry.scalar_product_metric import ScalarProductMetric
from geomstats.geometry.hypersphere import Hypersphere

sphere = Hypersphere(2)
point = sphere.random_point(1)
print(sphere.metric.injectivity_radius(point))

new_metric = 2.0 * sphere.metric
print(new_metric.injectivity_radius(point))

ScalarProductMetric.add_scaled_method('injectivity_radius', 'linear')
new_metric = 2.0 * sphere.metric
print(new_metric.injectivity_radius(point))
```

This has output

```
3.141592653589793
3.141592653589793
6.283185307179586
```

as expected.

### Questions

1. Should we add a functionality to remove items from the lists or to restore the 'factory default'?
2. Are we happy with allowing methods which are not explicitly handled to just silently go through untransformed? Maybe we should at least log that it's happening?