### PR TITLE
Fix injectivity radius

### DIFF
--- a/geomstats/geometry/connection.py
+++ b/geomstats/geometry/connection.py
@@ -759,25 +759,6 @@ class Connection(ABC):
             "use the ladder_parallel_transport instead."
         )
 
-    def injectivity_radius(self, base_point=None):
-        """Compute the radius of the injectivity domain.
-
-        This is is the supremum of radii r for which the exponential map is a
-        diffeomorphism from the open ball of radius r centered at the base
-        point onto its image.
-
-        Parameters
-        ----------
-        base_point : array-like, shape=[..., {dim, [n, m]}]
-            Point on the manifold.
-
-        Returns
-        -------
-        radius : array-like, shape=[...,]
-            Injectivity radius.
-        """
-        raise NotImplementedError("The injectivity range is not implemented yet.")
-
 
 _CONNECTION_METHODS = {
     "_space",
@@ -794,7 +775,6 @@ _CONNECTION_METHODS = {
     "directional_curvature_derivative",
     "geodesic",
     "parallel_transport",
-    "injectivity_radius",
 }
 
 

--- a/geomstats/geometry/grassmannian.py
+++ b/geomstats/geometry/grassmannian.py
@@ -406,12 +406,12 @@ class GrassmannianCanonicalMetric(RiemannianMetric):
         return _squared_dist(point_a, point_b)
 
     def injectivity_radius(self, base_point=None):
-        """Compute the radius of the injectivity domain.
+        r"""Compute the radius of the injectivity domain.
 
         This is is the supremum of radii r for which the exponential map is a
         diffeomorphism from the open ball of radius r centered at the base
         point onto its image.
-        In this case it is Pi / 2 everywhere.
+        In this case it is :math:`\pi / \sqrt(2)` everywhere.
 
         Parameters
         ----------
@@ -431,7 +431,7 @@ class GrassmannianCanonicalMetric(RiemannianMetric):
             ArXiv:2011.13699 [Cs, Math], November 27, 2020.
             https://arxiv.org/abs/2011.13699.
         """
-        radius = gs.array(gs.pi / 2)
+        radius = gs.array(gs.pi / gs.sqrt(2))
         return repeat_out(self._space.point_ndim, radius, base_point)
 
     def inner_product(self, tangent_vec_a, tangent_vec_b, base_point=None):

--- a/geomstats/geometry/riemannian_metric.py
+++ b/geomstats/geometry/riemannian_metric.py
@@ -627,3 +627,22 @@ class RiemannianMetric(Connection, ABC):
         ricci_tensor = self.ricci_tensor(base_point)
         cometric_matrix = self.cometric_matrix(base_point)
         return gs.einsum("...ij, ...ij -> ...", cometric_matrix, ricci_tensor)
+
+    def injectivity_radius(self, base_point=None):
+        """Compute the radius of the injectivity domain.
+
+        This is is the supremum of radii r for which the exponential map is a
+        diffeomorphism from the open ball of radius r centered at the base
+        point onto its image.
+
+        Parameters
+        ----------
+        base_point : array-like, shape=[..., {dim, [n, m]}]
+            Point on the manifold.
+
+        Returns
+        -------
+        radius : array-like, shape=[...,]
+            Injectivity radius.
+        """
+        raise NotImplementedError("The injectivity range is not implemented yet.")

--- a/geomstats/geometry/scalar_product_metric.py
+++ b/geomstats/geometry/scalar_product_metric.py
@@ -52,7 +52,14 @@ def _wrap_attr(scaling_factor, func):
 class _ScaledMethodsRegistry:
     """Class to hold lists of methods and their scaling functions."""
 
-    _SQRT_LIST = ["norm", "dist", "dist_broadcast", "dist_pairwise", "diameter"]
+    _SQRT_LIST = [
+        "norm",
+        "dist",
+        "dist_broadcast",
+        "dist_pairwise",
+        "diameter",
+        "injectivity_radius",
+    ]
     _LINEAR_LIST = [
         "metric_matrix",
         "inner_product",

--- a/geomstats/test_cases/geometry/connection.py
+++ b/geomstats/test_cases/geometry/connection.py
@@ -382,10 +382,6 @@ class ConnectionTestCase(GeodesicBVPTestCaseMixins, TestCase):
 
         self.assertAllEqual(res, expected)
 
-    def test_injectivity_radius(self, base_point, expected, atol):
-        res = self.space.metric.injectivity_radius(base_point)
-        self.assertAllClose(res, expected, atol=atol)
-
 
 class ConnectionComparisonTestCase(TestCase):
     def setup_method(self):
@@ -666,14 +662,3 @@ class ConnectionComparisonTestCase(TestCase):
         tangent_vec = self.data_generator.random_tangent_vec(base_point)
 
         self.test_parallel_transport_bvp(base_point, end_point, tangent_vec, atol)
-
-    def test_injectivity_radius(self, base_point, atol):
-        res = self.space.metric.injectivity_radius(base_point)
-        res_ = self.other_space.metric.injectivity_radius(base_point)
-        self.assertAllClose(res, res_, atol=atol)
-
-    @pytest.mark.random
-    def test_injectivity_radius_random(self, n_points, atol):
-        base_point = self.data_generator.random_point(n_points)
-
-        self.test_injectivity_radius(base_point, atol)

--- a/geomstats/test_cases/geometry/riemannian_metric.py
+++ b/geomstats/test_cases/geometry/riemannian_metric.py
@@ -347,6 +347,10 @@ class RiemannianMetricTestCase(DistTestCaseMixins, ConnectionTestCase):
             atol=atol,
         )
 
+    def test_injectivity_radius(self, base_point, expected, atol):
+        res = self.space.metric.injectivity_radius(base_point)
+        self.assertAllClose(res, expected, atol=atol)
+
 
 class RiemannianMetricComparisonTestCase(ConnectionComparisonTestCase):
     def test_metric_matrix(self, base_point, atol):
@@ -550,3 +554,14 @@ class RiemannianMetricComparisonTestCase(ConnectionComparisonTestCase):
         base_point = self.data_generator.random_point(n_points)
 
         self.test_scalar_curvature(base_point, atol)
+
+    def test_injectivity_radius(self, base_point, atol):
+        res = self.space.metric.injectivity_radius(base_point)
+        res_ = self.other_space.metric.injectivity_radius(base_point)
+        self.assertAllClose(res, res_, atol=atol)
+
+    @pytest.mark.random
+    def test_injectivity_radius_random(self, n_points, atol):
+        base_point = self.data_generator.random_point(n_points)
+
+        self.test_injectivity_radius(base_point, atol)

--- a/tests/tests_geomstats/test_geometry/data/connection.py
+++ b/tests/tests_geomstats/test_geometry/data/connection.py
@@ -67,9 +67,6 @@ class ConnectionTestData(GeodesicBVPMixinsTestData, TestData):
     def parallel_transport_ivp_transported_is_tangent_test_data(self):
         return self.generate_random_data()
 
-    def injectivity_radius_vec_test_data(self):
-        return self.generate_vec_data()
-
 
 class ConnectionComparisonTestData(TestData):
     def christoffels_random_test_data(self):
@@ -109,9 +106,6 @@ class ConnectionComparisonTestData(TestData):
         return self.generate_random_data()
 
     def parallel_transport_bvp_random_test_data(self):
-        return self.generate_random_data()
-
-    def injectivity_radius_random_test_data(self):
         return self.generate_random_data()
 
 

--- a/tests/tests_geomstats/test_geometry/data/riemannian_metric.py
+++ b/tests/tests_geomstats/test_geometry/data/riemannian_metric.py
@@ -83,6 +83,9 @@ class RiemannianMetricTestData(DistMixinsTestData, ConnectionTestData):
     def parallel_transport_bvp_norm_test_data(self):
         return self.generate_random_data()
 
+    def injectivity_radius_vec_test_data(self):
+        return self.generate_vec_data()
+
 
 class RiemannianMetricComparisonTestData(ConnectionComparisonTestData):
     def metric_matrix_random_test_data(self):
@@ -122,6 +125,9 @@ class RiemannianMetricComparisonTestData(ConnectionComparisonTestData):
         return self.generate_random_data()
 
     def scalar_curvature_random_test_data(self):
+        return self.generate_random_data()
+
+    def injectivity_radius_random_test_data(self):
         return self.generate_random_data()
 
 


### PR DESCRIPTION
This PR moves `injectivity_radius` from `Connection` to `RiemannianMetric` (a radius needs a notion of distance). Additionally it fixes the Grassmannian injectivity radius (\pi/2 is write for a difference scaling) and adds it to `ScalarProductMetric`.