### PR TITLE
Add manually triggered workflow to test other supported python versions

### DIFF
--- a/.github/workflows/test-python-backwards.yml
+++ b/.github/workflows/test-python-backwards.yml
@@ -1,0 +1,51 @@
+name: "Testing (Python versions)"
+
+on: workflow_dispatch
+
+jobs:
+  build:
+    runs-on: ${{matrix.os}}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: [3.9, 3.10, 3.12]
+        geomstats-backend: ["autograd", "numpy", "pytorch"]
+        test-folder: ["tests/tests_geomstats/", "tests/tests_scripts"]
+      fail-fast: false
+    env:
+      GEOMSTATS_BACKEND: ${{matrix.geomstats-backend}}
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build using Python ${{matrix.python-version}} and Backend ${{matrix.geomstats-backend}}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{matrix.python-version}}
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{matrix.geomstats-backend}}-${{matrix.os}}-${{matrix.python-version}}-${{ hashFiles('pyproject.toml') }}
+
+      - name: install dependencies [pip]
+        run: |
+          pip install --upgrade pip setuptools wheel
+          pip install -e .[opt,test,${{ matrix.geomstats-backend }}]
+
+      - name: Add annotations [pytest]
+        run: pip install pytest-github-actions-annotate-failures
+
+      - name: unit testing for geomstats [pytest]
+        if: ${{matrix.test-folder == 'tests/tests_geomstats/'}}
+        run: |
+          pytest --cov-report term -m "not (slow or redundant)" --cov=geomstats ${{matrix.test-folder}}
+
+      - name: unit testing for geomstats (slow) [pytest]
+        if: ${{matrix.test-folder == 'tests/tests_geomstats/'}}
+        run: |
+          pytest --cov-report term -m "slow and (not redundant)" --cov-append --cov=geomstats ${{matrix.test-folder}}
+
+      - name: unit testing for scripts [pytest]
+        if: ${{matrix.test-folder == 'tests/tests_scripts'}}
+        run: |
+          pytest ${{matrix.test-folder}}


### PR DESCRIPTION
This PR adds a manually triggered workflow to test other supported python versions. It runs the same tests as usual testing workflow, but for other python versions.

I think it is enough to have it manually triggered instead of running every time to save compute.