### PR TITLE
Check type of `equip` in Manifold __init__

### DIFF
--- a/geomstats/geometry/manifold.py
+++ b/geomstats/geometry/manifold.py
@@ -49,6 +49,9 @@ class Manifold(abc.ABC):
         if not isinstance(shape, tuple):
             raise ValueError("Expected a tuple for the shape argument.")
 
+        if not isinstance(equip, bool):
+            raise TypeError("Expected a boolean value for 'equip' argument.")
+
         self.dim = dim
         self.shape = shape
         self.intrinsic = intrinsic

--- a/geomstats/geometry/spd_matrices.py
+++ b/geomstats/geometry/spd_matrices.py
@@ -474,6 +474,8 @@ class SPDMatrices(VectorSpaceOpenSet):
     ----------
     n : int
         Integer representing the shape of the matrices: n x n.
+    equip : bool
+        If True, equip space with default metric.
     """
 
     def __init__(self, n, equip=True):

--- a/geomstats/test_cases/geometry/matrices.py
+++ b/geomstats/test_cases/geometry/matrices.py
@@ -83,7 +83,7 @@ class MatrixOperationsTestCase(TestCase):
     @pytest.mark.vec
     def test_bracket_vec(self, n_reps, atol):
         mat_a = self.data_generator.random_square_mat()
-        mat_b = self.data_generator.random_square_mat(shape=mat_a.shape[-2:])
+        mat_b = self.data_generator.random_square_mat(shape=mat_a.shape[-1:])
 
         expected = Matrices.bracket(mat_a, mat_b)
 
@@ -98,7 +98,7 @@ class MatrixOperationsTestCase(TestCase):
     @pytest.mark.random
     def test_bracket_bilinearity(self, n_points, atol):
         mat_a = self.data_generator.random_square_mat(n_points)
-        shape = mat_a.shape[-2:]
+        shape = mat_a.shape[-1:]
         mat_b = self.data_generator.random_square_mat(shape=shape)
         mat_c = self.data_generator.random_square_mat(shape=shape)
 
@@ -255,7 +255,7 @@ class MatrixOperationsTestCase(TestCase):
     @pytest.mark.vec
     def test_congruent_vec(self, n_reps, atol):
         mat_1 = self.data_generator.random_square_mat()
-        shape = mat_1.shape[-2:]
+        shape = mat_1.shape[-1:]
         mat_2 = self.data_generator.random_square_mat(shape=shape)
 
         expected = Matrices.congruent(mat_1, mat_2)


### PR DESCRIPTION
## Description

Added a check for `equip` argument type in the `Manifold` class. 

## Issue

#2032 Without such check, if a metric class is passed as `equip`, which seems a reasonable mistake (that I was making), no error will be raised, and the manifold will be initialized with the default metric instead of the passed metric.

## Additional context

I also added the `equip` parameter to the SPDMatrices docstring. The `equip` parameter is missing from the doscrings of all other manifolds I checked, I don't know if there's a motivation for this. It could be desirable to add `equip` to the docstring of all specific manifold classes, and specify there what is the default metric for the manifold.


closes #2032