### PR TITLE
Add equip_with_connection

### DIFF
--- a/geomstats/geometry/connection.py
+++ b/geomstats/geometry/connection.py
@@ -779,36 +779,47 @@ class Connection(ABC):
         raise NotImplementedError("The injectivity range is not implemented yet.")
 
 
-class MetricConnectionView:
-    """Metric wrapper exposing only connection-related methods."""
+_CONNECTION_METHODS = {
+    "_space",
+    "christoffels",
+    "geodesic_equation",
+    "exp",
+    "log",
+    "riemann_tensor",
+    "curvature",
+    "ricci_tensor",
+    "directional_curvature",
+    "curvature_derivative",
+    "directional_curvature_derivative",
+    "geodesic",
+    "parallel_transport",
+    "injectivity_radius",
+}
 
-    _CON_METHODS = {
-        "_space",
-        "christoffels",
-        "geodesic_equation",
-        "exp",
-        "log",
-        "riemann_tensor",
-        "curvature",
-        "ricci_tensor",
-        "directional_curvature",
-        "curvature_derivative",
-        "directional_curvature_derivative",
-        "geodesic",
-        "parallel_transport",
-        "injectivity_radius",
-    }
+
+def _make_delegated_method(name):
+    def method(self, *args, **kwargs):
+        return getattr(self._metric, name)(*args, **kwargs)
+
+    method.__name__ = name
+    method.__qualname__ = name
+    method.__doc__ = f"Delegate ``{name}`` to the wrapped metric."
+    return method
+
+
+def _delegate_methods(method_names):
+    def decorate(cls):
+        for name in method_names:
+            if name not in cls.__dict__:
+                setattr(cls, name, _make_delegated_method(name))
+        return cls
+
+    return decorate
+
+
+@_delegate_methods(_CONNECTION_METHODS)
+class ConnectionFromMetric:
+    """Metric wrapper exposing only connection-related methods."""
 
     def __init__(self, metric):
         self._metric = metric
-
-    def __getattr__(self, name):
-        """Get attribute."""
-        if name not in self._CON_METHODS:
-            raise AttributeError(f"{name} is not implemented.")
-
-        return getattr(self._metric, name)
-
-    def __dir__(self):
-        """Available connection-related attributes."""
-        return sorted(set(super().__dir__()) | self._CON_METHODS)

