### PR TITLE
Fix ScipyMinimize due to scipy updates

### DIFF
--- a/geomstats/numerics/optimization/_scipy.py
+++ b/geomstats/numerics/optimization/_scipy.py
@@ -52,10 +52,17 @@ class ScipyMinimize(Minimizer):
 
     def _handle_jac(self, fun, fun_jac):
         if fun_jac is not None:
-            fun_ = lambda x: gs.to_numpy(fun(gs.from_numpy(x)))
-            fun_jac_ = fun_jac
             if callable(fun_jac):
+                fun_ = lambda x: gs.to_numpy(fun(gs.from_numpy(x)))
                 fun_jac_ = lambda x: fun_jac(gs.from_numpy(x))
+
+            else:
+
+                def fun_(x):
+                    val, grad = fun(gs.from_numpy(x))
+                    return gs.to_numpy(val), grad
+
+                fun_jac_ = fun_jac
 
             return fun_, fun_jac_
 

--- a/geomstats/numerics/optimization/_scipy.py
+++ b/geomstats/numerics/optimization/_scipy.py
@@ -105,7 +105,12 @@ class ScipyMinimize(Minimizer):
         hessp : callable
         """
         fun_, jac = self._handle_jac(fun, fun_jac)
-        hess = self._handle_hess(fun, fun_hess)
+
+        fun_for_hess = fun
+        if fun_jac is not None and not callable(fun_jac):
+            fun_for_hess = lambda x: fun(x)[0]
+
+        hess = self._handle_hess(fun_for_hess, fun_hess)
 
         result = scipy.optimize.minimize(
             fun_,

--- a/geomstats/numerics/optimization/_scipy.py
+++ b/geomstats/numerics/optimization/_scipy.py
@@ -52,7 +52,7 @@ class ScipyMinimize(Minimizer):
 
     def _handle_jac(self, fun, fun_jac):
         if fun_jac is not None:
-            fun_ = lambda x: fun(gs.from_numpy(x))
+            fun_ = lambda x: gs.to_numpy(fun(gs.from_numpy(x)))
             fun_jac_ = fun_jac
             if callable(fun_jac):
                 fun_jac_ = lambda x: fun_jac(gs.from_numpy(x))
@@ -61,10 +61,14 @@ class ScipyMinimize(Minimizer):
 
         if self.autodiff_jac:
             jac = True
-            fun_ = lambda x: gs.autodiff.value_and_grad(fun)(gs.from_numpy(x))
+
+            def fun_(x):
+                val, grad = gs.autodiff.value_and_grad(fun)(gs.from_numpy(x))
+                return gs.to_numpy(val), grad
+
         else:
             jac = fun_jac
-            fun_ = lambda x: fun(gs.from_numpy(x))
+            fun_ = lambda x: gs.to_numpy(fun(gs.from_numpy(x)))
 
         return fun_, jac
 

--- a/tests/tests_geomstats/test_numerics/data/optimization.py
+++ b/tests/tests_geomstats/test_numerics/data/optimization.py
@@ -12,6 +12,10 @@ def _jacobian_sum_squares(x):
     return 2 * x
 
 
+def _sum_squares_val_and_grad(x):
+    return _sum_squares(x), _jacobian_sum_squares(x)
+
+
 def _hessian_sum_squares(x):
     return 2 * gs.eye(x.shape[0])
 
@@ -47,7 +51,13 @@ class OptimizationJacSmokeTestData(TestData):
                 fun_jac=_jacobian_sum_squares,
                 x0=gs.random.uniform(size=dim),
                 expected=gs.zeros(dim),
-            )
+            ),
+            dict(
+                fun=_sum_squares_val_and_grad,
+                fun_jac=True,
+                x0=gs.random.uniform(size=dim),
+                expected=gs.zeros(dim),
+            ),
         ]
 
         return self.generate_tests(data)


### PR DESCRIPTION
This PR updates `ScipyMinimize` to work with the changes introduced in `scipy == 1.18.0`.

`scipy== 1.18.0` expects the output of a scalar function to be a scalar and does not work with 0-dim `torch.Tensor`. Currently solution simply converts them to `np.array`.


