### PR TITLE
Clean signatures wrt kwargs and base_point=None

### DIFF
--- a/geomstats/errors.py
+++ b/geomstats/errors.py
@@ -40,7 +40,7 @@ def check_positive(param, param_name):
         raise ValueError(f"{param_name} must be positive.")
 
 
-def check_belongs(point, manifold, **kwargs):
+def check_belongs(point, manifold, atol=gs.atol):
     """Raise an error if point does not belong to the input manifold.
 
     Parameters
@@ -52,7 +52,7 @@ def check_belongs(point, manifold, **kwargs):
     manifold_name : string
         Name of the manifold for the error message.
     """
-    if not gs.all(manifold.belongs(point, **kwargs)):
+    if not gs.all(manifold.belongs(point, atol=atol)):
         raise RuntimeError(
             f"Some points do not belong to manifold '{type(manifold).__name__}'"
             f" of dimension {manifold.dim}."

--- a/geomstats/geometry/_my_manifold.py
+++ b/geomstats/geometry/_my_manifold.py
@@ -98,7 +98,6 @@ class MyManifold(Manifold):
             Vector.
         base_point : array-like, shape=[..., dim]
             Point on the manifold.
-            Optional, default: None.
         atol : float
             Absolute tolerance threshold
 
@@ -114,7 +113,7 @@ class MyManifold(Manifold):
             is_tangent = gs.tile([is_tangent], (vector.shape[0],))
         return is_tangent
 
-    def to_tangent(self, vector, base_point):
+    def to_tangent(self, vector, base_point=None):
         """Project a vector to a tangent space of the manifold.
 
         Parameters

--- a/geomstats/geometry/base.py
+++ b/geomstats/geometry/base.py
@@ -141,7 +141,7 @@ class VectorSpace(Manifold, abc.ABC):
             size = (n_samples,) + size
         return bound * (gs.random.rand(*size) - 0.5) * 2
 
-    def random_tangent_vec(self, base_point, n_samples=1):
+    def random_tangent_vec(self, base_point=None, n_samples=1):
         """Generate random tangent vec.
 
         Parameters
@@ -159,6 +159,7 @@ class VectorSpace(Manifold, abc.ABC):
         """
         if (
             n_samples > 1
+            and base_point is not None
             and base_point.ndim > len(self.shape)
             and n_samples != len(base_point)
         ):
@@ -569,7 +570,7 @@ class OpenSet(Manifold, abc.ABC):
             shape = embedding_space.shape
         super().__init__(shape=shape, **kwargs)
 
-    def is_tangent(self, vector, base_point, atol=gs.atol):
+    def is_tangent(self, vector, base_point=None, atol=gs.atol):
         """Check whether the vector is tangent at base_point.
 
         Parameters
@@ -589,7 +590,7 @@ class OpenSet(Manifold, abc.ABC):
         """
         return self.embedding_space.is_tangent(vector, base_point, atol)
 
-    def to_tangent(self, vector, base_point):
+    def to_tangent(self, vector, base_point=None):
         """Project a vector to a tangent space of the manifold.
 
         Parameters
@@ -1002,7 +1003,7 @@ class DiffeomorphicManifold(Manifold):
         self.image_space = image_space
         super().__init__(**kwargs)
 
-    def to_tangent(self, vector, base_point):
+    def to_tangent(self, vector, base_point=None):
         """Project a vector to a tangent space of the manifold.
 
         Parameters
@@ -1065,7 +1066,7 @@ class DiffeomorphicManifold(Manifold):
         regularized_image_point = self.image_space.regularize(image_point)
         return self.diffeo.inverse_diffeomorphism(regularized_image_point)
 
-    def random_tangent_vec(self, base_point, n_samples=1):
+    def random_tangent_vec(self, base_point=None, n_samples=1):
         """Generate random tangent vec.
 
         Parameters

--- a/geomstats/geometry/connection.py
+++ b/geomstats/geometry/connection.py
@@ -43,7 +43,7 @@ class Connection(ABC):
     def __init__(self, space):
         self._space = space
 
-    def christoffels(self, base_point):
+    def christoffels(self, base_point=None):
         """Christoffel symbols associated with the connection.
 
         The contravariant index is on the first dimension.
@@ -360,7 +360,7 @@ class Connection(ABC):
             "trajectory": trajectory,
         }
 
-    def riemann_tensor(self, base_point):
+    def riemann_tensor(self, base_point=None):
         r"""Compute Riemannian tensor at base_point.
 
         In the literature the Riemannian curvature tensor is noted :math:`R_{ijk}^l`.
@@ -408,7 +408,7 @@ class Connection(ABC):
 
         return riemann_curvature
 
-    def curvature(self, tangent_vec_a, tangent_vec_b, tangent_vec_c, base_point):
+    def curvature(self, tangent_vec_a, tangent_vec_b, tangent_vec_c, base_point=None):
         r"""Compute the Riemann curvature map R.
 
         For three tangent vectors at base point :math:`P`:
@@ -451,7 +451,7 @@ class Connection(ABC):
         )
         return curvature
 
-    def ricci_tensor(self, base_point):
+    def ricci_tensor(self, base_point=None):
         r"""Compute Ricci curvature tensor at base_point.
 
         The Ricci curvature tensor :math:`\mathrm{Ric}_{ij}` is defined as:
@@ -473,7 +473,7 @@ class Connection(ABC):
         ricci_tensor = gs.einsum("...ijkj -> ...ik", riemann_tensor)
         return ricci_tensor
 
-    def directional_curvature(self, tangent_vec_a, tangent_vec_b, base_point):
+    def directional_curvature(self, tangent_vec_a, tangent_vec_b, base_point=None):
         r"""Compute the directional curvature (tidal force operator).
 
         For two tangent vectors at base_point :math:`P`:
@@ -764,7 +764,7 @@ class Connection(ABC):
             "use the ladder_parallel_transport instead."
         )
 
-    def injectivity_radius(self, base_point):
+    def injectivity_radius(self, base_point=None):
         """Compute the radius of the injectivity domain.
 
         This is is the supremum of radii r for which the exponential map is a

--- a/geomstats/geometry/euclidean.py
+++ b/geomstats/geometry/euclidean.py
@@ -147,7 +147,7 @@ class EuclideanMetric(RiemannianMetric):
             self._space.point_ndim, gs.zeros(shape), base_point, out_shape=shape
         )
 
