### PR TITLE
Add horizontal projection from alignment

### DIFF
--- a/geomstats/geometry/discrete_curves.py
+++ b/geomstats/geometry/discrete_curves.py
@@ -1716,24 +1716,6 @@ class SRVReparametrizationBundle(FiberBundle):
 
         return tangent_vec_ver
 
-    def horizontal_projection(self, tangent_vec, base_point):
-        """Compute horizontal part of tangent vector at base point.
-
-        Parameters
-        ----------
-        tangent_vec : array-like, shape=[..., k_sampling_points, ambient_dim]
-            Tangent vector to decompose into horizontal and vertical parts.
-        base_point : array-like, shape=[..., k_sampling_points, ambient_dim]
-            Discrete curve, base point of tangent_vec in the manifold of curves.
-
-        Returns
-        -------
-        tangent_vec_hor : array-like, shape=[..., k_sampling_points, ambient_dim]
-            Horizontal part of tangent_vec.
-        """
-        tangent_vec_ver = self.vertical_projection(tangent_vec, base_point)
-        return tangent_vec - tangent_vec_ver
-
 
 class SRVRotationBundle(FiberBundle):
     """Principal bundle of curves modulo rotations with the SRV metric.
@@ -1751,10 +1733,6 @@ class SRVRotationBundle(FiberBundle):
     def _rotate(self, point, rotation):
         """Rotate discrete curve starting at origin."""
         return Matrices.transpose(gs.matmul(rotation, Matrices.transpose(point)))
-
-    def horizontal_projection(self, tangent_vec, base_point):
-        """Project to horizontal subspace."""
-        raise NotImplementedError("Horizontal projection is not implemented.")
 
     def align(self, point, base_point, return_rotation=False):
         """Align point to base point.
@@ -1841,10 +1819,6 @@ class SRVRotationReparametrizationBundle(FiberBundle):
         space.equip_with_group_action("reparametrizations")
         space.fiber_bundle = SRVReparametrizationBundle(space)
         return space
-
-    def horizontal_projection(self, tangent_vec, base_point):
-        """Project to horizontal subspace."""
-        raise NotImplementedError("Horizontal projection is not implemented.")
 
     def align_rotation(self, point, base_point, return_rotation=False):
         """Find optimal rotation of curve with respect to base curve.

--- a/geomstats/geometry/fiber_bundle.py
+++ b/geomstats/geometry/fiber_bundle.py
@@ -228,11 +228,6 @@ class FiberBundle(ABC):
         projection: array-like, shape=[..., {base_dim, [n, m]}]
             Tangent vector to the base manifold.
         """
-        if hasattr(self.horizontal_projection, "_from_base"):
-            raise NotImplementedError(
-                "Tangent Riemannian submersion is not implemented."
-            )
-
         return self.horizontal_projection(tangent_vec, base_point)
 
     def align(self, point, base_point):
@@ -312,9 +307,6 @@ class FiberBundle(ABC):
         vertical : array-like, shape=[..., {total_space.dim, [n, m]}]
             Vertical component of `tangent_vec`.
         """
-        if hasattr(self.horizontal_projection, "_from_base"):
-            raise NotImplementedError("Vertical projection is not implemented.")
-
         return tangent_vec - self.horizontal_projection(tangent_vec, base_point)
 
     def is_horizontal(self, tangent_vec, base_point, atol=gs.atol):
@@ -400,9 +392,6 @@ class FiberBundle(ABC):
         horizontal_lift : array-like, shape=[..., {total_space.dim, [n, m]}]
             Horizontal tangent vector to the total space at point.
         """
-        if hasattr(self.horizontal_projection, "_from_base"):
-            raise NotImplementedError("Horizontal lift is not implemented.")
-
         if base_point is None and fiber_point is None:
             raise ValueError(
                 "Either a point (of the total space) or a "

--- a/geomstats/geometry/fiber_bundle.py
+++ b/geomstats/geometry/fiber_bundle.py
@@ -259,8 +259,10 @@ class FiberBundle(ABC):
         r"""Project to horizontal subspace.
 
         Compute the horizontal component of a tangent vector at a
-        base point by removing the vertical component,
-        or by computing a horizontal lift of the tangent projection.
+        base point from:
+            1. the vertical projection
+            2. the horizontal lift of the tangent submersion
+            3. the align method
 
         Parameters
         ----------


### PR DESCRIPTION
This PR adds the possibility of obtaining the horizontal projection of a tangent vector from the alignment method.

Assuming `horizontal_projection` is not overriden, this method tries to obtain the horizontal projection from:

1) the vertical projection

2) the horizontal lift of the tangent submersion

3) (new) the alignment method


These different possibilities come from the fact that different methods are easier to define in certain bundles.

This is motivated by the `SRVRotationBundle`, where `align` is straighforward (and we didn't have an implementation for horizontal projection; now we use the generic one).