### PR TITLE
Scalar product metric API

### DIFF
--- a/geomstats/geometry/complex_manifold.py
+++ b/geomstats/geometry/complex_manifold.py
@@ -64,8 +64,12 @@ class ComplexManifold(abc.ABC):
         if inspect.isclass(Metric):
             self.metric = Metric(self, **metric_kwargs)
         else:
+            if self.metric._space is not self:
+                raise ValueError(
+                    "Cannot equip space with metric instantiated with another space."
+                )
+
             self.metric = Metric
-            self.metric._space = self
 
         return self
 

--- a/geomstats/geometry/complex_manifold.py
+++ b/geomstats/geometry/complex_manifold.py
@@ -7,6 +7,7 @@ Lead author: Yann Cabanes.
 """
 
 import abc
+import inspect
 
 import geomstats.backend as gs
 
@@ -48,7 +49,7 @@ class ComplexManifold(abc.ABC):
 
         Parameters
         ----------
-        Metric : Connection object
+        Metric : Connection object or instance or ScalarProductMetric instance
             If None, default metric will be used.
         """
         if Metric is None:
@@ -60,7 +61,13 @@ class ComplexManifold(abc.ABC):
             else:
                 Metric = out
 
-        self.metric = Metric(self, **metric_kwargs)
+        if inspect.isclass(Metric):
+            self.metric = Metric(self, **metric_kwargs)
+        else:
+            self.metric = Metric
+            self.metric._space = self
+
+        return self
 
     @abc.abstractmethod
     def belongs(self, point, atol=gs.atol):

--- a/geomstats/geometry/manifold.py
+++ b/geomstats/geometry/manifold.py
@@ -75,8 +75,12 @@ class Manifold(abc.ABC):
         if inspect.isclass(Metric):
             self.metric = Metric(self, **metric_kwargs)
         else:
+            if self.metric._space is not self:
+                raise ValueError(
+                    "Cannot equip space with metric instantiated with another space."
+                )
+
             self.metric = Metric
-            self.metric._space = self
 
         return self
 

--- a/geomstats/geometry/manifold.py
+++ b/geomstats/geometry/manifold.py
@@ -7,6 +7,7 @@ Lead author: Nina Miolane.
 """
 
 import abc
+import inspect
 
 import geomstats.backend as gs
 import geomstats.errors
@@ -59,7 +60,7 @@ class Manifold(abc.ABC):
 
         Parameters
         ----------
-        Metric : RiemannianMetric object
+        Metric : RiemannianMetric object or instance or ScalarProductMetric instance
             If None, default metric will be used.
         """
         if Metric is None:
@@ -71,7 +72,11 @@ class Manifold(abc.ABC):
             else:
                 Metric = out
 
-        self.metric = Metric(self, **metric_kwargs)
+        if inspect.isclass(Metric):
+            self.metric = Metric(self, **metric_kwargs)
+        else:
+            self.metric = Metric
+            self.metric._space = self
 
         return self
 