-    def christoffels(self, base_point):
+    def christoffels(self, base_point=None):
         """Christoffel symbols associated with the connection.
 
         The contravariant index is on the first dimension.
@@ -170,46 +170,6 @@ class EuclideanMetric(RiemannianMetric):
         shape = (dim, dim, dim)
         gamma = gs.zeros(shape)
         return repeat_out(self._space.point_ndim, gamma, base_point, out_shape=shape)
-
-    def inner_product(self, tangent_vec_a, tangent_vec_b, base_point=None):
-        """Inner product between two tangent vectors at a base point.
-
-        Parameters
-        ----------
-        tangent_vec_a: array-like, shape=[..., dim]
-            Tangent vector at base point.
-        tangent_vec_b: array-like, shape=[..., dim]
-            Tangent vector at base point.
-        base_point: array-like, shape=[..., dim]
-            Base point.
-
-        Returns
-        -------
-        inner_product : array-like, shape=[...,]
-            Inner-product.
-        """
-        return super().inner_product(tangent_vec_a, tangent_vec_b, base_point)
-
-    def inner_coproduct(self, cotangent_vec_a, cotangent_vec_b, base_point=None):
-        """Compute inner coproduct between two cotangent vectors at base point.
-
-        This is the inner product associated to the cometric matrix.
-
-        Parameters
-        ----------
-        cotangent_vec_a : array-like, shape=[..., dim]
-            Cotangent vector at `base_point`.
-        cotangent_vet_b : array-like, shape=[..., dim]
-            Cotangent vector at `base_point`.
-        base_point : array-like, shape=[..., dim]
-            Point on the manifold.
-
-        Returns
-        -------
-        inner_coproduct : float
-            Inner coproduct between the two cotangent vectors.
-        """
-        return super().inner_coproduct(cotangent_vec_a, cotangent_vec_b, base_point)
 
     def exp(self, tangent_vec, base_point):
         """Compute exp map of a base point in tangent vector direction.
@@ -355,7 +315,7 @@ class EuclideanMetric(RiemannianMetric):
 
         return path
 
-    def injectivity_radius(self, base_point):
+    def injectivity_radius(self, base_point=None):
         """Compute the radius of the injectivity domain.
 
         This is is the supremum of radii r for which the exponential map is a

--- a/geomstats/geometry/grassmannian.py
+++ b/geomstats/geometry/grassmannian.py
@@ -402,7 +402,7 @@ class GrassmannianCanonicalMetric(RiemannianMetric):
 
         return _squared_dist(point_a, point_b)
 
-    def injectivity_radius(self, base_point):
+    def injectivity_radius(self, base_point=None):
         """Compute the radius of the injectivity domain.
 
         This is is the supremum of radii r for which the exponential map is a

--- a/geomstats/geometry/hermitian.py
+++ b/geomstats/geometry/hermitian.py
@@ -132,7 +132,7 @@ class HermitianMetric(ComplexRiemannianMetric):
         return gs.linalg.norm(vector, axis=-1)
 
     @staticmethod
