### PR TITLE
Upgrade to python 3.12

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.11]
+        python-version: [3.12]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.11]
+        python-version: [3.12]
       fail-fast: false
 
     steps:

--- a/.github/workflows/test-python-backwards.yml
+++ b/.github/workflows/test-python-backwards.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.9, 3.10.x, 3.12]
+        python-version: [3.9, 3.10.x, 3.11]
         geomstats-backend: ["autograd", "numpy", "pytorch"]
         test-folder: ["tests/tests_geomstats/", "tests/tests_scripts"]
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.11]
+        python-version: [3.12]
         geomstats-backend: ["autograd", "numpy", "pytorch"]
         test-folder: ["tests/tests_geomstats/", "tests/tests_scripts"]
       fail-fast: false
@@ -70,6 +70,6 @@ jobs:
           pytest ${{matrix.test-folder}}
 
       - name: uploading code coverage [codecov]
-        if: ${{matrix.python-version == 3.11 && matrix.test-folder == 'tests/tests_geomstats/'}}
+        if: ${{matrix.test-folder == 'tests/tests_geomstats/'}}
         run: |
           bash <(curl -s https://codecov.io/bash) -c -F ${{matrix.geomstats-backend}}

--- a/docs/contributing/index.rst
+++ b/docs/contributing/index.rst
@@ -126,17 +126,17 @@ From the geomstats folder, create a virtual environment:
 
     .. code-block:: bash
 
-      $ conda create -n geomstats-3.11 python=3.11
+      $ conda create -n geomstats-312 python=3.12
 
 
-This command will create a new environment named `geomstats-3.11`.
+This command will create a new environment named `geomstats-312`.
 
 
 Then, activate the environment and install geomstats in editable mode:
 
   .. code-block:: bash
 
-    $ conda activate geomstats-3.11
+    $ conda activate geomstats-312
     $ pip install -e .
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,12 +17,12 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Mathematics",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 dependencies = [
     "joblib >= 0.17.0",
     "matplotlib >= 3.3.4",


### PR DESCRIPTION
Given the success with 3.12 tests (see [this](https://github.com/geomstats/geomstats/actions/runs/9499512495/)), I suggest to start testing the package with Python 3.12 (which has been released more than 6 months ago).

I've also dropped support to Python 3.8, as e.g. `numpy` asks for >=3.9.