### PR TITLE
Add LogScaled metrics on Cor+

### DIFF
--- a/geomstats/geometry/base.py
+++ b/geomstats/geometry/base.py
@@ -1050,3 +1050,62 @@ class DiffeomorphicManifold(Manifold):
         return self.diffeo.inverse_tangent_diffeomorphism(
             image_tangent_vec, image_point=image_point, base_point=base_point
         )
+
+
+class DiffeomorphicVectorSpace(VectorSpace, DiffeomorphicManifold):
+    """A vector space defined by a diffeomorphism."""
+
+    def projection(self, point):
+        r"""Make a matrix null-row-sum symmetric.
+
+        It considers only the first :math:`n-1 \times n-1` components.
+
+        Parameters
+        ----------
+        point : array-like, shape=[..., n, n]
+            Matrix.
+
+        Returns
+        -------
+        sym : array-like, shape=[..., n, n]
+            Symmetric matrix.
+        """
+        image_point = self.diffeo.diffeomorphism(point)
+        proj_image_point = self.image_space.projection(image_point)
+        return self.diffeo.inverse_diffeomorphism(proj_image_point)
+
+
+class DiffeomorphicMatrixVectorSpace(MatrixVectorSpace, DiffeomorphicVectorSpace):
+    """A matrix vector space defined by a diffeomorphism."""
+
+    def basis_representation(self, matrix_representation):
+        """Convert a symmetric matrix into a vector.
+
+        Parameters
+        ----------
+        matrix_representation : array-like, shape=[..., n, n]
+            Matrix.
+
+        Returns
+        -------
+        basis_representation : array-like, shape=[..., n(n+1)/2]
+            Vector.
+        """
+        image_matrix_representation = self.diffeo.diffeomorphism(matrix_representation)
+        return self.image_space.basis_representation(image_matrix_representation)
+
+    def matrix_representation(self, basis_representation):
+        """Convert a vector into a symmetric matrix.
+
+        Parameters
+        ----------
+        basis_representation : array-like, shape=[..., n(n+1)/2]
+            Vector.
+
+        Returns
+        -------
+        matrix_representation : array-like, shape=[..., n, n]
+            Symmetric matrix.
+        """
+        image_point = self.image_space.matrix_representation(basis_representation)
+        return self.diffeo.inverse_diffeomorphism(image_point)

--- a/geomstats/geometry/base.py
+++ b/geomstats/geometry/base.py
@@ -52,25 +52,6 @@ class VectorSpace(Manifold, abc.ABC):
             return gs.ones(shape, dtype=bool)
         return gs.zeros(shape, dtype=bool)
 
-    @staticmethod
-    def projection(point):
-        """Project a point to the vector space.
-
-        This method is for compatibility and returns `point`. `point` should
-        have the right shape,
-
-        Parameters
-        ----------
-        point: array-like, shape[..., *point_shape]
-            Point.
-
-        Returns
-        -------
-        point: array-like, shape[..., *point_shape]
-            Point.
-        """
-        return gs.copy(point)
-
     def is_tangent(self, vector, base_point=None, atol=gs.atol):
         """Check whether the vector is tangent at base_point.
 
@@ -284,25 +265,6 @@ class ComplexVectorSpace(ComplexManifold, abc.ABC):
         if belongs:
             return gs.ones(shape, dtype=bool)
         return gs.zeros(shape, dtype=bool)
-
-    @staticmethod
-    def projection(point):
-        """Project a point to the vector space.
-
-        This method is for compatibility and returns `point`. `point` should
-        have the right shape,
-
-        Parameters
-        ----------
-        point: array-like, shape[..., *point_shape]
-            Point.
-
-        Returns
-        -------
-        point: array-like, shape[..., *point_shape]
-            Point.
-        """
-        return gs.copy(point)
 
     def is_tangent(self, vector, base_point=None, atol=gs.atol):
         """Check whether the vector is tangent at base_point.
@@ -537,21 +499,6 @@ class LevelSet(Manifold, abc.ABC):
         """
         raise NotImplementedError("extrinsic_to_intrinsic_coords is not implemented.")
 
-    @abc.abstractmethod
-    def projection(self, point):
-        """Project a point in embedding manifold on embedded manifold.
-
-        Parameters
-        ----------
-        point : array-like, shape=[..., *embedding_space.point_shape]
-            Point in embedding manifold.
-
-        Returns
-        -------
-        projected : array-like, shape=[..., *point_shape]
-            Projected point.
-        """
-
 
 class OpenSet(Manifold, abc.ABC):
     """Class for manifolds that are open sets.
@@ -687,21 +634,6 @@ class VectorSpaceOpenSet(OpenSet, abc.ABC):
             return gs.broadcast_to(tangent_vec, base_point.shape)
         return tangent_vec
 
-    @abc.abstractmethod
-    def projection(self, point):
-        """Project a point in embedding manifold on manifold.
-
-        Parameters
-        ----------
-        point : array-like, shape=[..., *point_shape]
-            Point in embedding manifold.
-
-        Returns
-        -------
-        projected : array-like, shape=[..., *point_shape]
-            Projected point.
-        """
-
 
 class ComplexVectorSpaceOpenSet(ComplexManifold, abc.ABC):
     """Class for manifolds that are open sets of a complex vector space.
@@ -788,21 +720,6 @@ class ComplexVectorSpaceOpenSet(ComplexManifold, abc.ABC):
         """
         sample = self.embedding_space.random_point(n_samples, bound)
         return self.projection(sample)
