### PR TITLE
Fix numpy backend for 2.x

### DIFF
--- a/.github/workflows/test-python-backwards.yml
+++ b/.github/workflows/test-python-backwards.yml
@@ -25,7 +25,12 @@ jobs:
       - name: install dependencies [pip]
         run: |
           pip install --upgrade pip setuptools wheel
-          pip install -e .[opt,test,test-scripts,${{ matrix.geomstats-backend }}]
+          pip install -e .[opt,test,${{ matrix.geomstats-backend }}]
+
+      - name: install (extra) dependencies [pip]
+        if: ${{matrix.test-folder == 'tests/tests_scripts'}}
+        run: |
+          pip install -e .[test-scripts]
 
       - name: Add annotations [pytest]
         run: pip install pytest-github-actions-annotate-failures

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,12 +44,17 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: ~/.cache/pip
-          key: ${{matrix.geomstats-backend}}-${{matrix.os}}-${{matrix.python-version}}-${{ hashFiles('pyproject.toml') }}
+          key: ${{matrix.geomstats-backend}}-${{matrix.os}}-${{matrix.python-version}}-${{matrix.test-folder}}-${{ hashFiles('pyproject.toml') }}
 
       - name: install dependencies [pip]
         run: |
           pip install --upgrade pip setuptools wheel
-          pip install -e .[opt,test,test-scripts,${{ matrix.geomstats-backend }}]
+          pip install -e .[opt,test,${{ matrix.geomstats-backend }}]
+
+      - name: install (extra) dependencies [pip]
+        if: ${{matrix.test-folder == 'tests/tests_scripts'}}
+        run: |
+          pip install -e .[test-scripts]
 
       - name: Add annotations [pytest]
         run: pip install pytest-github-actions-annotate-failures

--- a/geomstats/_backend/_shared_numpy/linalg.py
+++ b/geomstats/_backend/_shared_numpy/linalg.py
@@ -110,3 +110,33 @@ def polar(*args, **kwargs):
     return _np.vectorize(
         _scipy.linalg.polar, signature="(n,n)->(n,n),(n,n)", excluded=["side"]
     )(*args, **kwargs)
+
+
+def solve(a, b):
+    """
+    Solve a linear matrix equation, or system of linear scalar equations.
+
+    Computes the "exact" solution, `x`, of the well-determined, i.e., full
+    rank, linear matrix equation `ax = b`.
+
+    Parameters
+    ----------
+    a : array-like, shape=[..., M, M]
+        Coefficient matrix.
+    b : array-like, shape=[..., M]
+        Ordinate or "dependent variable" values".
+
+    Returns
+    -------
+    x : array-like, shape=[..., M]
+        Solution to the system a x = b.
+    """
+    batch_shape = a.shape[:-2]
+    if batch_shape:
+        b = _np.expand_dims(b, axis=-1)
+
+    res = _np.linalg.solve(a, b)
+    if batch_shape:
+        return res[..., 0]
+
+    return res

--- a/geomstats/_backend/autograd/linalg.py
+++ b/geomstats/_backend/autograd/linalg.py
@@ -15,7 +15,6 @@ from autograd.numpy.linalg import (
     matrix_power,
     matrix_rank,
     norm,
-    solve,
     svd,
 )
 from autograd.scipy.linalg import expm
@@ -26,6 +25,7 @@ from .._shared_numpy.linalg import (
     is_single_matrix_pd,
     polar,
     qr,
+    solve,
     solve_sylvester,
     sqrtm,
 )

--- a/geomstats/_backend/numpy/linalg.py
+++ b/geomstats/_backend/numpy/linalg.py
@@ -23,36 +23,7 @@ from .._shared_numpy.linalg import (
     polar,
     qr,
     quadratic_assignment,
+    solve,
     solve_sylvester,
     sqrtm,
 )
-
-
-def solve(a, b):
-    """
-    Solve a linear matrix equation, or system of linear scalar equations.
-
-    Computes the "exact" solution, `x`, of the well-determined, i.e., full
-    rank, linear matrix equation `ax = b`.
-
-    Parameters
-    ----------
-    a : array-like, shape=[..., M, M]
-        Coefficient matrix.
-    b : array-like, shape=[..., M]
-        Ordinate or "dependent variable" values".
-
-    Returns
-    -------
-    x : array-like, shape=[..., M]
-        Solution to the system a x = b.
-    """
-    batch_shape = a.shape[:-2]
-    if batch_shape:
-        b = _np.expand_dims(b, axis=-1)
-
-    res = _np.linalg.solve(a, b)
-    if batch_shape:
-        return res[..., 0]
-
-    return res

--- a/geomstats/_backend/numpy/linalg.py
+++ b/geomstats/_backend/numpy/linalg.py
@@ -2,7 +2,7 @@
 
 import numpy as _np
 import scipy as _scipy
-from numpy.linalg import (  # NOQA
+from numpy.linalg import (
     cholesky,
     det,
     eig,
@@ -12,7 +12,6 @@ from numpy.linalg import (  # NOQA
     matrix_power,
     matrix_rank,
     norm,
-    solve,
     svd,
 )
 from scipy.linalg import expm
@@ -27,3 +26,33 @@ from .._shared_numpy.linalg import (
     solve_sylvester,
     sqrtm,
 )
+
+
+def solve(a, b):
+    """
+    Solve a linear matrix equation, or system of linear scalar equations.
+
+    Computes the "exact" solution, `x`, of the well-determined, i.e., full
+    rank, linear matrix equation `ax = b`.
+
+    Parameters
+    ----------
+    a : array-like, shape=[..., M, M]
+        Coefficient matrix.
+    b : array-like, shape=[..., M]
+        Ordinate or "dependent variable" values".
+
+    Returns
+    -------
+    x : array-like, shape=[..., M]
+        Solution to the system a x = b.
+    """
+    batch_shape = a.shape[:-2]
+    if batch_shape:
+        b = _np.expand_dims(b, axis=-1)
+
+    res = _np.linalg.solve(a, b)
+    if batch_shape:
+        return res[..., 0]
+
+    return res

--- a/tests/tests_geomstats/test_geometry/data/product_hpd_and_siegel_disks.py
+++ b/tests/tests_geomstats/test_geometry/data/product_hpd_and_siegel_disks.py
@@ -9,8 +9,8 @@ class ProductHPDMatricesAndSiegelDisksMetricTestData(ProductRiemannianMetricTest
     trials = 5
 
     tolerances = {
-        "dist_is_log_norm": {"atol": 1e-6},
-        "geodesic_bvp_reverse": {"atol": 1e-6},
-        "geodesic_ivp_belongs": {"atol": 1e-6},
-        "exp_belongs": {"atol": 1e-6},
+        "dist_is_log_norm": {"atol": 1e-4},
+        "geodesic_bvp_reverse": {"atol": 1e-4},
+        "geodesic_ivp_belongs": {"atol": 1e-4},
+        "exp_belongs": {"atol": 1e-4},
     }


### PR DESCRIPTION
This PR fixes `numpy` backend to work with numpy `2.x.x`. `solve` signature has changed in `numpy` `2.x` for multi-batch. For now, `geomstats` signature is kept unchanged and the calling to `numpy` is manipulated.


NB: main tests run with `numpy 2.x`, while scripts run with `numpy 1.x` due to `tensorflow` dependency.