### PR TITLE
Fix backend import for py312

### DIFF
--- a/geomstats/_backend/__init__.py
+++ b/geomstats/_backend/__init__.py
@@ -215,7 +215,8 @@ class BackendImporter:
     """Importer class to create the backend module."""
 
     def __init__(self, path):
-        self._path = path
+        self._path = self.name = path
+        self.loader = self
 
     @staticmethod
     def _import_backend(backend_name):
@@ -289,6 +290,10 @@ class BackendImporter:
 
         logging.debug(f"geomstats is using {BACKEND_NAME} backend")
         return module
+
+    def find_spec(self, fullname, path=None, target=None):
+        """Find module."""
+        return self.find_module(fullname, path=path)
 
 
 sys.meta_path.append(BackendImporter("geomstats.backend"))


### PR DESCRIPTION
This PR fixes the backend import for Python 3.12 which is not working due to changes on how `sys.meta_path` works (see [docs](https://docs.python.org/3/library/sys.html#sys.meta_path)).

The fix is compatible with previous python versions.

Full tests on correctness of all the code for Python 3.12 haven't been carried out yet.

closes #1951