### PR TITLE
Fix Sturms step length for cyclic variant

### DIFF
--- a/geomstats/learning/frechet_mean.py
+++ b/geomstats/learning/frechet_mean.py
@@ -698,7 +698,7 @@ class SturmsMean(BaseEstimator):
     def _step_length_cyclic(self, weights, k):
         n_weights = len(weights)
         cycles, remainder = divmod(k, n_weights)
-        total_weight_so_far = (cycles * 1.0) + gs.sum(weights[:remainder])
+        total_weight_so_far = (cycles * 1.0) + gs.sum(weights[: remainder + 1])
         return weights[k % n_weights] / total_weight_so_far
 
     def _step_length_stochastic(self, weights, k):


### PR DESCRIPTION
This PR fixes #2112. The issue arises from indexing/first point. Since for the first point t=1 (i.e. geodesic between point and itself), the first time we call `_step_length_cyclic` (to get the second point) we need to consider first's weight.

In other words, for uniform weights, it goes 1, 0.5, ..., but `_step_length_cyclic` first output is 0.5. For e.g. weights=[0.25, 0.75], it goes 1, 0.75, ...