### PR TITLE
Add (log-)Euclidean-Cholesky diffeo and metrics on Cor+

### DIFF
--- a/geomstats/_backend/__init__.py
+++ b/geomstats/_backend/__init__.py
@@ -189,6 +189,7 @@ BACKEND_ATTRIBUTES = {
         "inv",
         "is_single_matrix_pd",
         "logm",
+        "matrix_power",
         "norm",
         "qr",
         "quadratic_assignment",

--- a/geomstats/_backend/autograd/linalg.py
+++ b/geomstats/_backend/autograd/linalg.py
@@ -12,6 +12,7 @@ from autograd.numpy.linalg import (
     eigh,
     eigvalsh,
     inv,
+    matrix_power,
     matrix_rank,
     norm,
     solve,

--- a/geomstats/_backend/numpy/linalg.py
+++ b/geomstats/_backend/numpy/linalg.py
@@ -9,6 +9,7 @@ from numpy.linalg import (  # NOQA
     eigh,
     eigvalsh,
     inv,
+    matrix_power,
     matrix_rank,
     norm,
     solve,

--- a/geomstats/_backend/pytorch/linalg.py
+++ b/geomstats/_backend/pytorch/linalg.py
@@ -3,6 +3,18 @@
 import numpy as _np
 import scipy as _scipy
 import torch as _torch
+from torch.linalg import (
+    cholesky,
+    det,
+    eig,
+    eigh,
+    eigvalsh,
+    matrix_power,
+    qr,
+    solve,
+)
+from torch.linalg import inverse as inv
+from torch.linalg import matrix_exp as expm
 
 from .._backend_config import np_atol as atol
 from ..numpy import linalg as _gsnplinalg
@@ -46,15 +58,6 @@ class _Logm(_torch.autograd.Function):
         return _Logm._logm(backward_tensor).to(tensor.dtype)[..., :n, n:]
 
 
-cholesky = _torch.linalg.cholesky
-eig = _torch.linalg.eig
-eigh = _torch.linalg.eigh
-eigvalsh = _torch.linalg.eigvalsh
-expm = _torch.matrix_exp
-inv = _torch.inverse
-det = _torch.det
-solve = _torch.linalg.solve
-qr = _torch.linalg.qr
 logm = _Logm.apply
 
 

--- a/geomstats/_backend/pytorch/linalg.py
+++ b/geomstats/_backend/pytorch/linalg.py
@@ -9,11 +9,11 @@ from torch.linalg import (
     eig,
     eigh,
     eigvalsh,
+    inv,
     matrix_power,
     qr,
     solve,
 )
-from torch.linalg import inverse as inv
 from torch.linalg import matrix_exp as expm
 
 from .._backend_config import np_atol as atol

--- a/geomstats/algebra_utils.py
+++ b/geomstats/algebra_utils.py
@@ -226,3 +226,44 @@ def rotate_points(points, end_point):
     if not gs.allclose(gs.matmul(q, base_point[:, None])[:, 0], end_point):
         new_points = -new_points
     return new_points[0]
+
+
+def columnwise_scaling(vec, mat):
+    r"""Column-wise scaling.
+
+    Equivalent to :math:`AD`, where :math:`D` is a
+    diagonal matrix.
+
+    Parameters
+    ----------
+    vec : array-like, shape=[..., k]
+        Vector of scalings.
+    mat :array-like, shape=[..., n, k]
+        Matrix.
+
+    Returns
+    -------
+    column_scaled_mat : array-like, shape=[..., n, k]
+    """
+    return vec[..., None, :] * mat
+
+
+def rowwise_scaling(vec, mat):
+    r"""Row-wise scaling.
+
+    Equivalent to :math:`DA`, where :math:`D` is a
+    diagonal matrix.
+
+    Parameters
+    ----------
+    vec : array-like, shape=[..., n]
+        Vector of scalings.
+    mat :array-like, shape=[..., n, k]
+        Matrix.
+
+    Returns
+    -------
+    row_scaled_mat : array-like, shape=[..., n, k]
+    """
+    # TODO: add tests from notebook
+    return vec[..., :, None] * mat

--- a/geomstats/algebra_utils.py
+++ b/geomstats/algebra_utils.py
@@ -265,5 +265,4 @@ def rowwise_scaling(vec, mat):
     -------
     row_scaled_mat : array-like, shape=[..., n, k]
     """
-    # TODO: add tests from notebook
     return vec[..., :, None] * mat

--- a/geomstats/geometry/diffeo.py
+++ b/geomstats/geometry/diffeo.py
@@ -114,8 +114,11 @@ class Diffeo:
 class AutodiffDiffeo(Diffeo):
     """Diffeomorphism through autodiff."""
 
-    def __init__(self, space_shape, image_space_shape):
+    def __init__(self, space_shape, image_space_shape=None):
         super().__init__()
+        if image_space_shape is None:
+            image_space_shape = space_shape
+
         self._space_shape = space_shape
         self._space_point_ndim = len(space_shape)
 

--- a/geomstats/geometry/full_rank_correlation_matrices.py
+++ b/geomstats/geometry/full_rank_correlation_matrices.py
@@ -445,10 +445,13 @@ class EuclideanCholeskyDiffeo(Diffeo):
         Geometry [math.DG]. Université Côte d'Azur, 2022.
     """
 
-    # TODO: add equations
-
     def __call__(self, base_point):
-        """Diffeomorphism at base point.
+        r"""Diffeomorphism at base point.
+
+        .. math::
+
+           \Theta(C) = \operatorname{Diag}(\operatorname{Chol}(C))^{-1}
+           \operatorname{Chol}(C)
 
         Parameters
         ----------
@@ -467,7 +470,13 @@ class EuclideanCholeskyDiffeo(Diffeo):
     def inverse(self, image_point):
         r"""Inverse diffeomorphism at image point.
 
-        :math:`f^{-1}: N \rightarrow M`
+        .. math::
+
+            \begin{aligned}
+            \Phi(\Gamma) &= \operatorname{Diag}\left(\phi(\Gamma)\right)^{-1 / 2} 
+            \phi(\Gamma) \operatorname{Diag}\left(\phi(\Gamma)\right)^{-1 / 2} \\
+            &= \operatorname{Cor} \circ \phi(\Gamma)
+            \end{aligned}
 
         Parameters
         ----------
@@ -484,7 +493,10 @@ class EuclideanCholeskyDiffeo(Diffeo):
     def tangent(self, tangent_vec, base_point=None, image_point=None):
         r"""Tangent diffeomorphism at base point.
 
-        df_p is a linear map from T_pM to T_f(p)N.
+        .. math::
+
+            d_C \Theta (X)=\Theta(C) \operatorname{Low}_s\left(L^{-1} X L^{-\top}\right)
+            -\frac{1}{2} \operatorname{Diag}\left(L^{-1} X L^{-\top}\right) \Theta(C)
 
         Parameters
         ----------
@@ -520,7 +532,10 @@ class EuclideanCholeskyDiffeo(Diffeo):
     def inverse_tangent(self, image_tangent_vec, image_point=None, base_point=None):
         r"""Inverse tangent diffeomorphism at image point.
 
-        df^-1_p is a linear map from T_f(p)N to T_pM
+        .. math::
+
+            d_{\Gamma} \Phi (Y)= d_{\phi(\Gamma)} \operatorname{Cor}
+            \circ d_{\Gamma} \phi(Y)
 
         Parameters
         ----------

--- a/geomstats/geometry/lower_triangular_matrices.py
+++ b/geomstats/geometry/lower_triangular_matrices.py
@@ -175,7 +175,6 @@ class StrictlyLowerTriangularMatrices(LevelSet, MatrixVectorSpace):
             gs.one_hot(tril_idxs, self.n * self.n),
             dtype=gs.get_default_dtype(),
         )
-        print(vector_bases.shape)
         return gs.reshape(vector_bases, [-1, self.n, self.n])
 
     @staticmethod

--- a/geomstats/geometry/lower_triangular_matrices.py
+++ b/geomstats/geometry/lower_triangular_matrices.py
@@ -4,7 +4,7 @@ Lead author: Saiteja Utpala.
 """
 
 import geomstats.backend as gs
-from geomstats.geometry.base import MatrixVectorSpace
+from geomstats.geometry.base import LevelSet, MatrixVectorSpace
 from geomstats.geometry.matrices import Matrices, MatricesMetric
 
 
@@ -92,3 +92,120 @@ class LowerTriangularMatrices(MatrixVectorSpace):
             Symmetric matrix.
         """
         return gs.tril(point)
+
+
+class StrictlyLowerTriangularMatrices(LevelSet, MatrixVectorSpace):
+    r"""Strictly lower triangular matrices.
+
+    Set of lower triangular matrices with null diagonal:
+
+    .. math::
+
+        \operatorname{LT}^0(n)=\{L \in \operatorname{LT}(n)
+        \mid \operatorname{Diag}(L)=0\}
+
+    Parameters
+    ----------
+    n : int
+        Integer representing the shapes of the matrices: n x n.
+    equip : bool
+        If True, equip space with default metric.
+    """
+
+    def __init__(self, n, equip=True):
+        self.n = n
+        super().__init__(dim=int(n * (n - 1) / 2), equip=equip)
+
+    def _define_embedding_space(self):
+        """Define embedding space of the manifold.
+
+        Returns
+        -------
+        embedding_space : Manifold
+            Instance of Manifold.
+        """
+        return LowerTriangularMatrices(n=self.n)
+
+    @staticmethod
+    def default_metric():
+        """Metric to equip the space with if equip is True."""
+        return MatricesMetric
+
+    def submersion(self, point):
+        """Submersion that defines the manifold.
+
+        Parameters
+        ----------
+        point : array-like, shape=[..., n, n]
+
+        Returns
+        -------
+        submersed_point : array-like, shape=[..., n]
+        """
+        return Matrices.diagonal(point)
+
+    def tangent_submersion(self, vector, point):
+        """Tangent submersion.
+
+        Parameters
+        ----------
+        vector : array-like, shape=[..., n, n]
+        point : Ignored.
+
+        Returns
+        -------
+        submersed_vector : array-like, shape=[..., n]
+        """
+        submersed_vector = Matrices.diagonal(vector)
+        if point is not None and point.ndim > vector.ndim:
+            return gs.broadcast_to(submersed_vector, point.shape[:-1])
+
+        return submersed_vector
+
+    def _create_basis(self):
+        """Create a basis for the vector space.
+
+        Returns
+        -------
+        basis : array-like, shape=[dim, n, n]
+            Basis matrices of the space.
+        """
+        tril_idxs = gs.ravel_tril_indices(self.n, k=-1)
+        vector_bases = gs.cast(
+            gs.one_hot(tril_idxs, self.n * self.n),
+            dtype=gs.get_default_dtype(),
+        )
+        print(vector_bases.shape)
+        return gs.reshape(vector_bases, [-1, self.n, self.n])
+
+    @staticmethod
+    def basis_representation(matrix_representation):
+        """Compute the coefficients of matrices in the given basis.
+
+        Parameters
+        ----------
+        matrix_representation : array-like, shape=[..., n, n]
+            Matrix.
+
+        Returns
+        -------
+        vec : array-like, shape=[..., dim]
+            Vector.
+        """
+        return gs.tril_to_vec(matrix_representation, k=-1)
+
+    def projection(self, point):
+        """Project a point to the manifold.
+
+        Parameters
+        ----------
+        point: array-like, shape[..., n, n]
+            Point to project.
+
+        Returns
+        -------
+        proj_point: array-like, shape[..., n, n]
+            Projected point.
+        """
+        proj_point = self.embedding_space.projection(point)
+        return proj_point - gs.vec_to_diag(gs.diagonal(proj_point, axis1=-2, axis2=-1))

--- a/geomstats/geometry/matrices.py
+++ b/geomstats/geometry/matrices.py
@@ -13,6 +13,51 @@ from geomstats.geometry.euclidean import EuclideanMetric
 from geomstats.vectorization import repeat_out
 
 
+def matrix_matrix_transpose(point):
+    r"""Matrix multiplication with transpose.
+
+    .. math::
+
+        f(A) = A A^{\top}
+
+    Parameters
+    ----------
+    point : array-like, shape=[n, n]
+        Matrix.
+
+    Returns
+    -------
+    mat : array-like, shape=[n, n]
+        Matrix resulting from operation.
+    """
+    return Matrices.mul(point, Matrices.transpose(point))
+
+
+def tangent_matrix_matrix_transpose(tangent_vec, base_point):
+    r"""Tangent matrix multiplication with transpose.
+
+    .. math::
+
+        d_A f (X) = X A^\top + A X^\top
+
+
+    Parameters
+    ----------
+    tangent_vec : array-like, shape=[..., n, n]
+        Tangent vector.
+    base_point : array-like, shape=[..., n, n]
+        Base point.
+
+    Returns
+    -------
+    image_tangent_vec : array-like, shape=[n, n]
+        Matrix resulting from operation.
+    """
+    return Matrices.mul(tangent_vec, Matrices.transpose(base_point)) + Matrices.mul(
+        base_point, Matrices.transpose(tangent_vec)
+    )
+
+
 class FlattenDiffeo(VectorSpaceDiffeo):
     """A diffeo from matrices to Euclidean by flattening.
 

--- a/geomstats/geometry/positive_lower_triangular_matrices.py
+++ b/geomstats/geometry/positive_lower_triangular_matrices.py
@@ -725,8 +725,6 @@ class LowerMatrixLog(Diffeo):
     def tangent(cls, tangent_vec, base_point=None, image_point=None):
         r"""Tangent diffeomorphism at base point.
 
-        df_p is a linear map from T_pM to T_f(p)N.
-
         .. math::
 
             d_z \log (V) = \sum_{k=1}^{n-1}\left(\frac{(-1)^{k+1}}{k}
@@ -772,8 +770,6 @@ class LowerMatrixLog(Diffeo):
     @classmethod
     def inverse_tangent(cls, image_tangent_vec, image_point=None, base_point=None):
         r"""Inverse tangent diffeomorphism at image point.
-
-        df^-1_p is a linear map from T_f(p)N to T_pM.
 
         .. math::
 

--- a/geomstats/test_cases/algebra_utils.py
+++ b/geomstats/test_cases/algebra_utils.py
@@ -38,3 +38,25 @@ class AlgebraUtilsTestCase(TestCase):
         points = sphere.random_point(n_points)
         res = utils.rotate_points(points, north_pole)
         self.assertAllClose(res, points, atol=atol)
+
+    @pytest.mark.random
+    def test_columnwise_scaling(self, n_points, m, n, atol):
+        batch_shape = () if n_points == 1 else (n_points,)
+
+        diag_vec = gs.random.uniform(size=batch_shape + (n,))
+        point = gs.random.uniform(size=batch_shape + (m, n))
+
+        res = utils.columnwise_scaling(diag_vec, point)
+        res_ = gs.matmul(point, gs.vec_to_diag(diag_vec))
+        self.assertAllClose(res, res_, atol=atol)
+
+    @pytest.mark.random
+    def test_rowwise_scaling(self, n_points, m, n, atol):
+        batch_shape = () if n_points == 1 else (n_points,)
+
+        diag_vec = gs.random.uniform(size=batch_shape + (m,))
+        point = gs.random.uniform(size=batch_shape + (m, n))
+
+        res = utils.rowwise_scaling(diag_vec, point)
+        res_ = gs.matmul(gs.vec_to_diag(diag_vec), point)
+        self.assertAllClose(res, res_, atol=atol)

--- a/geomstats/test_cases/geometry/positive_lower_triangular_matrices.py
+++ b/geomstats/test_cases/geometry/positive_lower_triangular_matrices.py
@@ -1,4 +1,65 @@
+import geomstats.backend as gs
+from geomstats.geometry.diffeo import AutodiffDiffeo
 from geomstats.test_cases.geometry.riemannian_metric import RiemannianMetricTestCase
+
+
+class LowerMatrixLog(AutodiffDiffeo):
+    """Matrix logarithm diffeomorphism.
+
+    An alternative implementation for testing
+    purposes.
+    """
+
+    @staticmethod
+    def __call__(base_point):
+        """Compute the matrix log.
+
+        Parameters
+        ----------
+        base_point : array_like, shape=[..., n, n]
+            Symmetric matrix.
+
+        Returns
+        -------
+        log : array_like, shape=[..., n, n]
+            Matrix logarithm of base_point.
+        """
+        return gs.linalg.logm(base_point)
+
+    @staticmethod
+    def inverse(image_point):
+        """Compute the matrix exponential.
+
+        Parameters
+        ----------
+        image_point : array_like, shape=[..., n, n]
+            Symmetric matrix.
+
+        Returns
+        -------
+        exponential : array_like, shape=[..., n, n]
+            Exponential of image_point.
+        """
+        return gs.linalg.expm(image_point)
+
+    def tangent(self, tangent_vec, base_point=None, image_point=None):
+        r"""Tangent diffeomorphism at base point.
+
+        Parameters
+        ----------
+        tangent_vec : array-like, shape=[..., *space_shape]
+            Tangent vector at base point.
+        base_point : array-like, shape=[..., *space_shape]
+            Base point.
+        image_point : array-like, shape=[..., *image_shape]
+            Image point.
+
+        Returns
+        -------
+        image_tangent_vec : array-like, shape=[..., *image_shape]
+            Image tangent vector at image of the base point.
+        """
+        raise NotImplementedError("Not implemented.")
 
 
 class CholeskyMetricTestCase(RiemannianMetricTestCase):

--- a/tests/tests_geomstats/data/algebra_utils.py
+++ b/tests/tests_geomstats/data/algebra_utils.py
@@ -103,3 +103,17 @@ class AlgebraUtilsTestData(TestData):
 
     def rotate_points_test_data(self):
         return self.generate_random_data()
+
+    def columnwise_scaling_test_data(self):
+        data = [
+            dict(n_points=n_points, m=random.randint(2, 5), n=random.randint(2, 5))
+            for n_points in self.N_RANDOM_POINTS
+        ]
+        return self.generate_tests(data)
+
+    def rowwise_scaling_test_data(self):
+        data = [
+            dict(n_points=n_points, m=random.randint(2, 5), n=random.randint(2, 5))
+            for n_points in self.N_RANDOM_POINTS
+        ]
+        return self.generate_tests(data)

--- a/tests/tests_geomstats/test_geometry/data/full_rank_correlation_matrices.py
+++ b/tests/tests_geomstats/test_geometry/data/full_rank_correlation_matrices.py
@@ -56,6 +56,11 @@ class PolyHyperbolicCholeskyMetricTestData(PullbackDiffeoMetricTestData):
     fail_for_not_implemented_errors = False
 
 
+class EuclideanCholeskyMetricTestData(PullbackDiffeoMetricTestData):
+    fail_for_autodiff_exceptions = False
+    fail_for_not_implemented_errors = False
+
+
 class OffLogMetricTestData(PullbackDiffeoMetricTestData):
     fail_for_autodiff_exceptions = False
     fail_for_not_implemented_errors = False

--- a/tests/tests_geomstats/test_geometry/data/lower_triangular_matrices.py
+++ b/tests/tests_geomstats/test_geometry/data/lower_triangular_matrices.py
@@ -1,7 +1,7 @@
 import geomstats.backend as gs
 from geomstats.test.data import TestData
 
-from .base import MatrixVectorSpaceTestData
+from .base import LevelSetTestData, MatrixVectorSpaceTestData
 
 
 class LowerTriangularMatricesTestData(MatrixVectorSpaceTestData):
@@ -84,3 +84,9 @@ class LowerTriangularMatrices3TestData(TestData):
             ),
         ]
         return self.generate_tests(data)
+
+
+class StrictlyLowerTriangularMatricesTestData(
+    LevelSetTestData, MatrixVectorSpaceTestData
+):
+    pass

--- a/tests/tests_geomstats/test_geometry/data/positive_lower_triangular_matrices.py
+++ b/tests/tests_geomstats/test_geometry/data/positive_lower_triangular_matrices.py
@@ -3,7 +3,7 @@ import math
 import geomstats.backend as gs
 from geomstats.test.data import TestData
 
-from .base import VectorSpaceOpenSetTestData
+from .base import LevelSetTestData, VectorSpaceOpenSetTestData
 from .invariant_metric import InvariantMetricMatrixTestData
 from .lie_group import MatrixLieGroupTestData
 from .pullback_metric import PullbackDiffeoMetricTestData
@@ -201,3 +201,7 @@ class InvariantPositiveLowerTriangularMatricesMetricTestData(
 class UnitNormedRowsPLTMatricesPullbackMetricTestData(PullbackDiffeoMetricTestData):
     fail_for_autodiff_exceptions = False
     fail_for_not_implemented_errors = False
+
+
+class PLTUnitDiagMatricesTestData(LevelSetTestData):
+    pass

--- a/tests/tests_geomstats/test_geometry/data/positive_lower_triangular_matrices.py
+++ b/tests/tests_geomstats/test_geometry/data/positive_lower_triangular_matrices.py
@@ -4,6 +4,7 @@ import geomstats.backend as gs
 from geomstats.test.data import TestData
 
 from .base import LevelSetTestData, VectorSpaceOpenSetTestData
+from .diffeo import DiffeoComparisonTestData
 from .invariant_metric import InvariantMetricMatrixTestData
 from .lie_group import MatrixLieGroupTestData
 from .pullback_metric import PullbackDiffeoMetricTestData
@@ -205,3 +206,8 @@ class UnitNormedRowsPLTMatricesPullbackMetricTestData(PullbackDiffeoMetricTestDa
 
 class PLTUnitDiagMatricesTestData(LevelSetTestData):
     pass
+
+
+class LowerMatrixLogCmpTestData(DiffeoComparisonTestData):
+    fail_for_autodiff_exceptions = False
+    fail_for_not_implemented_errors = False

--- a/tests/tests_geomstats/test_geometry/test_full_rank_correlation_matrices.py
+++ b/tests/tests_geomstats/test_geometry/test_full_rank_correlation_matrices.py
@@ -5,7 +5,11 @@ import pytest
 import geomstats.backend as gs
 from geomstats.geometry.diffeo import ComposedDiffeo
 from geomstats.geometry.full_rank_correlation_matrices import (
+    EuclideanCholeskyDiffeo,
+    EuclideanCholeskyMetric,
     FullRankCorrelationMatrices,
+    LogEuclideanCholeskyDiffeo,
+    LogEuclideanCholeskyMetric,
     LogScaledMetric,
     LogScalingDiffeo,
     OffLogDiffeo,
@@ -17,12 +21,14 @@ from geomstats.geometry.full_rank_correlation_matrices import (
 from geomstats.geometry.general_linear import GeneralLinear
 from geomstats.geometry.hermitian_matrices import expmh
 from geomstats.geometry.hyperboloid import Hyperboloid
+from geomstats.geometry.lower_triangular_matrices import StrictlyLowerTriangularMatrices
 from geomstats.geometry.matrices import Matrices
 from geomstats.geometry.open_hemisphere import (
     OpenHemispheresProduct,
     OpenHemisphereToHyperboloidDiffeo,
 )
 from geomstats.geometry.positive_lower_triangular_matrices import (
+    PLTUnitDiagMatrices,
     UnitNormedRowsPLTDiffeo,
     UnitNormedRowsPLTMatrices,
 )
@@ -47,6 +53,7 @@ from geomstats.test_cases.geometry.quotient_metric import QuotientMetricTestCase
 from .data.diffeo import DiffeoTestData
 from .data.full_rank_correlation_matrices import (
     CorrelationMatricesBundleTestData,
+    EuclideanCholeskyMetricTestData,
     FullRankCorrelationAffineQuotientMetricTestData,
     FullRankCorrelationMatricesTestData,
     LogScaledMetricTestData,
@@ -174,6 +181,46 @@ class TestPolyHyperbolicCholeskyMetric(
     PullbackDiffeoMetricTestCase, metaclass=DataBasedParametrizer
 ):
     testing_data = PolyHyperbolicCholeskyMetricTestData()
+
+
+class TestEuclideanCholeskyDiffeo(DiffeoTestCase, metaclass=DataBasedParametrizer):
+    _n = random.randint(2, 5)
+
+    space = FullRankCorrelationMatrices(n=_n, equip=False)
+    image_space = PLTUnitDiagMatrices(n=_n, equip=False)
+    diffeo = EuclideanCholeskyDiffeo()
+    testing_data = DiffeoTestData()
+
+
+class TestEuclideanCholeskyMetric(
+    PullbackDiffeoMetricTestCase, metaclass=DataBasedParametrizer
+):
+    _n = random.randint(2, 5)
+
+    space = FullRankCorrelationMatrices(n=_n, equip=False).equip_with_metric(
+        EuclideanCholeskyMetric
+    )
+    testing_data = EuclideanCholeskyMetricTestData()
+
+
+class TestLogEuclideanCholeskyDiffeo(DiffeoTestCase, metaclass=DataBasedParametrizer):
+    _n = random.randint(2, 5)
+
+    space = FullRankCorrelationMatrices(n=_n, equip=False)
+    image_space = StrictlyLowerTriangularMatrices(n=_n, equip=False)
+    diffeo = LogEuclideanCholeskyDiffeo()
+    testing_data = DiffeoTestData()
+
+
+class TestLogEuclideanCholeskyMetric(
+    PullbackDiffeoMetricTestCase, metaclass=DataBasedParametrizer
+):
+    _n = random.randint(2, 5)
+
+    space = FullRankCorrelationMatrices(n=_n, equip=False).equip_with_metric(
+        LogEuclideanCholeskyMetric
+    )
+    testing_data = EuclideanCholeskyMetricTestData()
 
 
 class TestUniqueDiagonalMatrixAlgorithm(TestCase, metaclass=DataBasedParametrizer):

--- a/tests/tests_geomstats/test_geometry/test_lower_triangular_matrices.py
+++ b/tests/tests_geomstats/test_geometry/test_lower_triangular_matrices.py
@@ -2,17 +2,26 @@ import random
 
 import pytest
 
-from geomstats.geometry.lower_triangular_matrices import LowerTriangularMatrices
+from geomstats.geometry.lower_triangular_matrices import (
+    LowerTriangularMatrices,
+    StrictlyLowerTriangularMatrices,
+)
 from geomstats.test.parametrizers import DataBasedParametrizer
-from geomstats.test_cases.geometry.base import MatrixVectorSpaceTestCase
+from geomstats.test_cases.geometry.base import (
+    LevelSetTestCase,
+    MatrixVectorSpaceTestCase,
+)
 from geomstats.test_cases.geometry.matrices import MatricesMetricTestCase
 
 from .data.lower_triangular_matrices import (
     LowerTriangularMatrices2TestData,
     LowerTriangularMatrices3TestData,
     LowerTriangularMatricesTestData,
+    StrictlyLowerTriangularMatricesTestData,
 )
-from .data.matrices import MatricesMetricTestData
+from .data.matrices import (
+    MatricesMetricTestData,
+)
 
 
 @pytest.fixture(
@@ -56,3 +65,14 @@ class TestLowerTriangularMatrices3(
 class TestMatricesMetric(MatricesMetricTestCase, metaclass=DataBasedParametrizer):
     space = LowerTriangularMatrices(n=random.randint(3, 5))
     testing_data = MatricesMetricTestData()
+
+
+class TestStrictlyLowerTriangularMatrices(
+    LevelSetTestCase,
+    MatrixVectorSpaceTestCase,
+    metaclass=DataBasedParametrizer,
+):
+    _n = random.randint(2, 6)
+    space = StrictlyLowerTriangularMatrices(n=_n, equip=False)
+
+    testing_data = StrictlyLowerTriangularMatricesTestData()

--- a/tests/tests_geomstats/test_geometry/test_positive_lower_triangular_matrices.py
+++ b/tests/tests_geomstats/test_geometry/test_positive_lower_triangular_matrices.py
@@ -2,9 +2,12 @@ import random
 
 import pytest
 
+from geomstats.geometry.lower_triangular_matrices import StrictlyLowerTriangularMatrices
 from geomstats.geometry.positive_lower_triangular_matrices import (
     CholeskyMetric,
     InvariantPositiveLowerTriangularMatricesMetric,
+    LowerMatrixLog,
+    PLTUnitDiagMatrices,
     PositiveLowerTriangularMatrices,
     UnitNormedRowsPLTDiffeo,
     UnitNormedRowsPLTMatrices,
@@ -13,6 +16,7 @@ from geomstats.test.parametrizers import DataBasedParametrizer
 from geomstats.test.random import RandomDataGenerator
 from geomstats.test_cases.geometry.base import (
     DiffeomorphicManifoldTestCase,
+    LevelSetTestCase,
     VectorSpaceOpenSetTestCase,
 )
 from geomstats.test_cases.geometry.diffeo import DiffeoTestCase
@@ -29,26 +33,18 @@ from .data.positive_lower_triangular_matrices import (
     CholeskyMetric2TestData,
     CholeskyMetricTestData,
     InvariantPositiveLowerTriangularMatricesMetricTestData,
+    PLTUnitDiagMatricesTestData,
     PositiveLowerTriangularMatrices2TestData,
     PositiveLowerTriangularMatricesTestData,
     UnitNormedRowsPLTMatricesPullbackMetricTestData,
 )
 
 
-@pytest.fixture(
-    scope="class",
-    params=[
-        random.randint(2, 5),
-    ],
-)
-def spaces(request):
-    request.cls.space = PositiveLowerTriangularMatrices(n=request.param, equip=False)
-
-
-@pytest.mark.usefixtures("spaces")
 class TestPositiveLowerTriangularMatrices(
     MatrixLieGroupTestCase, VectorSpaceOpenSetTestCase, metaclass=DataBasedParametrizer
 ):
+    _n = random.randint(2, 5)
+    space = PositiveLowerTriangularMatrices(n=_n, equip=False)
     testing_data = PositiveLowerTriangularMatricesTestData()
 
 
@@ -116,3 +112,18 @@ class TestUnitNormedRowsPLTMatricesPullbackMetric(
     space = UnitNormedRowsPLTMatrices(n=_n)
     data_generator = RandomDataGenerator(space, amplitude=5.0)
     testing_data = UnitNormedRowsPLTMatricesPullbackMetricTestData()
+
+
+class TestPLTUnitDiagMatrices(LevelSetTestCase, metaclass=DataBasedParametrizer):
+    _n = random.randint(2, 5)
+    space = PLTUnitDiagMatrices(n=_n, equip=False)
+    testing_data = PLTUnitDiagMatricesTestData()
+
+
+class TestLowerMatrixLog(DiffeoTestCase, metaclass=DataBasedParametrizer):
+    _n = random.randint(2, 5)
+
+    space = PLTUnitDiagMatrices(n=_n, equip=False)
+    image_space = StrictlyLowerTriangularMatrices(n=_n, equip=False)
+    diffeo = LowerMatrixLog()
+    testing_data = DiffeoTestData()

--- a/tests/tests_geomstats/test_geometry/test_positive_lower_triangular_matrices.py
+++ b/tests/tests_geomstats/test_geometry/test_positive_lower_triangular_matrices.py
@@ -19,11 +19,17 @@ from geomstats.test_cases.geometry.base import (
     LevelSetTestCase,
     VectorSpaceOpenSetTestCase,
 )
-from geomstats.test_cases.geometry.diffeo import DiffeoTestCase
+from geomstats.test_cases.geometry.diffeo import (
+    DiffeoComparisonTestCase,
+    DiffeoTestCase,
+)
 from geomstats.test_cases.geometry.invariant_metric import InvariantMetricMatrixTestCase
 from geomstats.test_cases.geometry.lie_group import MatrixLieGroupTestCase
 from geomstats.test_cases.geometry.positive_lower_triangular_matrices import (
     CholeskyMetricTestCase,
+)
+from geomstats.test_cases.geometry.positive_lower_triangular_matrices import (
+    LowerMatrixLog as OtherLowerMatrixLog,
 )
 from geomstats.test_cases.geometry.pullback_metric import PullbackDiffeoMetricTestCase
 
@@ -33,6 +39,7 @@ from .data.positive_lower_triangular_matrices import (
     CholeskyMetric2TestData,
     CholeskyMetricTestData,
     InvariantPositiveLowerTriangularMatricesMetricTestData,
+    LowerMatrixLogCmpTestData,
     PLTUnitDiagMatricesTestData,
     PositiveLowerTriangularMatrices2TestData,
     PositiveLowerTriangularMatricesTestData,
@@ -127,3 +134,15 @@ class TestLowerMatrixLog(DiffeoTestCase, metaclass=DataBasedParametrizer):
     image_space = StrictlyLowerTriangularMatrices(n=_n, equip=False)
     diffeo = LowerMatrixLog()
     testing_data = DiffeoTestData()
+
+
+class TestLowerMatrixLogCmp(DiffeoComparisonTestCase, metaclass=DataBasedParametrizer):
+    _n = random.randint(2, 5)
+
+    space = PLTUnitDiagMatrices(n=_n, equip=False)
+    image_space = StrictlyLowerTriangularMatrices(n=_n, equip=False)
+
+    diffeo = LowerMatrixLog()
+    other_diffeo = OtherLowerMatrixLog(space.shape)
+
+    testing_data = LowerMatrixLogCmpTestData()


### PR DESCRIPTION
This PR adds the metrics defined in sections 7.4.2 (`EuclideanCholeskyMetric`) and 7.4.3 (`LogEuclideanCholeskyMetric`) of [thanwerdas2022](https://hal.science/tel-03698752).

To accomplish this, we add the following spaces:

* `PLTUnitDiagMatrices`

* `StrictlyLowerTriangularMatrices`


And the following diffeos:

* `LowerMatrixLog`

* `EuclideanCholeskyDiffeo`

* `LogEuclideanCholeskyDiffeo`


For code readability, we also add a bunch of new functions: `columnwise_scaling`, `rowwise_scaling`, `matrix_matrix_transpose`, `tangent_matrix_matrix_transpose`.


Lastly, `matrix_power` is added to the backend.

Everything is fully tested.

(Done with @olivierbisson)


