### PR TITLE
Update notebook running on tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,12 +5,10 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "geomstats"
 dynamic = ["version"]
-authors = [
-    {name = "Nina Miolane", email = "nmiolane@gmail.com"}
-]
+authors = [{ name = "Nina Miolane", email = "nmiolane@gmail.com" }]
 readme = "README.rst"
 description = "Geometric statistics on manifolds"
-license = {file = "LICENSE.md"}
+license = { file = "LICENSE.md" }
 classifiers = [
     "License :: OSI Approved :: MIT License",
     "Development Status :: 5 - Production/Stable",
@@ -22,10 +20,10 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11"
+    "Programming Language :: Python :: 3.11",
 ]
 requires-python = ">= 3.8"
-dependencies=[
+dependencies = [
     "joblib >= 0.17.0",
     "matplotlib >= 3.3.4",
     "numpy >= 1.18.1",
@@ -41,7 +39,7 @@ doc = [
     "nbsphinx_link",
     "sphinx",
     "sphinx_gallery",
-    "pydata-sphinx-theme"
+    "pydata-sphinx-theme",
 ]
 lint = [
     "black",
@@ -49,14 +47,9 @@ lint = [
     "flake8-docstrings",
     "Flake8-pyproject",
     "isort",
-    "pre-commit"
+    "pre-commit",
 ]
-test = [
-    "pytest",
-    "pytest-cov",
-    "coverage",
-    "jupyter"
-]
+test = ["pytest", "pytest-cov", "coverage", "jupyter", "ipython < 8.23"]
 graph = ["networkx"]
 autograd = ["autograd >= 1.3"]
 pytorch = ["torch >= 1.9.1"]
@@ -66,18 +59,15 @@ dev = ["geomstats[test, lint, doc]"]
 all = ["geomstats[dev, opt, backends]"]
 
 [project.urls]
-homepage="http://github.com/geomstats/geomstats"
-documentation="https://geomstats.github.io/"
-repository="http://github.com/geomstats/geomstats"
+homepage = "http://github.com/geomstats/geomstats"
+documentation = "https://geomstats.github.io/"
+repository = "http://github.com/geomstats/geomstats"
 
 [tool.setuptools.dynamic]
-version = {attr = "geomstats.__version__"}
+version = { attr = "geomstats.__version__" }
 
 [tool.setuptools.packages.find]
-include = [
-    "geomstats",
-    "geomstats.*"
-]
+include = ["geomstats", "geomstats.*"]
 
 [tool.setuptools.package-data]
 "*" = ["datasets/data/**/*"]
@@ -93,17 +83,14 @@ markers = [
     "type: checks output types.",
     "mathprop: mathematical properties tests.",
     "slow: for slow tests.",
-    "redundant: redundant test."
+    "redundant: redundant test.",
 ]
 
 [tool.flake8]
 application_import_names = "geomstats"
 docstring-convention = "numpy"
 exclude = "examples/*.ipynb"
-ignore = [
-    "W503",
-    "W504"
-]
+ignore = ["W503", "W504"]
 import_order_style = "smarkets"
 max-line-length = 88
 extend-ignore = "E203"
@@ -119,5 +106,5 @@ per-file-ignores = [
     "tests/*: D100, D101, D102, D103, D106, D200, D201, D205, D400, D404, I100, I101, I201, I202, E501, E731",
     "tests/conftest.py: D100, F401",
     "*/__init__.py: D104",
-    "geomstats/test*/*: D100, D101, D102, D103, D104, E501"
+    "geomstats/test*/*: D100, D101, D102, D103, D104, E501",
 ]


### PR DESCRIPTION
This PR updates strategy for running notebooks in tests to use `nbconvert` as a library instead of as a cli tool. It started as an attempt to solve  an error that started happening today in our CI (later discovered to be due to latest release of [ipython](https://github.com/ipython/ipython) ([8.23.0](https://pypi.org/project/ipython/8.23.0/))) .