### PR TITLE
Ignore notebooks as a language

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb linguist-vendored


### PR DESCRIPTION
This PR ignores notebooks for languages percentage distribution, since this is a python package and notebooks are used only for documentation.

This is particular important when we search github for e.g. `"manifold statistics  language:Python"`: `geomstats` does not appear as currently its main language is not python.