### PR TITLE
Use aligner abstraction within fiber bundle and rely on group action on total space

### DIFF
--- a/geomstats/geometry/group_action.py
+++ b/geomstats/geometry/group_action.py
@@ -29,6 +29,46 @@ class GroupAction(ABC):
         """
 
 
+class LieAlgebraBasedGroupAction(GroupAction):
+    """Action of a group on itself by composition.
+
+    Group elements are represented by the vector representation
+    of Lie algebra elements. This is amenable to perform gradient-based
+    optimizations on the Lie algebra.
+
+    Parameters
+    ----------
+    group : LieGroup.
+    """
+
+    def __init__(self, group):
+        self._group = group
+
+    @property
+    def group_elem_shape(self):
+        """Shape of the group element representation."""
+        return (self._group.lie_algebra.dim,)
+
+    def __call__(self, group_elem, point):
+        """Compose action of a group element on a point.
+
+        Parameters
+        ----------
+        group_elem : array-like, shape=[..., *group_elem_shape]
+            Group element represented in the Lie algebra as a vector.
+        point : array-like, shape=[..., *group.shape]
+            Point on the group.
+
+        Returns
+        -------
+        orbit_point : array-like, shape=[..., *group.shape]
+            A point in the orbit of point.
+        """
+        algebra_elt = self._group.lie_algebra.matrix_representation(group_elem)
+        group_elt = self._group.exp(algebra_elt)
+        return self._group.compose(point, group_elt)
+
+
 class CongruenceAction(GroupAction):
     """Congruence action."""
 

--- a/geomstats/geometry/rank_k_psd_matrices.py
+++ b/geomstats/geometry/rank_k_psd_matrices.py
@@ -7,6 +7,7 @@ import geomstats.backend as gs
 from geomstats.geometry.fiber_bundle import FiberBundle
 from geomstats.geometry.full_rank_matrices import FullRankMatrices
 from geomstats.geometry.general_linear import GeneralLinear
+from geomstats.geometry.group_action import LieAlgebraBasedGroupAction
 from geomstats.geometry.manifold import Manifold
 from geomstats.geometry.matrices import Matrices, MatricesMetric
 from geomstats.geometry.quotient_metric import QuotientMetric
@@ -228,10 +229,14 @@ class BuresWassersteinBundle(FiberBundle):
     """Class for the quotient structure on PSD matrices."""
 
     def __init__(self, total_space):
-        super().__init__(
-            total_space=total_space,
-            group=SpecialOrthogonal(total_space.k, equip=False),
-        )
+        if not hasattr(total_space, "group_action"):
+            total_space.equip_with_group_action(
+                LieAlgebraBasedGroupAction(
+                    SpecialOrthogonal(total_space.k, equip=False)
+                )
+            )
+
+        super().__init__(total_space=total_space, aligner=True)
 
     @staticmethod
     def riemannian_submersion(point):

--- a/geomstats/geometry/stratified/graph_space.py
+++ b/geomstats/geometry/stratified/graph_space.py
@@ -15,13 +15,10 @@ from abc import ABC, abstractmethod
 
 import geomstats.backend as gs
 from geomstats.errors import check_parameter_accepted_values
+from geomstats.geometry.fiber_bundle import AlignerAlgorithm
 from geomstats.geometry.group_action import PermutationAction
 from geomstats.geometry.matrices import Matrices, MatricesMetric
-from geomstats.geometry.stratified.quotient import (
-    Aligner,
-    AlignerAlgorithm,
-    QuotientMetric,
-)
+from geomstats.geometry.stratified.quotient import Aligner, QuotientMetric
 from geomstats.numerics.optimizers import ScipyMinimize
 from geomstats.vectorization import check_is_batch, get_batch_shape
 

--- a/geomstats/geometry/stratified/quotient.py
+++ b/geomstats/geometry/stratified/quotient.py
@@ -1,39 +1,9 @@
 """Quotient structure for a geodesic metric space."""
 
-from abc import ABC, abstractmethod
+from abc import ABC
 
 import geomstats.backend as gs
 from geomstats.geometry.stratified.point_set import PointSetMetric
-
-
-class AlignerAlgorithm(ABC):
-    """Base class for point to point aligner.
-
-    Parameters
-    ----------
-    total_space : PointSet
-        Set with quotient structure.
-    """
-
-    def __init__(self, total_space):
-        self._total_space = total_space
-
-    @abstractmethod
-    def align(self, point, base_point):
-        """Align point to base point.
-
-        Parameters
-        ----------
-        point : array-like, shape=[..., *point_shape]
-            Point to align.
-        base_point : array-like, shape=[..., *point_shape]
-            Base point.
-
-        Returns
-        -------
-        aligned_point : array-like, shape=[..., *point_shape]
-            Aligned point.
-        """
 
 
 class Aligner(ABC):

--- a/geomstats/test_cases/geometry/fiber_bundle.py
+++ b/geomstats/test_cases/geometry/fiber_bundle.py
@@ -2,6 +2,7 @@ import pytest
 
 import geomstats.backend as gs
 from geomstats.geometry.fiber_bundle import FiberBundle
+from geomstats.geometry.group_action import LieAlgebraBasedGroupAction
 from geomstats.geometry.matrices import Matrices
 from geomstats.geometry.special_orthogonal import SpecialOrthogonal
 from geomstats.test.random import RandomDataGenerator
@@ -508,10 +509,14 @@ class FiberBundleTestCase(TestCase):
 
 class GeneralLinearBuresWassersteinBundle(FiberBundle):
     def __init__(self, total_space):
-        super().__init__(
-            total_space=total_space,
-            group=SpecialOrthogonal(total_space.n),
-        )
+        if not hasattr(total_space, "group_action"):
+            total_space.equip_with_group_action(
+                LieAlgebraBasedGroupAction(
+                    SpecialOrthogonal(total_space.n, equip=False)
+                )
+            )
+
+        super().__init__(total_space=total_space, aligner=True)
 
     @staticmethod
     def riemannian_submersion(point):

--- a/tests/tests_geomstats/test_geometry/data/fiber_bundle.py
+++ b/tests/tests_geomstats/test_geometry/data/fiber_bundle.py
@@ -69,9 +69,8 @@ class FiberBundleTestData(TestData):
 class GeneralLinearBuresWassersteinBundleTestData(FiberBundleTestData):
     fail_for_autodiff_exceptions = False
     fail_for_not_implemented_errors = False
-    xfails = ("align_vec",)
 
     tolerances = {
-        "align_vec": {"atol": 1e-1},
-        "log_after_align_is_horizontal": {"atol": 1e-1},
+        "align_vec": {"atol": 1e-3},
+        "log_after_align_is_horizontal": {"atol": 1e-3},
     }

--- a/tests/tests_geomstats/test_geometry/test_discrete_curves.py
+++ b/tests/tests_geomstats/test_geometry/test_discrete_curves.py
@@ -203,8 +203,8 @@ class TestAlignerCmp(TestCase, metaclass=DataBasedParametrizer):
     total_space.fiber_bundle = SRVReparametrizationBundle(total_space)
     total_space.fiber_bundle.aligner = None
 
-    aligner = IterativeHorizontalGeodesicAligner()
-    other_aligner = DynamicProgrammingAligner()
+    aligner = IterativeHorizontalGeodesicAligner(total_space)
+    other_aligner = DynamicProgrammingAligner(total_space)
 
     testing_data = AlignerCmpTestData()
 
@@ -215,8 +215,8 @@ class TestAlignerCmp(TestCase, metaclass=DataBasedParametrizer):
         base_point = self.total_space.projection(curve_a(sampling_points))
         point = self.total_space.projection(curve_b(sampling_points))
 
-        aligned = self.aligner.align(self.total_space, point, base_point)
-        other_aligned = self.other_aligner.align(self.total_space, point, base_point)
+        aligned = self.aligner.align(point, base_point)
+        other_aligned = self.other_aligner.align(point, base_point)
 
         self.assertAllClose(aligned, other_aligned, atol=atol)
 

--- a/tests/tests_geomstats/test_geometry/test_fiber_bundle.py
+++ b/tests/tests_geomstats/test_geometry/test_fiber_bundle.py
@@ -1,7 +1,5 @@
 import random
 
-import pytest
-
 from geomstats.geometry.general_linear import GeneralLinear
 from geomstats.geometry.matrices import MatricesMetric
 from geomstats.geometry.spd_matrices import SPDMatrices
@@ -14,25 +12,16 @@ from geomstats.test_cases.geometry.fiber_bundle import (
 from .data.fiber_bundle import GeneralLinearBuresWassersteinBundleTestData
 
 
-@pytest.fixture(
-    scope="class",
-    params=[
-        2,
-        random.randint(3, 5),
-    ],
-)
-def bundle_spaces(request):
-    n = request.param
-
-    request.cls.total_space = total_space = GeneralLinear(n, equip=False)
-    total_space.equip_with_metric(MatricesMetric)
-    total_space.fiber_bundle = GeneralLinearBuresWassersteinBundle(total_space)
-
-    request.cls.base = SPDMatrices(n=n, equip=False)
-
-
-@pytest.mark.usefixtures("bundle_spaces")
 class TestGeneralLinearBuresWassersteinBundle(
     FiberBundleTestCase, metaclass=DataBasedParametrizer
 ):
+    _n = random.randint(2, 5)
+
+    total_space = GeneralLinear(_n, equip=False)
+    total_space.equip_with_metric(MatricesMetric)
+
+    total_space.fiber_bundle = GeneralLinearBuresWassersteinBundle(total_space)
+
+    base = SPDMatrices(n=_n, equip=False)
+
     testing_data = GeneralLinearBuresWassersteinBundleTestData()


### PR DESCRIPTION
This PR updates `FiberBundle` to:

1. use an `AlignerAlgorithm`: follows what was already being done in discrete curves and graph space (notice the abstraction was initially defined within the graph space context)

2. definitely moves `group_action` to the total space by removing it from fiber bundle


For 1., the main advantages are i) an easier control of the numerical parameters, ii) homogenization of the code among all the uses of quotient spaces (including graph space), iii) it becomes easier and more natural to plugin different aligner algorithms (this has already being taken advantage of within discrete curves).


For 2., we use `space.equip_with_group_action` method and make everything consistent, i.e. a group action endows the total space. Notice that a group action can simply be a callable (see e.g. `full_rank_correlation_matrices.CorrelationMatricesBundle`) or a child of `GroupAction`. The aligner algorithm works with just a little extra information regarding group dimensionality.