### PR TITLE
Update curves bundles

### DIFF
--- a/geomstats/geometry/discrete_curves.py
+++ b/geomstats/geometry/discrete_curves.py
@@ -1706,11 +1706,11 @@ class ReparametrizationBundle(FiberBundle):
         return tangent_vec_ver
 
 
-class SRVRotationBundle(FiberBundle):
-    """Principal bundle of curves modulo rotations with the SRV metric.
+class RotationBundle(FiberBundle):
+    """Principal bundle of curves modulo rotations with an elastic metric.
 
     This is the fiber bundle where the total space is the space of parameterized
-    curves equipped with the SRV metric, the action is given by rotations, and
+    curves equipped with an elastic metric, the action is given by rotations, and
     the base space is the shape space of curves modulo rotations.
 
     Parameters
@@ -1743,9 +1743,9 @@ class SRVRotationBundle(FiberBundle):
         aligned : array-like, shape=[..., k_sampling_points - 1, ambient_dim
             Curve optimally rotated with respect to reference curve.
         """
-        srv_transform = self._total_space.metric.diffeo
-        initial_srv = srv_transform.diffeomorphism(base_point)
-        end_srv = srv_transform.diffeomorphism(point)
+        transform = self._total_space.metric.diffeo
+        initial_srv = transform.diffeomorphism(base_point)
+        end_srv = transform.diffeomorphism(point)
 
         mat = gs.matmul(Matrices.transpose(initial_srv), end_srv)
         u_svd, _, vt_svd = gs.linalg.svd(mat)
@@ -1764,7 +1764,7 @@ register_quotient(
     Space=DiscreteCurvesStartingAtOrigin,
     Metric=SRVMetric,
     GroupAction="rotations",
-    FiberBundle=SRVRotationBundle,
+    FiberBundle=RotationBundle,
     QuotientMetric=QuotientMetric,
 )
 register_quotient(

--- a/geomstats/geometry/discrete_curves.py
+++ b/geomstats/geometry/discrete_curves.py
@@ -802,6 +802,8 @@ class SRVMetric(PullbackDiffeoMetric):
     """
 
     def __init__(self, space):
+        self.a = 1.0
+        self.b = 1 / 2
         self._check_ambient_manifold(space.ambient_manifold)
 
         image_space = self._instantiate_image_space(space)
@@ -1573,8 +1575,8 @@ class DynamicProgrammingAligner(AlignerAlgorithm):
         return aligned, sdists
 
 
-class SRVReparametrizationBundle(FiberBundle):
-    """Principal bundle of curves modulo reparametrizations with the SRV metric.
+class ReparametrizationBundle(FiberBundle):
+    """Principal bundle of curves modulo reparametrizations with an elastic metric.
 
     The space of parameterized curves is the total space of a principal bundle
     where the group action is given by reparametrization and the base space is
@@ -1631,7 +1633,7 @@ class SRVReparametrizationBundle(FiberBundle):
         """
         ambient_manifold = self._total_space.ambient_manifold
 
-        a_param, b_param = 1, 1 / 2
+        a_param, b_param = self._total_space.metric.a, self._total_space.metric.b
         squotient = (a_param / b_param) ** 2
 
         ndim = self._total_space.point_ndim
@@ -1769,6 +1771,6 @@ register_quotient(
     Space=DiscreteCurvesStartingAtOrigin,
     Metric=SRVMetric,
     GroupAction="reparametrizations",
-    FiberBundle=SRVReparametrizationBundle,
+    FiberBundle=ReparametrizationBundle,
     QuotientMetric=QuotientMetric,
 )

--- a/geomstats/geometry/fiber_bundle.py
+++ b/geomstats/geometry/fiber_bundle.py
@@ -141,7 +141,7 @@ class AlternatingAligner(AlignerAlgorithm):
 
     Assumes total space is equipped with several group actions.
     Aligns points wrt these group actions by alternate minimization
-    wrt each of them (similar approach used in e.g. [JKKS2012]_).
+    wrt each of them (see e.g. [SK2016]_ for more details).
 
     Parameters
     ----------
@@ -157,12 +157,8 @@ class AlternatingAligner(AlignerAlgorithm):
 
     References
     ----------
-    .. [JKKS2012] Ian H. Jermyn, Sebastian Kurtek, Eric Klassen, and Anuj Srivastava.
-        “Elastic Shape Matching of Parameterized Surfaces Using Square Root Normal
-        Fields.” In Computer Vision – ECCV 2012, edited by Andrew Fitzgibbon,
-        Svetlana Lazebnik, Pietro Perona, Yoichi Sato, and Cordelia Schmid,
-        804–17. Lecture Notes in Computer Science. Berlin, Heidelberg: Springer, 2012.
-        https://doi.org/10.1007/978-3-642-33715-4_58.
+    .. [SK2016] Anuj Srivastava, and Eric P. Klassen.
+        Functional and Shape Data Analysis. Springer, 2016.
     """
 
     def __init__(self, total_space, threshold=1e-3, max_iter=20, verbose=0):

--- a/geomstats/test_cases/geometry/discrete_curves.py
+++ b/geomstats/test_cases/geometry/discrete_curves.py
@@ -131,7 +131,7 @@ class DiscreteCurvesStartingAtOriginTestCase(NFoldManifoldTestCase):
         )
 
 