--- a/geomstats/geometry/product_hpd_and_siegel_disks.py
+++ b/geomstats/geometry/product_hpd_and_siegel_disks.py
@@ -27,10 +27,10 @@ References
     https://epubs.siam.org/doi/pdf/10.1137/15M102112X
 """
 
-from geomstats.geometry.hpd_matrices import HPDAffineMetric, HPDMatrices
+from geomstats.geometry.hpd_matrices import HPDMatrices
 from geomstats.geometry.product_manifold import ProductManifold, ProductRiemannianMetric
 from geomstats.geometry.scalar_product_metric import ScalarProductMetric
-from geomstats.geometry.siegel import Siegel, SiegelMetric
+from geomstats.geometry.siegel import Siegel
 
 
 class ProductHPDMatricesAndSiegelDisks(ProductManifold):

--- a/geomstats/geometry/product_hpd_and_siegel_disks.py
+++ b/geomstats/geometry/product_hpd_and_siegel_disks.py
@@ -52,14 +52,13 @@ class ProductHPDMatricesAndSiegelDisks(ProductManifold):
         self.n_manifolds = n_manifolds
         self.n = n
 
-        factors = [HPDMatrices(n=n, equip=False)] + [
-            Siegel(n=n, equip=False) for _ in range((n_manifolds - 1))
-        ]
+        factors = [HPDMatrices(n=n)] + [Siegel(n=n) for _ in range((n_manifolds - 1))]
 
         scales = [float(n_manifolds - i_manifold) for i_manifold in range(n_manifolds)]
-        factors[0].metric = ScalarProductMetric(HPDAffineMetric(factors[0]), scales[0])
-        for factor, scale in zip(factors[1:], scales[1:]):
-            factor.metric = ScalarProductMetric(SiegelMetric(factor), scale)
+        [
+            factor.equip_with_metric(ScalarProductMetric(factor, scale))
+            for factor, scale in zip(factors[1:], scales[1:])
+        ]
 
         super().__init__(
             factors=factors,

--- a/geomstats/geometry/product_hpd_and_siegel_disks.py
+++ b/geomstats/geometry/product_hpd_and_siegel_disks.py
@@ -55,10 +55,8 @@ class ProductHPDMatricesAndSiegelDisks(ProductManifold):
         factors = [HPDMatrices(n=n)] + [Siegel(n=n) for _ in range((n_manifolds - 1))]
 
         scales = [float(n_manifolds - i_manifold) for i_manifold in range(n_manifolds)]
-        [
+        for factor, scale in zip(factors[1:], scales[1:]):
             factor.equip_with_metric(ScalarProductMetric(factor, scale))
-            for factor, scale in zip(factors[1:], scales[1:])
-        ]
 
         super().__init__(
             factors=factors,

--- a/geomstats/geometry/product_positive_reals_and_poincare_disks.py
+++ b/geomstats/geometry/product_positive_reals_and_poincare_disks.py
@@ -46,11 +46,8 @@ References
     and Means With Applications to Radar Signal Processing, IEEE, 2013.
 """
 
-from geomstats.geometry.complex_poincare_disk import (
-    ComplexPoincareDisk,
-    ComplexPoincareDiskMetric,
-)
-from geomstats.geometry.positive_reals import PositiveReals, PositiveRealsMetric
+from geomstats.geometry.complex_poincare_disk import ComplexPoincareDisk
+from geomstats.geometry.positive_reals import PositiveReals
 from geomstats.geometry.product_manifold import ProductManifold, ProductRiemannianMetric
 from geomstats.geometry.scalar_product_metric import ScalarProductMetric
 

--- a/geomstats/geometry/product_positive_reals_and_poincare_disks.py
+++ b/geomstats/geometry/product_positive_reals_and_poincare_disks.py
@@ -71,18 +71,14 @@ class ProductPositiveRealsAndComplexPoincareDisks(ProductManifold):
     def __init__(self, n_manifolds, equip=True):
         self.n_manifolds = n_manifolds
 
-        factors = [PositiveReals(equip=False)] + [
+        factors = [PositiveReals()] + [
             ComplexPoincareDisk() for _ in range(n_manifolds - 1)
         ]
 
         scales = [float(n_manifolds - i_manifold) for i_manifold in range(n_manifolds)]
-        factors[0].metric = ScalarProductMetric(
-            PositiveRealsMetric(factors[0]), scales[0]
-        )
+        factors[0].equip_with_metric(scales[0] * factors[0].metric)
         for factor, scale in zip(factors[1:], scales[1:]):
-            factor.metric = ScalarProductMetric(
-                ComplexPoincareDiskMetric(factor), scale
-            )
+            factor.equip_with_metric(scale * factor.metric)
 
         super().__init__(factors=factors, point_ndim=3, equip=equip)
 

--- a/geomstats/geometry/product_positive_reals_and_poincare_disks.py
+++ b/geomstats/geometry/product_positive_reals_and_poincare_disks.py
@@ -76,9 +76,9 @@ class ProductPositiveRealsAndComplexPoincareDisks(ProductManifold):
         ]
 
         scales = [float(n_manifolds - i_manifold) for i_manifold in range(n_manifolds)]
