### PR TITLE
Update SPDBuresWassersteinMetric.squared_dist to fix numerical stability issues

### DIFF
--- a/geomstats/geometry/spd_matrices.py
+++ b/geomstats/geometry/spd_matrices.py
@@ -835,12 +835,12 @@ class SPDBuresWassersteinMetric(RiemannianMetric):
             Riemannian squared distance.
         """
         La, Qa = gs.linalg.eigh(point_a)
-        point_a_sqrt = Qx @ gs.diag(gs.sqrt(Lx*(Lx>0))) @ Qx.T
+        point_a_sqrt = Qa @ gs.diag(gs.sqrt(La*(La>0))) @ Qa.T
     
         Lc,Qc = gs.linalg.eigh(point_a_sqrt@point_b@point_a_sqrt)
         cross_term = Qc @ gs.diag(gs.sqrt((Lc*(Lc>0)))) @ Qc.T
     
-        return np.trace(point_a + point_b - 2*cross_term)
+        return gs.trace(point_a + point_b - 2*cross_term)
 
     def parallel_transport(
         self,

--- a/geomstats/geometry/spd_matrices.py
+++ b/geomstats/geometry/spd_matrices.py
@@ -834,15 +834,13 @@ class SPDBuresWassersteinMetric(RiemannianMetric):
         squared_dist : array-like, shape=[...]
             Riemannian squared distance.
         """
-        product = gs.matmul(point_a, point_b)
-        sqrt_product = gs.linalg.sqrtm(product)
-        trace_a = gs.trace(point_a)
-        trace_b = gs.trace(point_b)
-        trace_prod = gs.trace(sqrt_product)
-
-        squared_dist = trace_a + trace_b - 2.0 * trace_prod
-
-        return gs.where(squared_dist < 0.0, 0.0, squared_dist)
+        La, Qa = gs.linalg.eigh(point_a)
+        point_a_sqrt = Qx @ gs.diag(gs.sqrt(Lx*(Lx>0))) @ Qx.T
+    
+        Lc,Qc = gs.linalg.eigh(point_a_sqrt@point_b@point_a_sqrt)
+        cross_term = Qc @ gs.diag(gs.sqrt((Lc*(Lc>0)))) @ Qc.T
+    
+        return np.trace(point_a + point_b - 2*cross_term)
 
     def parallel_transport(
         self,

--- a/tests/tests_geomstats/test_geometry/data/spd_matrices.py
+++ b/tests/tests_geomstats/test_geometry/data/spd_matrices.py
@@ -316,17 +316,6 @@ class SPDBuresWassersteinMetricTestData(RiemannianMetricTestData):
     fail_for_autodiff_exceptions = False
     fail_for_not_implemented_errors = False
 
-    tolerances = {
-        "dist_point_to_itself_is_zero": {"atol": 1e-6},
-    }
-
-    skips = (
-        "parallel_transport_bvp_transported_is_tangent",
-        "parallel_transport_ivp_transported_is_tangent",
-        "parallel_transport_bvp_vec",
-        "parallel_transport_ivp_vec",
-    )
-
 
 class SPD2BuresWassersteinMetricTestData(TestData):
     def exp_test_data(self):


### PR DESCRIPTION
<!--
Thank you for opening this pull request!
-->

## Checklist

- [ ] My pull request has a clear and explanatory title.
- [ ] If necessary, my code is [vectorized](https://www.geeksforgeeks.org/vectorization-in-python/).
- [ ] I added appropriate unit tests.
- [ ] I made sure the code passes all unit tests. (refer to comment below)
- [ ] My PR follows [PEP8](https://peps.python.org/pep-0008/) guidelines. (refer to comment below)
- [ ] My PR follows [geomstats coding style](https://github.com/geomstats/geomstats/blob/main/docs/contributing.rst#coding-style-guidelines) and API.
- [ ] My code is properly documented and I made sure the documentation renders properly. ([Link](https://github.com/geomstats/geomstats/blob/main/docs/contributing.rst#documentation))
- [ ] I linked to issues and PRs that are relevant to this PR.


<!-- For checking consistency of entire codebase
First, run the tests related to your changes. For example, if you changed something in geomstats/spd_matrices_space.py:
$ pytest tests/tests_geomstats/test_spd_matrices.py

and then run the tests of the whole codebase to check that your feature is not breaking any of them:
$ pytest tests/

This way, further modifications on the code base are guaranteed to be consistent with the desired behavior. Merging your PR should not break any test in any backend (numpy, tensorflow or pytorch)."

For testing in alternative backends such as `numpy`, `pytorch`, `autograd`, `tensorflow` set the environment variable using:
$ export GEOMSTATS_BACKEND=<backend_name>

Next, import the `backend` module using:
import geomstats.backend as gs
-->


<!-- For flake8 tests
Install dependencies
$ pip3 install -r dev-requirements.txt

Then run the following commands:
$ flake8 --ignore=D,W503,W504 geomstats examples tests   #shadows .flake8
$ flake8 geomstats/geometry geomstats/learning           #passed two subfolders
-->

## Description

This is a response to [Bug: Error due to complex number distance in Bures-Wasserstein metric, using pytorch backend #1882 ](https://github.com/geomstats/geomstats/issues/1882) (closes #1882)

I've been working with Bures-Wasserstein for spd matrices. The issue is the result of the sqrtm function being used. The solution I have found is to use the fact that spd matrices are orthogonally diagonalizble (due to being symmetric) and full rank (due to positive definite) to calculate square roots via diagonalization. This both fixes the issue of imaginary outputs (even for matrices with spd.belongs(sigma)==True -- see Bures_distance_check), and increases the speed. I also have a torch implementation that allows for batch computation on the gpu (of space.metric.dist_pairwise), which greatly speeds up the computation, though it is not backend agnostic.

To be clear, this only works for spd-matrices. Bures-Wasserstein is technically a distance for symmetric positve semidefinite matrices. So, my approach is not actually valid for the Bures metric in general, but is correct (as far as I know) as the Riemannian metric for spd's.

## Issue

sqrtm in Bures-Wasserstein metric for spd's sometimes returns imaginary numbers

I wrote this code months ago, now that I'm looking at it again I think the 

gs.sqrt(Lx*(Lx>0))

might actually be intended to work for non-spd matrices.. so this might not be completely correct...

## Additional context

I'm not really sure how to make a pull request. 

# Reproducible example:

import numpy as np
import geomstats
from geomstats.geometry.spd_matrices import SPDMatrices, SPDBuresWassersteinMetric

spd = SPDMatrices(3)
spd.equip_with_metric(SPDBuresWassersteinMetric)

X = np.random.randn(3,1)
Sigma_x = X@X.T

Y = np.random.randn(3,1)
Sigma_y = Y@Y.T

#matrices not spd - should return false
print(spd.belongs(Sigma_x))
print(spd.belongs(Sigma_y))

Sigma_x_star = spd.projection(Sigma_x)
Sigma_y_star = spd.projection(Sigma_y)

#should return True
print(spd.belongs(Sigma_x_star))
print(spd.belongs(Sigma_y_star))

#will sometimes return imaginary numbers due to sqrtm
spd.metric.dist(Sigma_x_star, Sigma_y_star)


# Solutions:
Accuracy check: https://github.com/mwilson221/dtmrpy/blob/main/Bures_distance_check.ipynb
Speed check: https://github.com/mwilson221/dtmrpy/blob/main/Bures_distance_speed_check.ipynb

Thanks

