### PR TITLE
Clean discrete surfaces exp solver

### DIFF
--- a/geomstats/numerics/geodesic.py
+++ b/geomstats/numerics/geodesic.py
@@ -831,7 +831,7 @@ class PathStraightening(LogSolver):
         """
         discr_geod_path = self.discrete_geodesic_bvp(point, base_point)
         point_ndim_slc = (slice(None),) * self._space.point_ndim
-        return self.n_nodes * (
+        return (self.n_nodes - 1) * (
             discr_geod_path[..., 1, *point_ndim_slc]
             - discr_geod_path[..., 0, *point_ndim_slc]
         )

--- a/geomstats/numerics/interpolation.py
+++ b/geomstats/numerics/interpolation.py
@@ -80,5 +80,5 @@ class UniformUnitIntervalLinearInterpolator:
         diff = end_point - initial_point
         ratio = gs.mod(t, self._delta) / self._delta
 
-        ijk = "ijk"[self.point_ndim]
+        ijk = "ijk"[: self.point_ndim]
         return initial_point + gs.einsum(f"t,...t{ijk}->...t{ijk}", ratio, diff)

--- a/geomstats/test_cases/geometry/discrete_surfaces.py
+++ b/geomstats/test_cases/geometry/discrete_surfaces.py
@@ -29,6 +29,10 @@ class SurfacesLocalRandomDataGenerator(RandomDataGenerator):
     def random_point(self, n_points=1):
         return self.point + self._get_deformation(n_points)
 
+    def random_tangent_vec(self, point):
+        n_points = 1 if point.ndim == 2 else point.shape[0]
+        return self._get_deformation(n_points)
+
 
 class DiscreteSurfacesTestCase(ManifoldTestCase):
     def test_vertex_areas(self, point, expected, atol):


### PR DESCRIPTION
This PR cleans the exponential solver in discrete surfaces by taking advantage of machinery introduced in #1957. It also fixes small bugs in path straightening and interpolation. Performance is expected to be the same (no relevant improvement done), except for geodesic coming from the use of a tangent vector and a base point (which now takes advantage of the `path` module). Discrete geodesic ivp is also made public (following path straightening).