### PR TITLE
ENH Add checks for connectedness and compactness in various geometries

### DIFF
--- a/geomstats/geometry/euclidean.py
+++ b/geomstats/geometry/euclidean.py
@@ -67,16 +67,15 @@ class Euclidean(VectorSpace):
     def is_connected(self):
         """Indicates whether the geometric object is connected.
 
+        All Euclidean spaces are connected. See [M2000]_ page 155.
+
         Returns
         -------
-        bool
-            Always True for Euclidean spaces, as they are path-connected.
-            Any two points in a Euclidean space can be joined by a straight
-            line segment.
+        is_connected: bool
 
         References
         ----------
-        .. [1] James Munkres, "Topology," 2nd edition, page 155.
+        .. [M2000] James R. Munkres. "Topology." 2nd edition. Prentice Hall, 2000.
         """
         return True
 
@@ -84,16 +83,16 @@ class Euclidean(VectorSpace):
     def is_compact(self):
         """Indicates whether the geometric object is compact.
 
+        All Euclidean spaces are not compact. See [M2000]_
+        Theorem 27.3 on page 173.
+
         Returns
         -------
-        bool
-            Always False for Euclidean spaces, as they are not
-            bounded
+        is_compact: bool
 
         References
         ----------
-        .. [1] James Munkres, "Topology," 2nd edition, Theorem 27.3 on
-               page 173.
+        .. [M2000] James R. Munkres. "Topology." 2nd edition. Prentice Hall, 2000.
         """
         return False
 

--- a/geomstats/geometry/euclidean.py
+++ b/geomstats/geometry/euclidean.py
@@ -63,6 +63,40 @@ class Euclidean(VectorSpace):
         """
         return tangent_vec + base_point
 
+    @property
+    def is_connected(self):
+        """Indicates whether the geometric object is connected.
+
+        Returns
+        -------
+        bool
+            Always True for Euclidean spaces, as they are path-connected.
+            Any two points in a Euclidean space can be joined by a straight
+            line segment.
+
+        References
+        ----------
+        .. [1] James Munkres, "Topology," 2nd edition, page 155.
+        """
+        return True
+
+    @property
+    def is_compact(self):
+        """Indicates whether the geometric object is compact.
+
+        Returns
+        -------
+        bool
+            Always False for Euclidean spaces, as they are not
+            bounded
+
+        References
+        ----------
+        .. [1] James Munkres, "Topology," 2nd edition, Theorem 27.3 on
+               page 173.
+        """
+        return False
+
 
 class EuclideanMetric(RiemannianMetric):
     """Class for a Euclidean metric.

--- a/geomstats/geometry/grassmannian.py
+++ b/geomstats/geometry/grassmannian.py
@@ -237,6 +237,38 @@ class Grassmannian(LevelSet):
         p_d = gs.einsum("...ij,...j->...ij", eigvecs, diagonal)
         return Matrices.mul(p_d, Matrices.transpose(eigvecs))
 
+    @property
+    def is_connected(self):
+        """Indicates whether the geometric object is connected.
+
+        Returns
+        -------
+        bool
+            Always True for real Grassmannians.
+
+        References
+        ----------
+        .. [1] V.A. Rokhlin, D.B. Fuks, "Beginner's Course in Topology,"
+               page 177-179.
+        """
+        return True
+
+    @property
+    def is_compact(self):
+        """Indicates whether the geometric object is compact.
+
+        Returns
+        -------
+        bool
+            Always True for real Grassmannians.
+
+        References
+        ----------
+        .. [1] V.A. Rokhlin, D.B. Fuks, "Beginner's Course in Topology,"
+               page 179.
+        """
+        return True
+
 
 class GrassmannianCanonicalMetric(RiemannianMetric):
     """Canonical metric of the Grassmann manifold."""

--- a/geomstats/geometry/grassmannian.py
+++ b/geomstats/geometry/grassmannian.py
@@ -241,15 +241,16 @@ class Grassmannian(LevelSet):
     def is_connected(self):
         """Indicates whether the geometric object is connected.
 
+        Grassmannians are connected. See [FV1984]_.
+
         Returns
         -------
-        bool
-            Always True for real Grassmannians.
+        is_connected: bool
 
         References
         ----------
-        .. [1] V.A. Rokhlin, D.B. Fuks, "Beginner's Course in Topology,"
-               page 177-179.
+        .. [FR1984] Fuks, D. B., and V. A. Rokhlin. "Beginner's Course in Topology."
+           1st ed. Universitext. Springer, August 1984. Berlin, Germany.
         """
         return True
 