-    def exp(tangent_vec, base_point, **kwargs):
+    def exp(tangent_vec, base_point):
         """Compute exp map of a base point in tangent vector direction.
 
         The Riemannian exponential is vector addition in the Hermitian space.
@@ -152,7 +152,7 @@ class HermitianMetric(ComplexRiemannianMetric):
         return base_point + tangent_vec
 
     @staticmethod
-    def log(point, base_point, **kwargs):
+    def log(point, base_point):
         """Compute log map using a base point and other point.
 
         The Riemannian logarithm is the subtraction in the Hermitian space.

--- a/geomstats/geometry/hpd_matrices.py
+++ b/geomstats/geometry/hpd_matrices.py
@@ -282,7 +282,7 @@ class HPDAffineMetric(ComplexRiemannianMetric):
         congruence_mat = Matrices.mul(sqrt_bp, pdt, inv_sqrt_bp)
         return ComplexMatrices.congruent(tangent_vec, congruence_mat)
 
-    def injectivity_radius(self, base_point):
+    def injectivity_radius(self, base_point=None):
         """Radius of the largest ball where the exponential is injective.
 
         Because of the negative curvature of this space, the injectivity radius

--- a/geomstats/geometry/hyperboloid.py
+++ b/geomstats/geometry/hyperboloid.py
@@ -390,7 +390,7 @@ class HyperboloidMetric(HyperbolicMetric):
         )
         return transported
 
-    def injectivity_radius(self, base_point):
+    def injectivity_radius(self, base_point=None):
         """Compute the radius of the injectivity domain.
 
         This is is the supremum of radii r for which the exponential map is a

--- a/geomstats/geometry/hypersphere.py
+++ b/geomstats/geometry/hypersphere.py
@@ -1101,7 +1101,7 @@ class HypersphereMetric(RiemannianMetric):
             out_shape=self._space.shape,
         )
 
-    def injectivity_radius(self, base_point):
+    def injectivity_radius(self, base_point=None):
         """Compute the radius of the injectivity domain.
 
         This is is the supremum of radii r for which the exponential map is a

--- a/geomstats/geometry/hypersphere.py
+++ b/geomstats/geometry/hypersphere.py
@@ -719,7 +719,7 @@ class HypersphereMetric(RiemannianMetric):
         """
         return self._space.embedding_space.metric.squared_norm(vector)
 
-    def exp(self, tangent_vec, base_point, **kwargs):
+    def exp(self, tangent_vec, base_point):
         """Compute the Riemannian exponential of a tangent vector.
 
         Parameters
@@ -746,7 +746,7 @@ class HypersphereMetric(RiemannianMetric):
 
         return exp
 
-    def log(self, point, base_point, **kwargs):
+    def log(self, point, base_point):
         """Compute the Riemannian logarithm of a point.
 
         Parameters
@@ -802,7 +802,7 @@ class HypersphereMetric(RiemannianMetric):
 
         return gs.arccos(cos_angle)
 
-    def squared_dist(self, point_a, point_b, **kwargs):
+    def squared_dist(self, point_a, point_b):
         """Squared geodesic distance between two points.
 
         Parameters

--- a/geomstats/geometry/invariant_metric.py
+++ b/geomstats/geometry/invariant_metric.py
@@ -1306,7 +1306,7 @@ class BiInvariantMetric(RiemannianMetric):
         transported_vec = Matrices.mul(midpoint, transposed, midpoint)
         return (-1.0) * transported_vec
 
-    def injectivity_radius(self, base_point):
+    def injectivity_radius(self, base_point=None):
         """Compute the radius of the injectivity domain.
 
         This is is the supremum of radii r for which the exponential map is a

--- a/geomstats/geometry/invariant_metric.py
+++ b/geomstats/geometry/invariant_metric.py
@@ -925,7 +925,7 @@ class _InvariantMetricVector(RiemannianMetric):
 
         return self._space.regularize(exp)
 
-    def exp(self, tangent_vec, base_point=None, **kwargs):
+    def exp(self, tangent_vec, base_point=None):
         """Compute Riemannian exponential of tan. vector wrt to base point.
 
         Parameters
@@ -1011,7 +1011,7 @@ class _InvariantMetricVector(RiemannianMetric):
         left_log = self.left_log_from_identity(inv_point)
         return -left_log
 
-    def log(self, point, base_point=None, **kwargs):
+    def log(self, point, base_point=None):
         """Compute Riemannian logarithm of a point from a base point.
 
         Parameters
@@ -1148,7 +1148,7 @@ class BiInvariantMetric(RiemannianMetric):
         if not ("SpecialOrthogonal" in space.__str__() or "SO" in space.__str__()):
             raise ValueError("The bi-invariant metric is only implemented for SO(n)")
 
