### PR TITLE
Add ravel_multi_index

### DIFF
--- a/geomstats/_backend/__init__.py
+++ b/geomstats/_backend/__init__.py
@@ -124,7 +124,7 @@ BACKEND_ATTRIBUTES = {
         "power",
         "prod",
         "quantile",
-        "ravel_tril_indices",
+        "ravel_multi_index",
         "real",
         "repeat",
         "reshape",

--- a/geomstats/_backend/autograd/__init__.py
+++ b/geomstats/_backend/autograd/__init__.py
@@ -71,6 +71,7 @@ from autograd.numpy import (
     power,
     prod,
     quantile,
+    ravel_multi_index,
     repeat,
     reshape,
     searchsorted,
@@ -314,15 +315,6 @@ def divide(a, b, ignore_div_zero=False):
 
     wider_dtype, _ = _get_wider_dtype([a, b])
     return _np.divide(a, b, out=zeros(a.shape, dtype=wider_dtype), where=b != 0)
-
-
-def ravel_tril_indices(n, k=0, m=None):
-    if m is None:
-        size = (n, n)
-    else:
-        size = (n, m)
-    idxs = _np.tril_indices(n, k, m)
-    return _np.ravel_multi_index(idxs, size)
 
 
 def matmul(*args, **kwargs):

--- a/geomstats/_backend/numpy/__init__.py
+++ b/geomstats/_backend/numpy/__init__.py
@@ -72,6 +72,7 @@ from numpy import (
     power,
     prod,
     quantile,
+    ravel_multi_index,
     repeat,
     reshape,
     searchsorted,
@@ -298,15 +299,6 @@ def divide(a, b, ignore_div_zero=False):
 
     wider_dtype, _ = _get_wider_dtype([a, b])
     return _np.divide(a, b, out=zeros(a.shape, dtype=wider_dtype), where=b != 0)
-
-
-def ravel_tril_indices(n, k=0, m=None):
-    if m is None:
-        size = (n, n)
-    else:
-        size = (n, m)
-    idxs = _np.tril_indices(n, k, m)
-    return _np.ravel_multi_index(idxs, size)
 
 
 def matmul(*args, **kwargs):

--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -588,13 +588,32 @@ def divide(a, b, ignore_div_zero=False):
     return _torch.nan_to_num(quo, nan=0.0, posinf=0.0, neginf=0.0)
 
 
-def ravel_tril_indices(n, k=0, m=None):
-    if m is None:
-        size = (n, n)
-    else:
-        size = (n, m)
-    idxs = _np.tril_indices(n, k, m)
-    return _torch.from_numpy(_np.ravel_multi_index(idxs, size))
+def ravel_multi_index(multi_index, dims):
+    """Torch equivalent of np.ravel_multi_index(..., order='C').
+
+    Parameters
+    ----------
+    multi_index : tuple[torch.Tensor]
+        Coordinate tensors, e.g. (rows, cols).
+    dims : tuple[int]
+        Shape of the target array.
+
+    Returns
+    -------
+    flat_indices : torch.Tensor
+        Indices into the flattened array.
+    """
+    if len(multi_index) != len(dims):
+        raise ValueError("multi_index and dims must have the same length.")
+
+    flat_index = _torch.zeros_like(multi_index[0])
+    stride = 1
+
+    for idx, dim in zip(reversed(multi_index), reversed(dims)):
+        flat_index = flat_index + idx * stride
+        stride *= dim
+
+    return flat_index
 
 
 def sort(a, axis=-1):

--- a/geomstats/geometry/lower_triangular_matrices.py
+++ b/geomstats/geometry/lower_triangular_matrices.py
@@ -34,7 +34,7 @@ class LowerTriangularMatrices(MatrixVectorSpace):
         basis : array-like, shape=[dim, n, n]
             Basis matrices of the space.
         """
-        rows, cols = gs.tril(self.n)
+        rows, cols = gs.tril_indices(self.n)
         tril_idxs = gs.ravel_multi_index((rows, cols), (self.n, self.n))
 
         vector_bases = gs.cast(
@@ -172,7 +172,7 @@ class StrictlyLowerTriangularMatrices(LevelSet, MatrixVectorSpace):
         basis : array-like, shape=[dim, n, n]
             Basis matrices of the space.
         """
-        rows, cols = gs.tril(self.n, k=-1)
+        rows, cols = gs.tril_indices(self.n, k=-1)
         tril_idxs = gs.ravel_multi_index((rows, cols), (self.n, self.n))
 
         vector_bases = gs.cast(

--- a/geomstats/geometry/lower_triangular_matrices.py
+++ b/geomstats/geometry/lower_triangular_matrices.py
@@ -34,7 +34,9 @@ class LowerTriangularMatrices(MatrixVectorSpace):
         basis : array-like, shape=[dim, n, n]
             Basis matrices of the space.
         """
-        tril_idxs = gs.ravel_tril_indices(self.n)
+        rows, cols = gs.tril(self.n)
+        tril_idxs = gs.ravel_multi_index((rows, cols), (self.n, self.n))
+
         vector_bases = gs.cast(
             gs.one_hot(tril_idxs, self.n * self.n),
             dtype=gs.get_default_dtype(),
@@ -170,7 +172,9 @@ class StrictlyLowerTriangularMatrices(LevelSet, MatrixVectorSpace):
         basis : array-like, shape=[dim, n, n]
             Basis matrices of the space.
         """
-        tril_idxs = gs.ravel_tril_indices(self.n, k=-1)
+        rows, cols = gs.tril(self.n, k=-1)
+        tril_idxs = gs.ravel_multi_index((rows, cols), (self.n, self.n))
+
         vector_bases = gs.cast(
             gs.one_hot(tril_idxs, self.n * self.n),
             dtype=gs.get_default_dtype(),

--- a/tests/tests_geomstats/test_backend/data/against_numpy.py
+++ b/tests/tests_geomstats/test_backend/data/against_numpy.py
@@ -67,7 +67,18 @@ class AgainstNumpyTestData(TestData):
         return [{"func_name": func_name, "args": args_} for args_ in args]
 
     def func_like_np_test_data(self):
-        data = []
+        data = [
+            dict(
+                func_name="ravel_multi_index",
+                args=[
+                    (
+                        gs.array([0, 1, 1, 2, 2, 2]),
+                        gs.array([0, 0, 1, 0, 1, 2]),
+                    ),
+                    (3, 3),
+                ],
+            ),
+        ]
         data += self._einsum_data()
 
         return self.generate_tests(data)


### PR DESCRIPTION
This PR replaces the specific function `ravel_tril_indices` by the generic `ravel_multi_index`.