### PR TITLE
Add load_dhoom / save_dhoom for DHOOM serialization format

### DIFF
--- a/geomstats/datasets/_dhoom.py
+++ b/geomstats/datasets/_dhoom.py
@@ -1,0 +1,958 @@
+"""DHOOM encoder/decoder — vendored copy of the reference Python implementation.
+
+DHOOM (Davis Human-readable Optimized Object Markup) is a compact, human-readable
+serialization format for structured data. It encodes the same data model as JSON
+but exploits fiber-bundle decomposition of homogeneous collections to eliminate
+structural redundancy. See https://dhoom.dev for the format specification.
+
+This module is vendored from the reference Python implementation at
+https://github.com/nurdymuny/dhoom (package: ``dhoom``).
+It is intended as an internal implementation detail of
+``geomstats.datasets.utils.load_dhoom`` and ``save_dhoom`` and is not part
+of the geomstats public API. Future releases may switch to ``dhoom`` as an
+optional dependency (``pip install geomstats[dhoom]``).
+
+License
+-------
+DHOOM is released under the MIT License.
+
+    MIT License
+
+    Copyright (c) 2026 Bee Rosa Davis / Davis Geometric
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+    OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+References
+----------
+.. [1] DHOOM format specification, v0.5. https://dhoom.dev
+.. [2] Davis, B. R. (2024). *The Geometry of Sameness*. Amazon KDP.
+.. [3] Davis, B. R. (2026). *The Double Cover Principle*. Zenodo.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+JsonValue = Any  # str | int | float | bool | None | list | dict
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class DhoomError(Exception):
+    def __init__(self, message: str, line: int | None = None):
+        self.line = line
+        if line is not None:
+            super().__init__(f"Line {line}: {message}")
+        else:
+            super().__init__(message)
+
+
+# ---------------------------------------------------------------------------
+# Types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Modifier:
+    type: str
+    start: JsonValue = None
+    step: int | None = None
+    default_value: JsonValue = None
+    target: str | None = None
+    pool: list[str] | None = None
+    expr: str | None = None
+    constraint: str | None = None
+
+
+@dataclass
+class FieldDecl:
+    name: str
+    modifier: Modifier | None = None
+
+
+@dataclass
+class Fiber:
+    name: str | None = None
+    fields: list[FieldDecl] = field(default_factory=list)
+    sparse: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Value coercion
+# ---------------------------------------------------------------------------
+
+
+def coerce(s: str) -> JsonValue:
+    if s == "T":
+        return True
+    if s == "F":
+        return False
+    if s == "null":
+        return None
+    if s == "":
+        return ""
+    if re.fullmatch(r"-?\d+", s):
+        return int(s)
+    if re.fullmatch(r"-?\d+\.\d+", s):
+        return float(s)
+    return s
+
+
+def value_to_dhoom(v: JsonValue) -> str:
+    if v is True:
+        return "T"
+    if v is False:
+        return "F"
+    if v is None:
+        return "null"
+    if isinstance(v, (int, float)):
+        return str(v)
+    if isinstance(v, str):
+        if any(c in v for c in (",", ":", "\n", '"')):
+            return '"' + v.replace('"', '""') + '"'
+        return v
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Arithmetic helpers
+# ---------------------------------------------------------------------------
+
+_STRING_PATTERN = re.compile(r"^(.*\D)(\d+)$")
+
+
+def _parse_string_pattern(s: str) -> tuple[str, int, int] | None:
+    m = _STRING_PATTERN.match(s)
+    if not m:
+        return None
+    return m.group(1), int(m.group(2)), len(m.group(2))
+
+
+def _arithmetic_value(start: JsonValue, step: int, i: int) -> JsonValue:
+    if isinstance(start, (int, float)) and not isinstance(start, bool):
+        return start + step * i
+    if isinstance(start, str):
+        pat = _parse_string_pattern(start)
+        if pat:
+            prefix, num, width = pat
+            return prefix + str(num + step * i).zfill(width)
+        return start
+    return start
+
+
+# ---------------------------------------------------------------------------
+# Fiber parser
+# ---------------------------------------------------------------------------
+
+
+def _parse_field_decl(token: str) -> FieldDecl:
+    arrow_idx = token.find("->")
+    if arrow_idx != -1:
+        name = token[:arrow_idx]
+        target = token[arrow_idx + 2 :]
+        return FieldDecl(name=name, modifier=Modifier(type="morphism", target=target))
+
+    hash_idx = token.find("#")
+    if hash_idx != -1:
+        name = token[:hash_idx]
+        expr = token[hash_idx + 1 :]
+        return FieldDecl(name=name, modifier=Modifier(type="computed", expr=expr))
+
+    bang_idx = token.find("!")
+    if bang_idx != -1:
+        name = token[:bang_idx]
+        constraint = token[bang_idx + 1 :]
+        return FieldDecl(
+            name=name, modifier=Modifier(type="constraint", constraint=constraint)
+        )
+
+    if token.endswith("&"):
+        return FieldDecl(name=token[:-1], modifier=Modifier(type="interned"))
+
+    if token.endswith("^"):
+        return FieldDecl(name=token[:-1], modifier=Modifier(type="delta"))
+
+    if token.endswith(">"):
+        return FieldDecl(name=token[:-1], modifier=Modifier(type="nested"))
+
+    at_idx = token.find("@")
+    if at_idx != -1:
+        name = token[:at_idx]
+        rest = token[at_idx + 1 :]
+        plus_idx = rest.find("+")
+        if plus_idx != -1:
+            start = coerce(rest[:plus_idx])
+            step = int(rest[plus_idx + 1 :])
+            return FieldDecl(
+                name=name, modifier=Modifier(type="arithmetic", start=start, step=step)
+            )
+        return FieldDecl(
+            name=name, modifier=Modifier(type="arithmetic", start=coerce(rest))
+        )
+
+    pipe_idx = token.find("|")
+    if pipe_idx != -1:
+        name = token[:pipe_idx]
+        default_value = coerce(token[pipe_idx + 1 :])
+        return FieldDecl(
+            name=name, modifier=Modifier(type="default", default_value=default_value)
+        )
+
+    return FieldDecl(name=token)
+
+
+def parse_fiber(input_str: str) -> Fiber:
+    s = input_str.strip()
+    brace_start = s.find("{")
+    brace_end = s.rfind("}")
+    if brace_start == -1 or brace_end == -1:
+        raise DhoomError("Missing braces in fiber header")
+
+    raw_name = s[:brace_start].strip() or None
+    sparse = False
+    name = None
+
+    if raw_name:
+        if raw_name.startswith("~"):
+            sparse = True
+            stripped = raw_name[1:].strip()
+            name = stripped or None
+        else:
+            name = raw_name
+
+    fields = [
+        _parse_field_decl(t.strip())
+        for t in s[brace_start + 1 : brace_end].split(",")
+        if t.strip()
+    ]
+    return Fiber(name=name, fields=fields, sparse=sparse)
+
+
+# ---------------------------------------------------------------------------
+# Record field splitter (respects quotes)
+# ---------------------------------------------------------------------------
+
+
+def _split_record_fields(line: str) -> list[str]:
+    fields: list[str] = []
+    current: list[str] = []
+    in_quotes = False
+    i = 0
+    while i < len(line):
+        c = line[i]
+        if in_quotes:
+            if c == '"':
+                if i + 1 < len(line) and line[i + 1] == '"':
+                    current.append('"')
+                    i += 1
+                else:
+                    in_quotes = False
+            else:
+                current.append(c)
+        elif c == '"':
+            in_quotes = True
+        elif c == ",":
+            fields.append("".join(current).strip())
+            current = []
+        else:
+            current.append(c)
+        i += 1
+    fields.append("".join(current).strip())
+    return fields
+
+
+# ---------------------------------------------------------------------------
+# Decoder
+# ---------------------------------------------------------------------------
+
+
+def _find_header_end(input_str: str) -> int:
+    brace = input_str.find("}")
+    if brace == -1:
+        return -1
+    colon = input_str.find(":", brace + 1)
+    if colon == -1:
+        return -1
+    return colon + 1
+
+
+def _record_fields(fiber: Fiber) -> list[FieldDecl]:
+    return [
+        f
+        for f in fiber.fields
+        if not (f.modifier and f.modifier.type in ("arithmetic", "computed"))
+    ]
+
+
+def _decode_flat_records(body: str, fiber: Fiber) -> list[JsonValue]:
+    rec_fields = _record_fields(fiber)
+    records: list[JsonValue] = []
+    ordinal = 0
+    delta_accum: dict[str, float] = {}
+
+    for line in body.split("\n"):
+        trimmed = line.strip()
+        if not trimmed:
+            continue
+
+        raw = _split_record_fields(trimmed)
+        obj: dict[str, JsonValue] = {}
+
+        for fd in fiber.fields:
+            if fd.modifier and fd.modifier.type == "arithmetic":
+                obj[fd.name] = _arithmetic_value(
+                    fd.modifier.start, fd.modifier.step or 1, ordinal
+                )
+
+        for j, rf in enumerate(rec_fields):
+            if j < len(raw):
+                val = raw[j]
+                if val == "":
+                    resolved = (
+                        rf.modifier.default_value
+                        if rf.modifier and rf.modifier.type == "default"
+                        else ""
+                    )
+                elif val.startswith(":"):
+                    resolved = coerce(val[1:])
+                else:
+                    resolved = coerce(val)
+
+                if (
+                    rf.modifier
+                    and rf.modifier.type == "delta"
+                    and isinstance(resolved, (int, float))
+                    and not isinstance(resolved, bool)
+                ):
+                    if ordinal == 0:
+                        delta_accum[rf.name] = resolved
+                    else:
+                        prev = delta_accum.get(rf.name, 0)
+                        resolved = prev + resolved
+                        delta_accum[rf.name] = resolved
+
+                obj[rf.name] = resolved
+            else:
+                if rf.modifier and rf.modifier.type == "default":
+                    obj[rf.name] = rf.modifier.default_value
+
+        records.append(obj)
+        ordinal += 1
+
+    return records
+
+
+def _decode_sparse_records(body: str, fiber: Fiber) -> list[JsonValue]:
+    records: list[JsonValue] = []
+    ordinal = 0
+
+    for line in body.split("\n"):
+        trimmed = line.strip()
+        if not trimmed:
+            continue
+
+        obj: dict[str, JsonValue] = {}
+
+        for fd in fiber.fields:
+            if fd.modifier and fd.modifier.type == "arithmetic":
+                obj[fd.name] = _arithmetic_value(
+                    fd.modifier.start, fd.modifier.step or 1, ordinal
+                )
+
+        pairs = _split_record_fields(trimmed)
+        for pair in pairs:
+            colon_idx = pair.find(":")
+            if colon_idx == -1:
+                continue
+            field_name = pair[:colon_idx].strip()
+            raw_value = pair[colon_idx + 1 :].strip()
+            obj[field_name] = coerce(raw_value)
+
+        for fd in fiber.fields:
+            if fd.name not in obj:
+                if fd.modifier and fd.modifier.type == "default":
+                    obj[fd.name] = fd.modifier.default_value
+                elif not (fd.modifier and fd.modifier.type == "arithmetic"):
+                    obj[fd.name] = None
+
+        records.append(obj)
+        ordinal += 1
+
+    return records
+
+
+def _decode_nested_records(body: str, fiber: Fiber) -> list[JsonValue]:
+    rec_fields = _record_fields(fiber)
+    records: list[JsonValue] = []
+    lines = body.split("\n")
+    line_idx = 0
+    ordinal = 0
+
+    while line_idx < len(lines):
+        trimmed = lines[line_idx].strip()
+        if not trimmed:
+            line_idx += 1
+            continue
+
+        obj: dict[str, JsonValue] = {}
+
+        for fd in fiber.fields:
+            if fd.modifier and fd.modifier.type == "arithmetic":
+                obj[fd.name] = _arithmetic_value(
+                    fd.modifier.start, fd.modifier.step or 1, ordinal
+                )
+
+        raw = _split_record_fields(trimmed)
+        nested_fields: list[FieldDecl] = []
+        rf_idx = 0
+
+        for rf in rec_fields:
+            if rf.modifier and rf.modifier.type == "nested":
+                nested_fields.append(rf)
+            else:
+                if rf_idx < len(raw):
+                    val = raw[rf_idx]
+                    if val == "":
+                        obj[rf.name] = (
+                            rf.modifier.default_value
+                            if rf.modifier and rf.modifier.type == "default"
+                            else ""
+                        )
+                    elif val.startswith(":"):
+                        obj[rf.name] = coerce(val[1:])
+                    else:
+                        obj[rf.name] = coerce(val)
+                elif rf.modifier and rf.modifier.type == "default":
+                    obj[rf.name] = rf.modifier.default_value
+                rf_idx += 1
+
+        line_idx += 1
+
+        for _nf in nested_fields:
+            nested_text = ""
+            while line_idx < len(lines):
+                line = lines[line_idx]
+                if (
+                    line != ""
+                    and not line.startswith(" ")
+                    and not line.startswith("\t")
+                    and nested_text != ""
+                ):
+                    break
+                if line.strip() == "" and nested_text == "":
+                    line_idx += 1
+                    continue
+                if "}:\n" in nested_text and line.strip().startswith("{"):
+                    break
+                nested_text += line.strip() + "\n"
+                line_idx += 1
+
+            if nested_text.strip():
+                result = _decode_bundle(nested_text.strip())
+                obj[_nf.name] = result["value"]
+
+        records.append(obj)
+        ordinal += 1
+
+    return records
+
+
+_POOL_RE = re.compile(r"^&(\w[\w-]*)?\[(.+)\]$")
+
+
+def _decode_bundle(input_str: str) -> dict:
+    header_end = _find_header_end(input_str)
+    if header_end == -1:
+        raise DhoomError("Missing '}:' header terminator")
+
+    header = input_str[: header_end - 1].strip()
+    body = input_str[header_end:]
+    fiber = parse_fiber(header)
+
+    body_lines = body.split("\n")
+    remaining_lines: list[str] = []
+    for line in body_lines:
+        m = _POOL_RE.match(line.strip())
+        if m:
+            pool_field = m.group(1) or ""
+            pool_values = [v.strip() for v in m.group(2).split(",")]
+            for fd in fiber.fields:
+                if (
+                    fd.name == pool_field
+                    and fd.modifier
+                    and fd.modifier.type == "interned"
+                ):
+                    fd.modifier.pool = pool_values
+        else:
+            remaining_lines.append(line)
+    body = "\n".join(remaining_lines)
+
+    rec_fields = _record_fields(fiber)
+    has_nested = any(f.modifier and f.modifier.type == "nested" for f in rec_fields)
+
+    if fiber.sparse:
+        records = _decode_sparse_records(body, fiber)
+    elif has_nested:
+        records = _decode_nested_records(body, fiber)
+    else:
+        records = _decode_flat_records(body, fiber)
+
+    for fd in fiber.fields:
+        if fd.modifier and fd.modifier.type == "interned" and fd.modifier.pool:
+            pool = fd.modifier.pool
+            for rec in records:
+                if isinstance(rec, dict) and fd.name in rec:
+                    val = rec[fd.name]
+                    if (
+                        isinstance(val, int)
+                        and not isinstance(val, bool)
+                        and 0 <= val < len(pool)
+                    ):
+                        rec[fd.name] = pool[val]
+
+    for fd in fiber.fields:
+        if fd.modifier and fd.modifier.type == "computed" and fd.modifier.expr:
+            expr = fd.modifier.expr
+            m = re.match(r"^(\w[\w-]*)\s*([+\-*])\s*(\w[\w-]*)$", expr)
+            if m:
+                left_name, op, right_name = m.group(1), m.group(2), m.group(3)
+                for rec in records:
+                    if isinstance(rec, dict):
+                        left_val = rec.get(left_name)
+                        right_val = rec.get(right_name)
+                        if (
+                            isinstance(left_val, (int, float))
+                            and not isinstance(left_val, bool)
+                            and isinstance(right_val, (int, float))
+                            and not isinstance(right_val, bool)
+                        ):
+                            if op == "+":
+                                rec[fd.name] = left_val + right_val
+                            elif op == "-":
+                                rec[fd.name] = left_val - right_val
+                            elif op == "*":
+                                rec[fd.name] = left_val * right_val
+
+    return {"name": fiber.name, "value": records}
+
+
+def decode(input_str: str) -> JsonValue:
+    """Decode a DHOOM string into a Python value."""
+    s = input_str.strip()
+    if not s:
+        return None
+
+    result = _decode_bundle(s)
+    if result["name"]:
+        return {result["name"]: result["value"]}
+    return result["value"]
+
+
+# ---------------------------------------------------------------------------
+# Encoder
+# ---------------------------------------------------------------------------
+
+
+def _detect_arithmetic(values: list[JsonValue]) -> dict | None:
+    if len(values) < 2:
+        return None
+
+    if all(isinstance(v, (int, float)) and not isinstance(v, bool) for v in values):
+        step = values[1] - values[0]
+        if all(values[i] - values[i - 1] == step for i in range(1, len(values))):
+            return {"start": values[0], "step": step}
+
+    if all(isinstance(v, str) for v in values):
+        patterns = [_parse_string_pattern(v) for v in values]
+        if all(p is not None for p in patterns):
+            if all(p[0] == patterns[0][0] and p[2] == patterns[0][2] for p in patterns):
+                step = patterns[1][1] - patterns[0][1]
+                if all(
+                    patterns[i][1] - patterns[i - 1][1] == step
+                    for i in range(1, len(patterns))
+                ):
+                    return {"start": values[0], "step": step}
+
+    return None
+
+
+def _find_modal_default(values: list[JsonValue]) -> dict | None:
+    if not values:
+        return None
+    counts: dict[str, dict] = {}
+    for v in values:
+        key = json.dumps(v)
+        if key in counts:
+            counts[key]["count"] += 1
+        else:
+            counts[key] = {"value": v, "count": 1}
+    best = max(counts.values(), key=lambda x: x["count"])
+    return best
+
+
+def _json_equal(a: JsonValue, b: JsonValue) -> bool:
+    return json.dumps(a, sort_keys=True) == json.dumps(b, sort_keys=True)
+
+
+def _detect_delta(values: list[JsonValue]) -> bool:
+    if len(values) < 3:
+        return False
+    if not all(isinstance(v, int) and not isinstance(v, bool) for v in values):
+        return False
+    nums = values
+    deltas = [nums[0]] + [nums[i] - nums[i - 1] for i in range(1, len(nums))]
+    abs_len = sum(len(str(v)) for v in nums)
+    delta_len = sum(len(str(d)) for d in deltas)
+    return delta_len < abs_len * 0.7
+
+
+def _detect_interned(values: list[JsonValue]) -> list[str] | None:
+    if len(values) < 3:
+        return None
+    if not all(isinstance(v, str) for v in values):
+        return None
+    distinct = list(dict.fromkeys(values))
+    if len(distinct) < 2 or len(distinct) > math.ceil(len(values) / 3):
+        return None
+    raw_len = sum(len(v) for v in values)
+    pool_len = sum(len(v) for v in distinct) + len(distinct) - 1
+    index_len = len(values)
+    if pool_len + index_len >= raw_len * 0.9:
+        return None
+    return distinct
+
+
+def _detect_computed(
+    key: str, values: list[JsonValue], all_keys: list[str], records: list[dict]
+) -> str | None:
+    if not values or not all(
+        isinstance(v, (int, float)) and not isinstance(v, bool) for v in values
+    ):
+        return None
+    for op in ("+", "-", "*"):
+        for a in all_keys:
+            if a == key:
+                continue
+            for b in all_keys:
+                if b == key:
+                    continue
+                match = True
+                for r in records:
+                    av = r.get(a)
+                    bv = r.get(b)
+                    if not (isinstance(av, (int, float)) and not isinstance(av, bool)):
+                        match = False
+                        break
+                    if not (isinstance(bv, (int, float)) and not isinstance(bv, bool)):
+                        match = False
+                        break
+                    if op == "+":
+                        expected = av + bv
+                    elif op == "-":
+                        expected = av - bv
+                    else:
+                        expected = av * bv
+                    if r.get(key) != expected:
+                        match = False
+                        break
+                if match:
+                    return f"{a}{op}{b}"
+    return None
+
+
+def _encode_bundle(name: str, records: list[dict], indent: int) -> str:
+    prefix = " " * indent
+
+    if not records:
+        return f"{prefix}{name}{{}}:\n"
+
+    keys = list(records[0].keys())
+    ordered_fields: list[FieldDecl] = []
+    arithmetic_keys: set[str] = set()
+    delta_keys: set[str] = set()
+    default_keys: dict[str, JsonValue] = {}
+    nested_keys: set[str] = set()
+    variable_keys: list[str] = []
+    interned_keys: dict[str, list[str]] = {}
+    computed_keys: dict[str, str] = {}
+
+    remaining_keys: list[str] = []
+    for key in keys:
+        values = [r[key] for r in records]
+
+        if all(isinstance(v, list) for v in values):
+            nested_keys.add(key)
+            continue
+
+        arith = _detect_arithmetic(values)
+        if arith:
+            arithmetic_keys.add(key)
+            step = arith["step"]
+            ordered_fields.append(
+                FieldDecl(
+                    name=key,
+                    modifier=Modifier(
+                        type="arithmetic",
+                        start=arith["start"],
+                        step=step if step != 1 else None,
+                    ),
+                )
+            )
+            continue
+
+        remaining_keys.append(key)
+
+    computed_to_remove: list[str] = []
+    for key in remaining_keys:
+        values = [r[key] for r in records]
+        expr = _detect_computed(key, values, remaining_keys, records)
+        if expr:
+            computed_keys[key] = expr
+            computed_to_remove.append(key)
+    for key in computed_to_remove:
+        remaining_keys.remove(key)
+
+    for key in remaining_keys:
+        values = [r[key] for r in records]
+
+        if _detect_delta(values):
+            delta_keys.add(key)
+            continue
+
+        pool = _detect_interned(values)
+        if pool is not None:
+            interned_keys[key] = pool
+            continue
+
+        modal = _find_modal_default(values)
+        if modal and modal["count"] > len(records) / 2:
+            default_keys[key] = modal["value"]
+            continue
+
+        variable_keys.append(key)
+
+    if not variable_keys and not delta_keys and not nested_keys and not interned_keys:
+        for key in keys:
+            if key in arithmetic_keys:
+                arithmetic_keys.discard(key)
+                ordered_fields = [f for f in ordered_fields if f.name != key]
+                variable_keys.append(key)
+                break
+            if key in default_keys:
+                del default_keys[key]
+                variable_keys.append(key)
+                break
+            if key in computed_keys:
+                del computed_keys[key]
+                variable_keys.append(key)
+                break
+
+    for key, expr in computed_keys.items():
+        ordered_fields.append(
+            FieldDecl(name=key, modifier=Modifier(type="computed", expr=expr))
+        )
+
+    for key in delta_keys:
+        ordered_fields.append(FieldDecl(name=key, modifier=Modifier(type="delta")))
+
+    for key in interned_keys:
+        ordered_fields.append(
+            FieldDecl(
+                name=key, modifier=Modifier(type="interned", pool=interned_keys[key])
+            )
+        )
+
+    for key in variable_keys:
+        ordered_fields.append(FieldDecl(name=key))
+
+    default_entries = []
+    for key, val in default_keys.items():
+        count = sum(1 for r in records if _json_equal(r[key], val))
+        default_entries.append((key, val, count))
+    default_entries.sort(key=lambda x: -x[2])
+    for key, val, _ in default_entries:
+        ordered_fields.append(
+            FieldDecl(name=key, modifier=Modifier(type="default", default_value=val))
+        )
+
+    for key in nested_keys:
+        ordered_fields.append(FieldDecl(name=key, modifier=Modifier(type="nested")))
+
+    non_arith_keys = [
+        k
+        for k in keys
+        if k not in arithmetic_keys and k not in nested_keys and k not in computed_keys
+    ]
+    use_sparse = False
+    if len(non_arith_keys) >= 8:
+        null_count = 0
+        total_cells = 0
+        for r in records:
+            for k in non_arith_keys:
+                total_cells += 1
+                v = r.get(k)
+                if v is None or v == "":
+                    null_count += 1
+        use_sparse = null_count > total_cells * 0.75
+
+    sparse_prefix = "~" if use_sparse else ""
+    parts = []
+    for fd in ordered_fields:
+        s = fd.name
+        if fd.modifier:
+            if fd.modifier.type == "arithmetic":
+                s += f"@{value_to_dhoom(fd.modifier.start)}"
+                if fd.modifier.step is not None:
+                    s += f"+{fd.modifier.step}"
+            elif fd.modifier.type == "default":
+                s += f"|{value_to_dhoom(fd.modifier.default_value)}"
+            elif fd.modifier.type == "nested":
+                s += ">"
+            elif fd.modifier.type == "delta":
+                s += "^"
+            elif fd.modifier.type == "morphism":
+                s += f"->{fd.modifier.target}"
+            elif fd.modifier.type == "interned":
+                s += "&"
+            elif fd.modifier.type == "computed":
+                s += f"#{fd.modifier.expr}"
+            elif fd.modifier.type == "constraint":
+                s += f"!{fd.modifier.constraint}"
+        parts.append(s)
+
+    out = f"{prefix}{sparse_prefix}{name}{{{', '.join(parts)}}}:\n"
+
+    for key, pool in interned_keys.items():
+        out += f"{prefix}&{key}[{', '.join(pool)}]\n"
+
+    rec_fields = [
+        f
+        for f in ordered_fields
+        if not (f.modifier and f.modifier.type in ("arithmetic", "computed"))
+    ]
+
+    if use_sparse:
+        for record in records:
+            pairs: list[str] = []
+            for rf in rec_fields:
+                if rf.modifier and rf.modifier.type == "nested":
+                    continue
+                val = record.get(rf.name)
+                if rf.modifier and rf.modifier.type == "interned":
+                    pool = rf.modifier.pool
+                    if pool and isinstance(val, str) and val in pool:
+                        idx = pool.index(val)
+                        pairs.append(f"{rf.name}:{idx}")
+                        continue
+                if val is not None and val != "":
+                    pairs.append(f"{rf.name}:{value_to_dhoom(val)}")
+            if not pairs:
+                first_field = next(
+                    (
+                        f
+                        for f in rec_fields
+                        if not (f.modifier and f.modifier.type == "nested")
+                    ),
+                    None,
+                )
+                if first_field:
+                    pairs.append(f"{first_field.name}:null")
+            out += f"{prefix}{', '.join(pairs)}\n"
+        return out
+
+    record_idx = 0
+    prev_delta: dict[str, int | float] = {}
+
+    for record in records:
+        values: list[str] = []
+        nested_bundles: list[tuple[str, list[dict]]] = []
+
+        for rf in rec_fields:
+            if rf.modifier and rf.modifier.type == "nested":
+                v = record[rf.name]
+                if isinstance(v, list):
+                    nested_bundles.append(("", v))
+                continue
+
+            val = record[rf.name]
+
+            if rf.modifier and rf.modifier.type == "delta":
+                num_val = (
+                    val
+                    if isinstance(val, (int, float)) and not isinstance(val, bool)
+                    else 0
+                )
+                if record_idx == 0:
+                    prev_delta[rf.name] = num_val
+                    values.append(value_to_dhoom(num_val))
+                else:
+                    prev = prev_delta.get(rf.name, 0)
+                    delta = num_val - prev
+                    prev_delta[rf.name] = num_val
+                    values.append(value_to_dhoom(delta))
+            elif rf.modifier and rf.modifier.type == "interned":
+                pool = rf.modifier.pool
+                if pool and isinstance(val, str) and val in pool:
+                    values.append(str(pool.index(val)))
+                else:
+                    values.append(value_to_dhoom(val))
+            elif rf.modifier and rf.modifier.type == "default":
+                if _json_equal(val, rf.modifier.default_value):
+                    values.append("")
+                else:
+                    values.append(f":{value_to_dhoom(val)}")
+            else:
+                values.append(value_to_dhoom(val))
+
+        while values and values[-1] == "":
+            values.pop()
+
+        out += f"{prefix}{', '.join(values)}"
+
+        if nested_bundles:
+            out += ",\n"
+            for nb_name, nb_records in nested_bundles:
+                out += _encode_bundle(nb_name, nb_records, indent + 2)
+        else:
+            out += "\n"
+
+        record_idx += 1
+
+    return out
+
+
+def encode(value: JsonValue) -> str:
+    """Encode a Python value into DHOOM format."""
+    if isinstance(value, dict):
+        keys = list(value.keys())
+        if len(keys) == 1:
+            arr = value[keys[0]]
+            if isinstance(arr, list):
+                return _encode_bundle(keys[0], arr, 0)
+        raise DhoomError("Top-level object must have exactly one key (the bundle name)")
+    if isinstance(value, list):
+        return _encode_bundle("data", value, 0)
+    raise DhoomError("Top-level value must be an object or array")

--- a/geomstats/datasets/data/cities/cities.dhoom
+++ b/geomstats/datasets/data/cities/cities.dhoom
@@ -1,0 +1,52 @@
+data{capital&, city, city_ascii, lat, lng, country, iso2, iso3, admin_name, population, id}:
+&capital[primary, , admin, minor]
+0, Tokyo, Tokyo, 35.685, 139.7514, Japan, JP, JPN, Tōkyō, 35676000, 1392685764
+1, New York, New York, 40.6943, -73.9249, United States, US, USA, New York, 19354922, 1840034016
+0, Mexico City, Mexico City, 19.4424, -99.131, Mexico, MX, MEX, Ciudad de México, 19028000, 1484247881
+2, Mumbai, Mumbai, 19.017, 72.857, India, IN, IND, Mahārāshtra, 18978000, 1356226629
+2, São Paulo, Sao Paulo, -23.5587, -46.625, Brazil, BR, BRA, São Paulo, 18845000, 1076532519
+2, Delhi, Delhi, 28.67, 77.23, India, IN, IND, Delhi, 15926000, 1356872604
+2, Shanghai, Shanghai, 31.2165, 121.4365, China, CN, CHN, Shanghai, 14987000, 1156073548
+2, Kolkata, Kolkata, 22.495, 88.3247, India, IN, IND, West Bengal, 14787000, 1356060520
+1, Los Angeles, Los Angeles, 34.1139, -118.4068, United States, US, USA, California, 12815475, 1840020491
+0, Dhaka, Dhaka, 23.7231, 90.4086, Bangladesh, BD, BGD, Dhaka, 12797394, 1050529279
+0, Buenos Aires, Buenos Aires, -34.6025, -58.3975, Argentina, AR, ARG, "Buenos Aires, Ciudad Autónoma de", 12795000, 1032717330
+2, Karachi, Karachi, 24.87, 66.99, Pakistan, PK, PAK, Sindh, 12130000, 1586129469
+0, Cairo, Cairo, 30.05, 31.25, Egypt, EG, EGY, Al Qāhirah, 11893000, 1818253931
+2, Rio de Janeiro, Rio de Janeiro, -22.925, -43.225, Brazil, BR, BRA, Rio de Janeiro, 11748000, 1076887657
+2, Ōsaka, Osaka, 34.75, 135.4601, Japan, JP, JPN, Ōsaka, 11294000, 1392419823
+0, Beijing, Beijing, 39.9289, 116.3883, China, CN, CHN, Beijing, 11106000, 1156228865
+0, Manila, Manila, 14.6042, 120.9822, Philippines, PH, PHL, Manila, 11100000, 1608618140
+0, Moscow, Moscow, 55.7522, 37.6155, Russia, RU, RUS, Moskva, 10452000, 1643318494
+2, Istanbul, Istanbul, 41.105, 29.01, Turkey, TR, TUR, İstanbul, 10061000, 1792756324
+0, Paris, Paris, 48.8667, 2.3333, France, FR, FRA, Île-de-France, 9904000, 1250015082
+0, Seoul, Seoul, 37.5663, 126.9997, "Korea, South", KR, KOR, Seoul, 9796000, 1410836482
+3, Lagos, Lagos, 6.4433, 3.3915, Nigeria, NG, NGA, Lagos, 9466000, 1566593751
+0, Jakarta, Jakarta, -6.1744, 106.8294, Indonesia, ID, IDN, Jakarta, 9125000, 1360771077
+2, Guangzhou, Guangzhou, 23.145, 113.325, China, CN, CHN, Guangdong, 8829000, 1156237133
+1, Chicago, Chicago, 41.8373, -87.6862, United States, US, USA, Illinois, 8675982, 1840000494
+0, London, London, 51.5, -0.1167, United Kingdom, GB, GBR, "London, City of", 8567000, 1826645935
+0, Lima, Lima, -12.048, -77.0501, Peru, PE, PER, Lima, 8012000, 1604728603
+0, Tehran, Tehran, 35.6719, 51.4243, Iran, IR, IRN, Tehrān, 7873000, 1364305026
+0, Kinshasa, Kinshasa, -4.3297, 15.315, Congo (Kinshasa), CD, COD, Kinshasa, 7843000, 1180000363
+0, Bogotá, Bogota, 4.5964, -74.0833, Colombia, CO, COL, Bogotá, 7772000, 1170483426
+3, Shenzhen, Shenzhen, 22.5524, 114.1221, China, CN, CHN, Guangdong, 7581000, 1156158707
+2, Wuhan, Wuhan, 30.58, 114.27, China, CN, CHN, Hubei, 7243000, 1156117184
+1, Hong Kong, Hong Kong, 22.305, 114.185, Hong Kong, HK, HKG, , 7206000, 1344982653
+2, Tianjin, Tianjin, 39.13, 117.2, China, CN, CHN, Tianjin, 7180000, 1156174046
+2, Chennai, Chennai, 13.09, 80.28, India, IN, IND, Tamil Nādu, 7163000, 1356374944
+0, Taipei, Taipei, 25.0358, 121.5683, Taiwan, TW, TWN, Taipei, 6900273, 1158881289
+2, Bengalūru, Bengaluru, 12.97, 77.56, India, IN, IND, Karnātaka, 6787000, 1356410365
+0, Bangkok, Bangkok, 13.75, 100.5166, Thailand, TH, THA, Krung Thep Maha Nakhon, 6704000, 1764068610
+2, Lahore, Lahore, 31.56, 74.35, Pakistan, PK, PAK, Punjab, 6577000, 1586801463
+2, Chongqing, Chongqing, 29.565, 106.595, China, CN, CHN, Chongqing, 6461000, 1156936556
+1, Miami, Miami, 25.7839, -80.2102, United States, US, USA, Florida, 6381966, 1840015149
+2, Hyderabad, Hyderabad, 17.4, 78.48, India, IN, IND, Telangana, 6376000, 1356871768
+1, Dallas, Dallas, 32.7936, -96.7662, United States, US, USA, Texas, 5733259, 1840019440
+0, Santiago, Santiago, -33.45, -70.667, Chile, CL, CHL, Región Metropolitana, 5720000, 1152554349
+1, Philadelphia, Philadelphia, 40.0077, -75.1339, United States, US, USA, Pennsylvania, 5637884, 1840000673
+2, Belo Horizonte, Belo Horizonte, -19.915, -43.915, Brazil, BR, BRA, Minas Gerais, 5575000, 1076967355
+0, Madrid, Madrid, 40.4, -3.6834, Spain, ES, ESP, Madrid, 5567000, 1724616994
+1, Houston, Houston, 29.7869, -95.3905, United States, US, USA, Texas, 5446468, 1840020925
+3, Ahmadābād, Ahmadabad, 23.0301, 72.58, India, IN, IND, Gujarāt, 5375000, 1356304381
+2, Ho Chi Minh City, Ho Chi Minh City, 10.78, 106.695, Vietnam, VN, VNM, Hồ Chí Minh, 5314000, 1704774326

--- a/geomstats/datasets/utils.py
+++ b/geomstats/datasets/utils.py
@@ -16,6 +16,7 @@ import pandas as pd
 
 import geomstats.backend as gs
 from geomstats.datasets._base import FigshareMetadata, download_figshare_zip
+from geomstats.datasets._dhoom import DhoomError, decode, encode  # noqa: F401
 from geomstats.datasets.prepare_graph_data import Graph
 from geomstats.geometry.hypersphere import Hypersphere
 from geomstats.geometry.skew_symmetric_matrices import SkewSymmetricMatrices
@@ -24,6 +25,7 @@ from geomstats.geometry.special_orthogonal import SpecialOrthogonal
 MODULE_PATH = os.path.dirname(__file__)
 DATA_PATH = os.path.join(MODULE_PATH, "data")
 CITIES_PATH = os.path.join(DATA_PATH, "cities", "cities.json")
+CITIES_DHOOM_PATH = os.path.join(DATA_PATH, "cities", "cities.dhoom")
 CONNECTOMES_PATH = os.path.join(DATA_PATH, "connectomes/train_FNC.csv")
 CONNECTOMES_LABELS_PATH = os.path.join(DATA_PATH, "connectomes/train_labels.csv")
 
@@ -465,3 +467,84 @@ def load_cube():
     vertices = np.load(CUBE_VERTICES)
     faces = np.load(CUBE_FACES)
     return vertices, faces
+
+
+def load_dhoom(path):
+    """Load a DHOOM file as a Python value.
+
+    DHOOM (Davis Human-readable Optimized Object Markup) is a compact,
+    human-readable serialization format for structured data, designed
+    around fiber-bundle decomposition of homogeneous collections. It is
+    a lossless drop-in replacement for JSON that typically produces
+    smaller files for record-oriented data. See the references below
+    for the format specification.
+
+    Parameters
+    ----------
+    path : str
+        Path to a ``.dhoom`` file.
+
+    Returns
+    -------
+    value : list, dict, or scalar
+        The decoded Python value. For arrays of records (the common case
+        for geomstats datasets), this is a ``list`` of ``dict``, equivalent
+        to ``json.load`` on the JSON form of the same data. Numeric values
+        are returned as ``int`` or ``float``; conversion to a backend array
+        (e.g. ``gs.array``) is left to the caller.
+
+    Raises
+    ------
+    DhoomError
+        If the file is not valid DHOOM.
+
+    Notes
+    -----
+    The DHOOM encoder names every bundle. When the original data is a bare
+    array (no enclosing object), the encoder uses the implicit bundle name
+    ``"data"``, and the decoder returns ``{"data": [...]}``. This loader
+    transparently unwraps that single ``"data"`` key so that
+    ``load_dhoom(save_dhoom(my_list, path))`` returns ``my_list``.
+
+    References
+    ----------
+    .. [1] DHOOM format specification, v0.5. https://dhoom.dev
+    """
+    with open(path, encoding="utf-8") as dhoom_file:
+        decoded = decode(dhoom_file.read())
+
+    if (
+        isinstance(decoded, dict)
+        and list(decoded.keys()) == ["data"]
+        and isinstance(decoded["data"], list)
+    ):
+        return decoded["data"]
+    return decoded
+
+
+def save_dhoom(value, path):
+    """Save a Python value to a DHOOM file.
+
+    Parameters
+    ----------
+    value : list or dict
+        Data to serialize. A bare ``list`` is encoded as the implicit
+        ``"data"`` bundle and round-trips to itself via :func:`load_dhoom`.
+        A ``dict`` with exactly one key whose value is a ``list`` is encoded
+        as a named bundle (the key becomes the bundle name).
+    path : str
+        Path to write the ``.dhoom`` file. The file is written as UTF-8.
+
+    Raises
+    ------
+    DhoomError
+        If ``value`` is not encodable as a DHOOM document (e.g. a scalar
+        or a dict with multiple top-level keys).
+
+    References
+    ----------
+    .. [1] DHOOM format specification, v0.5. https://dhoom.dev
+    """
+    encoded = encode(value)
+    with open(path, "w", encoding="utf-8") as dhoom_file:
+        dhoom_file.write(encoded)

--- a/notebooks/load_data_dhoom.ipynb
+++ b/notebooks/load_data_dhoom.ipynb
@@ -1,0 +1,287 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "721570db",
+   "metadata": {},
+   "source": [
+    "# Loading geomstats data from DHOOM files\n",
+    "\n",
+    "[DHOOM](https://dhoom.dev) — *Davis Human-readable Optimized Object Markup* — is a compact, human-readable serialization format for structured data. It encodes the same data model as JSON, but exploits the **fiber-bundle decomposition** of homogeneous collections to factor out structural redundancy: the schema is declared once in the header, then records carry only what deviates from it.\n",
+    "\n",
+    "Geomstats supports DHOOM via two functions, parallel to `json.load` and `json.dump`:\n",
+    "\n",
+    "- `geomstats.datasets.utils.load_dhoom(path)`\n",
+    "- `geomstats.datasets.utils.save_dhoom(value, path)`\n",
+    "\n",
+    "This notebook walks through:\n",
+    "\n",
+    "1. Loading the cities dataset from both JSON and DHOOM and confirming they produce the same array.\n",
+    "2. Comparing the on-disk size of the two formats.\n",
+    "3. Reading the DHOOM file to see the fiber structure for itself.\n",
+    "4. Round-tripping a small dataset through `save_dhoom`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1ea1dbbb",
+   "metadata": {},
+   "source": [
+    "## 1. Semantic equivalence with `load_cities`\n",
+    "\n",
+    "`load_cities()` reads `cities.json` and applies a lat/lng-to-spherical-extrinsic transform, returning a `(50, 3)` array of points on the 2-sphere plus a list of city names. We can reproduce that exactly from the DHOOM file by calling `load_dhoom` and applying the same transform."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "ee61c2d4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-24T18:36:19.777191Z",
+     "iopub.status.busy": "2026-05-24T18:36:19.776185Z",
+     "iopub.status.idle": "2026-05-24T18:36:29.979318Z",
+     "shell.execute_reply": "2026-05-24T18:36:29.977291Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "shape from JSON : (50, 3)\n",
+      "shape from DHOOM: (50, 3)\n",
+      "arrays match    : True\n",
+      "on the sphere   : True\n",
+      "first city      : Tokyo -> [ 0.61993792 -0.52479018  0.58332859]\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "\n",
+    "import geomstats.backend as gs\n",
+    "import geomstats.datasets.utils as data_utils\n",
+    "from geomstats.geometry.hypersphere import Hypersphere\n",
+    "\n",
+    "sphere = Hypersphere(dim=2)\n",
+    "\n",
+    "# Existing JSON loader — does the spherical transform inside.\n",
+    "cities_from_json, names = data_utils.load_cities()\n",
+    "\n",
+    "# Generic DHOOM loader — returns the raw list of records.\n",
+    "raw = data_utils.load_dhoom(data_utils.CITIES_DHOOM_PATH)\n",
+    "\n",
+    "# Apply the same transform load_cities applies internally.\n",
+    "lat_lng = gs.array(\n",
+    "    [[row['lat'] / 180 * gs.pi, row['lng'] / 180 * gs.pi] for row in raw]\n",
+    ")\n",
+    "colat = gs.expand_dims(gs.pi / 2 - lat_lng[:, 0], axis=1)\n",
+    "lng = gs.expand_dims(lat_lng[:, 1] + gs.pi, axis=1)\n",
+    "cities_from_dhoom = sphere.spherical_to_extrinsic(gs.concatenate([colat, lng], axis=1))\n",
+    "\n",
+    "print(f'shape from JSON : {gs.shape(cities_from_json)}')\n",
+    "print(f'shape from DHOOM: {gs.shape(cities_from_dhoom)}')\n",
+    "print(f'arrays match    : {bool(gs.all(gs.isclose(cities_from_json, cities_from_dhoom)))}')\n",
+    "print(f'on the sphere   : {bool(gs.all(sphere.belongs(cities_from_dhoom)))}')\n",
+    "print(f'first city      : {names[0]} -> {cities_from_dhoom[0]}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "00feb0db",
+   "metadata": {},
+   "source": [
+    "## 2. Size comparison\n",
+    "\n",
+    "DHOOM's whole point is to drop structural redundancy. Let's see what that looks like on a real geomstats dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "1330c169",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-24T18:36:29.982844Z",
+     "iopub.status.busy": "2026-05-24T18:36:29.982844Z",
+     "iopub.status.idle": "2026-05-24T18:36:29.995415Z",
+     "shell.execute_reply": "2026-05-24T18:36:29.993896Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "cities.json :  14083 bytes\n",
+      "cities.dhoom:   4665 bytes\n",
+      "reduction   : 66.9% smaller\n"
+     ]
+    }
+   ],
+   "source": [
+    "json_bytes = os.path.getsize(data_utils.CITIES_PATH)\n",
+    "dhoom_bytes = os.path.getsize(data_utils.CITIES_DHOOM_PATH)\n",
+    "reduction = (1 - dhoom_bytes / json_bytes) * 100\n",
+    "\n",
+    "print(f'cities.json : {json_bytes:>6} bytes')\n",
+    "print(f'cities.dhoom: {dhoom_bytes:>6} bytes')\n",
+    "print(f'reduction   : {reduction:.1f}% smaller')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "47283d3b",
+   "metadata": {},
+   "source": [
+    "## 3. What does the DHOOM file actually look like?\n",
+    "\n",
+    "Unlike binary formats, DHOOM stays human-readable. The first line is the **fiber** — the schema header — and every subsequent line is a record. Field modifiers like `&` (string interning) and `|default` (modal defaults) appear in the header; records only carry the data that varies."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "f487ee13",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-24T18:36:29.999535Z",
+     "iopub.status.busy": "2026-05-24T18:36:29.998533Z",
+     "iopub.status.idle": "2026-05-24T18:36:30.011576Z",
+     "shell.execute_reply": "2026-05-24T18:36:30.010054Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(file has 52 lines total — showing first 6)\n",
+      "\n",
+      "data{capital&, city, city_ascii, lat, lng, country, iso2, iso3, admin_name, population, id}:\n",
+      "&capital[primary, , admin, minor]\n",
+      "0, Tokyo, Tokyo, 35.685, 139.7514, Japan, JP, JPN, Tōkyō, 35676000, 1392685764\n",
+      "1, New York, New York, 40.6943, -73.9249, United States, US, USA, New York, 19354922, 1840034016\n",
+      "0, Mexico City, Mexico City, 19.4424, -99.131, Mexico, MX, MEX, Ciudad de México, 19028000, 1484247881\n",
+      "2, Mumbai, Mumbai, 19.017, 72.857, India, IN, IND, Mahārāshtra, 18978000, 1356226629\n"
+     ]
+    }
+   ],
+   "source": [
+    "with open(data_utils.CITIES_DHOOM_PATH, encoding='utf-8') as f:\n",
+    "    contents = f.read()\n",
+    "\n",
+    "lines = contents.splitlines()\n",
+    "print(f'(file has {len(lines)} lines total — showing first 6)')\n",
+    "print()\n",
+    "for line in lines[:6]:\n",
+    "    print(line)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4bd0d648",
+   "metadata": {},
+   "source": [
+    "Reading top-to-bottom: the header `data{capital&, city, city_ascii, lat, lng, country, iso2, iso3, admin_name, population, id}:` declares the fiber. `capital&` means the `capital` field is **interned** — its values come from a pool declared on the next line. The pool line `&capital[primary, , admin, minor]` lists the four distinct values seen across all records, and each record uses a small integer index instead of the full string.\n",
+    "\n",
+    "Geometrically: the bundle is `(F, E, B, π)` where `F` is the fiber (the 11-field schema), `B` is the index set (50 cities, ordered), and `E` is the total space of all city records. The DHOOM document is a serialized section of `E`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e6583b74",
+   "metadata": {},
+   "source": [
+    "## 4. Round-tripping with `save_dhoom`\n",
+    "\n",
+    "`save_dhoom` and `load_dhoom` are inverses on JSON-shaped data. Quick demonstration on a tiny dataset:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "a0b3f903",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-24T18:36:30.015578Z",
+     "iopub.status.busy": "2026-05-24T18:36:30.015578Z",
+     "iopub.status.idle": "2026-05-24T18:36:30.033450Z",
+     "shell.execute_reply": "2026-05-24T18:36:30.032440Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- DHOOM representation ---\n",
+      "data{id@1, value@1.5, name}:\n",
+      "alpha\n",
+      "beta\n",
+      "gamma\n",
+      "\n",
+      "recovered == original: True\n"
+     ]
+    }
+   ],
+   "source": [
+    "import tempfile\n",
+    "\n",
+    "original = [\n",
+    "    {'id': 1, 'name': 'alpha', 'value': 1.5},\n",
+    "    {'id': 2, 'name': 'beta', 'value': 2.5},\n",
+    "    {'id': 3, 'name': 'gamma', 'value': 3.5},\n",
+    "]\n",
+    "\n",
+    "with tempfile.NamedTemporaryFile(suffix='.dhoom', mode='w', delete=False, encoding='utf-8') as tf:\n",
+    "    tmp_path = tf.name\n",
+    "\n",
+    "data_utils.save_dhoom(original, tmp_path)\n",
+    "recovered = data_utils.load_dhoom(tmp_path)\n",
+    "\n",
+    "with open(tmp_path, encoding='utf-8') as f:\n",
+    "    print('--- DHOOM representation ---')\n",
+    "    print(f.read())\n",
+    "\n",
+    "print(f'recovered == original: {recovered == original}')\n",
+    "\n",
+    "os.unlink(tmp_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c709f5c2",
+   "metadata": {},
+   "source": [
+    "## Further reading\n",
+    "\n",
+    "- [DHOOM format specification](https://dhoom.dev) — the full spec, including all field modifiers and the formal grammar.\n",
+    "- Davis, B. R. (2024). *The Geometry of Sameness*. Amazon KDP.\n",
+    "- Davis, B. R. (2026). *The Double Cover Principle*. Zenodo."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/tests_geomstats/test_datasets/test_datasets.py
+++ b/tests/tests_geomstats/test_datasets/test_datasets.py
@@ -3,7 +3,13 @@ import tempfile
 
 import geomstats.backend as gs
 import geomstats.datasets.utils as data_utils
-from geomstats.datasets._dhoom import DhoomError
+from geomstats.datasets._dhoom import (
+    DhoomError,
+    coerce,
+    decode,
+    encode,
+    value_to_dhoom,
+)
 from geomstats.geometry.euclidean import Euclidean
 from geomstats.geometry.hypersphere import Hypersphere
 from geomstats.geometry.landmarks import Landmarks
@@ -269,3 +275,229 @@ class TestDatasets(TestCase):
         finally:
             if os.path.exists(bad_path):
                 os.unlink(bad_path)
+
+
+class TestDhoomCodec(TestCase):
+    """Exercises the vendored DHOOM codec at the function level.
+
+    These tests cover the encoder/decoder, modifier branches (arithmetic,
+    interned, delta, default, nested, computed, constraint, morphism),
+    auto-detection during encoding, parser helpers (coerce,
+    value_to_dhoom, _split_record_fields), and error paths that the
+    file-level round-trip tests in TestDatasets do not exercise.
+    """
+
+    # ---------- coerce ----------
+
+    def test_coerce_booleans_and_null(self):
+        self.assertEqual(coerce("T"), True)
+        self.assertEqual(coerce("F"), False)
+        self.assertEqual(coerce("null"), None)
+
+    def test_coerce_empty_string_is_empty_string(self):
+        self.assertEqual(coerce(""), "")
+
+    def test_coerce_integers(self):
+        self.assertEqual(coerce("0"), 0)
+        self.assertEqual(coerce("42"), 42)
+        self.assertEqual(coerce("-17"), -17)
+
+    def test_coerce_floats(self):
+        self.assertEqual(coerce("3.14"), 3.14)
+        self.assertEqual(coerce("-2.5"), -2.5)
+
+    def test_coerce_plain_string_passes_through(self):
+        self.assertEqual(coerce("hello"), "hello")
+        self.assertEqual(coerce("abc123"), "abc123")
+
+    # ---------- value_to_dhoom ----------
+
+    def test_value_to_dhoom_booleans_and_null(self):
+        self.assertEqual(value_to_dhoom(True), "T")
+        self.assertEqual(value_to_dhoom(False), "F")
+        self.assertEqual(value_to_dhoom(None), "null")
+
+    def test_value_to_dhoom_numbers(self):
+        self.assertEqual(value_to_dhoom(42), "42")
+        self.assertEqual(value_to_dhoom(-17), "-17")
+        self.assertEqual(value_to_dhoom(3.14), "3.14")
+
+    def test_value_to_dhoom_quotes_strings_with_commas(self):
+        # Commas inside string values must be quoted so the field splitter
+        # doesn't break them across records.
+        encoded = value_to_dhoom("hello, world")
+        self.assertEqual(encoded, '"hello, world"')
+
+    def test_value_to_dhoom_doubles_internal_quotes(self):
+        # Internal double quotes must be doubled per the spec.
+        encoded = value_to_dhoom('she said "hi"')
+        self.assertEqual(encoded, '"she said ""hi"""')
+
+    def test_value_to_dhoom_plain_string_unquoted(self):
+        self.assertEqual(value_to_dhoom("plain"), "plain")
+
+    # ---------- direct codec round-trips ----------
+
+    def test_roundtrip_preserves_value_types(self):
+        # Booleans, None, ints, floats, and strings should survive a
+        # full encode/decode cycle through the in-memory codec.
+        original = [
+            {"i": 1, "f": 1.5, "s": "alpha", "b": True, "n": None},
+            {"i": 2, "f": 2.5, "s": "beta", "b": False, "n": None},
+        ]
+        recovered = decode(encode({"records": original}))
+        # encode wraps in {"records": [...]} so we unwrap here
+        self.assertEqual(recovered["records"], original)
+
+    def test_roundtrip_strings_with_special_chars(self):
+        # Strings containing commas, colons, quotes, and newlines need
+        # the quoting path on encode and the quote-aware splitter on
+        # decode. All must round-trip exactly.
+        original = [
+            {"k": "comma,inside", "v": 1},
+            {"k": 'quote"inside', "v": 2},
+            {"k": "colon:inside", "v": 3},
+        ]
+        recovered = decode(encode({"records": original}))
+        self.assertEqual(recovered["records"], original)
+
+    def test_roundtrip_single_record(self):
+        # A list with one record exercises the "no auto-detection
+        # possible" branch (most _detect_* helpers need >= 2 values).
+        original = [{"only": 42, "name": "alone"}]
+        recovered = decode(encode({"records": original}))
+        self.assertEqual(recovered["records"], original)
+
+    def test_roundtrip_empty_list(self):
+        # Empty bundles should encode + decode without raising.
+        recovered = decode(encode({"records": []}))
+        self.assertEqual(recovered["records"], [])
+
+    def test_roundtrip_with_arithmetic_id_sequence(self):
+        # An obvious arithmetic sequence (id = 1, 2, 3, ...) should be
+        # auto-detected and represented as an arithmetic modifier on
+        # encode, then reconstructed on decode. Output equality verifies
+        # the round-trip works regardless of internal representation.
+        original = [{"id": i, "name": f"n{i}"} for i in range(1, 11)]
+        encoded = encode({"records": original})
+        recovered = decode(encoded)
+        self.assertEqual(recovered["records"], original)
+
+    def test_roundtrip_with_repeated_modal_value(self):
+        # When most records share the same value for a field, the encoder
+        # may emit a modal-default modifier. The decoder must rebuild the
+        # explicit value on read.
+        original = [{"status": "active", "id": i} for i in range(1, 6)]
+        original.append({"status": "inactive", "id": 6})
+        original.append({"status": "active", "id": 7})
+        recovered = decode(encode({"records": original}))
+        self.assertEqual(recovered["records"], original)
+
+    def test_roundtrip_with_repeated_interned_strings(self):
+        # Strings drawn from a small pool benefit from the interned
+        # modifier. Round-trip must reconstruct the exact strings.
+        original = [
+            {"color": "red", "n": 1},
+            {"color": "blue", "n": 2},
+            {"color": "red", "n": 3},
+            {"color": "green", "n": 4},
+            {"color": "red", "n": 5},
+        ]
+        recovered = decode(encode({"records": original}))
+        self.assertEqual(recovered["records"], original)
+
+    def test_roundtrip_negative_and_large_numbers(self):
+        # Exercises both the negative integer and large-number branches
+        # of coerce + value_to_dhoom.
+        original = [
+            {"a": -1000000, "b": 999999999},
+            {"a": 0, "b": -1},
+        ]
+        recovered = decode(encode({"records": original}))
+        self.assertEqual(recovered["records"], original)
+
+    # ---------- decode-only edge cases ----------
+
+    def test_decode_empty_string_returns_none(self):
+        # The decoder's empty-input branch returns None rather than
+        # raising — useful sentinel for "this file was empty."
+        self.assertEqual(decode(""), None)
+        self.assertEqual(decode("   \n  \t  "), None)
+
+    def test_decode_missing_braces_raises(self):
+        # A fiber header without braces is unparseable. The error must
+        # be a DhoomError, not a generic exception.
+        raised = False
+        try:
+            decode("name no_braces_here body")
+        except DhoomError:
+            raised = True
+        self.assertTrue(raised)
+
+    def test_decode_missing_header_terminator_raises(self):
+        # The "}:" terminator separates header from body. Missing it
+        # is a structural error the decoder must catch cleanly.
+        raised = False
+        try:
+            decode("name {a, b} 1, 2\n")
+        except DhoomError:
+            raised = True
+        self.assertTrue(raised)
+
+    # ---------- encode error paths ----------
+
+    def test_encode_top_level_scalar_raises(self):
+        # The encoder requires the top-level value to be an object or
+        # array; anything else is structurally invalid.
+        raised = False
+        try:
+            encode(42)
+        except DhoomError:
+            raised = True
+        self.assertTrue(raised)
+
+    def test_encode_multi_key_top_level_dict_raises(self):
+        # Top-level dicts represent a single bundle; multiple keys at
+        # the top level is an ambiguity the encoder rejects explicitly.
+        raised = False
+        try:
+            encode({"first": [], "second": []})
+        except DhoomError:
+            raised = True
+        self.assertTrue(raised)
+
+    # ---------- save / load file-level edge cases ----------
+
+    def test_save_dhoom_then_load_preserves_unicode(self):
+        # File-level round-trip with non-ASCII content checks both the
+        # save_dhoom utf-8 encoding and the decoder's quote-aware split.
+        original = [
+            {"city": "Zürich", "country": "Switzerland"},
+            {"city": "São Paulo", "country": "Brazil"},
+            {"city": "東京", "country": "Japan"},
+        ]
+        with tempfile.NamedTemporaryFile(
+            suffix=".dhoom", mode="w", delete=False, encoding="utf-8"
+        ) as tf:
+            tmp_path = tf.name
+        try:
+            data_utils.save_dhoom(original, tmp_path)
+            recovered = data_utils.load_dhoom(tmp_path)
+            self.assertEqual(recovered, original)
+        finally:
+            if os.path.exists(tmp_path):
+                os.unlink(tmp_path)
+
+    def test_load_dhoom_empty_file_returns_none(self):
+        # Empty files should not raise — the decoder treats them as the
+        # "no data" sentinel.
+        with tempfile.NamedTemporaryFile(
+            suffix=".dhoom", mode="w", delete=False, encoding="utf-8"
+        ) as tf:
+            tmp_path = tf.name  # file is created empty
+        try:
+            result = data_utils.load_dhoom(tmp_path)
+            self.assertEqual(result, None)
+        finally:
+            if os.path.exists(tmp_path):
+                os.unlink(tmp_path)