-class SRVReparametrizationBundleTestCase(FiberBundleTestCase):
+class ReparametrizationBundleTestCase(FiberBundleTestCase):
     @pytest.mark.random
     def test_tangent_vector_projections_orthogonality_with_metric(self, n_points, atol):
         """Test horizontal and vertical projections.

--- a/tests/tests_geomstats/test_geometry/data/discrete_curves.py
+++ b/tests/tests_geomstats/test_geometry/data/discrete_curves.py
@@ -83,12 +83,12 @@ class ReparametrizationAlignerTestData(TestData):
         return self.generate_random_data()
 
 
-class SRVRotationBundleTestData(TestData):
+class RotationBundleTestData(TestData):
     def align_test_data(self):
         return self.generate_random_data()
 
 
-class SRVRotationReparametrizationsBundleTestData(TestData):
+class RotationReparametrizationBundleTestData(TestData):
     tolerances = {
         "align": {"atol": 1e-2},
     }
@@ -98,13 +98,13 @@ class SRVRotationReparametrizationsBundleTestData(TestData):
         return self.generate_random_data()
 
 
-class SRVReparametrizationsQuotientMetricTestData(QuotientMetricTestData):
+class ReparametrizationQuotientMetricTestData(QuotientMetricTestData):
     trials = 1
     fail_for_autodiff_exceptions = False
     fail_for_not_implemented_errors = False
 
 
-class SRVRotationsQuotientMetricTestData(QuotientMetricTestData):
+class RotationQuotientMetricTestData(QuotientMetricTestData):
     trials = 1
     fail_for_autodiff_exceptions = False
     fail_for_not_implemented_errors = False
@@ -116,7 +116,7 @@ class SRVRotationsQuotientMetricTestData(QuotientMetricTestData):
     )
 
 
-class SRVRotationsAndReparametrizationsQuotientMetricTestData(QuotientMetricTestData):
+class RotationReparametrizationQuotientMetricTestData(QuotientMetricTestData):
     trials = 1
     fail_for_autodiff_exceptions = False
     fail_for_not_implemented_errors = False

--- a/tests/tests_geomstats/test_geometry/data/discrete_curves.py
+++ b/tests/tests_geomstats/test_geometry/data/discrete_curves.py
@@ -48,7 +48,7 @@ class SRVMetricTestData(PullbackDiffeoMetricTestData):
     fail_for_autodiff_exceptions = False
 
 
-class SRVReparametrizationBundleTestData(FiberBundleTestData):
+class ReparametrizationBundleTestData(FiberBundleTestData):
     fail_for_not_implemented_errors = False
     skip_vec = True
 

--- a/tests/tests_geomstats/test_geometry/test_discrete_curves.py
+++ b/tests/tests_geomstats/test_geometry/test_discrete_curves.py
@@ -11,7 +11,7 @@ from geomstats.geometry.discrete_curves import (
     IterativeHorizontalGeodesicAligner,
     L2CurvesMetric,
     ReparametrizationBundle,
-    SRVRotationBundle,
+    RotationBundle,
     SRVTransform,
 )
 from geomstats.geometry.euclidean import Euclidean
@@ -45,12 +45,12 @@ from .data.discrete_curves import (
     L2CurvesMetricTestData,
     ReparametrizationAlignerTestData,
     ReparametrizationBundleTestData,
+    ReparametrizationQuotientMetricTestData,
+    RotationBundleTestData,
+    RotationQuotientMetricTestData,
+    RotationReparametrizationBundleTestData,
+    RotationReparametrizationQuotientMetricTestData,
     SRVMetricTestData,
-    SRVReparametrizationsQuotientMetricTestData,
-    SRVRotationBundleTestData,
-    SRVRotationReparametrizationsBundleTestData,
-    SRVRotationsAndReparametrizationsQuotientMetricTestData,
-    SRVRotationsQuotientMetricTestData,
 )
 
 
@@ -188,7 +188,7 @@ class TestElasticMetric(ElasticMetricTestCase, metaclass=DataBasedParametrizer):
         (random.randint(2, 3), random.choice([5, 7, 9])),
     ],
 )
-def srv_reparametrization_bundles(request):
+def reparametrization_bundles(request):
     ambient_dim, k_sampling_points = request.param
 
     total_space = request.cls.total_space = request.cls.base = (
@@ -201,7 +201,7 @@ def srv_reparametrization_bundles(request):
     )
 
 
-@pytest.mark.usefixtures("srv_reparametrization_bundles")
+@pytest.mark.usefixtures("reparametrization_bundles")
 class TestReparametrizationBundle(
     ReparametrizationBundleTestCase, metaclass=DataBasedParametrizer
 ):
@@ -252,7 +252,7 @@ class TestReparametrizationAligner(TestCase, metaclass=DataBasedParametrizer):
         self.assertAllClose(aligned_point, base_point, atol=atol)
 
 
-class TestSRVRotationBundle(TestCase, metaclass=DataBasedParametrizer):
+class TestRotationBundle(TestCase, metaclass=DataBasedParametrizer):
     _ambient_dim = random.randint(2, 3)
     _k_sampling_points = random.randint(5, 10)
 
@@ -260,9 +260,9 @@ class TestSRVRotationBundle(TestCase, metaclass=DataBasedParametrizer):
         ambient_dim=_ambient_dim,
         k_sampling_points=_k_sampling_points,
     )
-    bundle = SRVRotationBundle(total_space)
+    bundle = RotationBundle(total_space)
 
-    testing_data = SRVRotationBundleTestData()
+    testing_data = RotationBundleTestData()
 
     def test_align(self, n_points, atol):
         base_point = self.total_space.random_point(n_points)
@@ -283,9 +283,7 @@ class TestSRVRotationBundle(TestCase, metaclass=DataBasedParametrizer):
         self.assertAllClose(aligned_point, base_point, atol=atol)
 
 
-class TestSRVRotationReparametrizationsBundle(
-    TestCase, metaclass=DataBasedParametrizer
-):
+class TestRotationReparametrizationBundle(TestCase, metaclass=DataBasedParametrizer):
     _ambient_dim = random.randint(2, 3)
     _k_sampling_points = random.randint(5, 10)
 
@@ -296,7 +294,7 @@ class TestSRVRotationReparametrizationsBundle(
     total_space.equip_with_group_action(("rotations", "reparametrizations"))
     total_space.equip_with_quotient()
 
-    testing_data = SRVRotationReparametrizationsBundleTestData()
+    testing_data = RotationReparametrizationBundleTestData()
 
     def test_align(self, n_points, atol):
         base_point = self.total_space.random_point(n_points)
@@ -318,7 +316,7 @@ class TestSRVRotationReparametrizationsBundle(
 
 @pytest.mark.redundant
 @pytest.mark.xfail
-class TestSRVReparametrizationsQuotientMetric(
+class TestReparametrizationQuotientMetric(
     QuotientMetricTestCase, metaclass=DataBasedParametrizer
 ):
     _ambient_dim = random.randint(2, 3)
@@ -329,11 +327,11 @@ class TestSRVReparametrizationsQuotientMetric(
 
     space = _total_space.quotient
 
-    testing_data = SRVReparametrizationsQuotientMetricTestData()
+    testing_data = ReparametrizationQuotientMetricTestData()
 
 
 @pytest.mark.redundant
-class TestSRVRotationsQuotientMetric(
+class TestRotationQuotientMetric(
     QuotientMetricTestCase, metaclass=DataBasedParametrizer
 ):
     _ambient_dim = random.randint(2, 3)
@@ -344,11 +342,11 @@ class TestSRVRotationsQuotientMetric(
 
     space = _total_space.quotient
 
-    testing_data = SRVRotationsQuotientMetricTestData()
+    testing_data = RotationQuotientMetricTestData()
 
 
 @pytest.mark.redundant
-class TestSRVRotationsReparametrizationsQuotientMetric(
+class TestRotationReparametrizationQuotientMetric(
     QuotientMetricTestCase, metaclass=DataBasedParametrizer
 ):
     _ambient_dim = random.randint(2, 3)
@@ -359,4 +357,4 @@ class TestSRVRotationsReparametrizationsQuotientMetric(
 
     space = _total_space.quotient
 
-    testing_data = SRVRotationsAndReparametrizationsQuotientMetricTestData()
+    testing_data = RotationReparametrizationQuotientMetricTestData()

--- a/tests/tests_geomstats/test_geometry/test_discrete_curves.py
+++ b/tests/tests_geomstats/test_geometry/test_discrete_curves.py
@@ -10,7 +10,7 @@ from geomstats.geometry.discrete_curves import (
     FTransform,
     IterativeHorizontalGeodesicAligner,
     L2CurvesMetric,
-    SRVReparametrizationBundle,
+    ReparametrizationBundle,
     SRVRotationBundle,
     SRVTransform,
 )
@@ -28,7 +28,7 @@ from geomstats.test_cases.geometry.diffeo import (
 from geomstats.test_cases.geometry.discrete_curves import (
     DiscreteCurvesStartingAtOriginTestCase,
     ElasticMetricTestCase,
-    SRVReparametrizationBundleTestCase,
+    ReparametrizationBundleTestCase,
 )
 from geomstats.test_cases.geometry.nfold_manifold import NFoldMetricTestCase
 from geomstats.test_cases.geometry.pullback_metric import PullbackDiffeoMetricTestCase
@@ -44,8 +44,8 @@ from .data.discrete_curves import (
     ElasticMetricTestData,
     L2CurvesMetricTestData,
     ReparametrizationAlignerTestData,
+    ReparametrizationBundleTestData,
     SRVMetricTestData,
-    SRVReparametrizationBundleTestData,
     SRVReparametrizationsQuotientMetricTestData,
     SRVRotationBundleTestData,
     SRVRotationReparametrizationsBundleTestData,
@@ -194,7 +194,7 @@ def srv_reparametrization_bundles(request):
     total_space = request.cls.total_space = request.cls.base = (
         DiscreteCurvesStartingAtOrigin(ambient_dim, k_sampling_points)
     )
-    total_space.fiber_bundle = SRVReparametrizationBundle(total_space)
+    total_space.fiber_bundle = ReparametrizationBundle(total_space)
 
     request.cls.data_generator = request.cls.base_data_generator = (
         ShapeBundleRandomDataGenerator(total_space)
@@ -202,17 +202,17 @@ def srv_reparametrization_bundles(request):
 
 
 @pytest.mark.usefixtures("srv_reparametrization_bundles")
-class TestSRVReparametrizationBundle(
-    SRVReparametrizationBundleTestCase, metaclass=DataBasedParametrizer
+class TestReparametrizationBundle(
+    ReparametrizationBundleTestCase, metaclass=DataBasedParametrizer
 ):
     ambient_dim = random.randint(2, 3)
     k_sampling_points = random.randint(4, 8)
 
     total_space = base = DiscreteCurvesStartingAtOrigin(ambient_dim, k_sampling_points)
-    total_space.fiber_bundle = SRVReparametrizationBundle(total_space)
+    total_space.fiber_bundle = ReparametrizationBundle(total_space)
 
     data_generator = base_data_generator = ShapeBundleRandomDataGenerator(total_space)
-    testing_data = SRVReparametrizationBundleTestData()
+    testing_data = ReparametrizationBundleTestData()
 
 
 @pytest.fixture(
@@ -231,7 +231,7 @@ def aligners(request):
     )
 
     aligner = Aligner(total_space)
-    total_space.fiber_bundle = SRVReparametrizationBundle(total_space, aligner=aligner)
+    total_space.fiber_bundle = ReparametrizationBundle(total_space, aligner=aligner)
 
 
 @pytest.mark.usefixtures("aligners")


### PR DESCRIPTION
This PR updates SRVReparametrizationBundle to handle any elastic parameter (the code was already prepared for that) and renames it `ReparametrizationBundle`.

@alebrigant, regarding `SRVRotationBundle`, the `SRV` stands for the SRV transformation or for the elastic parameters of  the total space? In other words, if I use different a, b, is the alignment wrt rotations still proper?


EDIT: `SRVRotationBundle` -> `RotationBundle`. It uses the diffeo available in the `PullbackDiffeoMetric` that endows the space.