### PR TITLE
Implemented __mul__ and __pow__ in manifolds.py with correct type checking and vectorized sampling

### DIFF
--- a/geomstats/geometry/manifold.py
+++ b/geomstats/geometry/manifold.py
@@ -280,6 +280,45 @@ class Manifold(abc.ABC):
 
         raise NotImplementedError("`projection` is not implemented yet")
 
+    def __mul__(self, other):
+        """Multiplication operator.
+
+        Parameters
+        ----------
+        Other : manifold
+
+        Returns
+        -------
+        Product Manifold
+        """
+        from .product_manifold import ProductManifold
+
+        if not isinstance(other, Manifold):
+            raise TypeError("Expected a manifold")
+
+        return ProductManifold(factors=(self, other))
+
+    __rmul__ = __mul__
+
+    def __pow__(self, n):
+        """Exponentiation operator.
+
+        Parameters
+        ----------
+        n : int
+            Number of replication of the base manifold.
+
+        Returns
+        -------
+            N-fold Manifold
+        """
+        from .nfold_manifold import NFoldManifold
+
+        if not isinstance(n, int) or n < 1:
+            raise ValueError("Exponent must be a positive integer")
+
+        return NFoldManifold(self, n_copies=n)
+
 
 class _QuotientStructureRegistry:
     """Registry for quotient structures."""

--- a/tests/tests_geomstats/test_geometry/test_nfold_manifold.py
+++ b/tests/tests_geomstats/test_geometry/test_nfold_manifold.py
@@ -29,3 +29,33 @@ class TestNFoldMetricScales(NFoldMetricScalesTestCase, metaclass=DataBasedParame
     other_space.equip_with_metric(ScalarProductMetric(other_space, scale))
 
     testing_data = NFoldMetricScalesTestData()
+
+
+def test_pow_constructor():
+    nfold_1 = SpecialOrthogonal(n=2) ** 50
+    assert isinstance(nfold_1, NFoldManifold)
+
+    nfold_2 = Euclidean(dim=3) ** 3
+    assert isinstance(nfold_2, NFoldManifold)
+
+    nfold_3 = SpecialOrthogonal(n=5) ** 99
+    assert isinstance(nfold_3, NFoldManifold)
+
+
+def test_pow_constructor_vec():
+    nfold = SpecialOrthogonal(2) ** 50
+
+    one_point = nfold.random_point()
+    assert one_point.shape[0] == nfold.base_manifold.dim * nfold.n_copies
+
+    mult_points = nfold.random_point(n_samples=5)
+    assert mult_points.shape[0] == 5
+    assert mult_points.shape[1] == nfold.base_manifold.dim * nfold.n_copies
+
+
+def test_pow_invalid_nfold():
+    with pytest.raises(ValueError):
+        _ = SpecialOrthogonal(3) ** 0
+
+    with pytest.raises(ValueError):
+        _ = SpecialOrthogonal(3) ** -5

--- a/tests/tests_geomstats/test_geometry/test_product_manifold.py
+++ b/tests/tests_geomstats/test_geometry/test_product_manifold.py
@@ -5,6 +5,7 @@ from geomstats.geometry.hyperboloid import Hyperboloid
 from geomstats.geometry.hypersphere import Hypersphere
 from geomstats.geometry.product_manifold import ProductManifold
 from geomstats.geometry.siegel import Siegel
+from geomstats.geometry.spd_matrices import SPDMatrices
 from geomstats.geometry.special_orthogonal import SpecialOrthogonal
 from geomstats.test.parametrizers import DataBasedParametrizer
 from geomstats.test_cases.geometry.product_manifold import ProductManifoldTestCase
@@ -99,3 +100,31 @@ class TestProductRiemannianMetric(
     RiemannianMetricTestCase, metaclass=DataBasedParametrizer
 ):
     testing_data = ProductRiemannianMetricTestData()
+
+
+def test_mul_constructor():
+    a = SpecialOrthogonal(n=3)
+    b = SPDMatrices(n=4)
+    product_1 = a * b
+    assert isinstance(product_1, ProductManifold)
+
+    product_2 = SpecialOrthogonal(n=2) * Euclidean(dim=2)
+    assert isinstance(product_2, ProductManifold)
+
+    product_3 = Euclidean(dim=1) * SPDMatrices(n=1)
+    assert isinstance(product_3, ProductManifold)
+
+
+def test_mul_constructor_vect():
+    product = SpecialOrthogonal(n=3) * SPDMatrices(n=4)
+    one_point = product.random_point()
+    assert one_point.shape[0] == one_point.size
+
+    mult_points = product.random_point(n_samples=5)
+    assert mult_points.shape[0] == 5
+    assert mult_points.shape[1] == one_point.size
+
+
+def test_mul_invalid_factors():
+    with pytest.raises(TypeError):
+        _ = SpecialOrthogonal(3) * 5


### PR DESCRIPTION


<!--
Thank you for opening this pull request!
-->

## Checklist

- [ X] My pull request has a clear and explanatory title.
- [ X] If necessary, my code is [vectorized](https://www.geeksforgeeks.org/vectorization-in-python/).
- [ X] I added appropriate unit tests.
- [ X] I made sure the code passes all unit tests. (refer to comment below)
- [ X] My PR follows [PEP8](https://peps.python.org/pep-0008/) guidelines. (refer to comment below)
- [X ] My PR follows [geomstats coding style](https://github.com/geomstats/geomstats/blob/main/docs/contributing.rst#coding-style-guidelines) and API.
- [ X] My code is properly documented and I made sure the documentation renders properly. ([Link](https://github.com/geomstats/geomstats/blob/main/docs/contributing.rst#documentation))
- [X ] I linked to issues and PRs that are relevant to this PR.


<!-- For checking consistency of entire codebase
First, run the tests related to your changes. For example, if you changed something in geomstats/spd_matrices_space.py:
$ pytest tests/tests_geomstats/test_spd_matrices.py

and then run the tests of the whole codebase to check that your feature is not breaking any of them:
$ pytest tests/

This way, further modifications on the code base are guaranteed to be consistent with the desired behavior. Merging your PR should not break any test in any backend (numpy, autograd or pytorch)."

For testing in alternative backends such as `numpy`, `pytorch`, `autograd`, set the environment variable using:
$ export GEOMSTATS_BACKEND=<backend_name>

Next, import the `backend` module using:
import geomstats.backend as gs
-->


## Description

Made changes to manifold.py: 
 -  added __mul__ so now manifold * manifold works, accounted for __rmul__ (set equal to __mul__),  
 -  added __pow__  so now n-fold manifold works with manifold ** n
 - wrote unit test for __mul__ in test_product_manifold
 - wrote unit test for __pow__  in test_nfold_manifold
 - unit tests verified correctness and vectorization  


## Issue

Use operators *, /, ** to build product, quotient and power manifolds #1394 
https://github.com/geomstats/geomstats/issues/1394#issue-1161903096


## Additional context


Only implement __mul__ and __pow__ and added respective unit tests
