### PR TITLE
Faster more stable implementation of Affine Invariante SPD squared_dist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ doc = [
     "pydata-sphinx-theme",
 ]
 lint = ["ruff", "pre-commit"]
-test = ["pytest", "pytest-cov", "coverage", "jupyter", "ipython < 8.23"]
+test = ["pytest", "pytest-cov", "coverage", "jupyter", "ipython < 8.23", "pykeops"]
 test-scripts = ["scikeras", "tensorflow"]
 graph = ["networkx"]
 pykeops = ["pykeops"]


### PR DESCRIPTION
<!--
Thank you for opening this pull request!
-->

## Checklist

- [X] My pull request has a clear and explanatory title.
- [X] If necessary, my code is [vectorized](https://www.geeksforgeeks.org/vectorization-in-python/).
- [ ] I added appropriate unit tests.
- [X] I made sure the code passes all unit tests. (refer to comment below)
- [X] My PR follows [PEP8](https://peps.python.org/pep-0008/) guidelines. (refer to comment below)
- [X] My PR follows [geomstats coding style](https://github.com/geomstats/geomstats/blob/main/docs/contributing.rst#coding-style-guidelines) and API.
- [X] My code is properly documented and I made sure the documentation renders properly. ([Link](https://github.com/geomstats/geomstats/blob/main/docs/contributing.rst#documentation))
- [X] I linked to issues and PRs that are relevant to this PR.


<!-- For checking consistency of entire codebase
First, run the tests related to your changes. For example, if you changed something in geomstats/spd_matrices_space.py:
$ pytest tests/tests_geomstats/test_spd_matrices.py

and then run the tests of the whole codebase to check that your feature is not breaking any of them:
$ pytest tests/

This way, further modifications on the code base are guaranteed to be consistent with the desired behavior. Merging your PR should not break any test in any backend (numpy, tensorflow or pytorch)."

For testing in alternative backends such as `numpy`, `pytorch`, `autograd`, `tensorflow` set the environment variable using:
$ export GEOMSTATS_BACKEND=<backend_name>

Next, import the `backend` module using:
import geomstats.backend as gs
-->


## Description

I implemented an explicit formula for the squared Affine Invariant distance in the SPD manifold. The implementation uses the generalized-eigenvalue formula for the distance. Generalized eigenvalues are computed with the method of section 7.2 in the paper [Eigenvalue and Generalized Eigenvalue Problems: Tutorial](https://arxiv.org/pdf/1903.11240).


## Issue

The implementation can be up to 4 or 5 times faster than the current implementation, and it also seems more numerically stable in some tests I ran (where current implementation returned NaN's while the new implementation didn't). Also, it doesn't involve creating arrays with the gs backend. This means that if called for PyTorch Tensors that are in the GPU, the new implementation will work, while the current one will throw an error of arrays in different devices (https://github.com/geomstats/geomstats/issues/1082#issuecomment-2349334826).

I started Issue  #2028 with some questions about where to put the Generalized Eigenvalue function, but that could be closed now, since it will be reviewed.

## Additional context

I wrote a script (attached as .txt) that contains the new implementations as a stand-alone function, and compares both the results and the time of the stand-alone function to the geomstats implementation. I could incorporate this script as a benchmark or similar if guided as to where/how to do that.
[test_ai_distance.txt](https://github.com/user-attachments/files/17118489/test_ai_distance.txt).

I didn't add unit tests because it doesn't seem like it's a new functionality and there's already tests for Affine Invariant distance I suppose? But I can add tests if needed.

I also added the package pykeops to the list of packages for geomstats with tests, since it seemed to be a missing dependency when I was running the tests preparing this contribution.
