### PR TITLE
Fix positiveness issue in spd scaling finder

### DIFF
--- a/geomstats/geometry/full_rank_correlation_matrices.py
+++ b/geomstats/geometry/full_rank_correlation_matrices.py
@@ -1038,6 +1038,9 @@ class SPDScalingFinder:
 
     For details, check out [T2024]_'s section 3.5.
 
+    To ensure convergence, it is better to use a damped Newton method, which
+    leverages function being standard self-concordant and strictly convex
+    (check out section 5.1.5 of [N2018]_).
 
     Parameters
     ----------
@@ -1057,11 +1060,12 @@ class SPDScalingFinder:
         “Scaling of Symmetric Matrices by Positive Diagonal Congruence.”
         Linear and Multilinear Algebra 57, no. 2 (March 1, 2009): 123–40.
         https://doi.org/10.1080/03081080600872327.
+    .. [N2018] Yurii Nesterov. Lectures on Convex Optimization. Springer, 2018.
     """
 
     def __init__(self, root_finder=None):
         if root_finder is None:
-            root_finder = NewtonMethod()
+            root_finder = NewtonMethod(damped=True)
 
         self.root_finder = root_finder
 

--- a/geomstats/numerics/optimization.py
+++ b/geomstats/numerics/optimization.py
@@ -242,11 +242,18 @@ class NewtonMethod(RootFinder):
         Tolerance to check algorithm convergence.
     max_iter : int
         Maximum iterations.
+    damped : bool
+        Whether to use a damped version. Check p358 of [N2018]_.
+
+    References
+    ----------
+    .. [N2018] Yurii Nesterov. Lectures on Convex Optimization. Springer, 2018.
     """
 
-    def __init__(self, atol=gs.atol, max_iter=100):
+    def __init__(self, atol=gs.atol, max_iter=100, damped=False):
         self.atol = atol
         self.max_iter = max_iter
+        self.damped = damped
 
     def root(self, fun, x0, fun_jac):
         """Find a root of a vector-valued function.
@@ -269,7 +276,11 @@ class NewtonMethod(RootFinder):
                 break
 
             y = gs.linalg.solve(fun_jac(xk), fun_xk)
-            xk = xk - y
+            if self.damped:
+                lambda_xk = gs.sqrt(gs.dot(fun_xk, y))
+            else:
+                lambda_xk = 0.0
+            xk = xk - (1 / (1 + lambda_xk)) * y
         else:
             message = f"Maximum number of iterations {self.max_iter} reached. Results may be inaccurate"
             status = 0

--- a/tests/tests_geomstats/test_geometry/data/full_rank_correlation_matrices.py
+++ b/tests/tests_geomstats/test_geometry/data/full_rank_correlation_matrices.py
@@ -70,6 +70,9 @@ class SPDScalingFinderTestData(TestData):
     def rows_sum_to_one_test_data(self):
         return self.generate_random_data()
 
+    def values_are_positive_test_data(self):
+        return self.generate_random_data()
+
 
 class LogScaledMetricTestData(PullbackDiffeoMetricTestData):
     fail_for_autodiff_exceptions = False

--- a/tests/tests_geomstats/test_geometry/test_full_rank_correlation_matrices.py
+++ b/tests/tests_geomstats/test_geometry/test_full_rank_correlation_matrices.py
@@ -38,7 +38,7 @@ from geomstats.geometry.symmetric_matrices import (
     SymmetricHollowMatrices,
     SymmetricMatrices,
 )
-from geomstats.numerics.optimization import NewtonMethod, ScipyRoot
+from geomstats.numerics.optimization import NewtonMethod
 from geomstats.test.parametrizers import DataBasedParametrizer
 from geomstats.test.random import RandomDataGenerator
 from geomstats.test.test_case import TestCase
@@ -272,8 +272,7 @@ class TestOffLogMetric(PullbackDiffeoMetricTestCase, metaclass=DataBasedParametr
 @pytest.fixture(
     scope="class",
     params=[
-        NewtonMethod(),
-        ScipyRoot(),
+        NewtonMethod(damped=True),
     ],
 )
 def unique_positive_diagonal_matrix_algorithms(request):
@@ -299,6 +298,13 @@ class TestSPDScalingFinder(TestCase, metaclass=DataBasedParametrizer):
         batch_shape = (n_points,) if n_points > 1 else ()
         expected = gs.ones(batch_shape + (spd_mat.shape[-1],))
         self.assertAllClose(res, expected, atol=atol)
+
+    @pytest.mark.random
+    def test_values_are_positive(self, n_points):
+        spd_mat = self.data_generator.random_point(n_points)
+        diag_vec = self.algo(spd_mat)
+
+        self.assertAllEqual(diag_vec > 0.0, gs.ones_like(diag_vec, dtype=bool))
 
 
 class TestLogScalingDiffeo(DiffeoTestCase, metaclass=DataBasedParametrizer):


### PR DESCRIPTION
This PR fixes the positiveness issue found by @olivierbisson for the `SPDScalingFinder` (optimization was returning negative elements, whereas they must be positive) (this follows from #2024).

The solution consists in using a damped Newton method (@olivierbisson can you suggest a reference for this?), as suggested by @olivierbisson.

Additional positiveness tests have been added and are now passing consistently.