-        factors[0].equip_with_metric(scales[0] * factors[0].metric)
+        factors[0].equip_with_metric(ScalarProductMetric(factors[0], scales[0]))
         for factor, scale in zip(factors[1:], scales[1:]):
-            factor.equip_with_metric(scale * factor.metric)
+            factor.equip_with_metric(ScalarProductMetric(factor, scale))
 
         super().__init__(factors=factors, point_ndim=3, equip=equip)
 

--- a/geomstats/geometry/riemannian_metric.py
+++ b/geomstats/geometry/riemannian_metric.py
@@ -44,13 +44,14 @@ class RiemannianMetric(Connection, ABC):
         metric : ScalarProductMetric
             The metric multiplied by the scalar
         """
-        from geomstats.geometry.scalar_product_metric import \
-            ScalarProductMetric
+        from geomstats.geometry.scalar_product_metric import ScalarProductMetric
 
         if not isinstance(scalar, float):
             return NotImplemented
         if self != self._space.metric:
-            raise ValueError("A space must be equipped with this metric before it is scaled.")
+            raise ValueError(
+                "A space must be equipped with this metric before it is scaled."
+            )
         return ScalarProductMetric(self._space, scalar)
 
     def __rmul__(self, scalar):

--- a/geomstats/geometry/riemannian_metric.py
+++ b/geomstats/geometry/riemannian_metric.py
@@ -44,11 +44,14 @@ class RiemannianMetric(Connection, ABC):
         metric : ScalarProductMetric
             The metric multiplied by the scalar
         """
-        from geomstats.geometry.scalar_product_metric import ScalarProductMetric
+        from geomstats.geometry.scalar_product_metric import \
+            ScalarProductMetric
 
         if not isinstance(scalar, float):
             return NotImplemented
-        return ScalarProductMetric(self, scalar)
+        if self != self._space.metric:
+            raise ValueError("A space must be equipped with this metric before it is scaled.")
+        return ScalarProductMetric(self._space, scalar)
 
     def __rmul__(self, scalar):
         """Multiply the metric by a scalar.

--- a/geomstats/geometry/scalar_product_metric.py
+++ b/geomstats/geometry/scalar_product_metric.py
@@ -137,13 +137,13 @@ class _ScaledMethodsRegistry:
 class ScalarProductMetric:
     """Class for scalar products of Riemannian and pseudo-Riemannian metrics.
 
-    This class multiplies the (0,2) metric tensor 'underlying_metric' by a
+    This class multiplies the (0,2) metric tensor 'space.metric' by a
     scalar 'scaling_factor'. Note that this does not scale distances by
     'scaling_factor'. That would require multiplication by the square of the
     scalar.
 
     An object of this type can also be instantiated by the expression
-    scaling_factor * underlying_metric.
+    scaling_factor * space.metric.
 
     This class acts as a wrapper for the underlying Riemannian metric. All
     public attributes apart from 'underlying_metric' and 'scaling_factor' are
@@ -158,23 +158,24 @@ class ScalarProductMetric:
 
     Parameters
     ----------
-    underlying_metric : RiemannianMetric
-        The original metric of the manifold which is being scaled.
+    space : Manifold
+        A manifold equipped with a metric which is being scaled.
     scale : float
         The value by which to scale the metric. Note that this rescales the
         (0,2) metric tensor, so distances are rescaled by the square root of
         this.
     """
 
-    def __init__(self, underlying_metric, scale):
+    def __init__(self, space, scale):
         """Load all attributes from the underlying metric."""
         geomstats.errors.check_positive(scale, "scale")
 
-        if hasattr(underlying_metric, "underlying_metric"):
-            self.underlying_metric = underlying_metric.underlying_metric
-            self.scale = scale * underlying_metric.scale
+        self._space = space
+        if isinstance(space.metric, ScalarProductMetric):
+            self.underlying_metric = space.metric.underlying_metric
+            self.scale = scale * space.metric.scale
         else:
-            self.underlying_metric = underlying_metric
+            self.underlying_metric = space.metric
             self.scale = scale
 
         for attr_name in dir(self.underlying_metric):

--- a/geomstats/geometry/scalar_product_metric.py
+++ b/geomstats/geometry/scalar_product_metric.py
@@ -142,6 +142,8 @@ class ScalarProductMetric:
     'scaling_factor'. That would require multiplication by the square of the
     scalar.
 
+    The `space` is not automatically equipped with the `ScalarProductMetric`.
+
     An object of this type can also be instantiated by the expression
     scaling_factor * space.metric.
 
@@ -158,7 +160,7 @@ class ScalarProductMetric:
 
     Parameters
     ----------
-    space : Manifold
+    space : Manifold or ComplexManifold
         A manifold equipped with a metric which is being scaled.
     scale : float
         The value by which to scale the metric. Note that this rescales the

--- a/geomstats/geometry/scalar_product_metric.py
+++ b/geomstats/geometry/scalar_product_metric.py
@@ -226,6 +226,10 @@ class ScalarProductMetric:
         """
         if not isinstance(scalar, float):
             return NotImplemented
