### PR TITLE
Clean discrete surfaces elastic metric

### DIFF
--- a/geomstats/geometry/discrete_surfaces.py
+++ b/geomstats/geometry/discrete_surfaces.py
@@ -785,7 +785,7 @@ class ElasticMetric(RiemannianMetric):
                 laplacian_at_base_point(tangent_vec_a),
                 laplacian_at_base_point(tangent_vec_b),
             )
-            * vertex_areas_bp,
+            / vertex_areas_bp,
             axis=-1,
         )
 

--- a/geomstats/test_cases/geometry/discrete_surfaces.py
+++ b/geomstats/test_cases/geometry/discrete_surfaces.py
@@ -1,3 +1,5 @@
+import math
+
 import geomstats.backend as gs
 from geomstats.test.random import RandomDataGenerator
 from geomstats.test_cases.geometry.manifold import ManifoldTestCase
@@ -15,11 +17,16 @@ class SurfacesLocalRandomDataGenerator(RandomDataGenerator):
 
         batch_shape = () if n_points == 1 else (n_points,)
 
+        rand_shape = batch_shape + (dof, dim)
+
         return (
             gs.concatenate(
                 [
                     gs.zeros(batch_shape + (1, dim)),
-                    gs.random.rand(batch_shape + (dof, dim)),
+                    gs.reshape(
+                        gs.random.rand(math.prod(rand_shape)),
+                        rand_shape,
+                    ),
                 ],
                 axis=-2,
             )


### PR DESCRIPTION
This PR cleans the discrete surfaces elastic metric:

* einsums are replaced by proper backend functions

* docstrings are fixed and simplified

* default solvers are only instantiated if an autodiff-based backend is used (this way we can compute inner products with numpy)

* a potential bug is solved in `_inner_prod_a2` (@emmanuel-hartman, could you please confirm we should multiply by vertex areas instead of divide? this comes from the original implementation) 