-
-    @abc.abstractmethod
-    def projection(self, point):
-        """Project a point in embedding manifold on manifold.
-
-        Parameters
-        ----------
-        point : array-like, shape=[..., *point_shape]
-            Point in embedding manifold.
-
-        Returns
-        -------
-        projected : array-like, shape=[..., *point_shape]
-            Projected point.
-        """
 
 
 class ImmersedSet(Manifold, abc.ABC):

--- a/geomstats/geometry/complex_manifold.py
+++ b/geomstats/geometry/complex_manifold.py
@@ -194,3 +194,21 @@ class ComplexManifold(abc.ABC):
             size=batch_size + self.shape, dtype=gs.get_default_cdtype()
         )
         return self.to_tangent(vector, base_point)
+
+    def projection(self, point):
+        """Project a point to the manifold.
+
+        Parameters
+        ----------
+        point: array-like, shape[..., *point_shape]
+            Point.
+
+        Returns
+        -------
+        point: array-like, shape[..., *point_shape]
+            Point.
+        """
+        if self.intrinsic:
+            return gs.copy(point)
+
+        raise NotImplementedError("`projection` is not implemented yet")

--- a/geomstats/geometry/full_rank_correlation_matrices.py
+++ b/geomstats/geometry/full_rank_correlation_matrices.py
@@ -41,6 +41,8 @@ from geomstats.geometry.spd_matrices import (
 )
 from geomstats.geometry.symmetric_matrices import (
     HollowMatricesPermutationInvariantMetric,
+    NullRowSumPermutationInvariantMetric,
+    NullRowSumSymmetricMatrices,
     SymmetricHollowMatrices,
 )
 
@@ -1082,3 +1084,43 @@ class LogScalingDiffeo(Diffeo):
             base_point=base_point_row_1,
         )
         return tangent_corr_map(tangent_vec_row_1, base_point_row_1)
+
+
+class LogScaledMetric(PullbackDiffeoMetric):
+    """Pullback metric via a diffeomorphism.
+
+    Diffeormorphism between full-rank correlation matrices and
+    the space of symmetric matrices with null row sums.
+
+    Check out [T2023]_ for more details.
+
+    Parameters
+    ----------
+    space : FullRankCorrelationMatrices
+    alpha : float
+        Scalar multiplying first term of quadratic form.
+    delta : float
+        Scalar multiplying second term of quadratic form.
+    zeta : float
+        Scalar multiplying third term of quadratic form.
+
+    References
+    ----------
+    .. [T2023] Thanwerdas, Yann. “Permutation-Invariant Log-Euclidean Geometries
+        on Full-Rank Correlation Matrices,”
+        November 2023. https://hal.science/hal-03878729.
+    """
+
+    def __init__(self, space, alpha=1.0, delta=1.0, zeta=1.0):
+        diffeo = LogScalingDiffeo()
+
+        image_space = NullRowSumSymmetricMatrices(
+            n=space.n, equip=False
+        ).equip_with_metric(
+            NullRowSumPermutationInvariantMetric,
+            alpha=alpha,
+            delta=delta,
+            zeta=zeta,
+        )
+
+        super().__init__(space=space, diffeo=diffeo, image_space=image_space)

--- a/geomstats/geometry/full_rank_correlation_matrices.py
+++ b/geomstats/geometry/full_rank_correlation_matrices.py
@@ -41,8 +41,8 @@ from geomstats.geometry.spd_matrices import (
 )
 from geomstats.geometry.symmetric_matrices import (
     HollowMatricesPermutationInvariantMetric,
-    NullRowSumPermutationInvariantMetric,
-    NullRowSumSymmetricMatrices,
+    NullRowSumsPermutationInvariantMetric,
+    NullRowSumsSymmetricMatrices,
     SymmetricHollowMatrices,
 )
 
@@ -1114,10 +1114,10 @@ class LogScaledMetric(PullbackDiffeoMetric):
     def __init__(self, space, alpha=1.0, delta=1.0, zeta=1.0):
         diffeo = LogScalingDiffeo()
 