+        if self != self._space.metric:
+            raise ValueError(
+                "A space must be equipped with this metric before it is scaled."
+            )
         return ScalarProductMetric(self._space, scalar)
 
     def __rmul__(self, scalar):

--- a/geomstats/geometry/scalar_product_metric.py
+++ b/geomstats/geometry/scalar_product_metric.py
@@ -169,8 +169,11 @@ class ScalarProductMetric:
     def __init__(self, space, scale):
         """Load all attributes from the underlying metric."""
         geomstats.errors.check_positive(scale, "scale")
+        if not hasattr(space, "metric"):
+            raise ValueError("The variable 'space' must be equipped with a metric.")
 
         self._space = space
+
         if isinstance(space.metric, ScalarProductMetric):
             self.underlying_metric = space.metric.underlying_metric
             self.scale = scale * space.metric.scale
@@ -221,7 +224,7 @@ class ScalarProductMetric:
         """
         if not isinstance(scalar, float):
             return NotImplemented
-        return ScalarProductMetric(self, scalar)
+        return ScalarProductMetric(self._space, scalar)
 
     def __rmul__(self, scalar):
         """Multiply the metric by a scalar.

--- a/geomstats/geometry/scalar_product_metric.py
+++ b/geomstats/geometry/scalar_product_metric.py
@@ -104,6 +104,8 @@ class _ScaledMethodsRegistry:
                 raise ValueError(msg)
         if func_name in cls._RESERVED_NAMES:
             raise ValueError(f"'{func_name}' is reserved for internal use.")
+        if func_name.startswith("_"):
+            raise ValueError("Private methods cannot be rescaled")
 
         try:
             scaling_dict[scaling_type].append(func_name)

--- a/geomstats/geometry/scalar_product_metric.py
+++ b/geomstats/geometry/scalar_product_metric.py
@@ -172,7 +172,7 @@ class ScalarProductMetric:
         """Load all attributes from the underlying metric."""
         geomstats.errors.check_positive(scale, "scale")
         if not hasattr(space, "metric"):
-            raise ValueError("The variable 'space' must be equipped with a metric.")
+            raise TypeError("The variable 'space' must be equipped with a metric.")
 
         self._space = space
 

--- a/geomstats/information_geometry/normal.py
+++ b/geomstats/information_geometry/normal.py
@@ -663,7 +663,7 @@ class UnivariateNormalMetric(PullbackDiffeoMetric):
     def __init__(self, space):
         diffeo = UnivariateNormalToPoincareHalfSpaceDiffeo()
         image_space = PoincareHalfSpace(dim=2)
-        image_space.metric = ScalarProductMetric(image_space.metric, 2.0)
+        image_space.equip_with_metric(ScalarProductMetric(image_space, 2.0))
         super().__init__(space, diffeo, image_space)
 
     @staticmethod
@@ -731,7 +731,8 @@ class CenteredNormalMetric:
 
     def __new__(cls, space):
         """Instantiate a scaled SPD affine metric."""
-        return ScalarProductMetric(SPDAffineMetric(space), 1 / 2)
+        space.equip_with_metric(SPDAffineMetric)
+        return ScalarProductMetric(space, 1 / 2)
 
 
 class DiagonalNormalMetric(RiemannianMetric):

