### PR TITLE
Add torch optimizers

### DIFF
--- a/geomstats/geometry/fiber_bundle.py
+++ b/geomstats/geometry/fiber_bundle.py
@@ -55,7 +55,7 @@ class DistanceMinimizingAligner(AlignerAlgorithm):
     ----------
     total_space : Manifold
         Space equipped with a group action and a group-invariant metric.
-    optimizer : ScipyMinimize
+    optimizer : Minimizer
         Optimizer to solve minimization problem.
     group_elem_shape : tuple
         Shape of the group element representation.

--- a/geomstats/numerics/geodesic.py
+++ b/geomstats/numerics/geodesic.py
@@ -289,8 +289,8 @@ class LogShootingSolver:
     ----------
     space : Manifold
         Equipped manifold.
-    optimizer : ScipyMinimize
-        Instance of ScipyMinimize.
+    optimizer : Minimizer
+        Optimizer to solve minimization problem.
     initialization : callable
         Function to provide initial solution. `f(point, base_point)`.
         Defaults to linear initialization.
@@ -321,8 +321,8 @@ class _LogShootingSolver(LogSolver, ABC):
     ----------
     space : Manifold
         Equipped manifold.
-    optimizer : ScipyMinimize
-        Instance of ScipyMinimize.
+    optimizer : Minimizer
+        Optimizer to solve minimization problem.
     initialization : callable
         Function to provide initial solution. `f(point, base_point)`.
         Defaults to linear initialization.
@@ -381,8 +381,8 @@ class _LogShootingSolverFlatten(_LogShootingSolver):
     ----------
     space : Manifold
         Equipped manifold.
-    optimizer : ScipyMinimize
-        Instance of ScipyMinimize.
+    optimizer : Minimizer
+        Optimizer to solve minimization problem.
     initialization : callable
         Function to provide initial solution. `f(point, base_point)`.
         Defaults to linear initialization.
@@ -427,8 +427,8 @@ class _LogShootingSolverUnflatten(_LogBatchMixins, _LogShootingSolver):
     ----------
     space : Manifold
         Equipped manifold.
-    optimizer : ScipyMinimize
-        Instance of ScipyMinimize.
+    optimizer : Minimizer
+        Optimizer to solve minimization problem.
     initialization : callable
         Function to provide initial solution. `f(point, base_point)`.
         Defaults to linear initialization.
@@ -821,7 +821,7 @@ class PathStraightening(_DiscreteGeodesicBVPBatchMixins, PathBasedLogSolver):
         Method to compute Riemannian path energy.
     n_nodes : int
         Number of path discretization points.
-    optimizer : ScipyMinimize
+    optimizer : Minimizer
         An optimizer to solve path energy minimization problem.
     initialization : callable
         A method to get initial guess for optimization.