-        image_space = NullRowSumSymmetricMatrices(
+        image_space = NullRowSumsSymmetricMatrices(
             n=space.n, equip=False
         ).equip_with_metric(
-            NullRowSumPermutationInvariantMetric,
+            NullRowSumsPermutationInvariantMetric,
             alpha=alpha,
             delta=delta,
             zeta=zeta,

--- a/geomstats/geometry/full_rank_correlation_matrices.py
+++ b/geomstats/geometry/full_rank_correlation_matrices.py
@@ -791,7 +791,7 @@ class OffLogMetric(PullbackDiffeoMetric):
         Geometry [math.DG]. Université Côte d'Azur, 2022.
     """
 
-    def __init__(self, space, alpha=1.0, beta=1.0, gamma=1.0):
+    def __init__(self, space, alpha=None, beta=None, gamma=1.0):
         diffeo = OffLogDiffeo()
 
         image_space = SymmetricHollowMatrices(n=space.n, equip=False).equip_with_metric(
@@ -1111,7 +1111,7 @@ class LogScaledMetric(PullbackDiffeoMetric):
         November 2023. https://hal.science/hal-03878729.
     """
 
-    def __init__(self, space, alpha=1.0, delta=1.0, zeta=1.0):
+    def __init__(self, space, alpha=None, delta=None, zeta=1.0):
         diffeo = LogScalingDiffeo()
 
         image_space = NullRowSumsSymmetricMatrices(

--- a/geomstats/geometry/full_rank_correlation_matrices.py
+++ b/geomstats/geometry/full_rank_correlation_matrices.py
@@ -858,7 +858,7 @@ class UniquePositiveDiagonalMatrixAlgorithm:
         -------
         jacobian : array-like, shape=[..., n]
         """
-        return gs.matvec(spd_matrix, diag_vec) - 1.0 / diag_vec  #
+        return gs.matvec(spd_matrix, diag_vec) - 1.0 / diag_vec
 
     def _hessian_f(self, spd_matrix, diag_vec):
         r"""Hessian of objective function.
@@ -877,7 +877,7 @@ class UniquePositiveDiagonalMatrixAlgorithm:
         -------
         hessian : array-like, shape=[..., n, n]
         """
-        return spd_matrix + Matrices.to_diagonal(1.0 / diag_vec**2)
+        return spd_matrix + gs.vec_to_diag(1.0 / diag_vec**2)
 
     def _apply_single(self, spd_matrix):
         """Apply Newton method to find scaling.

--- a/geomstats/geometry/manifold.py
+++ b/geomstats/geometry/manifold.py
@@ -242,3 +242,21 @@ class Manifold(abc.ABC):
         return self.to_tangent(
             gs.random.normal(size=batch_size + self.shape), base_point
         )
+
+    def projection(self, point):
+        """Project a point to the manifold.
+
+        Parameters
+        ----------
+        point: array-like, shape[..., *point_shape]
+            Point.
+
+        Returns
+        -------
+        point: array-like, shape[..., *point_shape]
+            Point.
+        """
+        if self.intrinsic:
+            return gs.copy(point)
+
+        raise NotImplementedError("`projection` is not implemented yet")

--- a/geomstats/geometry/symmetric_matrices.py
+++ b/geomstats/geometry/symmetric_matrices.py
@@ -119,7 +119,7 @@ class SymmetricMatrices(MatrixVectorSpace):
         mat_dim = (gs.sqrt(8.0 * vec_dim + 1) - 1) / 2
         if mat_dim != int(mat_dim):
             raise ValueError(
-                "Invalid input dimension, it must be of the form"
+                "Invalid input dimension, it must be of the form "
                 "(n_samples, n * (n + 1) / 2)"
             )
         mat_dim = int(mat_dim)
@@ -281,7 +281,13 @@ class HollowMatricesPermutationInvariantMetric(EuclideanMetric):
         Geometry [math.DG]. Université Côte d'Azur, 2022.
     """
 
-    def __init__(self, space, alpha=1.0, beta=1.0, gamma=1.0):
+    def __init__(self, space, alpha=None, beta=None, gamma=1.0):
+        if alpha is None:
+            alpha = 1.0 if space.n > 3 else 0.0
+
+        if beta is None:
+            beta = 1.0 if space.n > 2 else 0.0
+
         self._check_params(space, alpha, beta, gamma)
         super().__init__(space=space)
         self.alpha = alpha
@@ -301,8 +307,9 @@ class HollowMatricesPermutationInvariantMetric(EuclideanMetric):
         if n == 2:
             if alpha > gs.atol or beta > gs.atol or gamma < gs.atol:
                 raise ValueError(
-                    f"When n==2: alpha ({alpha}) and beta({beta}) must be 0,"
+                    f"When n==2: alpha ({alpha}) and beta ({beta}) must be 0, "
                     f"and gamma ({gamma}) > 0. "
+                    "Check thanwerdas2022 theorem 8.7"
                 )
             return
 
@@ -310,8 +317,8 @@ class HollowMatricesPermutationInvariantMetric(EuclideanMetric):
             cond = beta + 3 * gamma
             if alpha > gs.atol or beta < gs.atol or cond < gs.atol:
                 raise ValueError(
-                    f"When n==3: alpha ({alpha}) must be 0, beta ({beta}) > 0"
-                    f"and an inequality greater than 0: {cond}."
+                    f"When n==3: alpha ({alpha}) must be 0, beta ({beta}) > 0 "
+                    f"and an inequality greater than 0: {cond}. "
                     "Check thanwerdas2022 theorem 8.7"
                 )
             return
@@ -320,7 +327,7 @@ class HollowMatricesPermutationInvariantMetric(EuclideanMetric):
         cond_2 = alpha + (n - 1) * (beta + n * gamma)
         if cond_1 < gs.atol or cond_2 < gs.atol:
             raise ValueError(
-                f"Inequalities should be greater than 0, but: {cond_1} and {cond_2}."
+                f"Inequalities should be greater than 0, but: {cond_1} and {cond_2}. "
                 "Check thanwerdas2022 theorem 8.7"
             )
 
@@ -655,7 +662,13 @@ class NullRowSumsPermutationInvariantMetric(EuclideanMetric):
         November 2023. https://hal.science/hal-03878729.
     """
 
-    def __init__(self, space, alpha=1.0, delta=1.0, zeta=1.0):
+    def __init__(self, space, alpha=None, delta=None, zeta=1.0):
+        if alpha is None:
+            alpha = 1.0 if space.n > 3 else 0.0
+
+        if delta is None:
+            delta = 1.0 if space.n > 2 else 0.0
+
         self._check_params(space, alpha, delta, zeta)
         super().__init__(space=space)
         self.alpha = alpha
@@ -675,8 +688,9 @@ class NullRowSumsPermutationInvariantMetric(EuclideanMetric):
         if n == 2:
             if alpha > gs.atol or delta > gs.atol or zeta < gs.atol:
                 raise ValueError(
-                    f"When n==2: alpha ({alpha}) and delta({delta}) must be 0,"
+                    f"When n==2: alpha ({alpha}) and delta ({delta}) must be 0, "
                     f"and zeta ({zeta}) > 0. "
+                    "Check thanwerdas2022 theorem 8.7"
                 )
             return
 
@@ -684,8 +698,8 @@ class NullRowSumsPermutationInvariantMetric(EuclideanMetric):
             cond = delta + 3 * zeta
             if alpha > gs.atol or delta < gs.atol or cond < gs.atol:
                 raise ValueError(
-                    f"When n==3: alpha ({alpha}) must be 0, delta ({delta}) > 0"
-                    f"and an inequality greater than 0: {cond}."
+                    f"When n==3: alpha ({alpha}) must be 0, delta ({delta}) > 0 "
+                    f"and an inequality greater than 0: {cond}. "
                     "Check thanwerdas2022 theorem 8.7"
                 )
             return
@@ -694,7 +708,7 @@ class NullRowSumsPermutationInvariantMetric(EuclideanMetric):
         cond_2 = n * alpha + (n - 1) * (delta + n * zeta)
         if cond_1 < gs.atol or cond_2 < gs.atol:
             raise ValueError(
-                f"Inequalities should be greater than 0, but: {cond_1} and {cond_2}."
+                f"Inequalities should be greater than 0, but: {cond_1} and {cond_2}. "
                 "Check thanwerdas2022 theorem 8.7"
             )
 

--- a/geomstats/geometry/symmetric_matrices.py
+++ b/geomstats/geometry/symmetric_matrices.py
@@ -390,7 +390,7 @@ class HollowMatricesPermutationInvariantMetric(EuclideanMetric):
         return self._quadratic_form(vector)
 
 
-class ConstantValueRowSumDiffeo(Diffeo):
+class ConstantValueRowSumsDiffeo(Diffeo):
     r"""A diffeomorphism from the constant-value-row-sum matrices to symmetric matrices.
 
     A particular case is the diffeomorphism between the space of null-row-sum symmetric
@@ -516,15 +516,17 @@ class ConstantValueRowSumDiffeo(Diffeo):
         )
 
 
-class NullRowSumSymmetricMatrices(LevelSet, DiffeomorphicMatrixVectorSpace):
-    r"""Space of null-row-sum symmetric matrices.
+class NullRowSumsSymmetricMatrices(LevelSet, DiffeomorphicMatrixVectorSpace):
+    r"""Space of null-row-sums symmetric matrices.
 
-    Set of symmetric matrices with null row sum:
+    Set of symmetric matrices with null row sums:
 
     .. math::
 
         \operatorname{Row_0}(n) = \{S \in \operatorname{Sym}(n)
         \mid S \mathbb{1}=0 \}
+
+    Check out chapter 8 of [T2022]_ and [T2023]_ for more details.
 
     Parameters
     ----------
@@ -536,6 +538,9 @@ class NullRowSumSymmetricMatrices(LevelSet, DiffeomorphicMatrixVectorSpace):
     .. [T2022] Yann Thanwerdas. Riemannian and stratified
         geometries on covariance and correlation matrices. Differential
         Geometry [math.DG]. Université Côte d'Azur, 2022.
+    .. [T2023] Thanwerdas, Yann. “Permutation-Invariant Log-Euclidean Geometries
+        on Full-Rank Correlation Matrices,”
+        November 2023. https://hal.science/hal-03878729.
     """
 
     def __init__(self, n, equip=True):
@@ -543,7 +548,7 @@ class NullRowSumSymmetricMatrices(LevelSet, DiffeomorphicMatrixVectorSpace):
         image_space = SymmetricMatrices(n - 1, equip=False)
         super().__init__(
             dim=image_space.dim,
-            diffeo=ConstantValueRowSumDiffeo(value=0.0),
+            diffeo=ConstantValueRowSumsDiffeo(value=0.0),
             image_space=image_space,
             shape=(n, n),
             equip=equip,
@@ -614,8 +619,8 @@ class NullRowSumSymmetricMatrices(LevelSet, DiffeomorphicMatrixVectorSpace):
         )
 
 
-class NullRowSumPermutationInvariantMetric(EuclideanMetric):
-    r"""A permutation-invariant metric on the space of null-row-sum symmetric matrices.
+class NullRowSumsPermutationInvariantMetric(EuclideanMetric):
+    r"""A permutation-invariant metric on the space of null-row-sums symmetric matrices.
 
     It is flat Riemannian metric invariant by the congruence action
     of permutation matrices defined over a matrix vector space.
@@ -628,6 +633,8 @@ class NullRowSumPermutationInvariantMetric(EuclideanMetric):
         +\delta \operatorname{tr}\left(\operatorname{Diag}(Y)^2\right)
         +\zeta \operatorname{tr}(Y)^2
 
+    Check out chapter 8 of [T2022]_ and [T2023]_ for more details.
+
     Parameters
     ----------
     space : Manifold
@@ -638,13 +645,14 @@ class NullRowSumPermutationInvariantMetric(EuclideanMetric):
     zeta : float
         Scalar multiplying third term of quadratic form.
 
-    Check out chapter 8 of [T2022]_ for more details.
-
     References
     ----------
     .. [T2022] Yann Thanwerdas. Riemannian and stratified
         geometries on covariance and correlation matrices. Differential
         Geometry [math.DG]. Université Côte d'Azur, 2022.
+    .. [T2023] Thanwerdas, Yann. “Permutation-Invariant Log-Euclidean Geometries
+        on Full-Rank Correlation Matrices,”
+        November 2023. https://hal.science/hal-03878729.
     """
 
     def __init__(self, space, alpha=1.0, delta=1.0, zeta=1.0):

--- a/tests/tests_geomstats/test_geometry/data/diffeo.py
+++ b/tests/tests_geomstats/test_geometry/data/diffeo.py
@@ -2,8 +2,6 @@ from geomstats.test.data import TestData
 
 
 class DiffeoTestData(TestData):
-    trials = 1
-
     def diffeomorphism_vec_test_data(self):
         return self.generate_vec_data()
 

--- a/tests/tests_geomstats/test_geometry/data/diffeo.py
+++ b/tests/tests_geomstats/test_geometry/data/diffeo.py
@@ -2,6 +2,8 @@ from geomstats.test.data import TestData
 
 
 class DiffeoTestData(TestData):
+    trials = 1
+
     def diffeomorphism_vec_test_data(self):
         return self.generate_vec_data()
 

--- a/tests/tests_geomstats/test_geometry/data/full_rank_correlation_matrices.py
+++ b/tests/tests_geomstats/test_geometry/data/full_rank_correlation_matrices.py
@@ -59,3 +59,8 @@ class PolyHyperbolicCholeskyMetricTestData(PullbackDiffeoMetricTestData):
 class OffLogMetricTestData(PullbackDiffeoMetricTestData):
     fail_for_autodiff_exceptions = False
     fail_for_not_implemented_errors = False
+
+
+class UniquePositiveDiagonalMatrixAlgorithmTestData(TestData):
+    def rows_sum_to_one_test_data(self):
+        return self.generate_random_data()

--- a/tests/tests_geomstats/test_geometry/data/full_rank_correlation_matrices.py
+++ b/tests/tests_geomstats/test_geometry/data/full_rank_correlation_matrices.py
@@ -64,3 +64,8 @@ class OffLogMetricTestData(PullbackDiffeoMetricTestData):
 class UniquePositiveDiagonalMatrixAlgorithmTestData(TestData):
     def rows_sum_to_one_test_data(self):
         return self.generate_random_data()
+
+
+class LogScaledMetricTestData(PullbackDiffeoMetricTestData):
+    fail_for_autodiff_exceptions = False
+    fail_for_not_implemented_errors = False

--- a/tests/tests_geomstats/test_geometry/data/symmetric_matrices.py
+++ b/tests/tests_geomstats/test_geometry/data/symmetric_matrices.py
@@ -100,3 +100,8 @@ class HollowMatricesPermutationInvariantMetricTestData(EuclideanMetricTestData):
 
 class NullRowSumSymmetricMatricesTestData(LevelSetTestData, MatrixVectorSpaceTestData):
     pass
+
+
+class NullRowSumPermutationInvariantMetricTestData(EuclideanMetricTestData):
+    fail_for_not_implemented_errors = False
+    fail_for_autodiff_exceptions = False

--- a/tests/tests_geomstats/test_geometry/data/symmetric_matrices.py
+++ b/tests/tests_geomstats/test_geometry/data/symmetric_matrices.py
@@ -96,3 +96,7 @@ class SymmetricHollowMatricesTestData(MatrixVectorSpaceTestData, LevelSetTestDat
 class HollowMatricesPermutationInvariantMetricTestData(EuclideanMetricTestData):
     fail_for_not_implemented_errors = False
     fail_for_autodiff_exceptions = False
+
+
+class NullRowSumSymmetricMatricesTestData(MatrixVectorSpaceTestData, LevelSetTestData):
+    fail_for_not_implemented_errors = False

--- a/tests/tests_geomstats/test_geometry/data/symmetric_matrices.py
+++ b/tests/tests_geomstats/test_geometry/data/symmetric_matrices.py
@@ -89,7 +89,7 @@ class SymmetricMatrices3TestData(TestData):
         return self.generate_tests(data)
 
 
-class SymmetricHollowMatricesTestData(MatrixVectorSpaceTestData, LevelSetTestData):
+class SymmetricHollowMatricesTestData(LevelSetTestData, MatrixVectorSpaceTestData):
     pass
 
 
@@ -98,5 +98,5 @@ class HollowMatricesPermutationInvariantMetricTestData(EuclideanMetricTestData):
     fail_for_autodiff_exceptions = False
 
 
-class NullRowSumSymmetricMatricesTestData(MatrixVectorSpaceTestData, LevelSetTestData):
+class NullRowSumSymmetricMatricesTestData(LevelSetTestData, MatrixVectorSpaceTestData):
     pass

--- a/tests/tests_geomstats/test_geometry/data/symmetric_matrices.py
+++ b/tests/tests_geomstats/test_geometry/data/symmetric_matrices.py
@@ -99,4 +99,4 @@ class HollowMatricesPermutationInvariantMetricTestData(EuclideanMetricTestData):
 
 
 class NullRowSumSymmetricMatricesTestData(MatrixVectorSpaceTestData, LevelSetTestData):
-    fail_for_not_implemented_errors = False
+    pass

--- a/tests/tests_geomstats/test_geometry/data/symmetric_matrices.py
+++ b/tests/tests_geomstats/test_geometry/data/symmetric_matrices.py
@@ -98,10 +98,10 @@ class HollowMatricesPermutationInvariantMetricTestData(EuclideanMetricTestData):
     fail_for_autodiff_exceptions = False
 
 
-class NullRowSumSymmetricMatricesTestData(LevelSetTestData, MatrixVectorSpaceTestData):
+class NullRowSumsSymmetricMatricesTestData(LevelSetTestData, MatrixVectorSpaceTestData):
     pass
 
 
-class NullRowSumPermutationInvariantMetricTestData(EuclideanMetricTestData):
+class NullRowSumsPermutationInvariantMetricTestData(EuclideanMetricTestData):
     fail_for_not_implemented_errors = False
     fail_for_autodiff_exceptions = False

--- a/tests/tests_geomstats/test_geometry/test_full_rank_correlation_matrices.py
+++ b/tests/tests_geomstats/test_geometry/test_full_rank_correlation_matrices.py
@@ -29,7 +29,7 @@ from geomstats.geometry.positive_lower_triangular_matrices import (
 )
 from geomstats.geometry.spd_matrices import CholeskyMap, SPDMatrices
 from geomstats.geometry.symmetric_matrices import (
-    NullRowSumSymmetricMatrices,
+    NullRowSumsSymmetricMatrices,
     SymmetricHollowMatrices,
     SymmetricMatrices,
 )
@@ -256,7 +256,7 @@ class TestLogScalingDiffeo(DiffeoTestCase, metaclass=DataBasedParametrizer):
     _n = random.randint(2, 5)
 
     space = FullRankCorrelationMatrices(n=_n, equip=False)
-    image_space = NullRowSumSymmetricMatrices(n=_n, equip=False)
+    image_space = NullRowSumsSymmetricMatrices(n=_n, equip=False)
     diffeo = LogScalingDiffeo()
     testing_data = DiffeoTestData()
 

--- a/tests/tests_geomstats/test_geometry/test_full_rank_correlation_matrices.py
+++ b/tests/tests_geomstats/test_geometry/test_full_rank_correlation_matrices.py
@@ -7,6 +7,7 @@ from geomstats.geometry.diffeo import ComposedDiffeo
 from geomstats.geometry.full_rank_correlation_matrices import (
     CorrelationMatricesBundle,
     FullRankCorrelationMatrices,
+    LogScaledMetric,
     LogScalingDiffeo,
     OffLogDiffeo,
     OffLogMetric,
@@ -48,6 +49,7 @@ from .data.full_rank_correlation_matrices import (
     CorrelationMatricesBundleTestData,
     FullRankCorrelationAffineQuotientMetricTestData,
     FullRankCorrelationMatricesTestData,
+    LogScaledMetricTestData,
     OffLogMetricTestData,
     PolyHyperbolicCholeskyMetricTestData,
     UniqueDiagonalMatrixAlgorithmTestData,
@@ -257,3 +259,25 @@ class TestLogScalingDiffeo(DiffeoTestCase, metaclass=DataBasedParametrizer):
     image_space = NullRowSumSymmetricMatrices(n=_n, equip=False)
     diffeo = LogScalingDiffeo()
     testing_data = DiffeoTestData()
+
+
+@pytest.fixture(
+    scope="class",
+    params=[
+        (2, (0.0, 0.0, 1.0)),
+        (3, (0.0, 1.0, 1.0)),
+        (random.randint(4, 5), (1.0, 1.0, 1.0)),
+    ],
+)
+def equipped_cor_with_log_scaled_metric(request):
+    n, (alpha, delta, zeta) = request.param
+    request.cls.space = FullRankCorrelationMatrices(n, equip=False).equip_with_metric(
+        LogScaledMetric, alpha=alpha, delta=delta, zeta=zeta
+    )
+
+
+@pytest.mark.usefixtures("equipped_cor_with_log_scaled_metric")
+class TestLogScaledMetric(
+    PullbackDiffeoMetricTestCase, metaclass=DataBasedParametrizer
+):
+    testing_data = LogScaledMetricTestData()

--- a/tests/tests_geomstats/test_geometry/test_symmetric_matrices.py
+++ b/tests/tests_geomstats/test_geometry/test_symmetric_matrices.py
@@ -4,6 +4,7 @@ import pytest
 
 from geomstats.geometry.symmetric_matrices import (
     HollowMatricesPermutationInvariantMetric,
+    NullRowSumSymmetricMatrices,
     SymmetricHollowMatrices,
     SymmetricMatrices,
 )
@@ -18,6 +19,7 @@ from geomstats.test_cases.geometry.matrices import MatricesMetricTestCase
 from .data.matrices import MatricesMetricTestData
 from .data.symmetric_matrices import (
     HollowMatricesPermutationInvariantMetricTestData,
+    NullRowSumSymmetricMatricesTestData,
     SymmetricHollowMatricesTestData,
     SymmetricMatrices1TestData,
     SymmetricMatrices2TestData,
@@ -100,3 +102,14 @@ class TestHollowMatricesPermutationInvariantMetric(
     EuclideanMetricTestCase, metaclass=DataBasedParametrizer
 ):
     testing_data = HollowMatricesPermutationInvariantMetricTestData()
+
+
+class TestNullRowSumSymmetricMatrices(
+    LevelSetTestCase,
+    MatrixVectorSpaceTestCase,
+    metaclass=DataBasedParametrizer,
+):
+    _n = random.randint(2, 6)
+    space = NullRowSumSymmetricMatrices(n=_n, equip=False)
+
+    testing_data = NullRowSumSymmetricMatricesTestData()

--- a/tests/tests_geomstats/test_geometry/test_symmetric_matrices.py
+++ b/tests/tests_geomstats/test_geometry/test_symmetric_matrices.py
@@ -5,6 +5,7 @@ import pytest
 from geomstats.geometry.symmetric_matrices import (
     ConstantValueRowSumDiffeo,
     HollowMatricesPermutationInvariantMetric,
+    NullRowSumPermutationInvariantMetric,
     NullRowSumSymmetricMatrices,
     SymmetricHollowMatrices,
     SymmetricMatrices,
@@ -22,6 +23,7 @@ from .data.diffeo import DiffeoTestData
 from .data.matrices import MatricesMetricTestData
 from .data.symmetric_matrices import (
     HollowMatricesPermutationInvariantMetricTestData,
+    NullRowSumPermutationInvariantMetricTestData,
     NullRowSumSymmetricMatricesTestData,
     SymmetricHollowMatricesTestData,
     SymmetricMatrices1TestData,
@@ -124,3 +126,25 @@ class TestNullRowSumDiffeo(DiffeoTestCase, metaclass=DataBasedParametrizer):
     image_space = SymmetricMatrices(n=_n - 1, equip=False)
     diffeo = ConstantValueRowSumDiffeo()
     testing_data = DiffeoTestData()
+
+
+@pytest.fixture(
+    scope="class",
+    params=[
+        (2, (0.0, 0.0, 1.0)),
+        (3, (0.0, 1.0, 1.0)),
+        (random.randint(4, 6), (1.0, 1.0, 1.0)),
+    ],
+)
+def equipped_null_row_sums_matrices(request):
+    n, (alpha, delta, zeta) = request.param
+    request.cls.space = NullRowSumSymmetricMatrices(n, equip=False).equip_with_metric(
+        NullRowSumPermutationInvariantMetric, alpha=alpha, delta=delta, zeta=zeta
+    )
+
+
+@pytest.mark.usefixtures("equipped_null_row_sums_matrices")
+class TestNullRowSumPermutationInvariantMetric(
+    EuclideanMetricTestCase, metaclass=DataBasedParametrizer
+):
+    testing_data = NullRowSumPermutationInvariantMetricTestData()

--- a/tests/tests_geomstats/test_geometry/test_symmetric_matrices.py
+++ b/tests/tests_geomstats/test_geometry/test_symmetric_matrices.py
@@ -4,6 +4,7 @@ import pytest
 
 from geomstats.geometry.symmetric_matrices import (
     HollowMatricesPermutationInvariantMetric,
+    NullRowSumDiffeo,
     NullRowSumSymmetricMatrices,
     SymmetricHollowMatrices,
     SymmetricMatrices,
@@ -13,9 +14,11 @@ from geomstats.test_cases.geometry.base import (
     LevelSetTestCase,
     MatrixVectorSpaceTestCase,
 )
+from geomstats.test_cases.geometry.diffeo import DiffeoTestCase
 from geomstats.test_cases.geometry.euclidean import EuclideanMetricTestCase
 from geomstats.test_cases.geometry.matrices import MatricesMetricTestCase
 
+from .data.diffeo import DiffeoTestData
 from .data.matrices import MatricesMetricTestData
 from .data.symmetric_matrices import (
     HollowMatricesPermutationInvariantMetricTestData,
@@ -113,3 +116,11 @@ class TestNullRowSumSymmetricMatrices(
     space = NullRowSumSymmetricMatrices(n=_n, equip=False)
 
     testing_data = NullRowSumSymmetricMatricesTestData()
+
+
+class TestNullRowSumDiffeo(DiffeoTestCase, metaclass=DataBasedParametrizer):
+    _n = random.randint(2, 5)
+    space = NullRowSumSymmetricMatrices(n=_n, equip=False)
+    image_space = SymmetricMatrices(n=_n - 1, equip=False)
+    diffeo = NullRowSumDiffeo()
+    testing_data = DiffeoTestData()

--- a/tests/tests_geomstats/test_geometry/test_symmetric_matrices.py
+++ b/tests/tests_geomstats/test_geometry/test_symmetric_matrices.py
@@ -3,8 +3,8 @@ import random
 import pytest
 
 from geomstats.geometry.symmetric_matrices import (
+    ConstantValueRowSumDiffeo,
     HollowMatricesPermutationInvariantMetric,
-    NullRowSumDiffeo,
     NullRowSumSymmetricMatrices,
     SymmetricHollowMatrices,
     SymmetricMatrices,
@@ -112,15 +112,15 @@ class TestNullRowSumSymmetricMatrices(
     MatrixVectorSpaceTestCase,
     metaclass=DataBasedParametrizer,
 ):
-    _n = random.randint(2, 6)
+    _n = random.randint(3, 6)
     space = NullRowSumSymmetricMatrices(n=_n, equip=False)
 
     testing_data = NullRowSumSymmetricMatricesTestData()
 
 
 class TestNullRowSumDiffeo(DiffeoTestCase, metaclass=DataBasedParametrizer):
-    _n = random.randint(2, 5)
+    _n = random.randint(3, 6)
     space = NullRowSumSymmetricMatrices(n=_n, equip=False)
     image_space = SymmetricMatrices(n=_n - 1, equip=False)
-    diffeo = NullRowSumDiffeo()
+    diffeo = ConstantValueRowSumDiffeo()
     testing_data = DiffeoTestData()

--- a/tests/tests_geomstats/test_geometry/test_symmetric_matrices.py
+++ b/tests/tests_geomstats/test_geometry/test_symmetric_matrices.py
@@ -3,10 +3,10 @@ import random
 import pytest
 
 from geomstats.geometry.symmetric_matrices import (
-    ConstantValueRowSumDiffeo,
+    ConstantValueRowSumsDiffeo,
     HollowMatricesPermutationInvariantMetric,
-    NullRowSumPermutationInvariantMetric,
-    NullRowSumSymmetricMatrices,
+    NullRowSumsPermutationInvariantMetric,
+    NullRowSumsSymmetricMatrices,
     SymmetricHollowMatrices,
     SymmetricMatrices,
 )
@@ -23,8 +23,8 @@ from .data.diffeo import DiffeoTestData
 from .data.matrices import MatricesMetricTestData
 from .data.symmetric_matrices import (
     HollowMatricesPermutationInvariantMetricTestData,
-    NullRowSumPermutationInvariantMetricTestData,
-    NullRowSumSymmetricMatricesTestData,
+    NullRowSumsPermutationInvariantMetricTestData,
+    NullRowSumsSymmetricMatricesTestData,
     SymmetricHollowMatricesTestData,
     SymmetricMatrices1TestData,
     SymmetricMatrices2TestData,
@@ -115,16 +115,16 @@ class TestNullRowSumSymmetricMatrices(
     metaclass=DataBasedParametrizer,
 ):
     _n = random.randint(3, 6)
-    space = NullRowSumSymmetricMatrices(n=_n, equip=False)
+    space = NullRowSumsSymmetricMatrices(n=_n, equip=False)
 
-    testing_data = NullRowSumSymmetricMatricesTestData()
+    testing_data = NullRowSumsSymmetricMatricesTestData()
 
 
-class TestNullRowSumDiffeo(DiffeoTestCase, metaclass=DataBasedParametrizer):
+class TestNullRowSumsDiffeo(DiffeoTestCase, metaclass=DataBasedParametrizer):
     _n = random.randint(3, 6)
-    space = NullRowSumSymmetricMatrices(n=_n, equip=False)
+    space = NullRowSumsSymmetricMatrices(n=_n, equip=False)
     image_space = SymmetricMatrices(n=_n - 1, equip=False)
-    diffeo = ConstantValueRowSumDiffeo()
+    diffeo = ConstantValueRowSumsDiffeo()
     testing_data = DiffeoTestData()
 
 
@@ -138,13 +138,13 @@ class TestNullRowSumDiffeo(DiffeoTestCase, metaclass=DataBasedParametrizer):
 )
 def equipped_null_row_sums_matrices(request):
     n, (alpha, delta, zeta) = request.param
-    request.cls.space = NullRowSumSymmetricMatrices(n, equip=False).equip_with_metric(
-        NullRowSumPermutationInvariantMetric, alpha=alpha, delta=delta, zeta=zeta
+    request.cls.space = NullRowSumsSymmetricMatrices(n, equip=False).equip_with_metric(
+        NullRowSumsPermutationInvariantMetric, alpha=alpha, delta=delta, zeta=zeta
     )
 
 
 @pytest.mark.usefixtures("equipped_null_row_sums_matrices")
-class TestNullRowSumPermutationInvariantMetric(
+class TestNullRowSumsPermutationInvariantMetric(
     EuclideanMetricTestCase, metaclass=DataBasedParametrizer
 ):
-    testing_data = NullRowSumPermutationInvariantMetricTestData()
+    testing_data = NullRowSumsPermutationInvariantMetricTestData()


### PR DESCRIPTION
This PR implements the log scaled metrics on full-rank correlation matrices (see "[Permutation-invariant log-Euclidean geometries on full-rank correlation matrices](https://hal.science/hal-03878729)").

To accomplish the goal, other spaces, metrics, and diffeos are created: 

* diffeos: `LogScalingDiffeo`, `ConstantValueRowSumDiffeo`

* spaces: `NullRowSumsSymmetricMatrices`

* abstract spaces: `DiffeomorphicVectorSpace`, `DiffeomorphicMatrixVectorSpace`

* metrics: `LogScaledMetric`, `NullRowSumsPermutationInvariantMetric`


`projection` is also moved to `Manifold` to avoid inheritance problems.


Done in collaboration with @olivierbisson.