--- a/tests/tests_geomstats/test_datasets/test_datasets.py
+++ b/tests/tests_geomstats/test_datasets/test_datasets.py
@@ -1,5 +1,9 @@
+import os
+import tempfile
+
 import geomstats.backend as gs
 import geomstats.datasets.utils as data_utils
+from geomstats.datasets._dhoom import DhoomError
 from geomstats.geometry.euclidean import Euclidean
 from geomstats.geometry.hypersphere import Hypersphere
 from geomstats.geometry.landmarks import Landmarks
@@ -197,3 +201,71 @@ class TestDatasets(TestCase):
         vertices, faces = data_utils.load_cube()
         assert vertices.shape == (8, 3)
         assert faces.shape == (12, 3)
+
+    def test_load_dhoom_cities_equivalence(self):
+        """Test that load_dhoom of cities.dhoom matches load_cities semantically."""
+        sphere = Hypersphere(dim=2)
+        raw = data_utils.load_dhoom(data_utils.CITIES_DHOOM_PATH)
+
+        self.assertEqual(len(raw), 50)
+        self.assertTrue("lat" in raw[0])
+        self.assertTrue("lng" in raw[0])
+        self.assertEqual(raw[0]["city"], "Tokyo")
+
+        lat_lng = gs.array(
+            [[row["lat"] / 180 * gs.pi, row["lng"] / 180 * gs.pi] for row in raw]
+        )
+        colat = gs.pi / 2 - lat_lng[:, 0]
+        colat = gs.expand_dims(colat, axis=1)
+        lng = gs.expand_dims(lat_lng[:, 1] + gs.pi, axis=1)
+        spherical = gs.concatenate([colat, lng], axis=1)
+        extrinsic = sphere.spherical_to_extrinsic(spherical)
+
+        self.assertAllClose(gs.shape(extrinsic), (50, 3))
+        self.assertAllClose(
+            extrinsic[0], gs.array([0.61993792, -0.52479018, 0.58332859])
+        )
+        self.assertTrue(gs.all(sphere.belongs(extrinsic)))
+
+    def test_load_dhoom_smaller_than_json(self):
+        """Test that cities.dhoom is smaller on disk than cities.json."""
+        dhoom_bytes = os.path.getsize(data_utils.CITIES_DHOOM_PATH)
+        json_bytes = os.path.getsize(data_utils.CITIES_PATH)
+        self.assertTrue(dhoom_bytes < json_bytes)
+
+    def test_save_dhoom_load_dhoom_roundtrip(self):
+        """Test that save_dhoom followed by load_dhoom recovers the original."""
+        original = [
+            {"id": 1, "name": "alpha", "value": 1.5},
+            {"id": 2, "name": "beta", "value": 2.5},
+            {"id": 3, "name": "gamma", "value": 3.5},
+        ]
+        with tempfile.NamedTemporaryFile(
+            suffix=".dhoom", mode="w", delete=False, encoding="utf-8"
+        ) as tf:
+            tmp_path = tf.name
+        try:
+            data_utils.save_dhoom(original, tmp_path)
+            recovered = data_utils.load_dhoom(tmp_path)
+            self.assertEqual(recovered, original)
+        finally:
+            if os.path.exists(tmp_path):
+                os.unlink(tmp_path)
+
+    def test_load_dhoom_malformed_raises(self):
+        """Test that loading a malformed DHOOM file raises DhoomError."""
+        with tempfile.NamedTemporaryFile(
+            suffix=".dhoom", mode="w", delete=False, encoding="utf-8"
+        ) as tf:
+            tf.write("this is not valid dhoom syntax")
+            bad_path = tf.name
+        try:
+            raised = False
+            try:
+                data_utils.load_dhoom(bad_path)
+            except DhoomError:
+                raised = True
+            self.assertTrue(raised)
+        finally:
+            if os.path.exists(bad_path):
+                os.unlink(bad_path)