--- a/geomstats/geometry/connection.py
+++ b/geomstats/geometry/connection.py
@@ -782,6 +782,7 @@ class Connection(ABC):
 _CONNECTION_METHODS = {
     "_space",
     "christoffels",
+    "jacobian_christoffels",
     "geodesic_equation",
     "exp",
     "log",

--- a/geomstats/geometry/connection.py
+++ b/geomstats/geometry/connection.py
@@ -777,3 +777,38 @@ class Connection(ABC):
             Injectivity radius.
         """
         raise NotImplementedError("The injectivity range is not implemented yet.")
+
+
+class MetricConnectionView:
+    """Metric wrapper exposing only connection-related methods."""
+
+    _CON_METHODS = {
+        "_space",
+        "christoffels",
+        "geodesic_equation",
+        "exp",
+        "log",
+        "riemann_tensor",
+        "curvature",
+        "ricci_tensor",
+        "directional_curvature",
+        "curvature_derivative",
+        "directional_curvature_derivative",
+        "geodesic",
+        "parallel_transport",
+        "injectivity_radius",
+    }
+
+    def __init__(self, metric):
+        self._metric = metric
+
+    def __getattr__(self, name):
+        """Get attribute."""
+        if name not in self._CON_METHODS:
+            raise AttributeError(f"{name} is not implemented.")
+
+        return getattr(self._metric, name)
+
+    def __dir__(self):
+        """Available connection-related attributes."""
+        return sorted(set(super().__dir__()) | self._CON_METHODS)

--- a/geomstats/geometry/manifold.py
+++ b/geomstats/geometry/manifold.py
@@ -12,7 +12,7 @@ import types
 
 import geomstats.backend as gs
 import geomstats.errors
-from geomstats.geometry.connection import MetricConnectionView
+from geomstats.geometry.connection import ConnectionFromMetric
 from geomstats.geometry.fiber_bundle import FiberBundle
 from geomstats.geometry.quotient_metric import QuotientMetric
 
@@ -89,7 +89,7 @@ class Manifold(abc.ABC):
 
             self.metric = Metric
 
-        self.connection = MetricConnectionView(self.metric)
+        self.connection = ConnectionFromMetric(self.metric)
 
         return self
 

--- a/geomstats/geometry/manifold.py
+++ b/geomstats/geometry/manifold.py
@@ -73,7 +73,10 @@ class Manifold(abc.ABC):
         if hasattr(self, "metric"):
             raise ValueError("Cannot equip a Riemannian manifold with a connection.")
 
-        self.connection = Connection(self)
+        if Connection is ConnectionFromMetric:
+            self.connection = Connection(**connection_kwargs)
+        else:
+            self.connection = Connection(self, **connection_kwargs)
 
         return self
 

--- a/geomstats/geometry/manifold.py
+++ b/geomstats/geometry/manifold.py
@@ -12,6 +12,7 @@ import types
 
 import geomstats.backend as gs
 import geomstats.errors
+from geomstats.geometry.connection import MetricConnectionView
 from geomstats.geometry.fiber_bundle import FiberBundle
 from geomstats.geometry.quotient_metric import QuotientMetric
 
@@ -87,6 +88,8 @@ class Manifold(abc.ABC):
                 )
 
             self.metric = Metric
+
+        self.connection = MetricConnectionView(self.metric)
 
         return self
 

--- a/geomstats/geometry/manifold.py
+++ b/geomstats/geometry/manifold.py
@@ -62,6 +62,21 @@ class Manifold(abc.ABC):
         if equip:
             self.equip_with_metric()
 
+    def equip_with_connection(self, Connection, **connection_kwargs):
+        """Equip manifold with a Riemannian metric.
+
+        Parameters
+        ----------
+        Connection : Connection object
+            If None, default metric will be used.
+        """
+        if hasattr(self, "metric"):
+            raise ValueError("Cannot equip a Riemannian manifold with a connection.")
+
+        self.connection = Connection(self)
+
+        return self
+
     def equip_with_metric(self, Metric=None, **metric_kwargs):
         """Equip manifold with a Riemannian metric.
 

--- a/geomstats/numerics/geodesic.py
+++ b/geomstats/numerics/geodesic.py
@@ -101,7 +101,7 @@ class ExpODESolver(ExpSolver):
         state_axis = -(self._space.point_ndim + 1)
         initial_state = gs.stack([base_point, tangent_vec], axis=state_axis)
 
-        force = lambda state, _: self._space.metric.geodesic_equation(state)
+        force = lambda state, _: self._space.connection.geodesic_equation(state)
         if t_eval is None:
             return self.integrator.integrate(force, initial_state)
 
@@ -370,7 +370,7 @@ class _LogShootingSolver(LogSolver, ABC):
             Batch shape.
         """
         tangent_vec = gs.reshape(flat_tangent_vec, batch_shape + self._space.shape)
-        delta = self._space.metric.exp(tangent_vec, base_point) - point
+        delta = self._space.connection.exp(tangent_vec, base_point) - point
         return gs.sum(delta**2)
 
 
@@ -538,7 +538,7 @@ class LogODESolver(_LogBatchMixins, LogSolver):
         state = gs.moveaxis(
             gs.reshape(raveled_state, (2,) + self._space.shape + (-1,)), -1, 0
         )
-        new_state = self._space.metric.geodesic_equation(state)
+        new_state = self._space.connection.geodesic_equation(state)
         return gs.moveaxis(gs.reshape(new_state, (-1, raveled_state.shape[0])), -2, -1)
 
     def _jacobian(self, _, raveled_state):
@@ -559,13 +559,13 @@ class LogODESolver(_LogBatchMixins, LogSolver):
         n_nodes = raveled_state.shape[-1]
         position, velocity = gs.transpose(raveled_state[:dim]), raveled_state[dim:]
 
-        dgamma = self._space.metric.jacobian_christoffels(position)
+        dgamma = self._space.connection.jacobian_christoffels(position)
 
         df_dposition = -gs.einsum(
             "j...,...ijkl,k...->il...", velocity, dgamma, velocity
         )
 
-        gamma = self._space.metric.christoffels(position)
+        gamma = self._space.connection.christoffels(position)
         df_dvelocity = -2 * gs.einsum("...ijk,k...->ij...", gamma, velocity)
 
         jac_nw = gs.zeros((dim, dim, raveled_state.shape[1]))


### PR DESCRIPTION
Following discussions with @alebrigant and @domingueslilou-cpu, this PR adds `equip_with_connection`.

Moreover, when doing `equip_with_metric`, we also endow the space with `connection` by wrapping the metric such that only the connection methods are visible. This is required in order to make the geodesic solvers more generic.