-    def exp(self, tangent_vec, base_point=None, **kwargs):
+    def exp(self, tangent_vec, base_point=None):
         """Compute Riemannian exponential of tangent vector from the identity.
 
         For a bi-invariant metric, this corresponds to the group exponential.
@@ -1175,7 +1175,7 @@ class BiInvariantMetric(RiemannianMetric):
         """
         return self._space.exp(tangent_vec, base_point)
 
-    def log(self, point, base_point=None, **kwargs):
+    def log(self, point, base_point=None):
         """Compute Riemannian logarithm of a point wrt the identity.
 
         For a bi-invariant metric this corresponds to the group logarithm.

--- a/geomstats/geometry/klein_bottle.py
+++ b/geomstats/geometry/klein_bottle.py
@@ -371,7 +371,7 @@ class KleinBottleMetric(RiemannianMetric):
         Underlying manifold.
     """
 
-    def injectivity_radius(self, base_point):
+    def injectivity_radius(self, base_point=None):
         """Compute the radius of the injectivity domain.
 
         This is is the supremum of radii r for which the exponential map is a

--- a/geomstats/geometry/klein_bottle.py
+++ b/geomstats/geometry/klein_bottle.py
@@ -411,7 +411,7 @@ class KleinBottleMetric(RiemannianMetric):
         """
         return gs.dot(tangent_vec_a, tangent_vec_b)
 
-    def exp(self, tangent_vec, base_point, **kwargs):
+    def exp(self, tangent_vec, base_point):
         """Exponential map.
 
         Computed by adding tangent_vec to base_point and finding canonical
@@ -436,7 +436,7 @@ class KleinBottleMetric(RiemannianMetric):
         point = base_point_canonical + tangent_vec
         return self._space.regularize(point)
 
-    def log(self, point, base_point, **kwargs):
+    def log(self, point, base_point):
         """Logarithm map.
 
         Computed by finding the representative of point closest to base_point and

--- a/geomstats/geometry/manifold.py
+++ b/geomstats/geometry/manifold.py
@@ -131,7 +131,7 @@ class Manifold(abc.ABC):
         """
 
     @abc.abstractmethod
-    def is_tangent(self, vector, base_point, atol=gs.atol):
+    def is_tangent(self, vector, base_point=None, atol=gs.atol):
         """Check whether the vector is tangent at base_point.
 
         Parameters
@@ -151,7 +151,7 @@ class Manifold(abc.ABC):
         """
 
     @abc.abstractmethod
-    def to_tangent(self, vector, base_point):
+    def to_tangent(self, vector, base_point=None):
         """Project a vector to a tangent space of the manifold.
 
         Parameters
@@ -203,7 +203,7 @@ class Manifold(abc.ABC):
         """
         return gs.copy(point)
 
-    def random_tangent_vec(self, base_point, n_samples=1):
+    def random_tangent_vec(self, base_point=None, n_samples=1):
         """Generate random tangent vec.
 
         Parameters
@@ -221,6 +221,7 @@ class Manifold(abc.ABC):
         """
         if (
             n_samples > 1
+            and base_point is not None
             and base_point.ndim > len(self.shape)
             and n_samples != len(base_point)
         ):

--- a/geomstats/geometry/poincare_ball.py
+++ b/geomstats/geometry/poincare_ball.py
@@ -426,7 +426,7 @@ class PoincareBallMetric(RiemannianMetric):
 
         return gs.squeeze(norm_factor), gs.squeeze(norm_factor_gradient)
 
-    def injectivity_radius(self, base_point):
+    def injectivity_radius(self, base_point=None):
         """Compute the radius of the injectivity domain.
 
         This is is the supremum of radii r for which the exponential map is a

--- a/geomstats/geometry/poincare_ball.py
+++ b/geomstats/geometry/poincare_ball.py
@@ -99,7 +99,7 @@ class PoincareBall(_Hyperbolic, VectorSpaceOpenSet):
 class PoincareBallMetric(RiemannianMetric):
     """Class that defines operations using a Poincare ball."""
 
-    def exp(self, tangent_vec, base_point, **kwargs):
+    def exp(self, tangent_vec, base_point):
         """Compute the Riemannian exponential of a tangent vector.
 
         Parameters
@@ -129,7 +129,7 @@ class PoincareBallMetric(RiemannianMetric):
             base_point, gs.einsum("...,...i->...i", factor, direction)
         )
 
-    def log(self, point, base_point, **kwargs):
+    def log(self, point, base_point):
         """Compute Riemannian logarithm of a point wrt a base point.
 
         Parameters