@@ -257,15 +258,16 @@ class Grassmannian(LevelSet):
     def is_compact(self):
         """Indicates whether the geometric object is compact.
 
+        All Grassmannians are compact. See [FR1984]_.
+
         Returns
         -------
-        bool
-            Always True for real Grassmannians.
+        is_compact: bool
 
         References
         ----------
-        .. [1] V.A. Rokhlin, D.B. Fuks, "Beginner's Course in Topology,"
-               page 179.
+        .. [FR1984] Fuks, D. B., and V. A. Rokhlin. "Beginner's Course in Topology."
+           1st ed. Universitext. Springer, August 1984. Berlin, Germany.
         """
         return True
 

--- a/geomstats/geometry/hypersphere.py
+++ b/geomstats/geometry/hypersphere.py
@@ -662,14 +662,16 @@ class _Hypersphere(LevelSet):
     def is_connected(self):
         """Indicates whether the geometric object is connected.
 
+        Only the 0-dimensional Hypersphere is not connected.
+        See [M2000]_ page 155.
+
         Returns
         -------
-        bool
-            Only False for 0-sphere, which is a set of two points.
+        is_connected: bool
 
         References
         ----------
-        .. [1] James Munkres, "Topology," 2nd edition, page 155.
+        .. [M2000] James R. Munkres. "Topology." 2nd edition. Prentice Hall, 2000.
         """
         return self.dim > 0
 
@@ -677,16 +679,16 @@ class _Hypersphere(LevelSet):
     def is_compact(self):
         """Indicates whether the geometric object is compact.
 
+        All Hyperspheres are compact.
+        See [M2000]_ Theorem 27.3 on page 173
+
         Returns
         -------
-        bool
-            Always True for n-spheres, as they are closed and
-            bounded subsets of the Euclidean space.
+        is_compact: bool
 
         References
         ----------
-        .. [1] James Munkres, "Topology," 2nd edition, Theorem 27.3 on
-               page 173.
+        .. [M2000] James R. Munkres. "Topology." 2nd edition. Prentice Hall, 2000.
         """
         return True
 

--- a/geomstats/geometry/hypersphere.py
+++ b/geomstats/geometry/hypersphere.py
@@ -665,14 +665,13 @@ class _Hypersphere(LevelSet):
         Returns
         -------
         bool
-            Always True for n-spheres, as they are path-connected.
-            Any two points in a Euclidean space can be joined by an arc
+            Only False for 0-sphere, which is a set of two points.
 
         References
         ----------
         .. [1] James Munkres, "Topology," 2nd edition, page 155.
         """
-        return True
+        return self.dim > 0
 
     @property
     def is_compact(self):

--- a/geomstats/geometry/hypersphere.py
+++ b/geomstats/geometry/hypersphere.py
@@ -658,6 +658,39 @@ class _Hypersphere(LevelSet):
         sample = self.metric.exp(tangent_sample_at_pt, mean)
         return sample[0] if (n_samples == 1) else sample
 
+    @property
+    def is_connected(self):
+        """Indicates whether the geometric object is connected.
+
+        Returns
+        -------
+        bool
+            Always True for n-spheres, as they are path-connected.
+            Any two points in a Euclidean space can be joined by an arc
+
+        References
+        ----------
+        .. [1] James Munkres, "Topology," 2nd edition, page 155.
+        """
+        return True
+
+    @property
+    def is_compact(self):
+        """Indicates whether the geometric object is compact.
+
+        Returns
+        -------
+        bool
+            Always True for n-spheres, as they are closed and
+            bounded subsets of the Euclidean space.
+
+        References
+        ----------
+        .. [1] James Munkres, "Topology," 2nd edition, Theorem 27.3 on
+               page 173.
+        """
+        return True
+
 
 class HypersphereMetric(RiemannianMetric):
     """Class for the Hypersphere Metric."""

--- a/geomstats/geometry/stiefel.py
+++ b/geomstats/geometry/stiefel.py
@@ -200,6 +200,55 @@ class Stiefel(LevelSet):
         mat_u, _, mat_v = gs.linalg.svd(point)
         return Matrices.mul(mat_u[..., :, : self.p], mat_v)
 
+    @property
+    def is_connected(self):
+        """Indicates whether the geometric object is connected.
+
+        Returns
+        -------
+        bool
+            The connectedness of the (real) Stiefel manifold St(n, p).
+
+            - St(n, 0) is a point.
+            - St(n, 1) is the (n-1)-sphere.
+            - St(n, n) is the orthogonal group O(n).
+            - St(n, n-1) is the special orthogonal group SO(n)
+            - St(n, p) with p < n-1 are continuous images of
+              St(n, n-1)
+
+        References
+        ----------
+        .. [1] V.A. Rokhlin, D.B. Fuks, "Beginner's Course in Topology,"
+               page 171--173.
+        """
+        if self.p == 0:
+            return True
+
+        elif self.p == 1:
+            return self.n > 1
+
+        elif self.p <= self.n - 1:
+            return True
+
+        else:
+            return False
+
+    @property
+    def is_compact(self):
+        """Indicates whether the geometric object is compact.
+
+        Returns
+        -------
+        bool
+            Always True for real Stiefel manifolds.
+
+        References
+        ----------
+        .. [1] V.A. Rokhlin, D.B. Fuks, "Beginner's Course in Topology,"
+               page 173.
+        """
+        return True
+
 
 class StiefelCanonicalMetric(RiemannianMetric):
     """Class that defines the canonical metric for Stiefel manifolds."""

--- a/geomstats/geometry/stiefel.py
+++ b/geomstats/geometry/stiefel.py
@@ -204,27 +204,27 @@ class Stiefel(LevelSet):
     def is_connected(self):
         """Indicates whether the geometric object is connected.
 
