### PR TITLE
Add root finders and improve SPDScalingFinder

### DIFF
--- a/geomstats/_backend/pytorch/_common.py
+++ b/geomstats/_backend/pytorch/_common.py
@@ -3,6 +3,8 @@ import torch as _torch
 
 
 def from_numpy(x):
+    if _torch.is_tensor(x):
+        return x
     return _torch.from_numpy(x)
 
 

--- a/geomstats/geometry/full_rank_correlation_matrices.py
+++ b/geomstats/geometry/full_rank_correlation_matrices.py
@@ -43,6 +43,7 @@ from geomstats.geometry.symmetric_matrices import (
     NullRowSumsSymmetricMatrices,
     SymmetricHollowMatrices,
 )
+from geomstats.numerics.optimizers import NewtonMethod
 
 
 def corr_map(point):
@@ -809,20 +810,28 @@ class UniquePositiveDiagonalMatrixAlgorithm:
     with unit row sums.
 
     This result is known as the existence and uniqueness of the scaling of
-    SPD matrices ([T2023]_, [MO1968]_, [JR2009]_).
+    SPD matrices ([T2024]_, [MO1968]_, [JR2009]_).
+
+    It finds the roots of the gradient of the strictly convex map
+
+    .. math::
+
+        F(D) = \frac{1}{2} \mathbb{1}^{\top} D^{\top}
+        \Sigma D \mathbb{1}-\operatorname{tr}(\log (D))
+
+    For details, check out [T2024]_'s section 3.5.
+
 
     Parameters
     ----------
-    atol : float
-        Tolerance to check algorithm convergence.
-    max_iter : int
-        Maximum iterations.
+    root_finder : RootFinder
 
     References
     ----------
-    .. [T2023] Thanwerdas, Yann. “Permutation-Invariant Log-Euclidean Geometries
-        on Full-Rank Correlation Matrices,”
-        November 2023. https://hal.science/hal-03878729.
+    .. [T2024] Thanwerdas, Yann. “Permutation-Invariant Log-Euclidean Geometries
+        on Full-Rank Correlation Matrices.”
+        SIAM Journal on Matrix Analysis and Applications, 2024, 930–53.
+        https://doi.org/10.1137/22M1538144.
     .. [MO1968] Marshall, Albert W., and Ingram Olkin.
         “Scaling of Matrices to Achieve Specified Row and Column Sums.”
         Numerische Mathematik 12, no. 1 (August 1, 1968): 83–90.
@@ -833,9 +842,11 @@ class UniquePositiveDiagonalMatrixAlgorithm:
         https://doi.org/10.1080/03081080600872327.
     """
 
-    def __init__(self, atol=gs.atol, max_iter=100):
-        self.atol = atol
-        self.max_iter = max_iter
+    def __init__(self, root_finder=None):
+        if root_finder is None:
+            root_finder = NewtonMethod()
+
+        self.root_finder = root_finder
 
     def _jacobian_f(self, spd_matrix, diag_vec):
         r"""Jacobian of objective function.
@@ -875,8 +886,8 @@ class UniquePositiveDiagonalMatrixAlgorithm:
         """
         return spd_matrix + gs.vec_to_diag(1.0 / diag_vec**2)
 
-    def _apply_single(self, spd_matrix):
-        """Apply Newton method to find scaling.
+    def _call_single(self, spd_matrix):
+        """Apply root finder to find scaling.
 
         Parameters
         ----------
@@ -888,25 +899,15 @@ class UniquePositiveDiagonalMatrixAlgorithm:
         diag_vec : array-like, shape=[n]
             Scaling of spd_matrix.
         """
-        xk = gs.ones(spd_matrix.shape[-1])
-        for _ in range(self.max_iter):
-            gradient = self._jacobian_f(spd_matrix, xk)
-            if gs.linalg.norm(gradient) <= self.atol:
-                break
+        x0 = gs.ones(spd_matrix.shape[-1])
 
-            y = gs.linalg.solve(self._hessian_f(spd_matrix, xk), gradient)
-            xk = xk - y
+        func = lambda x: self._jacobian_f(spd_matrix, x)
+        jac = lambda x: self._hessian_f(spd_matrix, x)
+        res = self.root_finder.root(func, x0, fun_jac=jac)
+        return res.x
 