--- a/geomstats/geometry/poincare_half_space.py
+++ b/geomstats/geometry/poincare_half_space.py
@@ -160,7 +160,7 @@ class PoincareHalfSpaceMetric(RiemannianMetric):
         log_ball = self._poincare_ball.metric.log(point_ball, base_point_ball)
         return self._poincare_ball.ball_to_half_space_tangent(log_ball, base_point_ball)
 
-    def injectivity_radius(self, base_point):
+    def injectivity_radius(self, base_point=None):
         """Compute the radius of the injectivity domain.
 
         This is is the supremum of radii r for which the exponential map is a

--- a/geomstats/geometry/positive_lower_triangular_matrices.py
+++ b/geomstats/geometry/positive_lower_triangular_matrices.py
@@ -205,7 +205,7 @@ class CholeskyMetric(RiemannianMetric):
         )
         return diag_inner_product + strictly_lower_inner_product
 
-    def exp(self, tangent_vec, base_point, **kwargs):
+    def exp(self, tangent_vec, base_point):
         """Compute the Cholesky exponential map.
 
         Compute the Riemannian exponential at point base_point
@@ -234,7 +234,7 @@ class CholeskyMetric(RiemannianMetric):
         diag_exp = gs.vec_to_diag(diag_base_point * diag_product_expm)
         return sl_exp + diag_exp
 
-    def log(self, point, base_point, **kwargs):
+    def log(self, point, base_point):
         """Compute the Cholesky logarithm map.
 
         Compute the Riemannian logarithm at point base_point,
@@ -263,7 +263,7 @@ class CholeskyMetric(RiemannianMetric):
         diag_log = gs.vec_to_diag(diag_base_point * diag_product_logm)
         return sl_log + diag_log
 
-    def squared_dist(self, point_a, point_b, **kwargs):
+    def squared_dist(self, point_a, point_b):
         """Compute the Cholesky Metric squared distance.
 
         Compute the Riemannian squared distance between point_a and point_b.

--- a/geomstats/geometry/pre_shape.py
+++ b/geomstats/geometry/pre_shape.py
@@ -244,7 +244,7 @@ class PreShapeSpace(LevelSet):
 class PreShapeSpaceBundle(FiberBundle):
     r"""Class for the Kendall pre-shape space bundle."""
 
-    def align(self, point, base_point, **kwargs):
+    def align(self, point, base_point):
         """Align point to base_point.
 
         Find the optimal rotation R in SO(m) such that the base point and
@@ -719,7 +719,7 @@ class PreShapeMetric(RiemannianMetric):
             tangent_vec_a, tangent_vec_b, base_point
         )
 
-    def exp(self, tangent_vec, base_point, **kwargs):
+    def exp(self, tangent_vec, base_point):
         """Compute the Riemannian exponential of a tangent vector.
 
         Parameters
@@ -740,7 +740,7 @@ class PreShapeMetric(RiemannianMetric):
         flat_exp = self._space._sphere.metric.exp(flat_tan, flat_bp)
         return gs.reshape(flat_exp, tangent_vec.shape)
 
-    def log(self, point, base_point, **kwargs):
+    def log(self, point, base_point):
         """Compute the Riemannian logarithm of a point.
 
         Parameters

--- a/geomstats/geometry/pre_shape.py
+++ b/geomstats/geometry/pre_shape.py
@@ -906,7 +906,7 @@ class PreShapeMetric(RiemannianMetric):
         )
         return gs.reshape(flat_transport, batch_shape + self._space.shape)
 
-    def injectivity_radius(self, base_point):
+    def injectivity_radius(self, base_point=None):
         """Compute the radius of the injectivity domain.
 
         This is is the supremum of radii r for which the exponential map is a

--- a/geomstats/geometry/pullback_metric.py
+++ b/geomstats/geometry/pullback_metric.py
@@ -197,7 +197,6 @@ class PullbackDiffeoMetric(RiemannianMetric):
         ----------
         base_point : array-like, shape=[..., *shape]
             Base point.
-            Optional, default: None.
 
         Returns
         -------
@@ -209,7 +208,7 @@ class PullbackDiffeoMetric(RiemannianMetric):
             " is not implemented yet in general shape setting."
         )
 
-    def inner_product(self, tangent_vec_a, tangent_vec_b, base_point):
+    def inner_product(self, tangent_vec_a, tangent_vec_b, base_point=None):
         """Inner product between two tangent vectors at a base point.
 
         Parameters
@@ -220,7 +219,6 @@ class PullbackDiffeoMetric(RiemannianMetric):
             Tangent vector at base point.
         base_point: array-like, shape=[..., *shape]
             Base point.
-            Optional, default: None.
 
         Returns
         -------
@@ -242,7 +240,7 @@ class PullbackDiffeoMetric(RiemannianMetric):
             image_point,
         )
 
-    def squared_norm(self, vector, base_point):
+    def squared_norm(self, vector, base_point=None):
         """Compute the square of the norm of a vector.
 
         Squared norm of a vector associated to the inner product
