### PR TITLE
More efficient Bures Wasserstein distance computation in SPD manifold

### DIFF
--- a/geomstats/geometry/spd_matrices.py
+++ b/geomstats/geometry/spd_matrices.py
@@ -892,16 +892,17 @@ class SPDBuresWassersteinMetric(RiemannianMetric):
         Use of `abs` in the output prevents nan when calling
         `sqrt` in very small negative outputs (e.g. -1e-16).
         """
+        tr_a = gs.trace(point_a)
+        tr_b = gs.trace(point_b)
+
         point_a_sqrt = apply_func_to_eigvalsh(point_a, gs.sqrt)
 
-        Lc, Qc = gs.linalg.eigh(point_a_sqrt @ point_b @ point_a_sqrt)
-        cross_term = Matrices.mul(
-            Qc,
-            gs.vec_to_diag(gs.sqrt(Lc * (Lc > 0))),
-            Matrices.transpose(Qc),
+        c_eigvals = gs.linalg.eigvalsh(
+          Matrices.mul(Matrices.mul(point_a_sqrt, point_b), point_a_sqrt)
         )
+        cross_term = gs.sum(gs.sqrt(c_eigvals), axis=-1)
 
-        return gs.abs(gs.trace(point_a + point_b - 2 * cross_term))
+        return gs.abs(tr_a + tr_b - 2 * cross_term)
 
     def parallel_transport(
         self,

--- a/geomstats/geometry/spd_matrices.py
+++ b/geomstats/geometry/spd_matrices.py
@@ -897,10 +897,10 @@ class SPDBuresWassersteinMetric(RiemannianMetric):
 
         point_a_sqrt = apply_func_to_eigvalsh(point_a, gs.sqrt)
 
-        c_eigvals = gs.linalg.eigvalsh(
-          Matrices.mul(Matrices.mul(point_a_sqrt, point_b), point_a_sqrt)
+        c_sq_eigvals = gs.linalg.eigvalsh(
+            Matrices.mul(Matrices.mul(point_a_sqrt, point_b), point_a_sqrt)
         )
-        cross_term = gs.sum(gs.sqrt(c_eigvals), axis=-1)
+        cross_term = gs.sum(gs.sqrt(c_sq_eigvals), axis=-1)
 
         return gs.abs(tr_a + tr_b - 2 * cross_term)
 

--- a/geomstats/geometry/spd_matrices.py
+++ b/geomstats/geometry/spd_matrices.py
@@ -892,14 +892,7 @@ class SPDBuresWassersteinMetric(RiemannianMetric):
         Use of `abs` in the output prevents nan when calling
         `sqrt` in very small negative outputs (e.g. -1e-16).
         """
-        La, Qa = gs.linalg.eigh(point_a)
-        point_a_sqrt = Matrices.mul(
-            Qa,
-            gs.vec_to_diag(
-                gs.sqrt(La * (La > 0)),
-            ),
-            Matrices.transpose(Qa),
-        )
+        point_a_sqrt = apply_func_to_eigvalsh(point_a, gs.sqrt)
 
         Lc, Qc = gs.linalg.eigh(point_a_sqrt @ point_b @ point_a_sqrt)
         cross_term = Matrices.mul(


### PR DESCRIPTION
- [X] My pull request has a clear and explanatory title.
- [X] If necessary, my code is [vectorized](https://www.geeksforgeeks.org/vectorization-in-python/).
- [ ] I added appropriate unit tests.
- [X] I made sure the code passes all unit tests. (refer to comment below)
- [X] My PR follows [PEP8](https://peps.python.org/pep-0008/) guidelines. (refer to comment below)
- [X] My PR follows [geomstats coding style](https://github.com/geomstats/geomstats/blob/main/docs/contributing.rst#coding-style-guidelines) and API.
- [X] My code is properly documented and I made sure the documentation renders properly. ([Link](https://github.com/geomstats/geomstats/blob/main/docs/contributing.rst#documentation))
- [ ] I linked to issues and PRs that are relevant to this PR.

## Description

I implemented a more efficient version of the Bures Wasserstein squared distance. The new method is 2 to 4 times faster than the original one.

The improved efficiency comes from the `cross_term`, which is the trace of matrix C, which is the square root of matrix C_sq = (A^{1/2} @ B @ A^{1/2}). Matrix C_sq is symmetric positive definite, so the eigenvalues of C are the square root of the eigenvalues of C_sq. Because tr(C) equals the sum of the eigenvalues of C, we compute tr(C) by:

- Computing eigenvalues of C2
- Taking their square root
- Adding the resulting eigenvalues

This procedure does not require actually computing C, but only the eigenvalues of C_sq.

The original method actually computed C, which requires computing both eigenvalues and eigenvectors of C_sq.

I also changed the computing of `point_a_sqrt` to use `apply_func_to_eigvalsh`, which seems to be preferred geomstats style.