@@ -986,7 +986,7 @@ class MultiresPathStraightening(_DiscreteGeodesicBVPBatchMixins, PathBasedLogSol
     n_levels : int
         Number of resolutions to use. Sets number of nodes following a sequence.
         Ignored if ``n_nodes`` is not None.
-    optimizer : ScipyMinimize
+    optimizer : Minimizer
         An optimizer to solve path energy minimization problem.
     initialization : callable
         A method to get initial guess for optimization.

--- a/geomstats/numerics/optimization/__init__.py
+++ b/geomstats/numerics/optimization/__init__.py
@@ -1,0 +1,12 @@
+try:
+    from ._torch import TorchLBFGS
+except ImportError:
+    pass
+
+try:
+    from ._torchmin import TorchminMinimize
+except ImportError:
+    pass
+
+from ._optimization import Minimizer, NewtonMethod, RootFinder
+from ._scipy import ScipyMinimize, ScipyRoot

--- a/geomstats/numerics/optimization/_optimization.py
+++ b/geomstats/numerics/optimization/_optimization.py
@@ -1,0 +1,133 @@
+"""Optimizers implementations."""
+
+import logging
+from abc import ABC, abstractmethod
+
+from scipy.optimize import OptimizeResult
+
+import geomstats.backend as gs
+
+
+class Minimizer(ABC):
+    """Minimizer.
+
+    Parameters
+    ----------
+    save_result : bool
+        Whether to save result.
+    """
+
+    def __init__(self, save_result=False):
+        self.save_result = save_result
+
+        self.result_ = None
+
+    @abstractmethod
+    def minimize(self, fun, x0, fun_jac=None, fun_hess=None, hessp=None):
+        """Minimize objective function.
+
+        Parameters
+        ----------
+        fun : callable
+            The objective function to be minimized.
+        x0 : array-like
+            Initial guess.
+        fun_jac : callable
+            Jacobian of fun.
+        fun_hess : callable
+            Hessian of fun.
+        hessp : callable
+        """
+
+
+class RootFinder(ABC):
+    """Find a root of a vector-valued function."""
+
+    @abstractmethod
+    def root(self, fun, x0, fun_jac=None):
+        """Find a root of a vector-valued function.
+
+        Parameters
+        ----------
+        fun : callable
+            Vector-valued function.
+        x0 : array-like
+            Initial guess.
+        fun_jac : callable
+            Ignored if None.
+
+        Returns
+        -------
+        res : OptimizeResult
+        """
+
+
+class NewtonMethod(RootFinder):
+    """Find a root of a vector-valued function with Newton's method.
+
+    Check https://en.wikipedia.org/wiki/Newton%27s_method_in_optimization
+    for details.
+
+    Parameters
+    ----------
+    atol : float
+        Tolerance to check algorithm convergence.
+    max_iter : int
+        Maximum iterations.
+    damped : bool
+        Whether to use a damped version. Check p358 of [N2018]_.
+
+    References
+    ----------
+    .. [N2018] Yurii Nesterov. Lectures on Convex Optimization. Springer, 2018.
+    """
+
+    def __init__(self, atol=gs.atol, max_iter=100, damped=False):
+        self.atol = atol
+        self.max_iter = max_iter
+        self.damped = damped
+
+    def root(self, fun, x0, fun_jac):
+        """Find a root of a vector-valued function.
+
+        Parameters
+        ----------
+        fun : callable
+            Vector-valued function.
+        x0 : array-like
+            Initial guess.
+        fun_jac : callable
+            Jacobian of fun.
+        """
+        xk = x0
+        message = "The solution converged."
+        status = 1
+        for it in range(self.max_iter):
+            fun_xk = fun(xk)
+            if gs.linalg.norm(fun_xk) <= self.atol:
+                break
+
+            y = gs.linalg.solve(fun_jac(xk), fun_xk)
+            if self.damped:
+                lambda_xk = gs.sqrt(gs.dot(fun_xk, y))
+            else:
+                lambda_xk = 0.0
+            xk = xk - (1 / (1 + lambda_xk)) * y
+        else:
+            message = f"Maximum number of iterations {self.max_iter} reached. Results may be inaccurate"
+            status = 0
+
+        result = OptimizeResult(
+            x=xk,
+            success=(status == 1),
+            status=status,
+            method="newton",
+            message=message,
+            nfev=it + 1,
+            njac=it,
+        )
+
+        if not result.success:
+            logging.warning(result.message)
+
+        return result

--- a/geomstats/numerics/optimization/_torch.py
+++ b/geomstats/numerics/optimization/_torch.py
@@ -1,0 +1,112 @@
+import logging
+
+from scipy.optimize import OptimizeResult
+from torch.optim import LBFGS
+
+import geomstats.backend as gs
+from geomstats.numerics._common import params_to_kwargs
+
+from ._optimization import Minimizer
+
+
+class TorchLBFGS(Minimizer):
+    """Wrapper for torch.optim.LBFGS.
+
+    Check out
+    https://pytorch.org/docs/stable/generated/torch.optim.LBFGS.html#lbfgs
+    for details.
+    """
+
+    def __init__(
+        self,
+        lr=1,
+        max_iter=100,
+        max_eval=None,
+        tolerance_grad=1e-7,
+        tolerance_change=1e-9,
+        line_search_fn=None,
+        save_result=False,
+    ):
+        self.lr = lr
+        self.max_iter = max_iter
+        self.max_eval = max_eval
+        self.tolerance_grad = tolerance_grad
+        self.tolerance_change = tolerance_change
+        self.line_search_fn = line_search_fn
+
+        self.history_size = 1
+
+        self.toptim_ = None
+
+        super().__init__(save_result=save_result)
+
+    def _instantiate_toptim(self, x0):
+        return LBFGS([x0], **params_to_kwargs(self, func=LBFGS))
+
+    def minimize(self, fun, x0, fun_jac=None, fun_hess=None, hessp=None):
+        """Minimize objective function.
+
+        Parameters
+        ----------
+        fun : callable
+            The objective function to be minimized.
+        x0 : array-like
+            Initial guess.
+        fun_jac : callable
+            Jacobian of fun. Ignored.
+        fun_hess : callable
+            Hessian of fun. Ignored.
+        hessp : callable
+            Ignored.
+        """
+        x0 = gs.copy(x0)
+        x0.requires_grad = True
+
+        toptim = self._instantiate_toptim(x0)
+
+        def closure():
+            toptim.zero_grad()
+            tobj = fun(x0)
+            tobj.backward()
+            return tobj
+
+        toptim.step(closure)
+        self.toptim_ = toptim
+
+        state = toptim.state_dict()["state"][0]
+        n_iter = state.get("n_iter")
+        nfev = state.get("func_evals")
+
+        message = "The solution converged."
+        status = 1
+        if n_iter == self.max_iter:
+            message = (
+                f"Maximum number of iterations {self.max_iter} reached."
+                "Results may be inaccurate"
+            )
+            status = 0
+
+        if nfev == self.max_eval:
+            message = (
+                f"Maximum number of function evalutations {self.max_eval} reached."
+                "Results may be inaccurate"
+            )
+            status = 0
+
+        result = OptimizeResult(
+            x=x0,
+            success=(status == 1),
+            status=status,
+            message=message,
+            nit=n_iter,
+            nfev=nfev,
+            njac=nfev,
+        )
+
+        if not result.success:
+            logging.warning(result.message)
+
+        if self.save_result:
+            self.result_ = result
+
+        return result

--- a/geomstats/numerics/optimization/_torchmin.py
+++ b/geomstats/numerics/optimization/_torchmin.py
@@ -1,0 +1,65 @@
+import logging
+
+from torchmin import minimize as torchmin_minimize
+
+from geomstats.numerics._common import params_to_kwargs
+
+from ._optimization import Minimizer
+
+
+class TorchminMinimize(Minimizer):
+    """Wrapper for torchmin.minimize.
+
+    Check out
+    https://pytorch-minimize.readthedocs.io/en/latest/api/index.html#functional-api
+    for details.
+    """
+
+    def __init__(
+        self,
+        method="l-bfgs",
+        max_iter=None,
+        tol=None,
+        options=None,
+        callback=None,
+        disp=0,
+        return_all=False,
+        save_result=False,
+    ):
+        self.method = method
+        self.max_iter = max_iter
+        self.tol = tol
+        self.options = options
+        self.callback = callback
+        self.disp = disp
+        self.return_all = return_all
+
+        super().__init__(save_result=save_result)
+
+    def minimize(self, fun, x0, fun_jac=None, fun_hess=None, hessp=None):
+        """Minimize objective function.
+
+        Parameters
+        ----------
+        fun : callable
+            The objective function to be minimized.
+        x0 : array-like
+            Initial guess.
+        fun_jac : callable
+            Jacobian of fun. Ignored.
+        fun_hess : callable
+            Hessian of fun. Ignored.
+        hessp : callable
+            Ignored.
+        """
+        result = torchmin_minimize(
+            fun, x0, **params_to_kwargs(self, func=torchmin_minimize)
+        )
+
+        if not result.success:
+            logging.warning(result.message)
+
+        if self.save_result:
+            self.result_ = result
+
+        return result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ pykeops = ["pykeops"]
 autograd = ["autograd >= 1.3"]
 pytorch = ["torch >= 1.9.1"]
 backends = ["geomstats[autograd, pytorch]"]
-opt = ["geomstats[graph, pykeops]"]
+opt = ["geomstats[graph, pykeops, pytorch-minimize]"]
 dev = ["geomstats[test, test-scripts, lint, doc]"]
 all = ["geomstats[dev, opt, backends]"]
 

--- a/tests/tests_geomstats/test_numerics/test_optimization.py
+++ b/tests/tests_geomstats/test_numerics/test_optimization.py
@@ -1,7 +1,11 @@
 import pytest
 
 import geomstats.backend as gs
-from geomstats.numerics.optimization import NewtonMethod, ScipyMinimize, ScipyRoot
+from geomstats.numerics.optimization import (
+    NewtonMethod,
+    ScipyMinimize,
+    ScipyRoot,
+)
 from geomstats.test.parametrizers import DataBasedParametrizer
 from geomstats.test_cases.numerics.optimization import (
     OptimizerTestCase,
@@ -15,6 +19,23 @@ from .data.optimization import (
     RootFindingJacSmokeTestData,
     RootFindingSmokeTestData,
 )
+
+TORCH_OPTIMIZERS = []
+
+try:
+    from geomstats.numerics.optimization import TorchLBFGS
+
+    TORCH_OPTIMIZERS.append(TorchLBFGS())
+except ImportError:
+    pass
+
+
+try:
+    from geomstats.numerics.optimization import TorchminMinimize
+
+    TORCH_OPTIMIZERS.append(TorchminMinimize())
+except ImportError:
+    pass
 
 
 @pytest.fixture(
@@ -30,7 +51,8 @@ from .data.optimization import (
         ]
         if gs.has_autodiff()
         else []
-    ),
+    )
+    + (TORCH_OPTIMIZERS if gs.__name__.endswith("pytorch") else []),
 )
 def optimizers(request):
     request.cls.optimizer = request.param


### PR DESCRIPTION
This PR reorganizes `numerics.optimization` and adds `torch` minimizers.

In particular, it wraps [torch.optim.LBFGS](https://pytorch.org/docs/stable/generated/torch.optim.LBFGS.html#lbfgs) and [torchmin.minimize](https://pytorch-minimize.readthedocs.io/en/latest/api/index.html#functional-api).