@@ -254,7 +252,6 @@ class PullbackDiffeoMetric(RiemannianMetric):
             Vector.
         base_point : array-like, shape=[..., dim]
             Base point.
-            Optional, default: None.
 
         Returns
         -------
@@ -271,7 +268,7 @@ class PullbackDiffeoMetric(RiemannianMetric):
             image_point,
         )
 
-    def norm(self, vector, base_point):
+    def norm(self, vector, base_point=None):
         """Compute norm of a vector.
 
         Norm of a vector associated to the inner product
@@ -286,7 +283,6 @@ class PullbackDiffeoMetric(RiemannianMetric):
             Vector.
         base_point : array-like, shape=[..., dim]
             Base point.
-            Optional, default: None.
 
         Returns
         -------
@@ -427,7 +423,7 @@ class PullbackDiffeoMetric(RiemannianMetric):
 
         return path
 
-    def curvature(self, tangent_vec_a, tangent_vec_b, tangent_vec_c, base_point):
+    def curvature(self, tangent_vec_a, tangent_vec_b, tangent_vec_c, base_point=None):
         """Compute the curvature via diffeomorphic pullback.
 
         Parameters

--- a/geomstats/geometry/quotient_metric.py
+++ b/geomstats/geometry/quotient_metric.py
@@ -257,7 +257,7 @@ class QuotientMetric(RiemannianMetric):
         tangent_vec_b,
         tangent_vec_c,
         tangent_vec_d,
-        base_point=None,
+        base_point,
     ):
         r"""Compute the covariant derivative of the curvature.
 
@@ -373,7 +373,7 @@ class QuotientMetric(RiemannianMetric):
         )
 
     def directional_curvature_derivative(
-        self, tangent_vec_a, tangent_vec_b, base_point=None
+        self, tangent_vec_a, tangent_vec_b, base_point
     ):
         r"""Compute the covariant derivative of the directional curvature.
 

--- a/geomstats/geometry/rank_k_psd_matrices.py
+++ b/geomstats/geometry/rank_k_psd_matrices.py
@@ -303,7 +303,7 @@ class BuresWassersteinBundle(FiberBundle):
         vertical = -gs.matmul(base_point, skew)
         return (vertical, skew) if return_skew else vertical
 
-    def align(self, point, base_point, **kwargs):
+    def align(self, point, base_point):
         """Align point to base_point.
 
         Find the optimal rotation R in SO(m) such that the base point and

--- a/geomstats/geometry/riemannian_metric.py
+++ b/geomstats/geometry/riemannian_metric.py
@@ -76,7 +76,6 @@ class RiemannianMetric(Connection, ABC):
         ----------
         base_point : array-like, shape=[..., dim]
             Base point.
-            Optional, default: None.
 
         Returns
         -------
@@ -97,7 +96,6 @@ class RiemannianMetric(Connection, ABC):
         ----------
         base_point : array-like, shape=[..., dim]
             Base point.
-            Optional, default: None.
 
         Returns
         -------
@@ -118,7 +116,6 @@ class RiemannianMetric(Connection, ABC):
         ----------
         base_point : array-like, shape=[..., dim]
             Base point.
-            Optional, default: None.
 
         Returns
         -------
@@ -128,7 +125,7 @@ class RiemannianMetric(Connection, ABC):
         """
         return gs.autodiff.jacobian_vec(self.metric_matrix)(base_point)
 
-    def christoffels(self, base_point):
+    def christoffels(self, base_point=None):
         r"""Compute Christoffel symbols of the Levi-Civita connection.
 
         The Koszul formula defining the Levi-Civita connection gives the
@@ -168,7 +165,7 @@ class RiemannianMetric(Connection, ABC):
 
         return 0.5 * (term_1 + term_2 + term_3)
 
-    def inner_product(self, tangent_vec_a, tangent_vec_b, base_point):
+    def inner_product(self, tangent_vec_a, tangent_vec_b, base_point=None):
         """Inner product between two tangent vectors at a base point.
 
         Parameters
@@ -189,7 +186,7 @@ class RiemannianMetric(Connection, ABC):
         aux = gs.einsum("...j,...jk->...k", tangent_vec_a, inner_prod_mat)
         return gs.dot(aux, tangent_vec_b)
 
