### PR TITLE
Import trapz or trapezoid in mupy backend depending on numpy version

### DIFF
--- a/geomstats/_backend/autograd/__init__.py
+++ b/geomstats/_backend/autograd/__init__.py
@@ -71,13 +71,12 @@ from autograd.numpy import (
     where,
     zeros_like,
 )
-# Import trapezoid or trapz depending on NumPy version
-from numpy import __version__ as numpy_version
-major_version = int(numpy_version.split('.')[0])
-if major_version >= 2:
+
+try:
     from autograd.numpy import trapezoid
-else:
+except ImportError:
     from autograd.numpy import trapz as trapezoid
+
 from autograd.scipy.special import erf, gamma, polygamma  # NOQA
 
 from .._shared_numpy import (

--- a/geomstats/_backend/autograd/__init__.py
+++ b/geomstats/_backend/autograd/__init__.py
@@ -61,7 +61,6 @@ from autograd.numpy import (
     take,
     tile,
     transpose,
-    trapezoid,
     tril,
     tril_indices,
     triu,
@@ -72,6 +71,13 @@ from autograd.numpy import (
     where,
     zeros_like,
 )
+# Import trapezoid or trapz depending on NumPy version
+from numpy import __version__ as numpy_version
+major_version = int(numpy_version.split('.')[0])
+if major_version >= 2:
+    from autograd.numpy import trapezoid
+else:
+    from autograd.numpy import trapz as trapezoid
 from autograd.scipy.special import erf, gamma, polygamma  # NOQA
 
 from .._shared_numpy import (

--- a/geomstats/_backend/numpy/__init__.py
+++ b/geomstats/_backend/numpy/__init__.py
@@ -71,7 +71,7 @@ from numpy import (
     where,
     zeros_like,
 )
-# Import trapezoid function with version-dependent name
+# Import trapezoid or trapz depending on NumPy version
 numpy_version = _np.__version__
 major_version = int(numpy_version.split('.')[0])
 if major_version >= 2:

--- a/geomstats/_backend/numpy/__init__.py
+++ b/geomstats/_backend/numpy/__init__.py
@@ -71,13 +71,12 @@ from numpy import (
     where,
     zeros_like,
 )
-# Import trapezoid or trapz depending on NumPy version
-numpy_version = _np.__version__
-major_version = int(numpy_version.split('.')[0])
-if major_version >= 2:
+
+try:
     from numpy import trapezoid
-else:
+except ImportError:
     from numpy import trapz as trapezoid
+
 from scipy.special import erf, gamma, polygamma  # NOQA
 
 from .._shared_numpy import (

--- a/geomstats/_backend/numpy/__init__.py
+++ b/geomstats/_backend/numpy/__init__.py
@@ -61,7 +61,6 @@ from numpy import (
     take,
     tile,
     transpose,
-    trapezoid,
     tril,
     tril_indices,
     triu,
@@ -72,6 +71,13 @@ from numpy import (
     where,
     zeros_like,
 )
+# Import trapezoid function with version-dependent name
+numpy_version = _np.__version__
+major_version = int(numpy_version.split('.')[0])
+if major_version >= 2:
+    from numpy import trapezoid
+else:
+    from numpy import trapz as trapezoid
 from scipy.special import erf, gamma, polygamma  # NOQA
 
 from .._shared_numpy import (


### PR DESCRIPTION
<!--
Thank you for opening this pull request!
-->

## Checklist

- [ X] My pull request has a clear and explanatory title.
- [ X] If necessary, my code is [vectorized](https://www.geeksforgeeks.org/vectorization-in-python/).
- [ ] I added appropriate unit tests.
- [ ] I made sure the code passes all unit tests. (refer to comment below)
- [ X] My PR follows [PEP8](https://peps.python.org/pep-0008/) guidelines. (refer to comment below)
- [ ] My PR follows [geomstats coding style](https://github.com/geomstats/geomstats/blob/main/docs/contributing.rst#coding-style-guidelines) and API.
- [ ] My code is properly documented and I made sure the documentation renders properly. ([Link](https://github.com/geomstats/geomstats/blob/main/docs/contributing.rst#documentation))
- [ X] I linked to issues and PRs that are relevant to this PR.


<!-- For checking consistency of entire codebase
First, run the tests related to your changes. For example, if you changed something in geomstats/spd_matrices_space.py:
$ pytest tests/tests_geomstats/test_spd_matrices.py

and then run the tests of the whole codebase to check that your feature is not breaking any of them:
$ pytest tests/

This way, further modifications on the code base are guaranteed to be consistent with the desired behavior. Merging your PR should not break any test in any backend (numpy, autograd or pytorch)."

For testing in alternative backends such as `numpy`, `pytorch`, `autograd`, set the environment variable using:
$ export GEOMSTATS_BACKEND=<backend_name>

Next, import the `backend` module using:
import geomstats.backend as gs
-->


## Description

In the `backend numpy/__init__.py` and `autograd/__init__.py` files, either `trapz` or `trapezoid` is imported, depending on the numpy version.

## Issue

Solves https://github.com/geomstats/geomstats/issues/2048#issue-2866746478

## Additional context
