### PR TITLE
Add has_autodiff to backend

### DIFF
--- a/geomstats/_backend/__init__.py
+++ b/geomstats/_backend/__init__.py
@@ -87,6 +87,7 @@ BACKEND_ATTRIBUTES = {
         "get_default_cdtype",
         "get_slice",
         "greater",
+        "has_autodiff",
         "hsplit",
         "hstack",
         "imag",

--- a/geomstats/_backend/autograd/__init__.py
+++ b/geomstats/_backend/autograd/__init__.py
@@ -154,6 +154,16 @@ linspace = _dyn_update_dtype(target=_np.linspace)
 empty = _dyn_update_dtype(target=_np.empty)
 
 
+def has_autodiff():
+    """If allows for automatic differentiation.
+
+    Returns
+    -------
+    has_autodiff : bool
+    """
+    return True
+
+
 def imag(x):
     out = _np.imag(x)
     if is_array(x):

--- a/geomstats/_backend/numpy/__init__.py
+++ b/geomstats/_backend/numpy/__init__.py
@@ -156,3 +156,13 @@ from ._common import (
 ones = _modify_func_default_dtype(target=_np.ones)
 linspace = _dyn_update_dtype(target=_np.linspace, dtype_pos=5)
 empty = _dyn_update_dtype(target=_np.empty, dtype_pos=1)
+
+
+def has_autodiff():
+    """If allows for automatic differentiation.
+
+    Returns
+    -------
+    has_autodiff : bool
+    """
+    return False

--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -109,6 +109,16 @@ power = _box_binary_scalar(target=_torch.pow, box_x2=False)
 std = _preserve_input_dtype(_add_default_dtype_by_casting(target=_torch.std))
 
 
+def has_autodiff():
+    """If allows for automatic differentiation.
+
+    Returns
+    -------
+    has_autodiff : bool
+    """
+    return True
+
+
 def matmul(x, y, out=None):
     for array_ in [x, y]:
         if array_.ndim == 1:

--- a/geomstats/geometry/discrete_surfaces.py
+++ b/geomstats/geometry/discrete_surfaces.py
@@ -564,7 +564,7 @@ class ElasticMetric(RiemannianMetric):
         self.d1 = d1
         self.a2 = a2
 
-        if not gs.__name__.endswith("numpy"):
+        if gs.has_autodiff():
             self.exp_solver = DiscreteSurfacesExpSolver(space, n_steps=10)
 
             optimizer = ScipyMinimize(

--- a/geomstats/geometry/fiber_bundle.py
+++ b/geomstats/geometry/fiber_bundle.py
@@ -275,7 +275,7 @@ class FiberBundle:
             else:
                 aligner = (
                     DistanceMinimizingAligner(total_space)
-                    if not gs.__name__.endswith("numpy")
+                    if gs.has_autodiff()
                     else None
                 )
 

--- a/geomstats/geometry/full_rank_correlation_matrices.py
+++ b/geomstats/geometry/full_rank_correlation_matrices.py
@@ -270,7 +270,7 @@ class CorrelationMatricesBundle(FiberBundle):
     def __init__(self, total_space):
         aligner = (
             DistanceMinimizingAligner(total_space, group_elem_shape=(total_space.n,))
-            if not gs.__name__.endswith("numpy")
+            if gs.has_autodiff()
             else None
         )
 

--- a/geomstats/geometry/pullback_metric.py
+++ b/geomstats/geometry/pullback_metric.py
@@ -34,7 +34,7 @@ class PullbackMetric(RiemannianMetric):
         self._instantiate_solvers()
 
     def _instantiate_solvers(self):
-        if not gs.__name__.endswith("numpy"):
+        if gs.has_autodiff():
             self.log_solver = LogShootingSolver(self._space)
 
         self.exp_solver = ExpODESolver(

--- a/geomstats/numerics/optimizers.py
+++ b/geomstats/numerics/optimizers.py
@@ -30,7 +30,7 @@ class ScipyMinimize:
         options=None,
         save_result=False,
     ):
-        if jac == "autodiff" and gs.__name__.endswith("numpy"):
+        if jac == "autodiff" and not gs.has_autodiff():
             raise AutodiffNotImplementedError(
                 "Minimization with 'autodiff' requires automatic differentiation."
                 "Change backend via the command "


### PR DESCRIPTION
In some parts of the code, we are verifying if the backend is not `numpy` in order to use autodiff capabilities. This PR adds `has_autodiff` to the backend in order to make this verification more robust. Then, we make use of the function when needed.