### PR TITLE
Fix slicing for python backward compatibility (3.10-)

### DIFF
--- a/geomstats/_mesh.py
+++ b/geomstats/_mesh.py
@@ -40,12 +40,12 @@ class Surface:
         face_areas : array-like, shape=[n_faces, 1]
             Face areas.
         """
-        slc = tuple([slice(None)] * len(self.vertices.shape[:-2]))
-        face_coordinates = self.vertices[*slc, self.faces]
+        batch_slc = tuple([slice(None)] * len(self.vertices.shape[:-2]))
+        face_coordinates = self.vertices[batch_slc + (self.faces,)]
         vertex_0, vertex_1, vertex_2 = (
-            face_coordinates[*slc, :, 0],
-            face_coordinates[*slc, :, 1],
-            face_coordinates[*slc, :, 2],
+            face_coordinates[batch_slc + (slice(None), 0)],
+            face_coordinates[batch_slc + (slice(None), 1)],
+            face_coordinates[batch_slc + (slice(None), 2)],
         )
 
         face_centroids = (vertex_0 + vertex_1 + vertex_2) / 3

--- a/geomstats/numerics/geodesic.py
+++ b/geomstats/numerics/geodesic.py
@@ -172,14 +172,14 @@ class ExpODESolver(ExpSolver):
 
     def _simplify_exp_result(self, result):
         y = result.get_last_y()
-        slc = tuple([slice(None)] * self._space.point_ndim)
-        return y[..., 0, *slc]
+        point_ndim_slc = tuple([slice(None)] * self._space.point_ndim)
+        return y[(..., 0) + point_ndim_slc]
 
     def _simplify_result_t(self, result):
         # assumes several t
         y = result.y
-        slc = tuple([slice(None)] * self._space.point_ndim)
-        return y[..., :, 0, *slc]
+        point_ndim_slc = tuple([slice(None)] * self._space.point_ndim)
+        return y[(..., slice(None), 0) + point_ndim_slc]
 
 
 class LogSolver(ABC):
@@ -717,8 +717,8 @@ class PathBasedLogSolver(LogSolver, ABC):
         discr_geod_path = self.discrete_geodesic_bvp(point, base_point)
         point_ndim_slc = (slice(None),) * self._space.point_ndim
         return (self.n_nodes - 1) * (
-            discr_geod_path[..., 1, *point_ndim_slc]
-            - discr_geod_path[..., 0, *point_ndim_slc]
+            discr_geod_path[(..., 1) + point_ndim_slc]
+            - discr_geod_path[(..., 0) + point_ndim_slc]
         )
 
     def geodesic_bvp(self, point, base_point):

--- a/geomstats/numerics/interpolation.py
+++ b/geomstats/numerics/interpolation.py
@@ -100,8 +100,8 @@ class _LinearInterpolator1D(Interpolator, ABC):
         end_index = gs.where(max_bound_reached, interval_index, interval_index + 1)
 
         point_ndim_slc = (slice(None),) * self.point_ndim
-        initial_point = self.data[..., interval_index, *point_ndim_slc]
-        end_point = self.data[..., end_index, *point_ndim_slc]
+        initial_point = self.data[(..., interval_index) + point_ndim_slc]
+        end_point = self.data[(..., end_index) + point_ndim_slc]
 
         ratio = self._get_ratio(t, interval_index, end_index)
 

--- a/geomstats/numerics/path.py
+++ b/geomstats/numerics/path.py
@@ -52,7 +52,7 @@ class UniformlySampledPathEnergy:
         tangent_vecs = forward_difference(path, axis=time_axis)
         return self._space.metric.squared_norm(
             tangent_vecs,
-            path[..., :-1, *point_ndim_slc],
+            path[(..., slice(0, -1)) + point_ndim_slc],
         ) / (2 * (n_time - 1))
 
     def energy(self, path):

--- a/geomstats/test_cases/numerics/interpolation.py
+++ b/geomstats/test_cases/numerics/interpolation.py
@@ -20,7 +20,8 @@ class InterpolatorTestCase(TestCase):
         res = self.interpolator(times)
 
         point_ndim_slc = (slice(None),) * self.interpolator.point_ndim
-        expected = self.data[..., :-1, *point_ndim_slc] + 0.5 * (
-            self.data[..., 1:, *point_ndim_slc] - self.data[..., :-1, *point_ndim_slc]
+        expected = self.data[(..., slice(0, -1)) + point_ndim_slc] + 0.5 * (
+            self.data[(..., slice(1, None)) + point_ndim_slc]
+            - self.data[(..., slice(0, -1)) + point_ndim_slc]
         )
         self.assertAllClose(res, expected, atol=atol)

--- a/tests/tests_geomstats/test_numerics/test_finite_differences.py
+++ b/tests/tests_geomstats/test_numerics/test_finite_differences.py
@@ -50,10 +50,10 @@ class TestForwardDifference(FiniteDifferenceTestCase, metaclass=DataBasedParamet
         delta = 1 / (n_times - 1)
         point_ndim_slc = tuple([slice(None)] * self.space.point_ndim)
         point_ = (
-            path[..., -2, *point_ndim_slc]
-            + delta * finite_diffs[..., -1, *point_ndim_slc]
+            path[(..., -2) + point_ndim_slc]
+            + delta * finite_diffs[(..., -1) + point_ndim_slc]
         )
-        self.assertAllClose(point_, path[..., -1, *point_ndim_slc], atol=atol)
+        self.assertAllClose(point_, path[(..., -1) + point_ndim_slc], atol=atol)
 
 
 @pytest.mark.usefixtures("spaces")
@@ -78,9 +78,9 @@ class TestCenteredDifference(FiniteDifferenceTestCase, metaclass=DataBasedParame
 
         point_ndim_slc = tuple([slice(None)] * self.space.point_ndim)
 
-        previous_point = path[..., index - 1, *point_ndim_slc]
-        next_point = path[..., index + 1, *point_ndim_slc]
-        diff = finite_diffs[..., fd_index, *point_ndim_slc]
+        previous_point = path[(..., index - 1) + point_ndim_slc]
+        next_point = path[(..., index + 1) + point_ndim_slc]
+        diff = finite_diffs[(..., fd_index) + point_ndim_slc]
 
         delta = 1 / (n_times - 1)
         expected_diff = (next_point - previous_point) / (2 * delta)
@@ -112,10 +112,10 @@ class TestSecondCenteredDifference(
 
         point_ndim_slc = tuple([slice(None)] * self.space.point_ndim)
 
-        previous_point = path[..., index - 1, *point_ndim_slc]
-        point = path[..., index, *point_ndim_slc]
-        next_point = path[..., index + 1, *point_ndim_slc]
-        diff = finite_diffs[..., fd_index, *point_ndim_slc]
+        previous_point = path[(..., index - 1) + point_ndim_slc]
+        point = path[(..., index) + point_ndim_slc]
+        next_point = path[(..., index + 1) + point_ndim_slc]
+        diff = finite_diffs[(..., fd_index) + point_ndim_slc]
 
         delta = 1 / (n_times - 1)
         expected_diff = (next_point + previous_point - 2 * point) / (delta**2)


### PR DESCRIPTION
This PR fixes slicing syntax for backward compatibility with Python 3.10-.

closes #1999.