--- a/geomstats/test_cases/geometry/scalar_product_metric.py
+++ b/geomstats/test_cases/geometry/scalar_product_metric.py
@@ -1,7 +1,10 @@
+import pytest
+
 from geomstats.geometry.scalar_product_metric import (
     ScalarProductMetric,
     _ScaledMethodsRegistry,
     _wrap_attr,
+    register_scaled_method,
 )
 from geomstats.test.test_case import TestCase
 
@@ -37,6 +40,21 @@ class InstantiationTestCase(TestCase):
         self.assertAllClose(scale * dist, dist_1)
         self.assertAllClose(scale * dist, dist_2)
 
+        with pytest.raises(ValueError):
+            scaled_metric_3 = scale * scaled_metric_1
+
+    def test_scalar_metric_multiplication_error(self, scale):
+        with pytest.raises(TypeError):
+            scaled_metric = scale * self.space.metric
+        with pytest.raises(TypeError):
+            scaled_metric = self.space.metric * scale
+        with pytest.raises(TypeError):
+            scaled_metric = self.space.metric * self.space.metric
+
+    def test_scalar_metric_signature(self, scale):
+        with pytest.raises(TypeError):
+            scaled_metric = ScalarProductMetric(self.space.metric, scale)
+
     def test_scaling_scalar_metric(self, scale):
         point_a, point_b = self.space.random_point(2)
 
@@ -62,3 +80,18 @@ class InstantiationTestCase(TestCase):
         self.assertAllClose(scale**2 * dist, dist_2_a)
         self.assertAllClose(dist_2_b, dist_2_a)
         self.assertAllClose(dist_2_c, dist_2_a)
+
+
+class CustomizationTestCase(TestCase):
+    def test_register_scaled_method_invalid(self, func_name, scaling_type):
+        with pytest.raises(ValueError):
+            register_scaled_method(func_name, scaling_type)
+
+    def test_register_scaled_method_valid(self, scale):
+        def dummy_method(self):
+            return 1
+
+        self.Metric.dummy_method = dummy_method
+        register_scaled_method("dummy_method", "linear")
+        scaled_metric_1 = scale * self.space.metric
+        self.assertAllClose(scale, scaled_metric_1.dummy_method())

--- a/geomstats/test_cases/geometry/scalar_product_metric.py
+++ b/geomstats/test_cases/geometry/scalar_product_metric.py
@@ -38,17 +38,25 @@ class InstantiationTestCase(TestCase):
         self.assertAllClose(scale * dist, dist_2)
 
     def test_scaling_scalar_metric(self, scale):
-        scaled_metric_1 = ScalarProductMetric(self.space.metric, scale)
-        scaled_metric_2_a = ScalarProductMetric(scaled_metric_1, scale)
-        scaled_metric_2_b = scale * scaled_metric_1
-        scaled_metric_2_c = scaled_metric_1 * scale
-
         point_a, point_b = self.space.random_point(2)
+
         dist = self.space.metric.squared_dist(point_a, point_b)
-        dist_1 = scaled_metric_1.squared_dist(point_a, point_b)
-        dist_2_a = scaled_metric_2_a.squared_dist(point_a, point_b)
-        dist_2_b = scaled_metric_2_b.squared_dist(point_a, point_b)
-        dist_2_c = scaled_metric_2_c.squared_dist(point_a, point_b)
+
+        self.space.equip_with_metric(ScalarProductMetric(self.space, scale))
+        dist_1 = self.space.metric.squared_dist(point_a, point_b)
+
+        self.space.equip_with_metric(ScalarProductMetric(self.space, scale))
+        dist_2_a = self.space.metric.squared_dist(point_a, point_b)
+
+        self.space.equip_with_metric().equip_with_metric(
+            ScalarProductMetric(self.space, scale)
+        ).equip_with_metric(scale * self.space.metric)
+        dist_2_b = self.space.metric.squared_dist(point_a, point_b)
+
+        self.space.equip_with_metric().equip_with_metric(
+            ScalarProductMetric(self.space, scale)
+        ).equip_with_metric(self.space.metric * scale)
+        dist_2_c = self.space.metric.squared_dist(point_a, point_b)
 
         self.assertAllClose(scale * dist, dist_1)
         self.assertAllClose(scale**2 * dist, dist_2_a)

