### PR TITLE
Add gpu backend for varifolds

### DIFF
--- a/geomstats/varifold/_device.py
+++ b/geomstats/varifold/_device.py
@@ -13,6 +13,9 @@ if gs.__name__.endswith("pytorch"):
     def get_device(array):
         return array.device
 
+    def to_cpu(array):
+        return array.cpu()
+
 
 else:
 
@@ -24,3 +27,6 @@ else:
 
     def get_device(array):
         return "cpu"
+
+    def to_cpu(array):
+        return array

--- a/geomstats/varifold/_device.py
+++ b/geomstats/varifold/_device.py
@@ -1,0 +1,26 @@
+import geomstats.backend as gs
+
+if gs.__name__.endswith("pytorch"):
+    import torch
+
+    def gpu_is_available():
+        return torch.cuda.is_available()
+
+    def to_device(array, device="cuda"):
+        # TODO: check autodiff
+        return array.to(device)
+
+    def get_device(array):
+        return array.device
+
+
+else:
+
+    def gpu_is_available():
+        return False
+
+    def to_device(array, *args, **kwargs):
+        return array
+
+    def get_device(array):
+        return "cpu"

--- a/geomstats/varifold/_varifold.py
+++ b/geomstats/varifold/_varifold.py
@@ -26,26 +26,8 @@ import logging
 import geomstats.backend as gs
 from geomstats._mesh import Surface
 
+from ._device import gpu_is_available, to_device
 from .kernel import GaussianBinetPairing
-
-if gs.__name__.endswith("pytorch"):
-    import torch
-
-    def _gpu_is_available():
-        return torch.cuda.is_available()
-
-    def _to_device(array, device="cuda"):
-        # TODO: check autodiff
-        return array.to(device)
-
-
-else:
-
-    def _gpu_is_available():
-        return False
-
-    def _to_device(array, *args, **kwargs):
-        return array
 
 
 class KernelInducedMetric(abc.ABC):
@@ -187,10 +169,10 @@ class VarifoldMetric(KernelInducedMetric):
         super().__init__(pairing)
 
         self._gpu = False
-        if _gpu_is_available() and (backend == "auto" or backend.endswith("_gpu")):
+        if gpu_is_available() and (backend == "auto" or backend.endswith("_gpu")):
             self._gpu = True
 
-        if backend.endswith("_gpu") and not _gpu_is_available():
+        if backend.endswith("_gpu") and not gpu_is_available():
             logging.info("No GPU available, computing on CPU.")
 
     def transform(self, point):
@@ -216,4 +198,4 @@ class VarifoldMetric(KernelInducedMetric):
         if not self._gpu:
             return arrays
 
-        return [_to_device(array) for array in arrays]
+        return [to_device(array) for array in arrays]

--- a/geomstats/varifold/_varifold.py
+++ b/geomstats/varifold/_varifold.py
@@ -21,11 +21,31 @@ References
 """
 
 import abc
+import logging
 
 import geomstats.backend as gs
 from geomstats._mesh import Surface
 
 from .kernel import GaussianBinetPairing
+
+if gs.__name__.endswith("pytorch"):
+    import torch
+
+    def _gpu_is_available():
+        return torch.cuda.is_available()
+
+    def _to_device(array, device="cuda"):
+        # TODO: check autodiff
+        return array.to(device)
+
+
+else:
+
+    def _gpu_is_available():
+        return False
+
+    def _to_device(array, *args, **kwargs):
+        return array
 
 
 class KernelInducedMetric(abc.ABC):
@@ -150,7 +170,7 @@ class VarifoldMetric(KernelInducedMetric):
     sigma : float
         Positive bandwidth parameter of the Gaussian kernel.
     backend : {"auto", "torch", "keops", "keops_genred", "keops_lazy"}
-        Implementation backend.
+        Implementation backend. Suffix with '_gpu' to control device.
 
         - "auto": Select an implementation automatically (prefers
           a KeOps-based implementation when available, otherwise falls back
@@ -166,6 +186,13 @@ class VarifoldMetric(KernelInducedMetric):
         pairing = GaussianBinetPairing(sigma, backend=backend)
         super().__init__(pairing)
 
+        self._gpu = False
+        if _gpu_is_available() and (backend == "auto" or backend.endswith("_gpu")):
+            self._gpu = True
+
+        if backend.endswith("_gpu") and not _gpu_is_available():
+            logging.info("No GPU available, computing on CPU.")
+
     def transform(self, point):
         """Extract geometric features used by the varifold representation.
 
@@ -180,8 +207,13 @@ class VarifoldMetric(KernelInducedMetric):
         tuple
             Tuple ``(centroids, normals, areas)`` used in the kernel pairing.
         """
-        return (
+        arrays = (
             point.face_centroids,
             point.face_normals,
             point.face_areas,
         )
+
+        if not self._gpu:
+            return arrays
+
+        return [_to_device(array) for array in arrays]

--- a/geomstats/varifold/_varifold.py
+++ b/geomstats/varifold/_varifold.py
@@ -26,7 +26,7 @@ import logging
 import geomstats.backend as gs
 from geomstats._mesh import Surface
 
-from ._device import gpu_is_available, to_device
+from ._device import gpu_is_available, to_cpu, to_device
 from .kernel import GaussianBinetPairing
 
 
@@ -67,7 +67,7 @@ class KernelInducedMetric(abc.ABC):
         point_a = self.transform(point_a)
         point_b = self.transform(point_b)
 
-        return self.pairing(point_a, point_b)
+        return to_cpu(self.pairing(point_a, point_b))
 
     def squared_dist(self, point_a, point_b):
         """Squared distance.
@@ -86,11 +86,12 @@ class KernelInducedMetric(abc.ABC):
         point_a = self.transform(point_a)
         point_b = self.transform(point_b)
 
-        return (
+        sdist = (
             self.pairing(point_a, point_a)
             - 2 * self.pairing(point_a, point_b)
             + self.pairing(point_b, point_b)
         )
+        return to_cpu(sdist)
 
     def dist(self, point_a, point_b):
         """Squared distance.

--- a/geomstats/varifold/keops/genred.py
+++ b/geomstats/varifold/keops/genred.py
@@ -8,6 +8,8 @@ if gs.__name__.endswith("pytorch"):
 else:
     from pykeops.numpy import Genred
 
+from .._device import get_device, to_device
+
 
 def GaussianKernel(sigma):
     r"""Gaussian kernel.
@@ -212,4 +214,6 @@ class GaussianBinetPairing(Pairing):
 
     def kernel_prod(self, *kernel_args):
         """Apply the kernel pairing to a vector."""
-        return self._expr(self._a_param, *kernel_args)
+        a_param = to_device(self._a_param, get_device(kernel_args[0]))
+
+        return self._expr(a_param, *kernel_args)

--- a/geomstats/varifold/kernel.py
+++ b/geomstats/varifold/kernel.py
@@ -60,6 +60,9 @@ def GaussianBinetPairing(sigma, backend="auto"):
         has_keops = importlib.util.find_spec("pykeops") is not None
         backend = "keops_genred" if has_keops else "backend"
 
+    if backend.endswith("_gpu"):
+        backend = backend[:-4]
+
     if backend == "keops":
         backend = "keops_genred"
 


### PR DESCRIPTION
This PR updates the varifold implementation to run on the gpu. (It simply takes advantage of `torch` or `pykeops` gpu capabilities.)