-    def inner_coproduct(self, cotangent_vec_a, cotangent_vec_b, base_point):
+    def inner_coproduct(self, cotangent_vec_a, cotangent_vec_b, base_point=None):
         """Compute inner coproduct between two cotangent vectors at base point.
 
         This is the inner product associated to the cometric matrix.
@@ -249,7 +246,6 @@ class RiemannianMetric(Connection, ABC):
             Vector.
         base_point : array-like, shape=[..., dim]
             Base point.
-            Optional, default: None.
 
         Returns
         -------
@@ -273,7 +269,6 @@ class RiemannianMetric(Connection, ABC):
             Vector.
         base_point : array-like, shape=[..., dim]
             Base point.
-            Optional, default: None.
 
         Returns
         -------
@@ -283,7 +278,7 @@ class RiemannianMetric(Connection, ABC):
         sq_norm = self.squared_norm(vector, base_point)
         return gs.sqrt(sq_norm)
 
-    def normalize(self, vector, base_point):
+    def normalize(self, vector, base_point=None):
         """Normalize tangent vector at a given point.
 
         Parameters
@@ -303,7 +298,7 @@ class RiemannianMetric(Connection, ABC):
         indices = "ijk"[: self._space.point_ndim]
         return gs.einsum(f"...{indices},...->...{indices}", vector, 1 / norm)
 
-    def random_unit_tangent_vec(self, base_point, n_vectors=1):
+    def random_unit_tangent_vec(self, base_point=None, n_vectors=1):
         """Generate a random unit tangent vector at a given point.
 
         Parameters
@@ -527,7 +522,8 @@ class RiemannianMetric(Connection, ABC):
         ----------
         basis : array-like, shape=[dim, dim]
             Matrix of a metric.
-        base_point
+        base_point : array-like, shape=[dim]
+            Base point.
 
         Returns
         -------
@@ -538,7 +534,7 @@ class RiemannianMetric(Connection, ABC):
 
         return gs.einsum("i, ikl->ikl", 1.0 / gs.sqrt(norms), basis)
 
-    def covariant_riemann_tensor(self, base_point):
+    def covariant_riemann_tensor(self, base_point=None):
         r"""Compute purely covariant version of Riemannian tensor at base_point.
 
         In the literature the covariant riemannian tensor is noted :math:`R_{ijkl}`.
@@ -606,7 +602,7 @@ class RiemannianMetric(Connection, ABC):
         normalization_factor = norm_a * norm_b - inner_ab**2
         return gs.divide(sectional, normalization_factor, ignore_div_zero=True)
 
-    def scalar_curvature(self, base_point):
+    def scalar_curvature(self, base_point=None):
         r"""Compute scalar curvature at base_point.
 
         In the literature scalar_curvature is noted S and writes:

--- a/geomstats/geometry/riemannian_metric.py
+++ b/geomstats/geometry/riemannian_metric.py
@@ -330,7 +330,7 @@ class RiemannianMetric(Connection, ABC):
         random_vector = gs.random.rand(*vec_shape)
         return self.normalize(random_vector, base_point)
 
-    def squared_dist(self, point_a, point_b, **kwargs):
+    def squared_dist(self, point_a, point_b):
         """Squared geodesic distance between two points.
 
         Parameters
@@ -345,11 +345,11 @@ class RiemannianMetric(Connection, ABC):
         sq_dist : array-like, shape=[...,]
             Squared distance.
         """
-        log = self.log(point=point_b, base_point=point_a, **kwargs)
+        log = self.log(point=point_b, base_point=point_a)
 
         return self.squared_norm(vector=log, base_point=point_a)
 
-    def dist(self, point_a, point_b, **kwargs):
+    def dist(self, point_a, point_b):
         """Geodesic distance between two points.
 
         Note: It only works for positive definite
@@ -367,7 +367,7 @@ class RiemannianMetric(Connection, ABC):
         dist : array-like, shape=[...,]
             Distance.
         """
-        sq_dist = self.squared_dist(point_a, point_b, **kwargs)
+        sq_dist = self.squared_dist(point_a, point_b)
         return gs.sqrt(sq_dist)
 
     def dist_broadcast(self, point_a, point_b):

--- a/geomstats/geometry/spd_matrices.py
+++ b/geomstats/geometry/spd_matrices.py
@@ -693,7 +693,7 @@ class SPDAffineMetric(RiemannianMetric):
         congruence_mat = Matrices.mul(sqrt_bp, pdt, inv_sqrt_bp)
         return Matrices.congruent(tangent_vec, congruence_mat)
 
-    def injectivity_radius(self, base_point):
+    def injectivity_radius(self, base_point=None):
         """Radius of the largest ball where the exponential is injective.
 
         Because of the negative curvature of this space, the injectivity radius