--- a/geomstats/test_cases/geometry/scalar_product_metric.py
+++ b/geomstats/test_cases/geometry/scalar_product_metric.py
@@ -28,6 +28,7 @@ class WrapperTestCase(TestCase):
 
 
 class InstantiationTestCase(TestCase):
+    @pytest.mark.random
     def test_scalar_metric_multiplication(self, scale):
         scaled_metric_1 = scale * self.space.metric
         scaled_metric_2 = self.space.metric * scale
@@ -41,20 +42,23 @@ class InstantiationTestCase(TestCase):
         self.assertAllClose(scale * dist, dist_2)
 
         with pytest.raises(ValueError):
-            scaled_metric_3 = scale * scaled_metric_1
+            scale * scaled_metric_1
 
     def test_scalar_metric_multiplication_error(self, scale):
         with pytest.raises(TypeError):
-            scaled_metric = scale * self.space.metric
+            scale * self.space.metric
+
         with pytest.raises(TypeError):
-            scaled_metric = self.space.metric * scale
+            self.space.metric * scale
+
         with pytest.raises(TypeError):
-            scaled_metric = self.space.metric * self.space.metric
+            self.space.metric * self.space.metric
 
     def test_scalar_metric_signature(self, scale):
         with pytest.raises(TypeError):
-            scaled_metric = ScalarProductMetric(self.space.metric, scale)
+            ScalarProductMetric(self.space.metric, scale)
 
+    @pytest.mark.random
     def test_scaling_scalar_metric(self, scale):
         point_a, point_b = self.space.random_point(2)
 

--- a/tests/tests_geomstats/test_geometry/data/scalar_product_metric.py
+++ b/tests/tests_geomstats/test_geometry/data/scalar_product_metric.py
@@ -37,6 +37,29 @@ class InstantiationTestData(TestData):
         data = [dict(scale=2.0)]
         return self.generate_tests(data)
 
+    def scalar_metric_multiplication_error_test_data(self):
+        data = [dict(scale=2), dict(scale="str")]
+        return self.generate_tests(data)
+
+    def scalar_metric_signature_test_data(self):
+        data = [dict(scale=2.0)]
+        return self.generate_tests(data)
+
     def scaling_scalar_metric_test_data(self):
+        data = [dict(scale=2.0)]
+        return self.generate_tests(data)
+
+
+class CustomizationTestData(TestData):
+    def register_scaled_method_invalid_test_data(self):
+        data = [
+            dict(func_name="dummy_func", scaling_type="unlisted"),
+            dict(func_name="_private_func", scaling_type="linear"),
+            dict(func_name="dist", scaling_type="linear"),
+            dict(func_name="underlying_metric", scaling_type="linear"),
+        ]
+        return self.generate_tests(data)
+
+    def register_scaled_method_valid_test_data(self):
         data = [dict(scale=2.0)]
         return self.generate_tests(data)

