### PR TITLE
Homogenize use of reparametrization

### DIFF
--- a/geomstats/geometry/discrete_curves.py
+++ b/geomstats/geometry/discrete_curves.py
@@ -1574,10 +1574,10 @@ class DynamicProgrammingAligner(AlignerAlgorithm):
 
 
 class SRVReparametrizationBundle(FiberBundle):
-    """Principal bundle of curves modulo reparameterizations with the SRV metric.
+    """Principal bundle of curves modulo reparametrizations with the SRV metric.
 
     The space of parameterized curves is the total space of a principal bundle
-    where the group action is given by reparameterization and the base space is
+    where the group action is given by reparametrization and the base space is
     the shape space of curves modulo reparametrization, i.e.unparametrized
     curves. In the discrete case, reparametrization corresponds to resampling.
 

--- a/tests/tests_geomstats/test_geometry/data/discrete_curves.py
+++ b/tests/tests_geomstats/test_geometry/data/discrete_curves.py
@@ -72,7 +72,7 @@ class SRVReparametrizationBundleTestData(FiberBundleTestData):
         return self.generate_random_data()
 
 
-class ReparameterizationAlignerTestData(TestData):
+class ReparametrizationAlignerTestData(TestData):
     N_RANDOM_POINTS = [1]
 
     tolerances = {

--- a/tests/tests_geomstats/test_geometry/test_discrete_curves.py
+++ b/tests/tests_geomstats/test_geometry/test_discrete_curves.py
@@ -43,7 +43,7 @@ from .data.discrete_curves import (
     DiscreteCurvesStartingAtOriginTestData,
     ElasticMetricTestData,
     L2CurvesMetricTestData,
-    ReparameterizationAlignerTestData,
+    ReparametrizationAlignerTestData,
     SRVMetricTestData,
     SRVReparametrizationBundleTestData,
     SRVReparametrizationsQuotientMetricTestData,
@@ -188,7 +188,7 @@ class TestElasticMetric(ElasticMetricTestCase, metaclass=DataBasedParametrizer):
         (random.randint(2, 3), random.choice([5, 7, 9])),
     ],
 )
-def srv_reparameterization_bundles(request):
+def srv_reparametrization_bundles(request):
     ambient_dim, k_sampling_points = request.param
 
     total_space = request.cls.total_space = request.cls.base = (
@@ -201,7 +201,7 @@ def srv_reparameterization_bundles(request):
     )
 
 
-@pytest.mark.usefixtures("srv_reparameterization_bundles")
+@pytest.mark.usefixtures("srv_reparametrization_bundles")
 class TestSRVReparametrizationBundle(
     SRVReparametrizationBundleTestCase, metaclass=DataBasedParametrizer
 ):
@@ -235,8 +235,8 @@ def aligners(request):
 
 
 @pytest.mark.usefixtures("aligners")
-class TestReparameterizationAligner(TestCase, metaclass=DataBasedParametrizer):
-    testing_data = ReparameterizationAlignerTestData()
+class TestReparametrizationAligner(TestCase, metaclass=DataBasedParametrizer):
+    testing_data = ReparametrizationAlignerTestData()
 
     def test_align_in_same_fiber(self, n_points, atol):
         base_point = self.total_space.random_point(n_points)


### PR DESCRIPTION
This PR replaces uses of "reparameterization" by "reparametrization". Though both are valid, the goal is to reduce confusion, as `space.equip_with_group_action("reparametrizations")` expects this exact spelling.