--- a/geomstats/geometry/special_euclidean.py
+++ b/geomstats/geometry/special_euclidean.py
@@ -523,7 +523,7 @@ class _SpecialEuclideanVectors(LieGroup):
 
         return gs.concatenate([rot_vec, log_translation], axis=-1)
 
-    def random_point(self, n_samples=1, bound=1.0, **kwargs):
+    def random_point(self, n_samples=1, bound=1.0):
         """Sample in SE(n) from the product distribution.
 
         This method uses the distributions defined on the Euclidean and Special
@@ -1085,7 +1085,7 @@ class SpecialEuclideanMatricesCanonicalLeftMetric(_InvariantMetricMatrix):
         return self._geodesic_from_exp(initial_point, initial_tangent_vec)
 
     def parallel_transport(
-        self, tangent_vec, base_point, direction=None, end_point=None, **kwargs
+        self, tangent_vec, base_point, direction=None, end_point=None
     ):
         r"""Compute the parallel transport of a tangent vector.
 
@@ -1136,7 +1136,7 @@ class SpecialEuclideanMatricesCanonicalLeftMetric(_InvariantMetricMatrix):
 
         return homogeneous_representation(transported_rot, translation, 0.0)
 
-    def squared_dist(self, point_a, point_b, **kwargs):
+    def squared_dist(self, point_a, point_b):
         """Squared geodesic distance between two points.
 
         Parameters

--- a/geomstats/geometry/stiefel.py
+++ b/geomstats/geometry/stiefel.py
@@ -384,7 +384,7 @@ class StiefelCanonicalMetric(RiemannianMetric):
 
         return gs.matmul(point, matrix_r) - base_point
 
-    def injectivity_radius(self, base_point):
+    def injectivity_radius(self, base_point=None):
         """Compute the radius of the injectivity domain.
 
         This is is the supremum of radii r for which the exponential map is a

--- a/geomstats/geometry/sub_riemannian_metric.py
+++ b/geomstats/geometry/sub_riemannian_metric.py
@@ -282,7 +282,7 @@ class SubRiemannianMetric:
         step_size = end_time / n_steps
         return self.iterate(step(hamiltonian, step_size), n_steps)
 
-    def exp(self, cotangent_vec, base_point, n_steps=20, **kwargs):
+    def exp(self, cotangent_vec, base_point, n_steps=20):
         """Exponential map associated to the cometric.
 
         Exponential map at base_point of cotangent_vec computed by integration
@@ -299,9 +299,6 @@ class SubRiemannianMetric:
         n_steps : int
             Number of discrete time steps to take in the integration.
             Optional, default: N_STEPS.
-        point_type : str, {'vector', 'matrix'}
-            Type of representation used for points.
-            Optional, default: None.
 
         Returns
         -------

--- a/geomstats/information_geometry/dirichlet.py
+++ b/geomstats/information_geometry/dirichlet.py
@@ -353,7 +353,7 @@ class DirichletMetric(RiemannianMetric):
             else gs.transpose(jac, [4, 3, 1, 0, 2])
         )
 
-    def injectivity_radius(self, base_point):
+    def injectivity_radius(self, base_point=None):
         """Compute the radius of the injectivity domain.
 
         This is is the supremum of radii r for which the exponential map is a

--- a/geomstats/information_geometry/exponential.py
+++ b/geomstats/information_geometry/exponential.py
@@ -170,7 +170,7 @@ class ExponentialMetric(RiemannianMetric):
         Sankhyā: The Indian Journal of Statistics, Series A, 345-365.
     """
 
-    def squared_dist(self, point_a, point_b, **kwargs):
+    def squared_dist(self, point_a, point_b):
         """Compute squared distance associated with the exponential Fisher Rao metric.
 
         Parameters

--- a/geomstats/information_geometry/geometric.py
+++ b/geomstats/information_geometry/geometric.py
@@ -176,7 +176,7 @@ class GeometricMetric(RiemannianMetric):
         Sankhyā: The Indian Journal of Statistics, Series A, 345-365.
     """
 
-    def squared_dist(self, point_a, point_b, **kwargs):
+    def squared_dist(self, point_a, point_b):
         """Compute squared distance associated with the geometric metric.
 
         Parameters

--- a/geomstats/information_geometry/normal.py
+++ b/geomstats/information_geometry/normal.py
@@ -856,7 +856,7 @@ class DiagonalNormalMetric(RiemannianMetric):
         log = self._univariate_normal.metric.log(point, base_point)
         return self._1d_pairs_to_stacked_mean_diagonal(log)
 
-    def injectivity_radius(self, base_point):
+    def injectivity_radius(self, base_point=None):
         """Compute the radius of the injectivity domain.
 
         Parameters


### PR DESCRIPTION
This PR removes uses of kwargs when unnecessary/misleading and makes use of `base_point=None` more consistent.