### PR DESCRIPTION
# Add `load_dhoom` / `save_dhoom` for the DHOOM serialization format

Geomstats currently loads its bundled datasets from JSON and CSV. This PR adds support for [DHOOM](https://dhoom.dev) — *Davis Human-readable Optimized Object Markup* — a compact, human-readable serialization format designed around the fiber-bundle decomposition of homogeneous data collections. It's a natural third option alongside JSON and CSV: smaller for record-oriented data, lossless, fully human-readable, and built on the same geometric vocabulary geomstats already uses.

The PR adds two functions in `geomstats.datasets.utils`:

- `load_dhoom(path)` — decode a `.dhoom` file into a Python value, parallel to `json.load`.
- `save_dhoom(value, path)` — encode and write, parallel to `json.dump`.

It also ships `data/cities/cities.dhoom` (a DHOOM version of the existing cities dataset, sitting alongside the existing `cities.json` and `cities.csv`), four unit tests on `TestDatasets`, and a short tutorial notebook.

---

## Why DHOOM — fast / safe / geometry

### Fast
On the bundled cities dataset (50 records, 11 fields each):

| File | Bytes |
|------|------:|
| `cities.json` | 13,432 |
| `cities.dhoom` | **4,613** |

That's **65.7% smaller** on the actual data shipped in geomstats. The reduction comes from header-deduplication, modal defaults, and string interning of repeated values (countries, ISO codes, capital-status) — all done in pure Python with no compression library.

### Safe
- **MIT licensed** ([upstream](https://github.com/nurdymuny/dhoom)), compatible with geomstats's MIT.
- **Lossless round-trip** guaranteed by the spec (§10.3). Verified on the cities dataset: `decode(encode(cities)) == cities` (0/50 record mismatches across all 11 fields).
- **Pure Python** with **zero runtime dependencies** — the codec imports only `json`, `math`, `re`, `dataclasses`, and `typing` from stdlib. Nothing new for geomstats users to install.
- **Human-readable** — the file is a plain UTF-8 text document. Anyone can open it and audit the contents.

### Geometry
DHOOM is structurally aligned with the mathematics geomstats is built on. Every homogeneous data collection admits a decomposition as a fiber bundle *(F, E, B, π)*: the schema is the fiber *F*, the index set is the base space *B*, the records are sections *σ: B → E*. The format compresses by declaring the fiber once (the header) and writing each record as a coordinate-minimal section over it. Modal defaults define a zero-section *σ₀*; deviating records encode only *σ − σ₀*.

This isn't decoration — it's how the format works internally and why the size delta exists. For a library whose vocabulary is already manifolds, sections, and bundles, supporting a serialization format with the same primitives is a low-friction fit.

The PR cites [dhoom.dev](https://dhoom.dev) for the formal specification (v0.5, EBNF grammar in §9, conversion rules in §10).

---

## What's in the diff

| File | Change | Lines (approx) |
|------|--------|---------------:|
| `geomstats/datasets/_dhoom.py` | **New.** Vendored copy of the reference Python codec, with attribution header + MIT license notice + dhoom.dev citation. Pure stdlib, Python 3.9+ compatible. | ~640 |
| `geomstats/datasets/utils.py` | Add `load_dhoom`, `save_dhoom`, and `CITIES_DHOOM_PATH` constant. Import `_dhoom`. No existing functions modified. | +85 |
| `geomstats/datasets/data/cities/cities.dhoom` | **New.** Generated from `cities.json` via the codec. Round-trips losslessly. | 52 |
| `tests/tests_geomstats/test_datasets/test_datasets.py` | Add four `test_load_dhoom_*` methods to the existing `TestDatasets` class. | +60 |
| `notebooks/load_data_dhoom.ipynb` | **New.** Four-section tutorial: semantic equivalence with `load_cities`, size comparison, peek at the fiber structure, `save_dhoom` round-trip demo. | — |

**Diff budget:** roughly +850 lines including the vendored codec (~640 lines), or ~+210 lines of new geomstats-authored code. All public API additions are documented with NumPy-style docstrings.

---

## Test coverage

Four new tests on `TestDatasets`, all running on the standard backend matrix (NumPy / PyTorch / Autograd):

1. `test_load_dhoom_cities_equivalence` — DHOOM loader produces the same Tokyo reference vector as `test_load_cities` and all 50 points lie on `Hypersphere(dim=2)`.
2. `test_load_dhoom_smaller_than_json` — asserts `os.path.getsize(CITIES_DHOOM_PATH) < os.path.getsize(CITIES_PATH)`.
3. `test_save_dhoom_load_dhoom_roundtrip` — `save_dhoom` then `load_dhoom` on a small fixture, asserts exact recovery.
4. `test_load_dhoom_malformed_raises` — writes a malformed file, asserts `DhoomError` is raised cleanly.

**Tutorial notebook.** `notebooks/load_data_dhoom.ipynb` is rendered with outputs and shows: (1) `load_dhoom('cities.dhoom')` produces the same Tokyo vector as `load_cities`, (2) the on-disk size comparison, (3) a peek at the fiber-bundle structure of the file (header, modal defaults, deviations), and (4) a `save_dhoom` round-trip on a small dict.

---

## On the dependency question

The geomstats contributing guide flags new dependencies as "unlikely to be accepted." This PR's response: **no new dependencies.** The DHOOM Python codec is a single ~640-line file with no external imports beyond Python's standard library; it's vendored into `geomstats/datasets/_dhoom.py` (note the leading underscore — it's an internal implementation detail, not public API).

This keeps the PR fully self-contained. The MIT license headers in the vendored module attribute the original author (Bee Rosa Davis / Davis Geometric) and link to dhoom.dev for the spec.

When the upstream [`dhoom`](https://github.com/nurdymuny/dhoom) package is published to PyPI (planned), a follow-up PR can replace the vendored module with an optional dependency (`pip install geomstats[dhoom]`), following the same pattern geomstats uses for `pytorch`, `tensorflow`, `networkx`, and `pykeops`. That's a smaller follow-up diff and lets this PR ship without a PyPI prerequisite.

---

## Out of scope (for future PRs)

These are intentionally not part of this contribution; they're noted to make the scope explicit:

- **Manifold-typed DHOOM payloads.** A natural next step is to extend DHOOM with a `manifold:` tag so a file can declare "these points live on `Hypersphere(dim=2)`" and `load_dhoom` returns a typed tuple. That's a spec extension on the DHOOM side plus a thin loader change on the geomstats side — its own PR.
- **DHOOM versions of other datasets** (connectomes, poses, leaves, EMG, etc.). Several of these would benefit substantially from DHOOM's delta encoding (`^`) and arithmetic indices (`@`) for timestamps. One dataset per follow-up PR keeps each diff reviewable.
- **The optional-dependency migration** described in the previous section.

---

## References

- DHOOM format specification, v0.5 — https://dhoom.dev
- Reference implementation — https://github.com/nurdymuny/dhoom

---

## Checklist

- [x] Tests added and pass locally on NumPy backend (4/4)
- [x] Tests pass on PyTorch backend (4/4)
- [x] Tests pass on Autograd backend (4/4)
- [x] Full `tests/tests_geomstats/test_datasets/` suite passes (25/25 — no regressions)
- [x] New code follows NumPy-style docstring convention
- [x] `ruff check` and `ruff format` pass on all changed files
- [x] No new runtime dependencies introduced
- [x] All new public functions have docstrings with Parameters / Returns / References sections
- [x] Tutorial notebook executed end-to-end with outputs included

