### PR TITLE
Add polar decomposition to backend

### DIFF
--- a/geomstats/_backend/__init__.py
+++ b/geomstats/_backend/__init__.py
@@ -192,6 +192,7 @@ BACKEND_ATTRIBUTES = {
         "norm",
         "qr",
         "quadratic_assignment",
+        "polar",
         "solve",
         "solve_sylvester",
         "sqrtm",

--- a/geomstats/_backend/_shared_numpy/linalg.py
+++ b/geomstats/_backend/_shared_numpy/linalg.py
@@ -103,3 +103,10 @@ def fractional_matrix_power(A, t):
         return _scipy.linalg.fractional_matrix_power(A, t)
 
     return _np.stack([_scipy.linalg.fractional_matrix_power(A_, t) for A_ in A])
+
+
+def polar(*args, **kwargs):
+    """Polar decomposition of a matrix."""
+    return _np.vectorize(
+        _scipy.linalg.polar, signature="(n,n)->(n,n),(n,n)", excluded=["side"]
+    )(*args, **kwargs)

--- a/geomstats/_backend/autograd/linalg.py
+++ b/geomstats/_backend/autograd/linalg.py
@@ -23,6 +23,7 @@ from scipy.optimize import quadratic_assignment as _quadratic_assignment
 from .._shared_numpy.linalg import (
     fractional_matrix_power,
     is_single_matrix_pd,
+    polar,
     qr,
     solve_sylvester,
     sqrtm,

--- a/geomstats/_backend/numpy/linalg.py
+++ b/geomstats/_backend/numpy/linalg.py
@@ -20,6 +20,7 @@ from .._shared_numpy.linalg import (
     fractional_matrix_power,
     is_single_matrix_pd,
     logm,
+    polar,
     qr,
     quadratic_assignment,
     solve_sylvester,

--- a/geomstats/_backend/pytorch/linalg.py
+++ b/geomstats/_backend/pytorch/linalg.py
@@ -147,3 +147,13 @@ def fractional_matrix_power(A, t):
         out = _np.stack([_scipy.linalg.fractional_matrix_power(A_, t) for A_ in A])
 
     return _torch.tensor(out)
+
+
+def polar(*args, **kwargs):
+    """Polar decomposition of a matrix."""
+    func = _np.vectorize(
+        _scipy.linalg.polar, signature="(n,n)->(n,n),(n,n)", excluded=["side"]
+    )
+    unitary, hermitian = func = func(*args, **kwargs)
+
+    return _torch.from_numpy(unitary), _torch.from_numpy(hermitian)


### PR DESCRIPTION
This PR adds [polar decomposition](https://docs.scipy.org/doc/scipy/reference/generated/scipy.linalg.polar.html) to the backend (`gs.linalg.polar`). It directly uses scipy function (also for pytorch). Adding this as I need it in for a different PR.