--- a/tests/tests_geomstats/test_geometry/test_nfold_manifold.py
+++ b/tests/tests_geomstats/test_geometry/test_nfold_manifold.py
@@ -26,6 +26,6 @@ class TestNFoldMetricScales(NFoldMetricScalesTestCase, metaclass=DataBasedParame
     space.equip_with_metric(NFoldMetric, scales=gs.array([scale]))
 
     other_space = Euclidean(dim=3)
-    other_space.metric = ScalarProductMetric(other_space.metric, scale)
+    other_space.equip_with_metric(ScalarProductMetric(other_space, scale))
 
     testing_data = NFoldMetricScalesTestData()

--- a/tests/tests_geomstats/test_geometry/test_scalar_product_metric.py
+++ b/tests/tests_geomstats/test_geometry/test_scalar_product_metric.py
@@ -1,11 +1,16 @@
-from geomstats.geometry.euclidean import Euclidean
+from geomstats.geometry.euclidean import Euclidean, EuclideanMetric
 from geomstats.test.parametrizers import DataBasedParametrizer
 from geomstats.test_cases.geometry.scalar_product_metric import (
     InstantiationTestCase,
     WrapperTestCase,
+    CustomizationTestCase,
 )
 
-from .data.scalar_product_metric import InstantiationTestData, WrapperTestData
+from .data.scalar_product_metric import (
+    InstantiationTestData,
+    WrapperTestData,
+    CustomizationTestData,
+)
 
 
 class TestWrapper(WrapperTestCase, metaclass=DataBasedParametrizer):
@@ -15,3 +20,9 @@ class TestWrapper(WrapperTestCase, metaclass=DataBasedParametrizer):
 class TestInstantiation(InstantiationTestCase, metaclass=DataBasedParametrizer):
     space = Euclidean(dim=3)
     testing_data = InstantiationTestData()
+
+
+class TestCustomization(CustomizationTestCase, metaclass=DataBasedParametrizer):
+    Metric = EuclideanMetric
+    space = Euclidean(dim=3)
+    testing_data = CustomizationTestData()

--- a/tests/tests_geomstats/test_geometry/test_scalar_product_metric.py
+++ b/tests/tests_geomstats/test_geometry/test_scalar_product_metric.py
@@ -1,15 +1,15 @@
 from geomstats.geometry.euclidean import Euclidean, EuclideanMetric
 from geomstats.test.parametrizers import DataBasedParametrizer
 from geomstats.test_cases.geometry.scalar_product_metric import (
+    CustomizationTestCase,
     InstantiationTestCase,
     WrapperTestCase,
-    CustomizationTestCase,
 )
 
 from .data.scalar_product_metric import (
+    CustomizationTestData,
     InstantiationTestData,
     WrapperTestData,
-    CustomizationTestData,
 )
 
 

--- a/tests/tests_geomstats/test_geometry/test_spd_matrices.py
+++ b/tests/tests_geomstats/test_geometry/test_spd_matrices.py
@@ -157,7 +157,7 @@ class TestSPD3AffineMetricPower05(
 
     image_space = SPDMatrices(n=3, equip=False)
     image_space.equip_with_metric(SPDAffineMetric)
-    image_space.metric = ScalarProductMetric(image_space.metric, scale=_scale)
+    image_space.equip_with_metric(ScalarProductMetric(image_space, scale=_scale))
 
     space = SPDMatrices(n=3, equip=False)
     space.equip_with_metric(SPDPowerMetric, image_space=image_space)
@@ -250,7 +250,7 @@ class TestSPD3EuclideanMetricPower05(
 
     image_space = SPDMatrices(n=3, equip=False)
     image_space.equip_with_metric(SPDEuclideanMetric)
-    image_space.metric = ScalarProductMetric(image_space.metric, scale=_scale)
+    image_space.equip_with_metric(ScalarProductMetric(image_space, scale=_scale))
 
     space = SPDMatrices(n=3, equip=False)
     space.equip_with_metric(SPDPowerMetric, image_space=image_space)


### PR DESCRIPTION
## Description

Changes the signature of `ScalarProductMetric` to take `space` instead of `metric` as suggested in #1968.

This means that `Manifold` and `ComplexManifold` needed changing: `equip_with_metric` must be able to take an instantiated metric, and not just a class. In particular, they can now be equipped with the specific `ScalarProductMetric`.

The `RiemannianMetric.__mul__` and `ScalarProductMetric.__mul__` methods can now only accept metrics that have been equipped by a particular space. I included a check here, as the user would probably expect `metric` to be scaled by this operation but it is `metric._space.metric` that is scaled. It could be quite confusing.

A number of other classes and tests use `ScalarProductMetric` and these have been refactored.

## Issue

Closes #1968

## Next steps

One issue with putting this together was that `ScalarProductMetric` can be used silently through `RiemannianMetric.__mul__`. It might be reasonable to remove this functionality and insist on explicitly creating these metrics for the sake of maintainability.

Another thing that came up was that there are two `equip_with_metric` methods with identical content, which both needed changing. Maybe there should be a parent `Manifold` with `RealManifold` and `ComplexManifold` as children?