-        else:
-            logging.warning(
-                "Maximum number of iterations %d reached. The mean may be inaccurate",
-                self.max_iter,
-            )
-
-        return xk
-
-    def apply(self, sym_mat):
-        r"""Apply Newton method to find scaling.
+    def __call__(self, spd_matrix):
+        """Apply Newton method to find scaling.
 
         Parameters
         ----------
@@ -918,16 +919,16 @@ class UniquePositiveDiagonalMatrixAlgorithm:
         diag_vec : array-like, shape=[..., n]
             Scaling of spd_matrix.
         """
-        if sym_mat.ndim == 2:
-            return self._apply_single(sym_mat)
+        if spd_matrix.ndim == 2:
+            return self._call_single(spd_matrix)
 
-        batch_shape = sym_mat.shape[:-2]
+        batch_shape = spd_matrix.shape[:-2]
         if len(batch_shape) == 1:
-            return gs.stack([self._apply_single(sym_mat_) for sym_mat_ in sym_mat])
+            return gs.stack([self._call_single(sym_mat_) for sym_mat_ in spd_matrix])
 
-        mat_shape = sym_mat.shape[-2:]
-        flat_sym_mat = gs.reshape(sym_mat, (-1,) + mat_shape)
-        out = gs.stack([self._apply_single(sym_mat_) for sym_mat_ in flat_sym_mat])
+        mat_shape = spd_matrix.shape[-2:]
+        flat_spd_mat = gs.reshape(spd_matrix, (-1,) + mat_shape)
+        out = gs.stack([self._call_single(sym_mat_) for sym_mat_ in flat_spd_mat])
         return gs.reshape(out, batch_shape + (mat_shape.shape[-1],))
 
 
@@ -944,18 +945,19 @@ class LogScalingDiffeo(Diffeo):
         \star \Sigma\right): \operatorname{Cor}^{+}(n)
         \longrightarrow \operatorname{Row}_0(n)
 
-    Check out [T2023]_ for more details.
+    Check out [T2024]_ for more details.
 
     References
     ----------
-    .. [T2023] Thanwerdas, Yann. “Permutation-Invariant Log-Euclidean Geometries
-        on Full-Rank Correlation Matrices,”
-        November 2023. https://hal.science/hal-03878729.
+    .. [T2024] Thanwerdas, Yann. “Permutation-Invariant Log-Euclidean Geometries
+        on Full-Rank Correlation Matrices.”
+        SIAM Journal on Matrix Analysis and Applications, 2024, 930–53.
+        https://doi.org/10.1137/22M1538144.
     """
 
     def __init__(self):
         super().__init__()
-        self.unique_diag_mat_algo = UniquePositiveDiagonalMatrixAlgorithm()
+        self.unique_diag_mat = UniquePositiveDiagonalMatrixAlgorithm()
 
     def diffeomorphism(self, base_point):
         """Diffeomorphism at base point.
@@ -972,7 +974,7 @@ class LogScalingDiffeo(Diffeo):
         image_point : array-like, shape=[..., n, n]
             Image point.
         """
-        diag_vec = self.unique_diag_mat_algo.apply(base_point)
+        diag_vec = self.unique_diag_mat(base_point)
         unit_row_sum_spd = FullRankCorrelationMatrices.diag_action(diag_vec, base_point)
 
         return logmh(unit_row_sum_spd)
@@ -1014,7 +1016,7 @@ class LogScalingDiffeo(Diffeo):
             Image tangent vector at image of the base point.
         """
         if image_point is None:
-            diag_vec = self.unique_diag_mat_algo.apply(base_point)
+            diag_vec = self.unique_diag_mat(base_point)
             base_point_row_1 = FullRankCorrelationMatrices.diag_action(
                 diag_vec, base_point
             )
@@ -1069,7 +1071,7 @@ class LogScalingDiffeo(Diffeo):
         if image_point is not None:
             base_point_row_1 = expmh(image_point)
         else:
-            diag_vec = self.unique_diag_mat_algo.apply(base_point)
+            diag_vec = self.unique_diag_mat(base_point)
             base_point_row_1 = FullRankCorrelationMatrices.diag_action(
                 diag_vec, base_point
             )
@@ -1088,7 +1090,7 @@ class LogScaledMetric(PullbackDiffeoMetric):
     Diffeormorphism between full-rank correlation matrices and
     the space of symmetric matrices with null row sums.
 
-    Check out [T2023]_ for more details.
+    Check out [T2024]_ for more details.
 
     Parameters
     ----------
@@ -1102,9 +1104,10 @@ class LogScaledMetric(PullbackDiffeoMetric):
 
     References
     ----------
-    .. [T2023] Thanwerdas, Yann. “Permutation-Invariant Log-Euclidean Geometries
-        on Full-Rank Correlation Matrices,”
-        November 2023. https://hal.science/hal-03878729.
+    .. [T2024] Thanwerdas, Yann. “Permutation-Invariant Log-Euclidean Geometries
+        on Full-Rank Correlation Matrices.”
+        SIAM Journal on Matrix Analysis and Applications, 2024, 930–53.
+        https://doi.org/10.1137/22M1538144.
     """
 
     def __init__(self, space, alpha=None, delta=None, zeta=1.0):

