### PR TITLE
Add multiresolution path straightening

### DIFF
--- a/geomstats/geometry/discrete_surfaces.py
+++ b/geomstats/geometry/discrete_surfaces.py
@@ -1239,7 +1239,7 @@ class RelaxedPathStraightening(PathBasedLogSolver, AlignerAlgorithm):
         optimizer=None,
         initialization=None,
     ):
-        PathBasedLogSolver.__init__(self, space=total_space, n_nodes=n_nodes)
+        PathBasedLogSolver.__init__(self, space=total_space)
         AlignerAlgorithm.__init__(self, total_space=total_space)
 
         if discrepancy_loss is None:
@@ -1258,6 +1258,7 @@ class RelaxedPathStraightening(PathBasedLogSolver, AlignerAlgorithm):
                 options={"disp": False},
             )
 
+        self.n_nodes = n_nodes
         self.lambda_ = lambda_
         self.discrepancy_loss = discrepancy_loss
         self.path_energy = path_energy


### PR DESCRIPTION
This PR builds on top of #1957 to:

1. add a multiresolution path straightening method
2. add a symmetrized version of the already-existing `PathStraightening`

Multiresolution means a sequence of optimization problems is solved (instead of a unique optimization problem), where the solution for a resolution is used as initialization for the next.

Symmetrization means that instead of minimizing the energy of a path A-B, we minimize the mean energy of paths A-B and B-A, given we expect the geodesic to be "symmetric". Results seem to be more accurate with this flag.

Everything is fully tested against Poincaré ball closed-form solution.