### PR TITLE
Rename PreShapeBundle

### DIFF
--- a/geomstats/geometry/pre_shape.py
+++ b/geomstats/geometry/pre_shape.py
@@ -237,7 +237,7 @@ class PreShapeSpace(LevelSet):
         return vector - gs.einsum("...,...ij->...ij", coef, base_point)
 
 
-class PreShapeSpaceBundle(FiberBundle):
+class PreShapeBundle(FiberBundle):
     r"""Class for the Kendall pre-shape space bundle."""
 
     def align(self, point, base_point):
@@ -923,6 +923,6 @@ register_quotient(
     Space=PreShapeSpace,
     Metric=PreShapeMetric,
     GroupAction="rotations",
-    FiberBundle=PreShapeSpaceBundle,
+    FiberBundle=PreShapeBundle,
     QuotientMetric=KendallShapeMetric,
 )

--- a/geomstats/test_cases/geometry/pre_shape.py
+++ b/geomstats/test_cases/geometry/pre_shape.py
@@ -117,7 +117,7 @@ class PreShapeSpaceTestCase(LevelSetTestCase):
         self.test_is_centered(res, expected, atol)
 
 
-class PreShapeSpaceBundleTestCase(FiberBundleTestCase):
+class PreShapeBundleTestCase(FiberBundleTestCase):
     def _test_is_tangent(self, vector, base_point, expected, atol):
         res = self.total_space.is_tangent(vector, base_point, atol=atol)
         self.assertAllEqual(res, expected)

--- a/tests/tests_geomstats/test_geometry/data/pre_shape.py
+++ b/tests/tests_geomstats/test_geometry/data/pre_shape.py
@@ -17,7 +17,7 @@ class PreShapeSpaceTestData(LevelSetTestData):
         return self.generate_random_data()
 
 
-class PreShapeSpaceBundleTestData(FiberBundleTestData):
+class PreShapeBundleTestData(FiberBundleTestData):
     skips = ("tangent_riemannian_submersion_after_horizontal_lift",)
 
     def vertical_projection_correctness_test_data(self):

--- a/tests/tests_geomstats/test_geometry/test_pre_shape.py
+++ b/tests/tests_geomstats/test_geometry/test_pre_shape.py
@@ -7,7 +7,7 @@ from geomstats.geometry.quotient_metric import QuotientMetric
 from geomstats.test.parametrizers import DataBasedParametrizer
 from geomstats.test_cases.geometry.pre_shape import (
     KendallShapeMetricTestCase,
-    PreShapeSpaceBundleTestCase,
+    PreShapeBundleTestCase,
     PreShapeSpaceTestCase,
 )
 from geomstats.test_cases.geometry.riemannian_metric import (
@@ -18,8 +18,8 @@ from geomstats.test_cases.geometry.riemannian_metric import (
 from .data.pre_shape import (
     KendallShapeMetricCmpTestData,
     KendallShapeMetricTestData,
+    PreShapeBundleTestData,
     PreShapeMetricTestData,
-    PreShapeSpaceBundleTestData,
     PreShapeSpaceTestData,
 )
 
@@ -60,10 +60,8 @@ def bundles(request):
 
 
 @pytest.mark.usefixtures("bundles")
-class TestPreShapeSpaceBundle(
-    PreShapeSpaceBundleTestCase, metaclass=DataBasedParametrizer
-):
-    testing_data = PreShapeSpaceBundleTestData()
+class TestPreShapeBundle(PreShapeBundleTestCase, metaclass=DataBasedParametrizer):
+    testing_data = PreShapeBundleTestData()
 
 
 @pytest.fixture(


### PR DESCRIPTION
Following shapes paper diagrams and text, this PR renames `PreShapeSpaceBundle` to `PreShapeBundle`.