--- a/geomstats/geometry/full_rank_correlation_matrices.py
+++ b/geomstats/geometry/full_rank_correlation_matrices.py
@@ -801,7 +801,7 @@ class OffLogMetric(PullbackDiffeoMetric):
         super().__init__(space=space, diffeo=diffeo, image_space=image_space)
 
 
-class UniquePositiveDiagonalMatrixAlgorithm:
+class SPDScalingFinder:
     r"""Find unique positive diagonal matrix corresponding to an SPD matrix.
 
     That is, for every symmetric positive-definite matrix :math:`\Sigma`,
@@ -957,7 +957,7 @@ class LogScalingDiffeo(Diffeo):
 
     def __init__(self):
         super().__init__()
-        self.unique_diag_mat = UniquePositiveDiagonalMatrixAlgorithm()
+        self.unique_diag_mat = SPDScalingFinder()
 
     def diffeomorphism(self, base_point):
         """Diffeomorphism at base point.

--- a/geomstats/numerics/optimizers.py
+++ b/geomstats/numerics/optimizers.py
@@ -1,8 +1,10 @@
 """Optimizers implementations."""
 
 import logging
+from abc import ABC, abstractmethod
 
 import scipy
+from scipy.optimize import OptimizeResult
 
 import geomstats.backend as gs
 from geomstats.exceptions import AutodiffNotImplementedError
@@ -111,5 +113,146 @@ class ScipyMinimize:
 
         if self.save_result:
             self.result_ = result
+
+        return result
+
+
+class RootFinder(ABC):
+    """Find a root of a vector function."""
+
+    @abstractmethod
+    def root(self, fun, x0, fun_jac=None):
+        """Find a root of a vector function.
+
+        Parameters
+        ----------
+        fun : callable
+            The objective function to be minimized.
+        x0 : array-like
+            Initial guess.
+        fun_jac : callable
+            Ignored if None.
+
+        Returns
+        -------
+        res : OptimizeResult
+        """
+
+
+class ScipyRoot(RootFinder):
+    """Wrapper for scipy.optimize.root.
+
+    Only `jac` differs from scipy: if `autodiff`, then
+    `gs.autodiff.value_and_grad` is used to compute the jacobian.
+    """
+
+    def __init__(
+        self,
+        method="hybr",
+        tol=None,
+        callback=None,
+        options=None,
+        save_result=False,
+    ):
+        self.method = method
+        self.tol = tol
+        self.callback = callback
+        self.options = options
+        self.save_result = save_result
+        self.result_ = None
+
+    def root(self, fun, x0, fun_jac=None):
+        """Find a root of a vector function.
+
+        Parameters
+        ----------
+        fun : callable
+            The objective function to be minimized.
+        x0 : array-like
+            Initial guess.
+        fun_jac : callable
+            Jacobian of fun. Ignored if None.
+
+        Returns
+        -------
+        res : OptimizeResult
+        """
+        result = scipy.optimize.root(
+            fun,
+            x0,
+            method=self.method,
+            jac=fun_jac,
+            tol=self.tol,
+            callback=self.callback,
+            options=self.options,
+        )
+
+        result = result_to_backend_type(result)
+
+        if not result.success:
+            logging.warning(result.message)
+
+        if self.save_result:
+            self.result_ = result
+
+        return result
+
+
+class NewtonMethod(RootFinder):
+    """Find a root of a vector function with Newton's method.
+
+    Check https://en.wikipedia.org/wiki/Newton%27s_method_in_optimization
+    for details.
+
+    Parameters
+    ----------
+    atol : float
+        Tolerance to check algorithm convergence.
+    max_iter : int
+        Maximum iterations.
+    """
+
+    def __init__(self, atol=gs.atol, max_iter=100):
+        self.atol = atol
+        self.max_iter = max_iter
+
+    def root(self, fun, x0, fun_jac):
+        """Find a root of a vector function.
+
+        Parameters
+        ----------
+        fun : callable
+            The objective function to be minimized.
+        x0 : array-like
+            Initial guess.
+        fun_jac : callable
+            Jacobian of fun.
+        """
+        xk = x0
+        message = "The solution converged."
+        status = 1
+        for it in range(self.max_iter):
+            fun_xk = fun(xk)
+            if gs.linalg.norm(fun_xk) <= self.atol:
+                break
+
+            y = gs.linalg.solve(fun_jac(xk), fun_xk)
+            xk = xk - y
+        else:
+            message = f"Maximum number of iterations {self.max_iter} reached. The mean may be inaccurate"
+            status = 0
+
+        result = OptimizeResult(
+            x=xk,
+            success=(status == 1),
+            status=status,
+            method="newton",
+            message=message,
+            nfev=it,
+            njac=it,
+        )
+
+        if not result.success:
+            logging.warning(result.message)
 
         return result

