### PR TITLE
Add L2SurfacesMetric

### DIFF
--- a/geomstats/geometry/discrete_surfaces.py
+++ b/geomstats/geometry/discrete_surfaces.py
@@ -1156,7 +1156,14 @@ class DiscreteSurfacesExpSolver(ExpSolver):
 
 
 class L2SurfacesMetric(NFoldMetric):
-    """L2 metric on the space of discrete surfaces."""
+    """L2 metric on the space of discrete surfaces.
+
+    Notes
+    -----
+    Adds ``base_manifold`` (manifold that is repeated ``n_copies``
+    times) and ``n_copies`` to ``space`` as attribute if it does
+    not have them as their expected by ``NFoldMetric``.
+    """
 
     def __init__(self, space):
         if not hasattr(space, "base_manifold"):

--- a/geomstats/geometry/quotient_metric.py
+++ b/geomstats/geometry/quotient_metric.py
@@ -12,14 +12,14 @@ class QuotientMetric(RiemannianMetric):
 
     Given a (principal) fiber bundle, or more generally a manifold with a
     Lie group acting on it by the right, the quotient space is the space of
-    orbits under this action. 
-    
-    In general, the quotient space is not a manifold, as it can exhibit singularities. 
+    orbits under this action.
+
+    In general, the quotient space is not a manifold, as it can exhibit singularities.
     Instead, the quotient space is a stratified space, whose principal stratum is a manifold.
 
     We restrict computations on the quotient space to computations on its principal stratum,
     that we equip with the quotient metric.
-    
+
     The quotient metric is defined such that the
     canonical projection is a Riemannian submersion, i.e., it is isometric to
     the restriction of the metric of the total space to horizontal subspaces.

--- a/tests/tests_geomstats/test_geometry/data/discrete_surfaces.py
+++ b/tests/tests_geomstats/test_geometry/data/discrete_surfaces.py
@@ -7,6 +7,7 @@ from geomstats.test.data import TestData
 from geomstats.vectorization import repeat_point
 
 from .manifold import ManifoldTestData
+from .riemannian_metric import RiemannianMetricTestData
 
 
 class SurfaceTestData(TestData):
@@ -139,6 +140,18 @@ class ElasticMetricTestData(TestData):
 
     def inner_product_is_symmetric_test_data(self):
         return self.generate_random_data()
+
+
+class L2SurfacesMetricTestData(RiemannianMetricTestData):
+    trials = 1
+    skips = (
+        "inner_product_derivative_matrix_vec",
+        "metric_matrix_is_spd",
+        "christoffels_vec",
+    )
+    N_RANDOM_POINTS = [1]
+    fail_for_autodiff_exceptions = False
+    fail_for_not_implemented_errors = False
 
 
 class QuotientElasticMetricTestData(TestData):

--- a/tests/tests_geomstats/test_geometry/test_discrete_surfaces.py
+++ b/tests/tests_geomstats/test_geometry/test_discrete_surfaces.py
@@ -2,7 +2,7 @@ import pytest
 
 import geomstats.backend as gs
 import geomstats.datasets.utils as data_utils
-from geomstats.geometry.discrete_surfaces import DiscreteSurfaces
+from geomstats.geometry.discrete_surfaces import DiscreteSurfaces, L2SurfacesMetric
 from geomstats.test.parametrizers import DataBasedParametrizer
 from geomstats.test.test_case import pytorch_backend, torch_only
 from geomstats.test_cases.geometry.discrete_surfaces import (
@@ -17,6 +17,7 @@ from .data.discrete_surfaces import (
     DiscreteSurfacesSmokeTestData,
     DiscreteSurfacesTestData,
     ElasticMetricTestData,
+    L2SurfacesMetricTestData,
     QuotientElasticMetricTestData,
     SurfaceTestData,
 )
@@ -29,10 +30,9 @@ class TestSurface(SurfaceTestCase, metaclass=DataBasedParametrizer):
 
 @torch_only
 class TestDiscreteSurfaces(DiscreteSurfacesTestCase, metaclass=DataBasedParametrizer):
-    vertices, faces = data_utils.load_cube()
-    vertices = gs.array(vertices, dtype=gs.float64)
-    faces = gs.array(faces)
-    space = DiscreteSurfaces(faces, equip=False)
+    _, _faces = data_utils.load_cube()
+    _faces = gs.array(_faces)
+    space = DiscreteSurfaces(_faces, equip=False)
 
     testing_data = DiscreteSurfacesTestData()
 
@@ -54,8 +54,7 @@ class TestDiscreteSurfacesSmoke(
     have area 2.
     """
 
-    _vertices, _faces = data_utils.load_cube()
-    _vertices = gs.array(_vertices, dtype=gs.float64)
+    _, _faces = data_utils.load_cube()
     _faces = gs.array(_faces)
     space = DiscreteSurfaces(_faces, equip=False)
 
@@ -78,6 +77,16 @@ class TestElasticMetric(RiemannianMetricTestCase, metaclass=DataBasedParametrize
             space, _vertices, amplitude=10.0
         )
     testing_data = ElasticMetricTestData()
+
+
+class TestL2SurfacesMetric(RiemannianMetricTestCase, metaclass=DataBasedParametrizer):
+    _, _faces = data_utils.load_cube()
+    _faces = gs.array(_faces)
+
+    space = DiscreteSurfaces(_faces, equip=False)
+    space.equip_with_metric(L2SurfacesMetric)
+
+    testing_data = L2SurfacesMetricTestData()
 
 
 @torch_only


### PR DESCRIPTION
This PR adds a very basic `L2SurfacesMetric` to put on `DiscreteSurfaces` that is basically a standard L2 metric on landmarks with inner products being weighted by number of vertices.