### PR TITLE
DOC: Use the intersphinx extension

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,6 +14,7 @@ extensions = [
     "sphinx.ext.coverage",
     "sphinx.ext.doctest",
     "sphinx.ext.githubpages",
+    "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
@@ -121,3 +122,16 @@ texinfo_documents = [
 
 epub_title = project
 epub_exclude_files = ["search.html"]
+
+# -- intersphinx -------------------------------------------------------------
+intersphinx_mapping = {
+    "joblib": ("https://joblib.readthedocs.io/en/latest", None),
+    "matplotlib": ("https://matplotlib.org/stable", None),
+    "numpy": ("https://numpy.org/doc/stable", None),
+    "pandas": ("https://pandas.pydata.org/pandas-docs/dev", None),
+    "python": ("https://docs.python.org/3", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy", None),
+    "sklearn": ("https://scikit-learn.org/stable", None),
+    "torch": ("https://pytorch.org/docs/stable", None),
+}
+intersphinx_timeout = 5


### PR DESCRIPTION
<!--
Thank you for opening this pull request!
-->

## Checklist

- [ ] My pull request has a clear and explanatory title.
- [ ] If necessary, my code is [vectorized](https://www.geeksforgeeks.org/vectorization-in-python/).
- [ ] I added appropriate unit tests.
- [ ] I made sure the code passes all unit tests. (refer to comment below)
- [ ] My PR follows [PEP8](https://peps.python.org/pep-0008/) guidelines. (refer to comment below)
- [ ] My PR follows [geomstats coding style](https://github.com/geomstats/geomstats/blob/main/docs/contributing.rst#coding-style-guidelines) and API.
- [ ] My code is properly documented and I made sure the documentation renders properly. ([Link](https://github.com/geomstats/geomstats/blob/main/docs/contributing.rst#documentation))
- [ ] I linked to issues and PRs that are relevant to this PR.


<!-- For checking consistency of entire codebase
First, run the tests related to your changes. For example, if you changed something in geomstats/spd_matrices_space.py:
$ pytest tests/tests_geomstats/test_spd_matrices.py

and then run the tests of the whole codebase to check that your feature is not breaking any of them:
$ pytest tests/

This way, further modifications on the code base are guaranteed to be consistent with the desired behavior. Merging your PR should not break any test in any backend (numpy, autograd or pytorch)."

For testing in alternative backends such as `numpy`, `pytorch`, `autograd`, set the environment variable using:
$ export GEOMSTATS_BACKEND=<backend_name>

Next, import the `backend` module using:
import geomstats.backend as gs
-->


## Description

<!-- Include a description of your pull request. If relevant, feel free to use this space to talk about time and space complexity as well scalability of your code-->

## Issue

This PR adds the  [sphinx intersphinx](https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html) extension, which creates clickable hyperlinks between Python libraries when they are referenced in the documentation (for example like this page in the [MNE-Python](https://mne.tools/1.8/generated/mne.decoding.CSP.html#mne.decoding.CSP) documentation).

Using the TangentPCA module as an example, one can now click through to the Scikit-Learn page when it is referenced in the documentation:


| Branch | Rendered code |
|---------|---------|
| Main      |  <img width="600" alt="Screenshot 2025-02-07 at 7 15 26 PM" src="https://github.com/user-attachments/assets/a02abc7d-7dda-4e93-895f-09c23d77fdfa" />
| This PR |  <img width="600" alt="Screenshot 2025-02-07 at 7 14 48 PM" src="https://github.com/user-attachments/assets/ef760a60-4570-4e6b-b533-f9f72cdc6dad" /> |







<!-- Tell us which issue does this PR fix . Why this feature implementation/fix is important in practice ?-->

## Additional context

<!-- Add any extra information -->
