### PR TITLE
Fix + add argument to pad for pytorch backend

### DIFF
--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -747,9 +747,9 @@ def _unnest_iterable(ls):
     return out
 
 
-def pad(a, pad_width, constant_value=0.0):
+def pad(a, pad_width, mode="constant", constant_values=0.0):
     return _torch.nn.functional.pad(
-        a, _unnest_iterable(reversed(pad_width)), value=constant_value
+        a, _unnest_iterable(reversed(pad_width)), mode=mode, value=constant_values
     )
 
 


### PR DESCRIPTION
<!--
Thank you for opening this pull request!
-->

## Checklist

- [X] My pull request has a clear and explanatory title.
- [X] If necessary, my code is [vectorized](https://www.geeksforgeeks.org/vectorization-in-python/).
- [ ] I added appropriate unit tests.
- [ ] I made sure the code passes all unit tests. **No, but I'm not sure if that might be some random failure?**
- [X] My PR follows [PEP8](https://peps.python.org/pep-0008/) guidelines. (refer to comment below)
- [X] My PR follows [geomstats coding style](https://github.com/geomstats/geomstats/blob/main/docs/contributing.rst#coding-style-guidelines) and API.
- [ ] My code is properly documented and I made sure the documentation renders properly. ([Link](https://github.com/geomstats/geomstats/blob/main/docs/contributing.rst#documentation))
- [ ] I linked to issues and PRs that are relevant to this PR.


<!-- For checking consistency of entire codebase
First, run the tests related to your changes. For example, if you changed something in geomstats/spd_matrices_space.py:
$ pytest tests/tests_geomstats/test_spd_matrices.py

and then run the tests of the whole codebase to check that your feature is not breaking any of them:
$ pytest tests/

This way, further modifications on the code base are guaranteed to be consistent with the desired behavior. Merging your PR should not break any test in any backend (numpy, tensorflow or pytorch)."

For testing in alternative backends such as `numpy`, `pytorch`, `autograd`, `tensorflow` set the environment variable using:
$ export GEOMSTATS_BACKEND=<backend_name>

Next, import the `backend` module using:
import geomstats.backend as gs
-->


<!-- For flake8 tests
Install dependencies
$ pip3 install -r dev-requirements.txt

Then run the following commands:
$ flake8 --ignore=D,W503,W504 geomstats examples tests   #shadows .flake8
$ flake8 geomstats/geometry geomstats/learning           #passed two subfolders
-->

## Description

<!-- Include a description of your pull request. If relevant, feel free to use this space to talk about time and space complexity as well scalability of your code-->

In the pytroch backend, the argument used for padding values was "constant_value". However, the naming in jax and numpy is constant_value**s**. See https://numpy.org/doc/stable/reference/generated/numpy.pad.html
and https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.pad.html. I also added passing on the "mode" argument, which is supported by pytorch.

## Issue

<!-- Tell us which issue does this PR fix . Why this feature implementation/fix is important in practice ?-->
This patch ensures that passing "constant_values" is compatible with all backends.

## Additional context

<!-- Add any extra information -->
