### PR TITLE
Correct number of samples for `VectorSpace.random_tangent_vec`

### DIFF
--- a/geomstats/geometry/base.py
+++ b/geomstats/geometry/base.py
@@ -125,8 +125,9 @@ class VectorSpace(Manifold, abc.ABC):
     def random_tangent_vec(self, base_point=None, n_samples=1):
         """Generate random tangent vec.
 
-        This method is not recommended for statistical purposes, as the tangent vectors generated are not
-        drawn from a distribution related to the Riemannian metric.
+        This method is not recommended for statistical purposes, as the
+        tangent vectors generated are not drawn from a distribution related
+        to the Riemannian metric.
 
         Parameters
         ----------
@@ -141,22 +142,20 @@ class VectorSpace(Manifold, abc.ABC):
         tangent_vec : array-like, shape=[..., *point_shape]
             Tangent vec at base point.
         """
+        if base_point is None:
+            return self.random_point(n_samples)
+
         if (
             n_samples > 1
-            and base_point is not None
-            and base_point.ndim > len(self.shape)
-            and n_samples != len(base_point)
+            and base_point.ndim > self.point_ndim
+            and n_samples != base_point.shape[0]
         ):
             raise ValueError(
                 "The number of base points must be the same as the "
                 "number of samples, when the number of base points is different from 1."
             )
-        if (
-            n_samples == 1
-            and base_point is not None
-            and base_point.ndim > len(self.shape)
-        ):
-            n_samples = len(base_point)
+        if n_samples == 1 and base_point.ndim > self.point_ndim:
+            n_samples = base_point.shape[0]
         return self.random_point(n_samples)
 
     @property

--- a/geomstats/geometry/base.py
+++ b/geomstats/geometry/base.py
@@ -148,8 +148,14 @@ class VectorSpace(Manifold, abc.ABC):
                 "The number of base points must be the same as the "
                 "number of samples, when the number of base points is different from 1."
             )
-        n_samples = base_point.shape[0] if base_point.ndim > len(self.shape) else 1
+        if (
+            n_samples == 1
+            and base_point is not None
+            and base_point.ndim > len(self.shape)
+        ):
+            n_samples = len(base_point)
         return self.random_point(n_samples)
+
 
     @property
     def basis(self):

--- a/geomstats/geometry/base.py
+++ b/geomstats/geometry/base.py
@@ -125,6 +125,9 @@ class VectorSpace(Manifold, abc.ABC):
     def random_tangent_vec(self, base_point=None, n_samples=1):
         """Generate random tangent vec.
 
+        This method is not recommended for statistical purposes, as the tangent vectors generated are not
+        drawn from a distribution related to the Riemannian metric.
+
         Parameters
         ----------
         n_samples : int

--- a/geomstats/geometry/base.py
+++ b/geomstats/geometry/base.py
@@ -156,7 +156,6 @@ class VectorSpace(Manifold, abc.ABC):
             n_samples = len(base_point)
         return self.random_point(n_samples)
 
-
     @property
     def basis(self):
         """Basis of the vector space."""

--- a/geomstats/geometry/manifold.py
+++ b/geomstats/geometry/manifold.py
@@ -215,8 +215,9 @@ class Manifold(abc.ABC):
     def random_tangent_vec(self, base_point=None, n_samples=1):
         """Generate random tangent vec.
 
-        This method is not recommended for statistical purposes, as the tangent vectors generated are not
-        drawn from a distribution related to the Riemannian metric.
+        This method is not recommended for statistical purposes,
+        as the tangent vectors generated are not drawn from a
+        distribution related to the Riemannian metric.
 
         Parameters
         ----------

--- a/geomstats/geometry/manifold.py
+++ b/geomstats/geometry/manifold.py
@@ -215,6 +215,9 @@ class Manifold(abc.ABC):
     def random_tangent_vec(self, base_point=None, n_samples=1):
         """Generate random tangent vec.
 
+        This method is not recommended for statistical purposes, as the tangent vectors generated are not
+        drawn from a distribution related to the Riemannian metric.
+
         Parameters
         ----------
         n_samples : int


### PR DESCRIPTION
## Description

When there are multiple basepoints, both implementations of `random_tangent_vec` (the implementations in `manifold.py` and `base.py`) should now check that `n_samples` matches the number of basepoints. If the values do not match, then in case `n_samples == 1` (default option), it resets it to be equal to the number of basepoints. Otherwise an error is raised.

Docstrings have been updated to clarify that the vectors generated have no statistical value.

## Issue

Fixes #1989 insofar as the bug is no longer present. The reference to uniformity of direction understated the difficulty of that problem, so it should probably be ignored.