+        The connectedness of the (real) Stiefel manifold St(n, p)
+        are:
+
+        - St(n, 1) is the (n-1)-sphere.
+        - St(n, n) is the orthogonal group O(n).
+        - St(n, n-1) is the special orthogonal group SO(n)
+        - St(n, p) with p < n-1 are continuous images of
+          St(n, n-1)
+
+        See [FR1984]_ page 171--173.
+
         Returns
         -------
-        bool
-            The connectedness of the (real) Stiefel manifold St(n, p).
-
-            - St(n, 0) is a point.
-            - St(n, 1) is the (n-1)-sphere.
-            - St(n, n) is the orthogonal group O(n).
-            - St(n, n-1) is the special orthogonal group SO(n)
-            - St(n, p) with p < n-1 are continuous images of
-              St(n, n-1)
+        is_connected: bool
 
         References
         ----------
-        .. [1] V.A. Rokhlin, D.B. Fuks, "Beginner's Course in Topology,"
-               page 171--173.
+        .. [FR1984] Fuks, D. B., and V. A. Rokhlin. Beginner's Course in Topology.
+           1st ed. Universitext. Springer, August 1984. Berlin, Germany.
         """
-        if self.p == 0:
-            return True
-
-        elif self.p == 1:
+        if self.p == 1:
             return self.n > 1
 
         elif self.p <= self.n - 1:
@@ -237,15 +237,17 @@ class Stiefel(LevelSet):
     def is_compact(self):
         """Indicates whether the geometric object is compact.
 
+        All real Stiefel manifolds are compact. See [FR1984]_
+        page 173.
+
         Returns
         -------
-        bool
-            Always True for real Stiefel manifolds.
+        is_compact: bool
 
         References
         ----------
-        .. [1] V.A. Rokhlin, D.B. Fuks, "Beginner's Course in Topology,"
-               page 173.
+        .. [FR1984] Fuks, D. B., and V. A. Rokhlin. Beginner's Course in Topology.
+           1st ed. Universitext. Springer, August 1984. Berlin, Germany.
         """
         return True
 

--- a/geomstats/geometry/stiefel.py
+++ b/geomstats/geometry/stiefel.py
@@ -221,7 +221,7 @@ class Stiefel(LevelSet):
 
         References
         ----------
-        .. [FR1984] Fuks, D. B., and V. A. Rokhlin. Beginner's Course in Topology.
+        .. [FR1984] Fuks, D. B., and V. A. Rokhlin. "Beginner's Course in Topology."
            1st ed. Universitext. Springer, August 1984. Berlin, Germany.
         """
         if self.p == 1:
@@ -246,7 +246,7 @@ class Stiefel(LevelSet):
 
         References
         ----------
-        .. [FR1984] Fuks, D. B., and V. A. Rokhlin. Beginner's Course in Topology.
+        .. [FR1984] Fuks, D. B., and V. A. Rokhlin. "Beginner's Course in Topology."
            1st ed. Universitext. Springer, August 1984. Berlin, Germany.
         """
         return True

--- a/geomstats/test_cases/geometry/euclidean.py
+++ b/geomstats/test_cases/geometry/euclidean.py
@@ -1,6 +1,7 @@
 import pytest
 
 import geomstats.backend as gs
+from geomstats.test.test_case import TestCase
 from geomstats.test_cases.geometry.base import VectorSpaceTestCase
 from geomstats.test_cases.geometry.mixins import GroupExpTestCaseMixins
 from geomstats.test_cases.geometry.riemannian_metric import RiemannianMetricTestCase
@@ -55,3 +56,15 @@ class CanonicalEuclideanMetricTestCase(EuclideanMetricTestCase):
             gs.eye(self.space.dim), batch_shape + 2 * (self.space.dim,)
         )
         self.assertAllClose(res, expected, atol=atol)
+
+
+class EuclideanConnectednessTestCase(TestCase):
+    def test_is_connected(self):
+        msg = "All Euclidean spaces are connected"
+        self.assertTrue(self.space.is_connected, msg=msg)
+
+
+class EuclideanCompactnessTestCase(TestCase):
+    def test_is_compact(self):
+        msg = "Euclidean spaces are not compact."
+        self.assertTrue(not self.space.is_compact, msg=msg)

--- a/geomstats/test_cases/geometry/grassmannian.py
+++ b/geomstats/test_cases/geometry/grassmannian.py
@@ -2,7 +2,7 @@ from geomstats.test.test_case import TestCase
 
 
 class GrassmannianConnectednessTestCase(TestCase):
-    def test_is_connected(self, n, p, expected):
+    def test_is_connected(self):
         msg = "All Grassmannians are connected."
         self.assertTrue(self.space.is_connected, msg=msg)
 

--- a/geomstats/test_cases/geometry/grassmannian.py
+++ b/geomstats/test_cases/geometry/grassmannian.py
@@ -1,0 +1,13 @@
+from geomstats.test.test_case import TestCase
+
+
+class GrassmannianConnectednessTestCase(TestCase):
+    def test_is_connected(self, n, p, expected):
+        msg = "All Grassmannians are connected."
+        self.assertTrue(self.space.is_connected, msg=msg)
+
+
+class GrassmannianCompactnessTestCase(TestCase):
+    def test_is_compact(self):
+        msg = "All Grassmannians are compact."
+        self.assertTrue(self.space.is_compact, msg=msg)

--- a/geomstats/test_cases/geometry/hypersphere.py
+++ b/geomstats/test_cases/geometry/hypersphere.py
@@ -569,3 +569,15 @@ class HypersphereIntrinsicTestCase(ManifoldTestCase):
             n_reps=n_reps,
         )
         self._test_vectorization(vec_data)
+
+
+class HypersphereConnectednessTestCase(TestCase):
+    def test_is_connected(self):
+        msg = "Only 0-dimensional Hypersphere is disconnected."
+        self.assertTrue(self.space.is_connected, msg=msg)
+
+
+class HypersphereCompactnessTestCase(TestCase):
+    def test_is_compact(self):
+        msg = "All Hyperspheres are compact."
+        self.assertTrue(self.space.is_compact, msg=msg)

--- a/geomstats/test_cases/geometry/stiefel.py
+++ b/geomstats/test_cases/geometry/stiefel.py
@@ -2,6 +2,7 @@ import pytest
 
 import geomstats.backend as gs
 from geomstats.geometry.grassmannian import Grassmannian
+from geomstats.geometry.stiefel import Stiefel
 from geomstats.test.test_case import TestCase
 from geomstats.test.vectorization import generate_vectorization_data
 from geomstats.test_cases.geometry.base import LevelSetTestCase
@@ -122,3 +123,12 @@ class StiefelCanonicalMetricTestCase(RiemannianMetricTestCase):
 
         with pytest.raises(ValueError):
             self.space.metric.log(point, base_point)
+
+
+class StiefelConnectednessTestCase(TestCase):
+    def test_is_connected(self, point, expected):
+        n, k = point
+        connectedness = Stiefel(n=n, k=k, equip=False).is_connected()
+        expected_connected = " " if expected else " not "
+        msg = f"St({n}, {k}) is{expected_connected}connected."
+        self.assertTrue(connectedness & expected, msg=msg)

--- a/geomstats/test_cases/geometry/stiefel.py
+++ b/geomstats/test_cases/geometry/stiefel.py
@@ -131,4 +131,4 @@ class StiefelConnectednessTestCase(TestCase):
         connectedness = Stiefel(n=n, p=p, equip=False).is_connected
         expected_connected = " " if expected else " not "
         msg = f"St({n}, {p}) is{expected_connected}connected."
-        self.assertTrue(connectedness and expected, msg=msg)
+        self.assertTrue(connectedness == expected, msg=msg)

--- a/geomstats/test_cases/geometry/stiefel.py
+++ b/geomstats/test_cases/geometry/stiefel.py
@@ -128,7 +128,7 @@ class StiefelCanonicalMetricTestCase(RiemannianMetricTestCase):
 class StiefelConnectednessTestCase(TestCase):
     def test_is_connected(self, point, expected):
         n, p = point
-        connectedness = Stiefel(n=n, p=p, equip=False).is_connected()
+        connectedness = Stiefel(n=n, p=p, equip=False).is_connected
         expected_connected = " " if expected else " not "
         msg = f"St({n}, {p}) is{expected_connected}connected."
         self.assertTrue(connectedness & expected, msg=msg)

--- a/geomstats/test_cases/geometry/stiefel.py
+++ b/geomstats/test_cases/geometry/stiefel.py
@@ -2,7 +2,6 @@ import pytest
 
 import geomstats.backend as gs
 from geomstats.geometry.grassmannian import Grassmannian
-from geomstats.geometry.stiefel import Stiefel
 from geomstats.test.test_case import TestCase
 from geomstats.test.vectorization import generate_vectorization_data
 from geomstats.test_cases.geometry.base import LevelSetTestCase
@@ -126,9 +125,14 @@ class StiefelCanonicalMetricTestCase(RiemannianMetricTestCase):
 
 
 class StiefelConnectednessTestCase(TestCase):
-    def test_is_connected(self, point, expected):
-        n, p = point
-        connectedness = Stiefel(n=n, p=p, equip=False).is_connected
+    def test_is_connected(self, n, p, expected):
+        connectedness = self.Space(n=n, p=p, equip=False).is_connected
         expected_connected = " " if expected else " not "
         msg = f"St({n}, {p}) is{expected_connected}connected."
         self.assertTrue(connectedness == expected, msg=msg)
+
+
+class StiefelCompactnessTestCase(TestCase):
+    def test_is_compact(self):
+        msg = "All real Stiefel manifolds are compact."
+        self.assertTrue(self.space.is_compact, msg=msg)

--- a/geomstats/test_cases/geometry/stiefel.py
+++ b/geomstats/test_cases/geometry/stiefel.py
@@ -127,8 +127,8 @@ class StiefelCanonicalMetricTestCase(RiemannianMetricTestCase):
 
 class StiefelConnectednessTestCase(TestCase):
     def test_is_connected(self, point, expected):
-        n, k = point
-        connectedness = Stiefel(n=n, k=k, equip=False).is_connected()
+        n, p = point
+        connectedness = Stiefel(n=n, p=p, equip=False).is_connected()
         expected_connected = " " if expected else " not "
-        msg = f"St({n}, {k}) is{expected_connected}connected."
+        msg = f"St({n}, {p}) is{expected_connected}connected."
         self.assertTrue(connectedness & expected, msg=msg)

--- a/geomstats/test_cases/geometry/stiefel.py
+++ b/geomstats/test_cases/geometry/stiefel.py
@@ -131,4 +131,4 @@ class StiefelConnectednessTestCase(TestCase):
         connectedness = Stiefel(n=n, p=p, equip=False).is_connected
         expected_connected = " " if expected else " not "
         msg = f"St({n}, {p}) is{expected_connected}connected."
-        self.assertTrue(connectedness & expected, msg=msg)
+        self.assertTrue(connectedness and expected, msg=msg)

--- a/tests/tests_geomstats/test_geometry/data/stiefel.py
+++ b/tests/tests_geomstats/test_geometry/data/stiefel.py
@@ -67,7 +67,6 @@ class StiefelConnectednessTestData(TestData):
         p = random.randint(2, n_gt_5 - 2)
 
         data = [
-            dict(point=(1, 1), expected=False),
             dict(point=(n, 1), expected=True),
             dict(point=(n, n), expected=False),
             dict(point=(n_gt_3, n_gt_3 - 1), expected=True),

--- a/tests/tests_geomstats/test_geometry/data/stiefel.py
+++ b/tests/tests_geomstats/test_geometry/data/stiefel.py
@@ -1,3 +1,5 @@
+import random
+
 import geomstats.backend as gs
 from geomstats.geometry.general_linear import GeneralLinear
 from geomstats.geometry.matrices import Matrices
@@ -55,3 +57,19 @@ class StiefelCanonicalMetricTestData(RiemannianMetricTestData):
 class StiefelCanonicalMetricSquareTestData(TestData):
     def two_sheets_error_test_data(self):
         return self.generate_random_data()
+
+
+class StiefelConnectednessTestData(TestData):
+    def is_connected_test_data(self):
+        n = random.randint(2, 8)
+        n_gt_3 = random.randint(3, 8)
+        n_gt_5 = random.randint(5, 8)
+        k = random.randint(2, n_gt_5 - 2)
+
+        data = [
+            dict(point=(n, 1), expected=True),
+            dict(point=(n, n), expected=False),
+            dict(point=(n_gt_3, n_gt_3 - 1), expected=False),
+            dict(point=(n_gt_5, k), expected=True),
+        ]
+        return self.generate_tests(data)

--- a/tests/tests_geomstats/test_geometry/data/stiefel.py
+++ b/tests/tests_geomstats/test_geometry/data/stiefel.py
@@ -67,9 +67,9 @@ class StiefelConnectednessTestData(TestData):
         p = random.randint(2, n_gt_5 - 2)
 
         data = [
-            dict(point=(n, 1), expected=True),
-            dict(point=(n, n), expected=False),
-            dict(point=(n_gt_3, n_gt_3 - 1), expected=True),
-            dict(point=(n_gt_5, p), expected=True),
+            dict(n=n, p=1, expected=True),
+            dict(n=n, p=n, expected=False),
+            dict(n=n_gt_3, p=n_gt_3 - 1, expected=True),
+            dict(n=n_gt_5, p=p, expected=True),
         ]
         return self.generate_tests(data)

--- a/tests/tests_geomstats/test_geometry/data/stiefel.py
+++ b/tests/tests_geomstats/test_geometry/data/stiefel.py
@@ -64,12 +64,12 @@ class StiefelConnectednessTestData(TestData):
         n = random.randint(2, 8)
         n_gt_3 = random.randint(3, 8)
         n_gt_5 = random.randint(5, 8)
-        k = random.randint(2, n_gt_5 - 2)
+        p = random.randint(2, n_gt_5 - 2)
 
         data = [
             dict(point=(n, 1), expected=True),
             dict(point=(n, n), expected=False),
             dict(point=(n_gt_3, n_gt_3 - 1), expected=False),
-            dict(point=(n_gt_5, k), expected=True),
+            dict(point=(n_gt_5, p), expected=True),
         ]
         return self.generate_tests(data)

--- a/tests/tests_geomstats/test_geometry/data/stiefel.py
+++ b/tests/tests_geomstats/test_geometry/data/stiefel.py
@@ -67,9 +67,10 @@ class StiefelConnectednessTestData(TestData):
         p = random.randint(2, n_gt_5 - 2)
 
         data = [
+            dict(point=(1, 1), expected=False),
             dict(point=(n, 1), expected=True),
             dict(point=(n, n), expected=False),
-            dict(point=(n_gt_3, n_gt_3 - 1), expected=False),
+            dict(point=(n_gt_3, n_gt_3 - 1), expected=True),
             dict(point=(n_gt_5, p), expected=True),
         ]
         return self.generate_tests(data)

--- a/tests/tests_geomstats/test_geometry/test_euclidean.py
+++ b/tests/tests_geomstats/test_geometry/test_euclidean.py
@@ -7,6 +7,8 @@ from geomstats.geometry.spd_matrices import SPDMatrices
 from geomstats.test.parametrizers import DataBasedParametrizer
 from geomstats.test_cases.geometry.euclidean import (
     CanonicalEuclideanMetricTestCase,
+    EuclideanCompactnessTestCase,
+    EuclideanConnectednessTestCase,
     EuclideanMetricTestCase,
     EuclideanTestCase,
 )
@@ -46,3 +48,11 @@ class TestCanonicalEuclideanMetric2(
 ):
     space = Euclidean(dim=2)
     testing_data = CanonicalEuclideanMetric2TestData()
+
+
+class TestEuclideanConnectedness(EuclideanConnectednessTestCase):
+    space = Euclidean(dim=random.randint(2, 5))
+
+
+class TestEuclideanCompactness(EuclideanCompactnessTestCase):
+    space = Euclidean(dim=random.randint(2, 5))

--- a/tests/tests_geomstats/test_geometry/test_grassmannian.py
+++ b/tests/tests_geomstats/test_geometry/test_grassmannian.py
@@ -5,6 +5,10 @@ import pytest
 from geomstats.geometry.grassmannian import Grassmannian, GrassmannianCanonicalMetric
 from geomstats.test.parametrizers import DataBasedParametrizer
 from geomstats.test_cases.geometry.base import LevelSetTestCase
+from geomstats.test_cases.geometry.grassmannian import (
+    GrassmannianCompactnessTestCase,
+    GrassmannianConnectednessTestCase,
+)
 from geomstats.test_cases.geometry.riemannian_metric import RiemannianMetricTestCase
 
 from .data.base import LevelSetTestData
@@ -78,3 +82,13 @@ class TestGrassmannianCanonicalMetric32(
 ):
     space = Grassmannian(3, 2)
     testing_data = GrassmannianCanonicalMetric32TestData()
+
+
+@pytest.mark.usefixtures("spaces")
+class TestGrassmannianConnectedness(GrassmannianConnectednessTestCase):
+    pass
+
+
+@pytest.mark.usefixtures("spaces")
+class TestGrassmannianCompactness(GrassmannianCompactnessTestCase):
+    pass

--- a/tests/tests_geomstats/test_geometry/test_hypersphere.py
+++ b/tests/tests_geomstats/test_geometry/test_hypersphere.py
@@ -7,6 +7,8 @@ from geomstats.geometry.hypersphere import Hypersphere, HypersphereMetric
 from geomstats.test.parametrizers import DataBasedParametrizer
 from geomstats.test.random import HypersphereIntrinsicRandomDataGenerator
 from geomstats.test_cases.geometry.hypersphere import (
+    HypersphereCompactnessTestCase,
+    HypersphereConnectednessTestCase,
     HypersphereCoordsTransformTestCase,
     HypersphereExtrinsicTestCase,
     HypersphereIntrinsicTestCase,
@@ -56,6 +58,21 @@ class TestHypersphereCoordsTransform(
 def extrinsic_spaces(request):
     dim = request.param
     request.cls.space = Hypersphere(dim, intrinsic=False, equip=True)
+
+
+@pytest.fixture(
+    scope="class",
+    params=[
+        (
+            random.randint(1, 5),
+            random.choice([True, False]),
+            random.choice([True, False]),
+        )
+    ],
+)
+def random_space(request):
+    dim, intrinsic, equip = request.param
+    request.cls.space = Hypersphere(dim, intrinsic=intrinsic, equip=equip)
 
 
 @pytest.mark.usefixtures("extrinsic_spaces")
@@ -182,3 +199,13 @@ class TestHypersphere4ExtrinsicMetric(
         result = self.space.metric.dist(base_point, exp)
         expected = gs.linalg.norm(tangent_vec) % (2 * gs.pi)
         self.assertAllClose(result, expected)
+
+
+@pytest.mark.usefixtures("random_space")
+class TestHypersphereConnectedness(HypersphereConnectednessTestCase):
+    pass
+
+
+@pytest.mark.usefixtures("random_space")
+class TestHypersphereCompactness(HypersphereCompactnessTestCase):
+    pass

--- a/tests/tests_geomstats/test_geometry/test_stiefel.py
+++ b/tests/tests_geomstats/test_geometry/test_stiefel.py
@@ -6,6 +6,7 @@ from geomstats.geometry.stiefel import Stiefel, StiefelCanonicalMetric
 from geomstats.test.parametrizers import DataBasedParametrizer, Parametrizer
 from geomstats.test_cases.geometry.stiefel import (
     StiefelCanonicalMetricTestCase,
+    StiefelConnectednessTestCase,
     StiefelStaticMethodsTestCase,
     StiefelTestCase,
 )
@@ -13,6 +14,7 @@ from geomstats.test_cases.geometry.stiefel import (
 from .data.stiefel import (
     StiefelCanonicalMetricSquareTestData,
     StiefelCanonicalMetricTestData,
+    StiefelConnectednessTestData,
     StiefelStaticMethodsTestData,
     StiefelTestData,
 )
@@ -84,3 +86,7 @@ class TestStiefelCanonicalMetricSquare(
     space = Stiefel(n=k, p=k, equip=False)
     space.equip_with_metric(StiefelCanonicalMetric)
     testing_data = StiefelCanonicalMetricSquareTestData()
+
+
+class TestStiefelConnectedness(StiefelConnectednessTestCase, metaclass=Parametrizer):
+    testing_data = StiefelConnectednessTestData()

--- a/tests/tests_geomstats/test_geometry/test_stiefel.py
+++ b/tests/tests_geomstats/test_geometry/test_stiefel.py
@@ -6,6 +6,7 @@ from geomstats.geometry.stiefel import Stiefel, StiefelCanonicalMetric
 from geomstats.test.parametrizers import DataBasedParametrizer, Parametrizer
 from geomstats.test_cases.geometry.stiefel import (
     StiefelCanonicalMetricTestCase,
+    StiefelCompactnessTestCase,
     StiefelConnectednessTestCase,
     StiefelStaticMethodsTestCase,
     StiefelTestCase,
@@ -89,4 +90,10 @@ class TestStiefelCanonicalMetricSquare(
 
 
 class TestStiefelConnectedness(StiefelConnectednessTestCase, metaclass=Parametrizer):
+    Space = Stiefel
     testing_data = StiefelConnectednessTestData()
+
+
+@pytest.mark.usefixtures("spaces")
+class TestStiefelCompactness(StiefelCompactnessTestCase):
+    pass


### PR DESCRIPTION
<!--
Thank you for opening this pull request!
-->

## Checklist

- [x] My pull request has a clear and explanatory title.
- [x] If necessary, my code is [vectorized](https://www.geeksforgeeks.org/vectorization-in-python/).
- [x] I added appropriate unit tests.
- [ ] I made sure the code passes all unit tests. (refer to comment below)
- [x] My PR follows [PEP8](https://peps.python.org/pep-0008/) guidelines. (refer to comment below)
- [x] My PR follows [geomstats coding style](https://github.com/geomstats/geomstats/blob/main/docs/contributing.rst#coding-style-guidelines) and API.
- [x] My code is properly documented and I made sure the documentation renders properly. ([Link](https://github.com/geomstats/geomstats/blob/main/docs/contributing.rst#documentation))
- [x] I linked to issues and PRs that are relevant to this PR.


<!-- For checking consistency of entire codebase
First, run the tests related to your changes. For example, if you changed something in geomstats/spd_matrices_space.py:
$ pytest tests/tests_geomstats/test_spd_matrices.py

and then run the tests of the whole codebase to check that your feature is not breaking any of them:
$ pytest tests/

This way, further modifications on the code base are guaranteed to be consistent with the desired behavior. Merging your PR should not break any test in any backend (numpy, autograd or pytorch)."

For testing in alternative backends such as `numpy`, `pytorch`, `autograd`, set the environment variable using:
$ export GEOMSTATS_BACKEND=<backend_name>

Next, import the `backend` module using:
import geomstats.backend as gs
-->


## Description

<!-- Include a description of your pull request. If relevant, feel free to use this space to talk about time and space complexity as well scalability of your code-->

This PR adds methods to check [connectedness](https://en.wikipedia.org/wiki/Connected_space) and [compactness](https://en.wikipedia.org/wiki/Compact_space) for the following geometry classes:

- `Euclidean`
- `Hypersphere`
- `Grassmannian`
- `Stiefel`

These methods return a Boolean value indicating whether the underlying geometry is connected or compact.

## Issue

<!-- Tell us which issue does this PR fix . Why this feature implementation/fix is important in practice ?-->

Towards #1475 

## Additional context

<!-- Add any extra information -->

N / A