--- a/geomstats/numerics/optimizers.py
+++ b/geomstats/numerics/optimizers.py
@@ -173,11 +173,14 @@ class ScipyRoot(RootFinder):
         -------
         res : OptimizeResult
         """
+        fun_ = lambda x: fun(gs.from_numpy(x))
+        fun_jac_ = fun_jac if fun_jac is None else lambda x: fun_jac(gs.from_numpy(x))
+
         result = scipy.optimize.root(
-            fun,
+            fun_,
             x0,
             method=self.method,
-            jac=fun_jac,
+            jac=fun_jac_,
             tol=self.tol,
             callback=self.callback,
             options=self.options,
@@ -244,7 +247,7 @@ class NewtonMethod(RootFinder):
             status=status,
             method="newton",
             message=message,
-            nfev=it,
+            nfev=it + 1,
             njac=it,
         )
 

--- a/geomstats/numerics/optimizers.py
+++ b/geomstats/numerics/optimizers.py
@@ -118,16 +118,16 @@ class ScipyMinimize:
 
 
 class RootFinder(ABC):
-    """Find a root of a vector function."""
+    """Find a root of a vector-valued function."""
 
     @abstractmethod
     def root(self, fun, x0, fun_jac=None):
-        """Find a root of a vector function.
+        """Find a root of a vector-valued function.
 
         Parameters
         ----------
         fun : callable
-            The objective function to be minimized.
+            Vector-valued function.
         x0 : array-like
             Initial guess.
         fun_jac : callable
@@ -140,11 +140,7 @@ class RootFinder(ABC):
 
 
 class ScipyRoot(RootFinder):
-    """Wrapper for scipy.optimize.root.
-
-    Only `jac` differs from scipy: if `autodiff`, then
-    `gs.autodiff.value_and_grad` is used to compute the jacobian.
-    """
+    """Wrapper for scipy.optimize.root."""
 
     def __init__(
         self,
@@ -162,12 +158,12 @@ class ScipyRoot(RootFinder):
         self.result_ = None
 
     def root(self, fun, x0, fun_jac=None):
-        """Find a root of a vector function.
+        """Find a root of a vector-valued function.
 
         Parameters
         ----------
         fun : callable
-            The objective function to be minimized.
+            Vector-valued function.
         x0 : array-like
             Initial guess.
         fun_jac : callable
@@ -199,7 +195,7 @@ class ScipyRoot(RootFinder):
 
 
 class NewtonMethod(RootFinder):
-    """Find a root of a vector function with Newton's method.
+    """Find a root of a vector-valued function with Newton's method.
 
     Check https://en.wikipedia.org/wiki/Newton%27s_method_in_optimization
     for details.
@@ -217,12 +213,12 @@ class NewtonMethod(RootFinder):
         self.max_iter = max_iter
 
     def root(self, fun, x0, fun_jac):
-        """Find a root of a vector function.
+        """Find a root of a vector-valued function.
 
         Parameters
         ----------
         fun : callable
-            The objective function to be minimized.
+            Vector-valued function.
         x0 : array-like
             Initial guess.
         fun_jac : callable

--- a/tests/tests_geomstats/test_geometry/data/full_rank_correlation_matrices.py
+++ b/tests/tests_geomstats/test_geometry/data/full_rank_correlation_matrices.py
@@ -61,7 +61,7 @@ class OffLogMetricTestData(PullbackDiffeoMetricTestData):
     fail_for_not_implemented_errors = False
 
 
-class UniquePositiveDiagonalMatrixAlgorithmTestData(TestData):
+class SPDScalingFinderTestData(TestData):
     def rows_sum_to_one_test_data(self):
         return self.generate_random_data()
 

--- a/tests/tests_geomstats/test_geometry/test_full_rank_correlation_matrices.py
+++ b/tests/tests_geomstats/test_geometry/test_full_rank_correlation_matrices.py
@@ -11,8 +11,8 @@ from geomstats.geometry.full_rank_correlation_matrices import (
     OffLogDiffeo,
     OffLogMetric,
     PolyHyperbolicCholeskyMetric,
+    SPDScalingFinder,
     UniqueDiagonalMatrixAlgorithm,
-    UniquePositiveDiagonalMatrixAlgorithm,
 )
 from geomstats.geometry.general_linear import GeneralLinear
 from geomstats.geometry.hermitian_matrices import expmh
@@ -52,8 +52,8 @@ from .data.full_rank_correlation_matrices import (
     LogScaledMetricTestData,
     OffLogMetricTestData,
     PolyHyperbolicCholeskyMetricTestData,
+    SPDScalingFinderTestData,
     UniqueDiagonalMatrixAlgorithmTestData,
-    UniquePositiveDiagonalMatrixAlgorithmTestData,
 )
 
 
@@ -231,16 +231,14 @@ class TestOffLogMetric(PullbackDiffeoMetricTestCase, metaclass=DataBasedParametr
 )
 def unique_positive_diagonal_matrix_algorithms(request):
     root_finder = request.param
-    request.cls.algo = UniquePositiveDiagonalMatrixAlgorithm(root_finder)
+    request.cls.algo = SPDScalingFinder(root_finder)
 
 
 @pytest.mark.usefixtures("unique_positive_diagonal_matrix_algorithms")
-class TestUniquePositiveDiagonalMatrixAlgorithm(
-    TestCase, metaclass=DataBasedParametrizer
-):
+class TestSPDScalingFinder(TestCase, metaclass=DataBasedParametrizer):
     _n = random.randint(2, 5)
     data_generator = RandomDataGenerator(SPDMatrices(n=_n, equip=False))
-    testing_data = UniquePositiveDiagonalMatrixAlgorithmTestData()
+    testing_data = SPDScalingFinderTestData()
 
     @pytest.mark.random
     def test_rows_sum_to_one(self, n_points, atol):

--- a/tests/tests_geomstats/test_geometry/test_full_rank_correlation_matrices.py
+++ b/tests/tests_geomstats/test_geometry/test_full_rank_correlation_matrices.py
@@ -187,7 +187,7 @@ class TestUniqueDiagonalMatrixAlgorithm(TestCase, metaclass=DataBasedParametrize
     def test_belongs_to_full_rank_cor(self, n_points, atol):
         sym_mat = self.sym_data_generator.random_point(n_points)
 
-        diag_mat = self.algo.apply(sym_mat)
+        diag_mat = self.algo(sym_mat)
         cor_mat = expmh(diag_mat + sym_mat)
         res = self.full_rank_cor.belongs(cor_mat, atol=atol)
         expected = gs.ones_like(res)


### PR DESCRIPTION
This PR improves on  #1980 to make more clear what is the problem being solved by `SPDScalingFinder` (previously `UniquePositiveDiagonalMatrixAlgorithm`).

This class finds the unique scaling of an SPD matrix, i.e. the matrix D such that `D A D e = e`, where `A` is an SPD matrix and `e` a vector of ones. Following [Thanwerdas, 2024](https://epubs.siam.org/doi/full/10.1137/22M1538144), this is accomplished by finding the roots of the gradient of a particular function.

Up until now, we were hardcoding a Newton method to solve this problem. This PR brings in `scipy.optimize.root` in a similar way as it has been done for `scipy.optimize.minimize` and implements the Newton method in a general way that is also compatible with `ScipyMinimize`. 

(It probably interests you @olivierbisson.) 