### PR TITLE
Fix issues with sklearn 1.5.0

### DIFF
--- a/geomstats/learning/aac.py
+++ b/geomstats/learning/aac.py
@@ -10,7 +10,7 @@ from sklearn.base import BaseEstimator
 
 import geomstats.backend as gs
 from geomstats.errors import check_parameter_accepted_values
-from geomstats.learning._sklearn_wrapper import WrappedLinearRegression, WrappedPCA
+from geomstats.learning._sklearn import PCA, LinearRegression
 from geomstats.learning.frechet_mean import FrechetMean
 
 
@@ -205,7 +205,7 @@ class _AACGGPCA(BaseEstimator):
         self.n_components = n_components
         self.save_last_X = save_last_X
 
-        self.total_space_estimator = WrappedPCA(n_components=self.n_components)
+        self.total_space_estimator = PCA(n_components=self.n_components)
         self.n_iter_ = None
         self.aligned_X_ = None
 
@@ -351,7 +351,7 @@ class _AACRegression(BaseEstimator):
         self.save_last_y = save_last_y
 
         self.total_space_estimator_kwargs = total_space_estimator_kwargs or {}
-        self.total_space_estimator = WrappedLinearRegression(
+        self.total_space_estimator = LinearRegression(
             **self.total_space_estimator_kwargs
         )
         self.n_iter_ = None

--- a/geomstats/learning/wrapped_gaussian_process.py
+++ b/geomstats/learning/wrapped_gaussian_process.py
@@ -14,10 +14,11 @@ References
 
 """
 
-from sklearn.base import BaseEstimator, MultiOutputMixin, RegressorMixin
+from sklearn.base import BaseEstimator, MultiOutputMixin
 from sklearn.gaussian_process import GaussianProcessRegressor
 
 import geomstats.backend as gs
+from geomstats.learning._sklearn import RegressorMixin
 
 
 class WrappedGaussianProcess(MultiOutputMixin, RegressorMixin, BaseEstimator):
@@ -165,11 +166,11 @@ class WrappedGaussianProcess(MultiOutputMixin, RegressorMixin, BaseEstimator):
         )
 
         return_multiple = return_tangent_std or return_tangent_cov
-        tangent_means = euc_result[0] if return_multiple else euc_result
+        tangent_means = gs.from_numpy(euc_result[0] if return_multiple else euc_result)
 
         base_points = self.prior(X)
         tangent_means = gs.reshape(
-            gs.from_numpy(tangent_means),
+            tangent_means,
             (X.shape[0], *self.space.shape),
         )
         y_mean = self.space.metric.exp(tangent_means, base_point=base_points)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ import_order_style = "smarkets"
 max-line-length = 88
 extend-ignore = "E203"
 per-file-ignores = [
-    "geomstats/learning/_sklearn_wrapper.py: D101, D102, D105",
+    "geomstats/learning/_sklearn.py: D101, D102, D105",
     "geomstats/*: E731",
     "geomstats/_backend/*:F401, D103",
     "geomstats/numerics/*:D104,E731",


### PR DESCRIPTION
This PR is a quick fix for issues that appear with [sklearn 1.5.0. release](https://pypi.org/project/scikit-learn/1.5.0/) when  using `torch` as backend. `sklearn` now checks the device, in a way that invalidates passing `torch` tensors for some functions. 

For now, a quick and dirty wrapper does the job. We should think about a strategy for the long term though. I believe that changes in `sklearn` can actually benefit us in the long run, but we should confirm where they're aiming towards. 