### PR TITLE
Update gs.transpose

### DIFF
--- a/geomstats/_backend/__init__.py
+++ b/geomstats/_backend/__init__.py
@@ -118,6 +118,7 @@ BACKEND_ATTRIBUTES = {
         "ones_like",
         "outer",
         "pad",
+        "permute_dims",
         "pi",
         "polygamma",
         "power",

--- a/geomstats/_backend/autograd/__init__.py
+++ b/geomstats/_backend/autograd/__init__.py
@@ -89,7 +89,6 @@ from autograd.numpy import (
     tan,
     tanh,
     tile,
-    transpose,
     tril,
     tril_indices,
     triu,
@@ -202,6 +201,22 @@ def flatten(x):
 
 def ndim(x):
     return x.ndim
+
+
+def transpose(x):
+    """Return the transpose of a matrix.
+
+    Parameters
+    ----------
+    x : array-like, shape=[..., n, m]
+        Matrix.
+
+    Returns
+    -------
+    transpose : array-like, shape=[..., n, m]
+        Transposed matrix.
+    """
+    return _np.swapaxes(x, -1, -2)
 
 
 def vectorize(x, pyfunc, multiple_args=False, signature=None, **kwargs):

--- a/geomstats/_backend/autograd/__init__.py
+++ b/geomstats/_backend/autograd/__init__.py
@@ -68,6 +68,7 @@ from autograd.numpy import (
     ones,
     ones_like,
     pad,
+    permute_dims,
     power,
     prod,
     quantile,

--- a/geomstats/_backend/numpy/__init__.py
+++ b/geomstats/_backend/numpy/__init__.py
@@ -90,7 +90,6 @@ from numpy import (
     tan,
     tanh,
     tile,
-    transpose,
     tril,
     tril_indices,
     triu,
@@ -182,6 +181,22 @@ def squeeze(x, axis=None):
 
 def flatten(x):
     return x.flatten()
+
+
+def transpose(x):
+    """Return the transpose of a matrix.
+
+    Parameters
+    ----------
+    x : array-like, shape=[..., n, m]
+        Matrix.
+
+    Returns
+    -------
+    transpose : array-like, shape=[..., n, m]
+        Transposed matrix.
+    """
+    return _np.swapaxes(x, -1, -2)
 
 
 def ndim(x):

--- a/geomstats/_backend/numpy/__init__.py
+++ b/geomstats/_backend/numpy/__init__.py
@@ -69,6 +69,7 @@ from numpy import (
     ones,
     ones_like,
     pad,
+    permute_dims,
     power,
     prod,
     quantile,

--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -301,6 +301,13 @@ def transpose(x):
     return _torch.transpose(x, -1, -2)
 
 
+def permute_dims(x, axes=None):
+    if axes is None:
+        axes = tuple(range(x.ndim - 1, -1, -1))
+
+    return _torch.permute(x, *axes)
+
+
 def squeeze(x, axis=None):
     if not is_array(x):
         return x

--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -253,8 +253,8 @@ def minimum(a, b):
     return _torch.min(array(a), array(b))
 
 
-def mean(x, axis=None, keepdims=False):
-    return _torch.mean(x, dim=axis, keepdim=keepdims)
+def mean(x, axis=None, dtype=None, keepdims=False, out=None):
+    return _torch.mean(x, dim=axis, dtype=dtype, keepdim=keepdims, out=out)
 
 
 def to_ndarray(x, to_ndim, axis=0, dtype=None):

--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -308,7 +308,7 @@ def permute_dims(x, axes=None):
     if axes is None:
         axes = tuple(range(x.ndim - 1, -1, -1))
 
-    return _torch.permute(x, *axes)
+    return _torch.permute(x, axes)
 
 
 def squeeze(x, axis=None):

--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -297,14 +297,8 @@ def einsum(equation, *inputs):
     return _torch.einsum(equation, *input_tensors_list)
 
 
-def transpose(x, axes=None):
-    if axes:
-        return x.permute(axes)
-    if x.dim() == 1:
-        return x
-    if x.dim() > 2 and axes is None:
-        return x.permute(tuple(range(x.ndim)[::-1]))
-    return x.t()
+def transpose(x):
+    return _torch.transpose(x, -1, -2)
 
 
 def squeeze(x, axis=None):

--- a/geomstats/_backend/pytorch/__init__.py
+++ b/geomstats/_backend/pytorch/__init__.py
@@ -28,7 +28,6 @@ from torch import (
     kron,
     less,
     logical_or,
-    mean,
     median,
     meshgrid,
     moveaxis,
@@ -252,6 +251,10 @@ def maximum(a, b):
 
 def minimum(a, b):
     return _torch.min(array(a), array(b))
+
+
+def mean(x, axis=None, keepdims=False):
+    return _torch.mean(x, dim=axis, keepdim=keepdims)
 
 
 def to_ndarray(x, to_ndim, axis=0, dtype=None):

--- a/geomstats/datasets/utils.py
+++ b/geomstats/datasets/utils.py
@@ -182,8 +182,8 @@ def load_connectomes(as_vectors=False):
     if as_vectors:
         return data, patient_id, target
     mat = SkewSymmetricMatrices(28).matrix_representation(data)
-    mat = gs.eye(28) - gs.transpose(gs.tril(mat), (0, 2, 1))
-    mat = 1.0 / 2.0 * (mat + gs.transpose(mat, (0, 2, 1)))
+    mat = gs.eye(28) - gs.transpose(gs.tril(mat))
+    mat = 1.0 / 2.0 * (mat + gs.transpose(mat))
 
     return mat, patient_id, target
 

--- a/geomstats/geometry/complex_matrices.py
+++ b/geomstats/geometry/complex_matrices.py
@@ -69,7 +69,7 @@ class ComplexMatrices(ComplexMatrixVectorSpace):
         axes = list(range(0, ndim))
         axes[-1] = ndim - 2
         axes[-2] = ndim - 1
-        return gs.transpose(gs.conj(mat), axes)
+        return gs.transpose(gs.conj(mat))
 
     @classmethod
     def is_hermitian(cls, mat, atol=gs.atol):

--- a/geomstats/geometry/discrete_curves.py
+++ b/geomstats/geometry/discrete_curves.py
@@ -17,7 +17,6 @@ from geomstats.geometry.fiber_bundle import AlignerAlgorithm, FiberBundle
 from geomstats.geometry.hypersphere import Hypersphere
 from geomstats.geometry.landmarks import Landmarks
 from geomstats.geometry.manifold import register_quotient
-from geomstats.geometry.matrices import Matrices
 from geomstats.geometry.nfold_manifold import NFoldManifold, NFoldMetric
 from geomstats.geometry.pullback_metric import PullbackDiffeoMetric
 from geomstats.geometry.quotient_metric import QuotientMetric
@@ -1767,7 +1766,7 @@ class RotationBundle(FiberBundle):
 
     def _rotate(self, point, rotation):
         """Rotate discrete curve starting at origin."""
-        return Matrices.transpose(gs.matmul(rotation, Matrices.transpose(point)))
+        return gs.transpose(gs.matmul(rotation, gs.transpose(point)))
 
     def align(self, point, base_point, return_rotation=False):
         """Align point to base point.
@@ -1793,7 +1792,7 @@ class RotationBundle(FiberBundle):
         initial_srv = transform(base_point)
         end_srv = transform(point)
 
-        mat = gs.matmul(Matrices.transpose(initial_srv), end_srv)
+        mat = gs.matmul(gs.transpose(initial_srv), end_srv)
         u_svd, _, vt_svd = gs.linalg.svd(mat)
         sign = gs.linalg.det(gs.matmul(u_svd, vt_svd))
         vt_svd[..., -1, :] = gs.einsum("...,...j->...j", sign, vt_svd[..., -1, :])

--- a/geomstats/geometry/discrete_surfaces.py
+++ b/geomstats/geometry/discrete_surfaces.py
@@ -368,7 +368,7 @@ class DiscreteSurfaces(Manifold):
             Surface metric matrices evaluated at each face of
             the triangulated surface.
         """
-        return gs.matmul(one_forms, Matrices.transpose(one_forms))
+        return gs.matmul(one_forms, gs.transpose(one_forms))
 
     def surface_metric_matrices(self, point):
         """Compute the surface metric matrices.
@@ -744,22 +744,20 @@ class ElasticMetric(RiemannianMetric):
         inner_prod_d1 : array-like, shape=[...,]
             Term of order 1, and coefficient d1, of the inner-product.
         """
-        one_forms_bp_t = Matrices.transpose(one_forms_bp)
+        one_forms_bp_t = gs.transpose(one_forms_bp)
 
         aux = gs.matmul(one_forms_bp_t, ginv_bp)
 
         xa = one_forms_a - one_forms_bp
         xa_0 = gs.matmul(
             aux,
-            gs.matmul(xa, one_forms_bp_t)
-            - gs.matmul(one_forms_bp, Matrices.transpose(xa)),
+            gs.matmul(xa, one_forms_bp_t) - gs.matmul(one_forms_bp, gs.transpose(xa)),
         )
 
         xb = one_forms_b - one_forms_bp
         xb_0 = gs.matmul(
             aux,
-            gs.matmul(xb, one_forms_bp_t)
-            - gs.matmul(one_forms_bp, Matrices.transpose(xb)),
+            gs.matmul(xb, one_forms_bp_t) - gs.matmul(one_forms_bp, gs.transpose(xb)),
         )
 
         return self.d1 * gs.sum(
@@ -767,7 +765,7 @@ class ElasticMetric(RiemannianMetric):
                 Matrices.mul(
                     xa_0,
                     ginv_bp,
-                    Matrices.transpose(xb_0),
+                    gs.transpose(xb_0),
                 ),
             )
             * areas_bp,

--- a/geomstats/geometry/full_rank_correlation_matrices.py
+++ b/geomstats/geometry/full_rank_correlation_matrices.py
@@ -520,7 +520,7 @@ class EuclideanCholeskyDiffeo(Diffeo):
 
         chol = gs.linalg.cholesky(base_point)
         chol_inv = gs.linalg.inv(chol)
-        aux = Matrices.mul(chol_inv, tangent_vec, Matrices.transpose(chol_inv))
+        aux = Matrices.mul(chol_inv, tangent_vec, gs.transpose(chol_inv))
         term_1 = Matrices.mul(
             image_point,
             Matrices.to_lower_triangular_diagonal_scaled(aux),

--- a/geomstats/geometry/grassmannian.py
+++ b/geomstats/geometry/grassmannian.py
@@ -115,16 +115,16 @@ class Grassmannian(LevelSet):
 
         _, eigvecs = gs.linalg.eigh(point)
         eigvecs = gs.flip(eigvecs, -1)
-        flipped_point = Matrices.mul(Matrices.transpose(eigvecs), point, eigvecs)
+        flipped_point = Matrices.mul(gs.transpose(eigvecs), point, eigvecs)
         b = flipped_point[..., p:, :p]
         d = flipped_point[..., p:, p:]
         a = flipped_point[..., :p, :p] - gs.eye(p)
         first = d - Matrices.mul(
-            b, GeneralLinear.inverse(a + gs.eye(p)), Matrices.transpose(b)
+            b, GeneralLinear.inverse(a + gs.eye(p)), gs.transpose(b)
         )
-        second = a + Matrices.mul(a, a) + Matrices.mul(Matrices.transpose(b), b)
+        second = a + Matrices.mul(a, a) + Matrices.mul(gs.transpose(b), b)
         row_1 = gs.concatenate([first, gs.zeros_like(b)], axis=-1)
-        row_2 = gs.concatenate([Matrices.transpose(gs.zeros_like(b)), second], axis=-1)
+        row_2 = gs.concatenate([gs.transpose(gs.zeros_like(b)), second], axis=-1)
         return gs.concatenate([row_1, row_2], axis=-2)
 
     def tangent_submersion(self, vector, point):
@@ -166,9 +166,9 @@ class Grassmannian(LevelSet):
             New York: Springer-Verlag. 2003, 10.1007/978-0-387-21540-2
         """
         points = gs.random.normal(size=(n_samples, self.n, self.p))
-        full_rank = Matrices.mul(Matrices.transpose(points), points)
+        full_rank = Matrices.mul(gs.transpose(points), points)
         projector = Matrices.mul(
-            points, GeneralLinear.inverse(full_rank), Matrices.transpose(points)
+            points, GeneralLinear.inverse(full_rank), gs.transpose(points)
         )
         return projector[0] if n_samples == 1 else projector
 
@@ -238,7 +238,7 @@ class Grassmannian(LevelSet):
         _, eigvecs = gs.linalg.eigh(mat)
         diagonal = gs.array([0.0] * (self.n - self.p) + [1.0] * self.p)
         p_d = gs.einsum("...ij,...j->...ij", eigvecs, diagonal)
-        return Matrices.mul(p_d, Matrices.transpose(eigvecs))
+        return Matrices.mul(p_d, gs.transpose(eigvecs))
 
 
 class GrassmannianCanonicalMetric(RiemannianMetric):
@@ -519,7 +519,7 @@ class GrassmannianBundle(FiberBundle):
         projection : array-like, shape=[..., n, n]
             Point of the base manifold.
         """
-        return gs.matmul(point, Matrices.transpose(point))
+        return gs.matmul(point, gs.transpose(point))
 
     def tangent_riemannian_submersion(self, tangent_vec, base_point):
         """Project a tangent vector to base manifold.
@@ -536,8 +536,8 @@ class GrassmannianBundle(FiberBundle):
         projection: array-like, shape=[..., n, n]
             Tangent vector to the base manifold.
         """
-        return gs.matmul(base_point, Matrices.transpose(tangent_vec)) + gs.matmul(
-            tangent_vec, Matrices.transpose(base_point)
+        return gs.matmul(base_point, gs.transpose(tangent_vec)) + gs.matmul(
+            tangent_vec, gs.transpose(base_point)
         )
 
     def lift(self, point):

--- a/geomstats/geometry/group_action.py
+++ b/geomstats/geometry/group_action.py
@@ -111,7 +111,7 @@ class CongruenceAction(GroupAction):
         orbit_point : array-like, shape=[..., n, n]
             A point on the orbit of point.
         """
-        return Matrices.mul(group_elem, point, Matrices.transpose(group_elem))
+        return Matrices.mul(group_elem, point, gs.transpose(group_elem))
 
 
 class PermutationAction(CongruenceAction):
@@ -157,7 +157,7 @@ class RowPermutationAction(GroupAction):
             Permuted matrices.
         """
         perm_mat = permutation_matrix_from_vector(group_elem, dtype=point.dtype)
-        return gs.matmul(Matrices.transpose(perm_mat), point)
+        return gs.matmul(gs.transpose(perm_mat), point)
 
 
 def permutation_matrix_from_vector(group_elem, dtype=gs.int64):

--- a/geomstats/geometry/hermitian_matrices.py
+++ b/geomstats/geometry/hermitian_matrices.py
@@ -94,7 +94,7 @@ def apply_func_to_eigvalsh(mat, function, check_positive=False):
     if gs.is_complex(mat):
         transp_eigvecs = ComplexMatrices.transconjugate(eigvecs)
     else:
-        transp_eigvecs = Matrices.transpose(eigvecs)
+        transp_eigvecs = gs.transpose(eigvecs)
 
     for fun in function:
         eigvals_f = fun(eigvals)

--- a/geomstats/geometry/hypersphere.py
+++ b/geomstats/geometry/hypersphere.py
@@ -230,7 +230,6 @@ class _Hypersphere(LevelSet):
                 " only in dimension 2."
             )
 
-        axes = (2, 0, 1) if base_point_spherical.ndim == 2 else (0, 1)
         theta = base_point_spherical[..., 0]
         phi = base_point_spherical[..., 1]
         phi = gs.where(theta == 0.0, 0.0, phi)
@@ -245,7 +244,8 @@ class _Hypersphere(LevelSet):
             ]
         )
 
-        jac = gs.transpose(jac, axes)
+        if base_point_spherical.ndim == 2:
+            jac = gs.moveaxis(jac, -1, 0)
 
         return gs.einsum("...ij,...j->...i", jac, tangent_vec_spherical)
 
@@ -318,7 +318,6 @@ class _Hypersphere(LevelSet):
         if base_point_spherical is None and base_point is not None:
             base_point_spherical = self.extrinsic_to_spherical(base_point)
 
-        axes = (2, 0, 1) if base_point_spherical.ndim == 2 else (0, 1)
         theta = base_point_spherical[..., 0]
         phi = base_point_spherical[..., 1]
 
@@ -350,8 +349,10 @@ class _Hypersphere(LevelSet):
             ]
         )
 
-        jac = gs.transpose(jac, axes)
-        jac_close_0 = gs.transpose(jac_close_0, axes)
+        if base_point_spherical.ndim == 2:
+            jac = gs.moveaxis(jac, -1, 0)
+            jac_close_0 = gs.moveaxis(jac_close_0, -1, 0)
+
         theta_criterion = gs.einsum("...,...ij->...ij", theta, gs.ones_like(jac))
         jac = gs.where(gs.abs(theta_criterion) < gs.atol, jac_close_0, jac)
 

--- a/geomstats/geometry/invariant_metric.py
+++ b/geomstats/geometry/invariant_metric.py
@@ -873,7 +873,7 @@ class _InvariantMetricVector(RiemannianMetric):
         jacobian = self._space.jacobian_translation(point=base_point, left=self.left)
 
         inv_jacobian = gs.linalg.inv(jacobian)
-        inv_jacobian_transposed = Matrices.transpose(inv_jacobian)
+        inv_jacobian_transposed = gs.transpose(inv_jacobian)
 
         return Matrices.mul(
             inv_jacobian_transposed, self.metric_mat_at_identity, inv_jacobian
@@ -1300,7 +1300,7 @@ class BiInvariantMetric(RiemannianMetric):
                     " geodesic along which to transport."
                 )
         midpoint = self.exp(1.0 / 2.0 * direction, base_point)
-        transposed = Matrices.transpose(tangent_vec)
+        transposed = gs.transpose(tangent_vec)
         transported_vec = Matrices.mul(midpoint, transposed, midpoint)
         return (-1.0) * transported_vec
 

--- a/geomstats/geometry/matrices.py
+++ b/geomstats/geometry/matrices.py
@@ -30,7 +30,7 @@ def matrix_matrix_transpose(point):
     mat : array-like, shape=[n, n]
         Matrix resulting from operation.
     """
-    return Matrices.mul(point, Matrices.transpose(point))
+    return Matrices.mul(point, gs.transpose(point))
 
 
 def tangent_matrix_matrix_transpose(tangent_vec, base_point):
@@ -53,8 +53,8 @@ def tangent_matrix_matrix_transpose(tangent_vec, base_point):
     image_tangent_vec : array-like, shape=[n, n]
         Matrix resulting from operation.
     """
-    return Matrices.mul(tangent_vec, Matrices.transpose(base_point)) + Matrices.mul(
-        base_point, Matrices.transpose(tangent_vec)
+    return Matrices.mul(tangent_vec, gs.transpose(base_point)) + Matrices.mul(
+        base_point, gs.transpose(tangent_vec)
     )
 
 
@@ -260,26 +260,6 @@ class Matrices(MatrixVectorSpace):
             Commutator.
         """
         return cls.mul(mat_a, mat_b) - cls.mul(mat_b, mat_a)
-
-    @staticmethod
-    def transpose(mat):
-        """Return the transpose of matrices.
-
-        Parameters
-        ----------
-        mat : array-like, shape=[..., n, n]
-            Matrix.
-
-        Returns
-        -------
-        transpose : array-like, shape=[..., n, n]
-            Transposed matrix.
-        """
-        ndim = gs.ndim(mat)
-        axes = list(range(0, ndim))
-        axes[-1] = ndim - 2
-        axes[-2] = ndim - 1
-        return gs.transpose(mat, axes)
 
     @staticmethod
     def diagonal(mat):

--- a/geomstats/geometry/matrices.py
+++ b/geomstats/geometry/matrices.py
@@ -411,7 +411,7 @@ class Matrices(MatrixVectorSpace):
         is_sym : array-like, shape=[...,]
             Boolean evaluating if the matrix is symmetric.
         """
-        return cls.equal(mat, cls.transpose(mat), atol)
+        return cls.equal(mat, gs.transpose(mat), atol)
 
     @classmethod
     def is_pd(cls, mat):
@@ -473,7 +473,7 @@ class Matrices(MatrixVectorSpace):
         is_skew_sym : array-like, shape=[...,]
             Boolean evaluating if the matrix is skew-symmetric.
         """
-        return cls.equal(mat, -cls.transpose(mat), atol)
+        return cls.equal(mat, -gs.transpose(mat), atol)
 
     @classmethod
     def to_diagonal(cls, mat):
@@ -584,7 +584,7 @@ class Matrices(MatrixVectorSpace):
         sym : array-like, shape=[..., n, n]
             Symmetric matrix.
         """
-        return 1 / 2 * (mat + cls.transpose(mat))
+        return 1 / 2 * (mat + gs.transpose(mat))
 
     @classmethod
     def to_skew_symmetric(cls, mat):
@@ -603,7 +603,7 @@ class Matrices(MatrixVectorSpace):
         skew_sym : array-like, shape=[..., n, n]
             Skew-symmetric matrix.
         """
-        return 1 / 2 * (mat - cls.transpose(mat))
+        return 1 / 2 * (mat - gs.transpose(mat))
 
     @classmethod
     def to_lower_triangular_diagonal_scaled(cls, mat, K=2.0):
@@ -666,7 +666,7 @@ class Matrices(MatrixVectorSpace):
         cong : array-like, shape=[..., n, n]
             Result of the congruent action.
         """
-        return cls.mul(mat_2, mat_1, cls.transpose(mat_2))
+        return cls.mul(mat_2, mat_1, gs.transpose(mat_2))
 
     @staticmethod
     def frobenius_product(mat_1, mat_2):
@@ -791,7 +791,7 @@ class Matrices(MatrixVectorSpace):
         aligned : array-like, shape=[..., m, n]
             R.point.
         """
-        mat = gs.matmul(cls.transpose(point), base_point)
+        mat = gs.matmul(gs.transpose(point), base_point)
         left, singular_values, right = gs.linalg.svd(mat, full_matrices=False)
         det = gs.linalg.det(mat)
         conditioning = (
@@ -807,10 +807,10 @@ class Matrices(MatrixVectorSpace):
             logging.warning("Alignment matrix is not unique.")
 
         if flip:
-            flipped = flip_determinant(cls.transpose(right), det)
+            flipped = flip_determinant(gs.transpose(right), det)
         else:
-            flipped = cls.transpose(right)
-        return Matrices.mul(point, left, cls.transpose(flipped))
+            flipped = gs.transpose(right)
+        return Matrices.mul(point, left, gs.transpose(flipped))
 
 
 class MatricesMetric(EuclideanMetric):

--- a/geomstats/geometry/pre_shape.py
+++ b/geomstats/geometry/pre_shape.py
@@ -289,10 +289,10 @@ class PreShapeBundle(FiberBundle):
         skew : array-like, shape=[..., ambient_dim, ambient_dim]
             Vertical component of `tangent_vec`.
         """
-        transposed_point = Matrices.transpose(base_point)
+        transposed_point = gs.transpose(base_point)
         left_term = gs.matmul(transposed_point, base_point)
-        alignment = gs.matmul(Matrices.transpose(tangent_vec), base_point)
-        right_term = alignment - Matrices.transpose(alignment)
+        alignment = gs.matmul(gs.transpose(tangent_vec), base_point)
+        right_term = alignment - gs.transpose(alignment)
         skew = gs.linalg.solve_sylvester(left_term, left_term, right_term)
 
         vertical = -gs.matmul(base_point, skew)
@@ -317,7 +317,7 @@ class PreShapeBundle(FiberBundle):
         is_tangent : bool
             Boolean denoting if tangent vector is horizontal.
         """
-        product = gs.matmul(Matrices.transpose(tangent_vec), base_point)
+        product = gs.matmul(gs.transpose(tangent_vec), base_point)
         is_tangent = self._total_space.is_tangent(tangent_vec, base_point, atol)
         is_symmetric = Matrices.is_symmetric(product, atol)
         return gs.logical_and(is_tangent, is_symmetric)
@@ -362,16 +362,16 @@ class PreShapeBundle(FiberBundle):
             in Kendall shape spaces. Unpublished.
         """
         hor_x = self.horizontal_projection(tangent_vec_x, base_point)
-        p_top = Matrices.transpose(base_point)
+        p_top = gs.transpose(base_point)
         p_top_p = gs.matmul(p_top, base_point)
 
         def sylv_p(mat_b):
             """Solves Sylvester equation for vertical component."""
             return gs.linalg.solve_sylvester(
-                p_top_p, p_top_p, mat_b - Matrices.transpose(mat_b)
+                p_top_p, p_top_p, mat_b - gs.transpose(mat_b)
             )
 
-        e_top_hor_x = gs.matmul(Matrices.transpose(tangent_vec_e), hor_x)
+        e_top_hor_x = gs.matmul(gs.transpose(tangent_vec_e), hor_x)
         sylv_e_top_hor_x = sylv_p(e_top_hor_x)
 
         p_top_e = gs.matmul(p_top, tangent_vec_e)
@@ -452,16 +452,16 @@ class PreShapeBundle(FiberBundle):
         if not gs.all(self._total_space.is_tangent(nabla_x_e, base_point)):
             raise ValueError("Vector nabla_x_e is not tangent")
 
-        p_top = Matrices.transpose(base_point)
+        p_top = gs.transpose(base_point)
         p_top_p = gs.matmul(p_top, base_point)
-        e_top = Matrices.transpose(tangent_vec_e)
-        x_top = Matrices.transpose(horizontal_vec_x)
-        y_top = Matrices.transpose(horizontal_vec_y)
+        e_top = gs.transpose(tangent_vec_e)
+        x_top = gs.transpose(horizontal_vec_x)
+        y_top = gs.transpose(horizontal_vec_y)
 
         def sylv_p(mat_b):
             """Solves Sylvester equation for vertical component."""
             return gs.linalg.solve_sylvester(
-                p_top_p, p_top_p, mat_b - Matrices.transpose(mat_b)
+                p_top_p, p_top_p, mat_b - gs.transpose(mat_b)
             )
 
         omega_ep = sylv_p(gs.matmul(p_top, tangent_vec_e))
@@ -546,17 +546,17 @@ class PreShapeBundle(FiberBundle):
         if not gs.all(self.is_horizontal(horizontal_vec_z, base_point)):
             raise ValueError("Tangent vector z is not horizontal")
 
-        p_top = Matrices.transpose(base_point)
+        p_top = gs.transpose(base_point)
         p_top_p = gs.matmul(p_top, base_point)
 
         def sylv_p(mat_b):
             """Solves Sylvester equation for vertical component."""
             return gs.linalg.solve_sylvester(
-                p_top_p, p_top_p, mat_b - Matrices.transpose(mat_b)
+                p_top_p, p_top_p, mat_b - gs.transpose(mat_b)
             )
 
-        z_top = Matrices.transpose(horizontal_vec_z)
-        y_top = Matrices.transpose(horizontal_vec_y)
+        z_top = gs.transpose(horizontal_vec_z)
+        y_top = gs.transpose(horizontal_vec_y)
         omega_yz = sylv_p(gs.matmul(z_top, horizontal_vec_y))
         a_y_z = gs.matmul(base_point, omega_yz)
         omega_xy = sylv_p(gs.matmul(y_top, horizontal_vec_x))
@@ -635,24 +635,24 @@ class PreShapeBundle(FiberBundle):
         if not gs.all(self.is_horizontal(horizontal_vec_y, base_point)):
             raise ValueError("Tangent vector y is not horizontal")
 
-        p_top = Matrices.transpose(base_point)
+        p_top = gs.transpose(base_point)
         p_top_p = gs.matmul(p_top, base_point)
 
         def sylv_p(mat_b):
             """Solves Sylvester equation for vertical component."""
             return gs.linalg.solve_sylvester(
-                p_top_p, p_top_p, mat_b - Matrices.transpose(mat_b)
+                p_top_p, p_top_p, mat_b - gs.transpose(mat_b)
             )
 
-        y_top = Matrices.transpose(horizontal_vec_y)
-        x_top = Matrices.transpose(horizontal_vec_x)
+        y_top = gs.transpose(horizontal_vec_y)
+        x_top = gs.transpose(horizontal_vec_x)
         x_y_top = gs.matmul(y_top, horizontal_vec_x)
         omega_xy = sylv_p(x_y_top)
         vertical_vec_v = gs.matmul(base_point, omega_xy)
         omega_xy_x = gs.matmul(horizontal_vec_x, omega_xy)
         omega_xy_y = gs.matmul(horizontal_vec_y, omega_xy)
 
-        v_top = Matrices.transpose(vertical_vec_v)
+        v_top = gs.transpose(vertical_vec_v)
         x_v_top = gs.matmul(v_top, horizontal_vec_x)
         omega_xv = sylv_p(x_v_top)
         omega_xv_p = gs.matmul(base_point, omega_xv)
@@ -908,9 +908,9 @@ class KendallShapeMetric(QuotientMetric):
             coef = self.inner_product(speed, state, gamma_t)
             normal = gs.einsum("...,...ij->...ij", coef, gamma_t)
 
-            align = gs.matmul(Matrices.transpose(speed), state)
-            right = align - Matrices.transpose(align)
-            left = gs.matmul(Matrices.transpose(gamma_t), gamma_t)
+            align = gs.matmul(gs.transpose(speed), state)
+            right = align - gs.transpose(align)
+            left = gs.matmul(gs.transpose(gamma_t), gamma_t)
             skew_ = gs.linalg.solve_sylvester(left, left, right)
             vertical_ = -gs.matmul(gamma_t, skew_)
             return vertical_ - normal

--- a/geomstats/geometry/rank_k_psd_matrices.py
+++ b/geomstats/geometry/rank_k_psd_matrices.py
@@ -103,7 +103,7 @@ class RankKPSDMatrices(Manifold):
         """
         sym = Matrices.to_symmetric(point)
         _, s, v = gs.linalg.svd(sym)
-        h = gs.matmul(Matrices.transpose(v), s[..., None] * v)
+        h = gs.matmul(gs.transpose(v), s[..., None] * v)
         sym_proj = (sym + h) / 2
         eigvals, eigvecs = gs.linalg.eigh(sym_proj)
         k = self.n - self.rank
@@ -113,7 +113,7 @@ class RankKPSDMatrices(Manifold):
         )
         reconstruction = gs.einsum("...ij,...j->...ij", eigvecs, regularized)
 
-        return Matrices.mul(reconstruction, Matrices.transpose(eigvecs))
+        return Matrices.mul(reconstruction, gs.transpose(eigvecs))
 
     def random_point(self, n_samples=1, bound=1.0):
         r"""Sample in PSD(n,k) from the log-uniform distribution.
@@ -162,7 +162,7 @@ class RankKPSDMatrices(Manifold):
 
         r, _, _ = gs.linalg.svd(base_point)
         r_ort = r[..., :, -(self.n - self.rank) :]
-        r_ort_t = Matrices.transpose(r_ort)
+        r_ort_t = gs.transpose(r_ort)
         rr = gs.matmul(r_ort, r_ort_t)
         candidates = Matrices.mul(rr, vector_sym, rr)
         return gs.all(gs.isclose(candidates, 0.0, atol=atol), axis=(-2, -1))
@@ -186,7 +186,7 @@ class RankKPSDMatrices(Manifold):
         vector_sym = Matrices.to_symmetric(vector)
         r, _, _ = gs.linalg.svd(base_point)
         r_ort = r[..., :, : (self.rank - 1)]
-        r_ort_t = Matrices.transpose(r_ort)
+        r_ort_t = gs.transpose(r_ort)
         rr = gs.matmul(r_ort, r_ort_t)
         return vector_sym - Matrices.mul(rr, vector_sym, rr)
 
@@ -233,12 +233,12 @@ class BuresWassersteinBundle(FiberBundle):
     @staticmethod
     def riemannian_submersion(point):
         """Project."""
-        return Matrices.mul(point, Matrices.transpose(point))
+        return Matrices.mul(point, gs.transpose(point))
 
     def tangent_riemannian_submersion(self, tangent_vec, base_point):
         """Differential."""
-        product = Matrices.mul(base_point, Matrices.transpose(tangent_vec))
-        return product + Matrices.transpose(product)
+        product = Matrices.mul(base_point, gs.transpose(tangent_vec))
+        return product + gs.transpose(product)
 
     def lift(self, point):
         """Find a representer in top space."""
@@ -253,7 +253,7 @@ class BuresWassersteinBundle(FiberBundle):
         n = self._total_space.n
         if fiber_point is None:
             fiber_point = self.lift(base_point)
-        transposed_point = Matrices.transpose(fiber_point)
+        transposed_point = gs.transpose(fiber_point)
         alignment = Matrices.mul(transposed_point, fiber_point)
         projector = Matrices.mul(fiber_point, GeneralLinear.inverse(alignment))
         right_term = Matrices.mul(transposed_point, tangent_vec, fiber_point)
@@ -291,10 +291,10 @@ class BuresWassersteinBundle(FiberBundle):
         skew : array-like, shape=[..., m_ambient, m_ambient]
             Vertical component of `tangent_vec`.
         """
-        transposed_point = Matrices.transpose(base_point)
+        transposed_point = gs.transpose(base_point)
         left_term = gs.matmul(transposed_point, base_point)
-        alignment = gs.matmul(Matrices.transpose(tangent_vec), base_point)
-        right_term = alignment - Matrices.transpose(alignment)
+        alignment = gs.matmul(gs.transpose(tangent_vec), base_point)
+        right_term = alignment - gs.transpose(alignment)
         skew = gs.linalg.solve_sylvester(left_term, left_term, right_term)
 
         vertical = -gs.matmul(base_point, skew)

--- a/geomstats/geometry/skew_symmetric_matrices.py
+++ b/geomstats/geometry/skew_symmetric_matrices.py
@@ -136,13 +136,13 @@ class SkewSymmetricMatrices(MatrixLieAlgebra):
         if self.n == 2:
             return matrix_representation[..., 1, 0][..., None]
         if self.n == 3:
-            vec = gs.stack(
+            return gs.stack(
                 [
                     matrix_representation[..., 2, 1],
                     matrix_representation[..., 0, 2],
                     matrix_representation[..., 1, 0],
-                ]
+                ],
+                axis=-1,
             )
-            return gs.transpose(vec)
 
         return gs.triu_to_vec(matrix_representation, k=1)

--- a/geomstats/geometry/spd_matrices.py
+++ b/geomstats/geometry/spd_matrices.py
@@ -86,7 +86,7 @@ def _aux_differential_power(power, tangent_vec, base_point):
     if gs.is_complex(base_point):
         transp_eigvectors = ComplexMatrices.transconjugate(eigvectors)
     else:
-        transp_eigvectors = Matrices.transpose(eigvectors)
+        transp_eigvectors = gs.transpose(eigvectors)
 
     temp_result = Matrices.mul(transp_eigvectors, tangent_vec, eigvectors)
 
@@ -129,7 +129,7 @@ def generalized_eigenvalues(point_a, point_b):
     scaled_b_eigvecs = columnwise_scaling(inv_sqrt_eigvals_b, eigvecs_b)
 
     point_a_scaled = Matrices.mul(
-        Matrices.transpose(scaled_b_eigvecs), point_a, scaled_b_eigvecs
+        gs.transpose(scaled_b_eigvecs), point_a, scaled_b_eigvecs
     )
     return gs.linalg.eigvalsh(point_a_scaled)
 
@@ -436,7 +436,7 @@ class CholeskyMap(Diffeo):
             image_point = cls.__call__(base_point)
 
         inv_base_point = gs.linalg.inv(image_point)
-        inv_transpose_base_point = Matrices.transpose(inv_base_point)
+        inv_transpose_base_point = gs.transpose(inv_base_point)
         aux = Matrices.to_lower_triangular_diagonal_scaled(
             Matrices.mul(inv_base_point, tangent_vec, inv_transpose_base_point)
         )
@@ -532,7 +532,7 @@ class SPDMatrices(VectorSpaceOpenSet):
         eigvals, eigvecs = gs.linalg.eigh(sym)
         regularized = gs.where(eigvals < gs.atol, gs.atol, eigvals)
         reconstruction = gs.einsum("...ij,...j->...ij", eigvecs, regularized)
-        return Matrices.mul(reconstruction, Matrices.transpose(eigvecs))
+        return Matrices.mul(reconstruction, gs.transpose(eigvecs))
 
     def random_point(self, n_samples=1, bound=1.0):
         """Sample in SPD(n) from the log-uniform distribution.
@@ -579,9 +579,7 @@ class SPDMatrices(VectorSpaceOpenSet):
         sqrt_base_point = gs.linalg.sqrtm(base_point)
 
         tangent_vec_at_id_aux = 2 * gs.random.rand(*size) - 1
-        tangent_vec_at_id = tangent_vec_at_id_aux + Matrices.transpose(
-            tangent_vec_at_id_aux
-        )
+        tangent_vec_at_id = tangent_vec_at_id_aux + gs.transpose(tangent_vec_at_id_aux)
 
         return Matrices.mul(sqrt_base_point, tangent_vec_at_id, sqrt_base_point)
 
@@ -805,7 +803,7 @@ class SPDBuresWassersteinMetric(RiemannianMetric):
             Inner-product.
         """
         eigvals, eigvecs = gs.linalg.eigh(base_point)
-        transp_eigvecs = Matrices.transpose(eigvecs)
+        transp_eigvecs = gs.transpose(eigvecs)
         rotated_tangent_vec_a = Matrices.mul(transp_eigvecs, tangent_vec_a, eigvecs)
         rotated_tangent_vec_b = Matrices.mul(transp_eigvecs, tangent_vec_b, eigvecs)
 
@@ -835,7 +833,7 @@ class SPDBuresWassersteinMetric(RiemannianMetric):
             Riemannian exponential.
         """
         eigvals, eigvecs = gs.linalg.eigh(base_point)
-        transp_eigvecs = Matrices.transpose(eigvecs)
+        transp_eigvecs = gs.transpose(eigvecs)
         rotated_tangent_vec = Matrices.mul(transp_eigvecs, tangent_vec, eigvecs)
         coefficients = 1 / (eigvals[..., :, None] + eigvals[..., None, :])
         rotated_sylvester = rotated_tangent_vec * coefficients
@@ -868,7 +866,7 @@ class SPDBuresWassersteinMetric(RiemannianMetric):
         sqrt_bp, inv_sqrt_bp = powermh(base_point, [0.5, -0.5])
         pdt = powermh(Matrices.mul(sqrt_bp, point, sqrt_bp), 0.5)
         sqrt_product = Matrices.mul(sqrt_bp, pdt, inv_sqrt_bp)
-        transp_sqrt_product = Matrices.transpose(sqrt_product)
+        transp_sqrt_product = gs.transpose(sqrt_product)
         return sqrt_product + transp_sqrt_product - 2 * base_point
 
     def squared_dist(self, point_a, point_b):
@@ -969,7 +967,7 @@ class SPDBuresWassersteinMetric(RiemannianMetric):
 
         horizontal_velocity = gs.matmul(inverse_square_root_bp, square_root_lift)
         partial_horizontal_velocity = Matrices.mul(horizontal_velocity, square_root_bp)
-        partial_horizontal_velocity = partial_horizontal_velocity + Matrices.transpose(
+        partial_horizontal_velocity = partial_horizontal_velocity + gs.transpose(
             partial_horizontal_velocity
         )
 
@@ -985,15 +983,15 @@ class SPDBuresWassersteinMetric(RiemannianMetric):
 
             align = Matrices.mul(
                 horizontal_geodesic_t,
-                Matrices.transpose(horizontal_velocity - square_root_bp),
+                gs.transpose(horizontal_velocity - square_root_bp),
                 state,
             )
-            right = align + Matrices.transpose(align)
+            right = align + gs.transpose(align)
             return gs.linalg.solve_sylvester(geodesic_t, geodesic_t, -right)
 
         flow = integrate(force, horizontal_lift_a, n_steps=n_steps, step=step)
         final_align = Matrices.mul(end_point, flow[-1])
-        return final_align + Matrices.transpose(final_align)
+        return final_align + gs.transpose(final_align)
 
     def injectivity_radius(self, base_point):
         """Compute the upper bound of the injectivity domain.

--- a/geomstats/geometry/special_euclidean.py
+++ b/geomstats/geometry/special_euclidean.py
@@ -149,7 +149,7 @@ class _SpecialEuclideanMatrices(MatrixLieGroup, LevelSet):
         rot = point[..., :n, :n]
         vec = point[..., n, :n]
         scalar = point[..., n, n]
-        submersed_rot = Matrices.mul(rot, Matrices.transpose(rot))
+        submersed_rot = Matrices.mul(rot, gs.transpose(rot))
         return (
             homogeneous_representation(submersed_rot, vec, constant=scalar)
             - self._value
@@ -175,9 +175,7 @@ class _SpecialEuclideanMatrices(MatrixLieGroup, LevelSet):
         skew = vector[..., :n, :n]
         vec = vector[..., n, :n]
         scalar = vector[..., n, n]
-        submersed_rot = Matrices.to_symmetric(
-            Matrices.mul(Matrices.transpose(skew), rot)
-        )
+        submersed_rot = Matrices.to_symmetric(Matrices.mul(gs.transpose(skew), rot))
         return homogeneous_representation(submersed_rot, vec, constant=scalar)
 
     def random_point(self, n_samples=1, bound=1.0):
@@ -221,7 +219,7 @@ class _SpecialEuclideanMatrices(MatrixLieGroup, LevelSet):
             Inverse of point.
         """
         n = point.shape[-1] - 1
-        transposed_rot = Matrices.transpose(point[..., :n, :n])
+        transposed_rot = gs.transpose(point[..., :n, :n])
         translation = point[..., :n, -1]
         translation = gs.einsum("...ij,...j->...i", transposed_rot, translation)
         return homogeneous_representation(transposed_rot, -translation)
@@ -648,7 +646,7 @@ class _SpecialEuclidean2Vectors(_SpecialEuclideanVectors):
             rot_vec**2, utils.cosc_close_0, order=4
         )
         transform = gs.einsum(
-            "...l, ...jk -> ...jk", inv_determinant, Matrices.transpose(exp_transform)
+            "...l, ...jk -> ...jk", inv_determinant, gs.transpose(exp_transform)
         )
 
         return transform

--- a/geomstats/geometry/special_orthogonal.py
+++ b/geomstats/geometry/special_orthogonal.py
@@ -56,7 +56,7 @@ class _SpecialOrthogonalMatrices(MatrixLieGroup, LevelSet):
         return GeneralLinear(self.n, positive_det=True, equip=False)
 
     def _aux_submersion(self, point):
-        return Matrices.mul(Matrices.transpose(point), point)
+        return Matrices.mul(gs.transpose(point), point)
 
     def submersion(self, point):
         """Submersion that defines the manifold.
@@ -83,9 +83,7 @@ class _SpecialOrthogonalMatrices(MatrixLieGroup, LevelSet):
         -------
         submersed_vector : array-like, shape=[..., n, n]
         """
-        return 2 * Matrices.to_symmetric(
-            Matrices.mul(Matrices.transpose(point), vector)
-        )
+        return 2 * Matrices.to_symmetric(Matrices.mul(gs.transpose(point), vector))
 
     @classmethod
     def inverse(cls, point):
@@ -101,7 +99,7 @@ class _SpecialOrthogonalMatrices(MatrixLieGroup, LevelSet):
         inverse : array-like, shape=[..., n, n]
             Inverse.
         """
-        return Matrices.transpose(point)
+        return gs.transpose(point)
 
     def projection(self, point):
         """Project a matrix on SO(n) by minimizing the Frobenius norm.
@@ -855,7 +853,7 @@ class _SpecialOrthogonal3Vectors(_SpecialOrthogonalVectors):
         trace_num = gs.clip(trace, -1, 3)
         angle = gs.arccos(0.5 * (trace_num - 1))
 
-        rot_mat_transpose = Matrices.transpose(rot_mat)
+        rot_mat_transpose = gs.transpose(rot_mat)
         rot_vec_not_pi = self.skew.basis_representation(rot_mat - rot_mat_transpose)
 
         mask_0 = gs.cast(gs.isclose(angle, 0.0), angle.dtype)

--- a/geomstats/geometry/stiefel.py
+++ b/geomstats/geometry/stiefel.py
@@ -64,7 +64,7 @@ class Stiefel(LevelSet):
         -------
         submersed_point : array-like, shape=[..., n, p]
         """
-        return Matrices.mul(Matrices.transpose(point), point) - self._value
+        return Matrices.mul(gs.transpose(point), point) - self._value
 
     def tangent_submersion(self, vector, point):
         """Tangent submersion.
@@ -78,9 +78,7 @@ class Stiefel(LevelSet):
         -------
         submersed_vector : array-like, shape=[..., n, p]
         """
-        return 2 * Matrices.to_symmetric(
-            Matrices.mul(Matrices.transpose(point), vector)
-        )
+        return 2 * Matrices.to_symmetric(Matrices.mul(gs.transpose(point), vector))
 
     @staticmethod
     def to_grassmannian(point):
@@ -101,7 +99,7 @@ class Stiefel(LevelSet):
         projected : array-like, shape=[..., n, n]
             Projected point.
         """
-        return Matrices.mul(point, Matrices.transpose(point))
+        return Matrices.mul(point, gs.transpose(point))
 
     def random_uniform(self, n_samples=1):
         r"""Sample on St(n,p) from the uniform distribution.
@@ -125,7 +123,7 @@ class Stiefel(LevelSet):
         size = (n_samples, n, p) if n_samples != 1 else (n, p)
 
         std_normal = gs.random.normal(size=size)
-        std_normal_transpose = Matrices.transpose(std_normal)
+        std_normal_transpose = gs.transpose(std_normal)
         aux = Matrices.mul(std_normal_transpose, std_normal)
         inv_sqrt_aux = powermh(aux, -1.0 / 2)
         samples = Matrices.mul(std_normal, inv_sqrt_aux)
@@ -171,7 +169,7 @@ class Stiefel(LevelSet):
         tangent_vec : array-like, shape=[..., n, p]
             Tangent vector at base point.
         """
-        aux = Matrices.mul(Matrices.transpose(base_point), vector)
+        aux = Matrices.mul(gs.transpose(base_point), vector)
         sym_aux = Matrices.to_symmetric(aux)
         return vector - Matrices.mul(base_point, sym_aux)
 
@@ -243,10 +241,10 @@ class StiefelCanonicalMetric(RiemannianMetric):
             322-342, 2017. https://epubs.siam.org/doi/pdf/10.1137/16M1074485
 
         """
-        base_point_transpose = Matrices.transpose(base_point)
+        base_point_transpose = gs.transpose(base_point)
 
         aux = gs.matmul(
-            Matrices.transpose(tangent_vec_a),
+            gs.transpose(tangent_vec_a),
             gs.eye(self._space.n) - 0.5 * gs.matmul(base_point, base_point_transpose),
         )
         return Matrices.trace_product(aux, tangent_vec_b)
@@ -268,12 +266,12 @@ class StiefelCanonicalMetric(RiemannianMetric):
             of tangent_vec at the base point.
         """
         p = self._space.p
-        matrix_a = Matrices.mul(Matrices.transpose(base_point), tangent_vec)
+        matrix_a = Matrices.mul(gs.transpose(base_point), tangent_vec)
         matrix_k = tangent_vec - Matrices.mul(base_point, matrix_a)
 
         matrix_q, matrix_r = gs.linalg.qr(matrix_k)
 
-        matrix_ar = gs.concatenate([matrix_a, -Matrices.transpose(matrix_r)], axis=-1)
+        matrix_ar = gs.concatenate([matrix_a, -gs.transpose(matrix_r)], axis=-1)
 
         zeros = gs.zeros_like(tangent_vec)[..., :p, :p]
         matrix_rz = gs.concatenate([matrix_r, zeros], axis=-1)
@@ -372,7 +370,7 @@ class StiefelCanonicalMetric(RiemannianMetric):
         """
         point, base_point = gs.broadcast_arrays(point, base_point)
 
-        matrix_m = gs.matmul(Matrices.transpose(base_point), point)
+        matrix_m = gs.matmul(gs.transpose(base_point), point)
 
         if gs.any(matrix_m[..., 0, 0] < 0.0):
             raise ValueError("Algorithm does no work if m11 <= 0.")
@@ -491,7 +489,7 @@ class _StiefelLogSolver(LogSolver):
         [matrix_d, _, matrix_r] = gs.linalg.svd(matrix_v[..., p:, p:])
         matrix_v_final = gs.copy(matrix_v)
         for i in range(1, p + 1):
-            matrix_rd = Matrices.mul(matrix_r, Matrices.transpose(matrix_d))
+            matrix_rd = Matrices.mul(matrix_r, gs.transpose(matrix_d))
             sub_matrix_v = gs.matmul(matrix_v[..., :, p:], matrix_rd)
             matrix_v_final = gs.concatenate(
                 [gs.concatenate([matrix_m, matrix_n], axis=-2), sub_matrix_v], axis=-1
@@ -504,9 +502,7 @@ class _StiefelLogSolver(LogSolver):
             reflection_vec = gs.concatenate([ones[:-i], gs.array([-1.0] * i)], axis=0)
             mask = gs.cast(det < 0, matrix_v.dtype)
             sign = mask[..., None] * reflection_vec + (1.0 - mask)[..., None] * ones
-            matrix_d = gs.einsum(
-                "...ij,...i->...ij", Matrices.transpose(matrix_d), sign
-            )
+            matrix_d = gs.einsum("...ij,...i->...ij", gs.transpose(matrix_d), sign)
 
         return matrix_v_final
 
@@ -552,7 +548,7 @@ class _StiefelLogSolver(LogSolver):
             if not gs.all(det_point * det_base_point > 0.0):
                 raise ValueError("Points from different sheets in log")
 
-        transpose_base_point = Matrices.transpose(base_point)
+        transpose_base_point = gs.transpose(base_point)
         matrix_m = gs.matmul(transpose_base_point, point)
 
         matrix_q, matrix_n = self._normal_component_qr(point, base_point, matrix_m)

--- a/geomstats/information_geometry/dirichlet.py
+++ b/geomstats/information_geometry/dirichlet.py
@@ -196,7 +196,18 @@ class DirichletMetric(RiemannianMetric):
     def christoffels(self, base_point):
         r"""Compute the Christoffel symbols.
 
-        Compute the Christoffel symbols of the Fisher information metric.
+        Compute the Christoffel symbols of the Fisher information metric:
+
+        .. math::
+
+            \Gamma_{j k}^i=\frac{1}{2}\left[\frac{d_i L_0}{D}-\delta_{j k} \frac{d_i L_j}{D}-\delta_{i j} \delta_{i k} L_i\right]
+
+        where
+
+        .. math::
+
+            d_i=\frac{1}{\psi_1\left(\alpha_i\right)}, \quad L_i=\partial_i \log d_i, \quad L_0=\partial_{\alpha_0} \log d_0, \quad D=d_0-\sum_i d_i
+
 
         Parameters
         ----------
@@ -216,51 +227,54 @@ class DirichletMetric(RiemannianMetric):
             geometry of Dirichlet Distributions. Differential Geometry
             and its Applications, 74, 101702, 2021.
         """
-        base_point = gs.to_ndarray(base_point, to_ndim=2)
-        n_points = base_point.shape[0]
+        dim = self._space.dim
+        param = base_point
 
-        def coefficients(ind_k):
-            """Christoffel symbols for contravariant index ind_k."""
-            param_k = base_point[..., ind_k]
-            param_sum = gs.sum(base_point, -1)
-            c1 = (
-                1
-                / gs.polygamma(1, param_k)
-                / (
-                    1 / gs.polygamma(1, param_sum)
-                    - gs.sum(1 / gs.polygamma(1, base_point), -1)
-                )
+        param_sum = gs.sum(param, axis=-1, keepdims=True)
+
+        trigamma_param = gs.polygamma(1, param)
+        trigamma_sum = gs.polygamma(1, param_sum)
+
+        tetragamma_param = gs.polygamma(2, param)
+        tetragamma_sum = gs.polygamma(2, param_sum)
+
+        inv_trigamma_param = 1 / trigamma_param
+        inv_trigamma_sum = 1 / trigamma_sum
+
+        d_inv_trigamma_param = -tetragamma_param / trigamma_param**2
+        d_inv_trigamma_sum = -tetragamma_sum / trigamma_sum**2
+
+        d_log_inv_trigamma_param = d_inv_trigamma_param / inv_trigamma_param
+        d_log_inv_trigamma_sum = d_inv_trigamma_sum / inv_trigamma_sum
+
+        inv_metric_denominator = inv_trigamma_sum - gs.sum(
+            inv_trigamma_param, axis=-1, keepdims=True
+        )
+
+        eye = gs.eye(dim)
+
+        christoffels_1 = (
+            inv_trigamma_param * d_log_inv_trigamma_sum / inv_metric_denominator
+        )[..., :, None, None]
+
+        christoffels_2 = (
+            -gs.einsum(
+                "...i,...j,jk->...ijk",
+                inv_trigamma_param,
+                d_log_inv_trigamma_param,
+                eye,
             )
-            c2 = -c1 * gs.polygamma(2, param_sum) / gs.polygamma(1, param_sum)
+            / inv_metric_denominator[..., None, None]
+        )
 
-            mat_ones = gs.ones((n_points, self._space.dim, self._space.dim))
-            mat_diag = from_vector_to_diagonal_matrix(
-                -gs.polygamma(2, base_point) / gs.polygamma(1, base_point)
-            )
-            arrays = [
-                gs.zeros((1, ind_k)),
-                gs.ones((1, 1)),
-                gs.zeros((1, self._space.dim - ind_k - 1)),
-            ]
-            vec_k = gs.tile(gs.hstack(arrays), (n_points, 1))
-            val_k = gs.polygamma(2, param_k) / gs.polygamma(1, param_k)
-            vec_k = gs.einsum("i,ij->ij", val_k, vec_k)
-            mat_k = from_vector_to_diagonal_matrix(vec_k)
+        christoffels_3 = -gs.einsum(
+            "...i,ij,ik->...ijk",
+            d_log_inv_trigamma_param,
+            eye,
+            eye,
+        )
 
-            mat = (
-                gs.einsum("i,ijk->ijk", c2, mat_ones)
-                - gs.einsum("i,ijk->ijk", c1, mat_diag)
-                + mat_k
-            )
-
-            return 1 / 2 * mat
-
-        christoffels = []
-        for ind_k in range(self._space.dim):
-            christoffels.append(coefficients(ind_k))
-        christoffels = gs.stack(christoffels, 1)
-
-        return gs.squeeze(christoffels)
+        return 1 / 2 * (christoffels_1 + christoffels_2 + christoffels_3)
 
     def jacobian_christoffels(self, base_point):
         r"""Compute the Jacobian of the Christoffel symbols.
@@ -280,58 +294,95 @@ class DirichletMetric(RiemannianMetric):
             :math:`jac[..., i, j, k, l] = dGamma^i_{jk} / dx_l`
         """
         dim = self._space.dim
-        n_dim = base_point.ndim
-        param = gs.transpose(base_point)
-        sum_param = gs.sum(param, 0)
-        term_1 = 1 / gs.polygamma(1, param)
-        term_2 = 1 / gs.polygamma(1, sum_param)
-        term_3 = -gs.polygamma(2, param) / gs.polygamma(1, param) ** 2
-        term_4 = -gs.polygamma(2, sum_param) / gs.polygamma(1, sum_param) ** 2
-        term_5 = term_3 / term_1
-        term_6 = term_4 / term_2
-        term_7 = (
-            gs.polygamma(2, param) ** 2
-            - gs.polygamma(1, param) * gs.polygamma(3, param)
-        ) / gs.polygamma(1, param) ** 2
-        term_8 = (
-            gs.polygamma(2, sum_param) ** 2
-            - gs.polygamma(1, sum_param) * gs.polygamma(3, sum_param)
-        ) / gs.polygamma(1, sum_param) ** 2
-        term_9 = term_2 - gs.sum(term_1, 0)
+        param = base_point
 
-        jac_1 = term_1 * term_8 / term_9
-        jac_1_mat = gs.squeeze(gs.tile(jac_1, (dim, dim, dim, 1, 1)))
-        jac_2 = (
-            -term_6 / term_9**2 * gs.einsum("j...,i...->ji...", term_4 - term_3, term_1)
+        param_sum = gs.sum(param, axis=-1, keepdims=True)
+
+        trigamma_param = gs.polygamma(1, param)
+        trigamma_sum = gs.polygamma(1, param_sum)
+
+        tetragamma_param = gs.polygamma(2, param)
+        tetragamma_sum = gs.polygamma(2, param_sum)
+
+        pentagamma_param = gs.polygamma(3, param)
+        pentagamma_sum = gs.polygamma(3, param_sum)
+
+        inv_trigamma_param = 1 / trigamma_param
+        inv_trigamma_sum = 1 / trigamma_sum
+
+        d_inv_trigamma_param = -tetragamma_param / trigamma_param**2
+        d_inv_trigamma_sum = -tetragamma_sum / trigamma_sum**2
+
+        d_log_inv_trigamma_param = d_inv_trigamma_param / inv_trigamma_param
+        d_log_inv_trigamma_sum = d_inv_trigamma_sum / inv_trigamma_sum
+
+        dd_log_inv_trigamma_param = (
+            tetragamma_param**2 - trigamma_param * pentagamma_param
+        ) / trigamma_param**2
+        dd_log_inv_trigamma_sum = (
+            tetragamma_sum**2 - trigamma_sum * pentagamma_sum
+        ) / trigamma_sum**2
+
+        inv_metric_denominator = inv_trigamma_sum - gs.sum(
+            inv_trigamma_param, axis=-1, keepdims=True
         )
-        jac_2_mat = gs.squeeze(gs.tile(jac_2, (dim, dim, 1, 1, 1)))
-        jac_3 = term_3 * term_6 / term_9
-        jac_3_mat = gs.transpose(from_vector_to_diagonal_matrix(gs.transpose(jac_3)))
-        jac_3_mat = gs.squeeze(gs.tile(jac_3_mat, (dim, dim, 1, 1, 1)))
-        jac_4 = (
-            1
-            / term_9**2
-            * gs.einsum("k...,j...,i...->kji...", term_5, term_4 - term_3, term_1)
+
+        grad_inv_metric_denominator = d_inv_trigamma_sum - d_inv_trigamma_param
+
+        eye = gs.eye(dim)
+
+        jac_1 = inv_trigamma_param * dd_log_inv_trigamma_sum / inv_metric_denominator
+        jac_1_mat = jac_1[..., :, None, None, None]
+
+        jac_2 = (-d_log_inv_trigamma_sum / inv_metric_denominator**2)[
+            ..., None
+        ] * gs.einsum(
+            "...i,...l->...il",
+            inv_trigamma_param,
+            grad_inv_metric_denominator,
         )
-        jac_4_mat = gs.transpose(from_vector_to_diagonal_matrix(gs.transpose(jac_4)))
-        jac_5 = -gs.einsum("j...,i...->ji...", term_7, term_1) / term_9
-        jac_5_mat = from_vector_to_diagonal_matrix(gs.transpose(jac_5))
-        jac_5_mat = gs.transpose(from_vector_to_diagonal_matrix(jac_5_mat))
-        jac_6 = -gs.einsum("k...,j...->kj...", term_5, term_3) / term_9
-        jac_6_mat = gs.transpose(from_vector_to_diagonal_matrix(gs.transpose(jac_6)))
-        jac_6_mat = (
-            gs.permute_dims(
-                from_vector_to_diagonal_matrix(
-                    gs.permute_dims(jac_6_mat, [0, 1, 3, 2])
-                ),
-                [0, 1, 3, 4, 2],
+        jac_2_mat = jac_2[..., :, None, None, :]
+
+        jac_3 = d_inv_trigamma_param * d_log_inv_trigamma_sum / inv_metric_denominator
+        jac_3_mat = from_vector_to_diagonal_matrix(jac_3)[..., :, None, None, :]
+
+        jac_4_mat = (1 / inv_metric_denominator**2)[..., None, None, None] * gs.einsum(
+            "...i,...j,...l,jk->...ijkl",
+            inv_trigamma_param,
+            d_log_inv_trigamma_param,
+            grad_inv_metric_denominator,
+            eye,
+        )
+
+        jac_5_mat = (
+            -gs.einsum(
+                "...i,...j,jk,jl->...ijkl",
+                inv_trigamma_param,
+                dd_log_inv_trigamma_param,
+                eye,
+                eye,
             )
-            if n_dim > 1
-            else from_vector_to_diagonal_matrix(jac_6_mat)
+            / inv_metric_denominator[..., None, None, None]
         )
-        jac_7 = -from_vector_to_diagonal_matrix(gs.transpose(term_7))
-        jac_7_mat = from_vector_to_diagonal_matrix(jac_7)
-        jac_7_mat = gs.transpose(from_vector_to_diagonal_matrix(jac_7_mat))
+
+        jac_6_mat = (
+            -gs.einsum(
+                "...i,...j,jk,il->...ijkl",
+                d_inv_trigamma_param,
+                d_log_inv_trigamma_param,
+                eye,
+                eye,
+            )
+            / inv_metric_denominator[..., None, None, None]
+        )
+
+        jac_7_mat = -gs.einsum(
+            "...i,ij,ik,il->...ijkl",
+            dd_log_inv_trigamma_param,
+            eye,
+            eye,
+            eye,
+        )
 
         jac = (
             1
@@ -346,12 +397,7 @@ class DirichletMetric(RiemannianMetric):
                 + jac_7_mat
             )
         )
-
-        return (
-            gs.permute_dims(jac, [3, 1, 0, 2])
-            if n_dim == 1
-            else gs.permute_dims(jac, [4, 3, 1, 0, 2])
-        )
+        return jac
 
     def injectivity_radius(self, base_point=None):
         """Compute the radius of the injectivity domain.

--- a/geomstats/information_geometry/dirichlet.py
+++ b/geomstats/information_geometry/dirichlet.py
@@ -320,8 +320,10 @@ class DirichletMetric(RiemannianMetric):
         jac_6 = -gs.einsum("k...,j...->kj...", term_5, term_3) / term_9
         jac_6_mat = gs.transpose(from_vector_to_diagonal_matrix(gs.transpose(jac_6)))
         jac_6_mat = (
-            gs.transpose(
-                from_vector_to_diagonal_matrix(gs.transpose(jac_6_mat, [0, 1, 3, 2])),
+            gs.permute_dims(
+                from_vector_to_diagonal_matrix(
+                    gs.permute_dims(jac_6_mat, [0, 1, 3, 2])
+                ),
                 [0, 1, 3, 4, 2],
             )
             if n_dim > 1
@@ -346,9 +348,9 @@ class DirichletMetric(RiemannianMetric):
         )
 
         return (
-            gs.transpose(jac, [3, 1, 0, 2])
+            gs.permute_dims(jac, [3, 1, 0, 2])
             if n_dim == 1
-            else gs.transpose(jac, [4, 3, 1, 0, 2])
+            else gs.permute_dims(jac, [4, 3, 1, 0, 2])
         )
 
     def injectivity_radius(self, base_point=None):

--- a/geomstats/information_geometry/multinomial.py
+++ b/geomstats/information_geometry/multinomial.py
@@ -230,8 +230,8 @@ class MultinomialDistributions(InformationManifoldMixin, LevelSet):
             Tangent vector in the tangent space of the simplex
             at the base point.
         """
-        component_mean = gs.mean(vector, axis=-1)
-        tangent_vec = gs.transpose(gs.transpose(vector) - component_mean)
+        component_mean = gs.mean(vector, axis=-1, keepdims=True)
+        tangent_vec = vector - component_mean
 
         return repeat_out(
             self.point_ndim, tangent_vec, vector, base_point, out_shape=self.shape

--- a/geomstats/learning/kalman_filter.py
+++ b/geomstats/learning/kalman_filter.py
@@ -374,7 +374,7 @@ class Localization:
         """
         theta, _, _ = state
         rot = self.rotation_matrix(theta)
-        return Matrices.mul(Matrices.transpose(rot), observation_cov, rot)
+        return Matrices.mul(gs.transpose(rot), observation_cov, rot)
 
     def observation_model(self, state):
         """Model used to create the measurements.
@@ -415,7 +415,7 @@ class Localization:
         theta, _, _ = state
         rot = self.rotation_matrix(theta)
         expected = self.observation_model(state)
-        return gs.matvec(Matrices.transpose(rot), observation - expected)
+        return gs.matvec(gs.transpose(rot), observation - expected)
 
 
 class KalmanFilter:
@@ -464,8 +464,8 @@ class KalmanFilter:
         prop_jac = self.model.propagation_jacobian(self.state, sensor_input)
         noise_jac = self.model.noise_jacobian(self.state, sensor_input)
 
-        prop_cov = Matrices.mul(prop_jac, self.covariance, Matrices.transpose(prop_jac))
-        noise_cov = Matrices.mul(noise_jac, prop_noise, Matrices.transpose(noise_jac))
+        prop_cov = Matrices.mul(prop_jac, self.covariance, gs.transpose(prop_jac))
+        noise_cov = Matrices.mul(noise_jac, prop_noise, gs.transpose(noise_jac))
         self.covariance = prop_cov + noise_cov
         self.state = self.model.propagate(self.state, sensor_input)
 
@@ -491,12 +491,10 @@ class KalmanFilter:
             self.state, self.measurement_noise
         )
         obs_jac = self.model.observation_jacobian(self.state, observation)
-        expected_cov = Matrices.mul(
-            obs_jac, self.covariance, Matrices.transpose(obs_jac)
-        )
+        expected_cov = Matrices.mul(obs_jac, self.covariance, gs.transpose(obs_jac))
         innovation_cov = expected_cov + obs_cov
         return Matrices.mul(
-            self.covariance, Matrices.transpose(obs_jac), gs.linalg.inv(innovation_cov)
+            self.covariance, gs.transpose(obs_jac), gs.linalg.inv(innovation_cov)
         )
 
     def update(self, observation):

--- a/geomstats/numerics/geodesic.py
+++ b/geomstats/numerics/geodesic.py
@@ -557,7 +557,8 @@ class LogODESolver(_LogBatchMixins, LogSolver):
         """
         dim = self._space.dim
         n_nodes = raveled_state.shape[-1]
-        position, velocity = gs.transpose(raveled_state[:dim]), raveled_state[dim:]
+        position = gs.moveaxis(raveled_state[:dim], -1, 0)
+        velocity = raveled_state[dim:]
 
         dgamma = self._space.connection.jacobian_christoffels(position)
 
@@ -569,18 +570,17 @@ class LogODESolver(_LogBatchMixins, LogSolver):
         df_dvelocity = -2 * gs.einsum("...ijk,k...->ij...", gamma, velocity)
 
         jac_nw = gs.zeros((dim, dim, raveled_state.shape[1]))
-        jac_ne = gs.squeeze(gs.transpose(gs.tile(gs.eye(dim), (n_nodes, 1, 1))))
+        jac_ne = gs.squeeze(gs.permute_dims(gs.tile(gs.eye(dim), (n_nodes, 1, 1))))
+
         jac_sw = df_dposition
         jac_se = df_dvelocity
-        jac = gs.concatenate(
+        return gs.concatenate(
             (
                 gs.concatenate((jac_nw, jac_ne), axis=1),
                 gs.concatenate((jac_sw, jac_se), axis=1),
             ),
             axis=0,
         )
-
-        return jac
 
     def _solve(self, point, base_point):
         bvp = lambda t, state: self._bvp(state)

--- a/geomstats/test_cases/geometry/fiber_bundle.py
+++ b/geomstats/test_cases/geometry/fiber_bundle.py
@@ -517,10 +517,10 @@ class GeneralLinearBuresWassersteinBundle(FiberBundle):
 
     @staticmethod
     def riemannian_submersion(point):
-        return Matrices.mul(point, Matrices.transpose(point))
+        return Matrices.mul(point, gs.transpose(point))
 
     def tangent_riemannian_submersion(self, tangent_vec, base_point):
-        product = Matrices.mul(base_point, Matrices.transpose(tangent_vec))
+        product = Matrices.mul(base_point, gs.transpose(tangent_vec))
         return 2 * Matrices.to_symmetric(product)
 
     def horizontal_lift(self, tangent_vec, base_point=None, fiber_point=None):

--- a/geomstats/test_cases/geometry/matrices.py
+++ b/geomstats/test_cases/geometry/matrices.py
@@ -114,13 +114,13 @@ class MatrixOperationsTestCase(TestCase):
         self.assertAllClose(left, right, atol=atol)
 
     def test_transpose(self, mat, expected, atol):
-        res = Matrices.transpose(mat)
+        res = gs.transpose(mat)
         self.assertAllClose(res, expected, atol=atol)
 
     @pytest.mark.vec
     def test_transpose_vec(self, n_reps, atol):
         mat = self.data_generator.random_mat()
-        expected = Matrices.transpose(mat)
+        expected = gs.transpose(mat)
 
         vec_data = generate_vectorization_data(
             data=[dict(mat=mat, expected=expected, atol=atol)],

--- a/geomstats/test_cases/geometry/pre_shape.py
+++ b/geomstats/test_cases/geometry/pre_shape.py
@@ -56,10 +56,10 @@ def integrability_tensor_alt(total_space, tangent_vec_a, tangent_vec_b, base_poi
     horizontal_b = tangent_vec_b - vertical_b
 
     # For the horizontal part of b
-    transposed_point = Matrices.transpose(base_point)
+    transposed_point = gs.transpose(base_point)
     sigma = gs.matmul(transposed_point, base_point)
-    alignment = gs.matmul(Matrices.transpose(horizontal_a), horizontal_b)
-    right_term = alignment - Matrices.transpose(alignment)
+    alignment = gs.matmul(gs.transpose(horizontal_a), horizontal_b)
+    right_term = alignment - gs.transpose(alignment)
     skew_hor = gs.linalg.solve_sylvester(sigma, sigma, right_term)
     vertical = -gs.matmul(base_point, skew_hor)
 
@@ -162,15 +162,15 @@ class PreShapeBundleTestCase(FiberBundleTestCase):
         base_point = self.data_generator.random_point(n_points)
         tangent_vec = self.data_generator.random_tangent_vec(base_point)
 
-        transposed_point = Matrices.transpose(base_point)
+        transposed_point = gs.transpose(base_point)
         tmp_expected = gs.matmul(transposed_point, tangent_vec)
-        expected = Matrices.transpose(tmp_expected) - tmp_expected
+        expected = gs.transpose(tmp_expected) - tmp_expected
 
         vertical = self.total_space.fiber_bundle.vertical_projection(
             tangent_vec, base_point
         )
         tmp_result = gs.matmul(transposed_point, vertical)
-        result = Matrices.transpose(tmp_result) - tmp_result
+        result = gs.transpose(tmp_result) - tmp_result
 
         self.assertAllClose(result, expected, atol=atol)
 
@@ -183,8 +183,8 @@ class PreShapeBundleTestCase(FiberBundleTestCase):
             tangent_vec, base_point
         )
 
-        result = gs.matmul(Matrices.transpose(base_point), horizontal)
-        self.assertAllClose(result, Matrices.transpose(result), atol=atol)
+        result = gs.matmul(gs.transpose(base_point), horizontal)
+        self.assertAllClose(result, gs.transpose(result), atol=atol)
 
     @pytest.mark.random
     def test_horizontal_projection_is_tangent(self, n_points, atol):
@@ -204,8 +204,8 @@ class PreShapeBundleTestCase(FiberBundleTestCase):
         base_point = self.data_generator.random_point(n_points)
 
         aligned_point = self.total_space.fiber_bundle.align(point, base_point)
-        alignment = Matrices.mul(Matrices.transpose(aligned_point), base_point)
-        self.assertAllClose(alignment, Matrices.transpose(alignment), atol=atol)
+        alignment = Matrices.mul(gs.transpose(aligned_point), base_point)
+        self.assertAllClose(alignment, gs.transpose(alignment), atol=atol)
 
     @pytest.mark.random
     def test_integrability_tensor_identity_1(self, n_points, atol):

--- a/geomstats/test_cases/learning/wrapped_gaussian_process.py
+++ b/geomstats/test_cases/learning/wrapped_gaussian_process.py
@@ -74,7 +74,7 @@ class WrappedGaussianProcessTestCase(BaseEstimatorTestCase):
 
         self.estimator.fit(X, y)
         y_ = self.estimator.sample_y(X)
-        y_ = gs.reshape(gs.transpose(y_, [0, 2, 1]), (-1, y_.shape[1]))
+        y_ = gs.reshape(gs.transpose(y_), (-1, y_.shape[1]))
 
         res = self.estimator.space.belongs(y_, atol=atol)
         expected = gs.ones(n_samples, dtype=bool)

--- a/geomstats/visualization/pre_shape.py
+++ b/geomstats/visualization/pre_shape.py
@@ -121,8 +121,8 @@ class KendallSphere:
         coords_x = 0.5 * gs.cos(coords_theta) * gs.sin(coords_phi)
         coords_y = 0.5 * gs.sin(coords_theta) * gs.sin(coords_phi)
         coords_z = 0.5 * gs.cos(coords_phi)
-        spherical_coords = gs.transpose(gs.stack((coords_x, coords_y, coords_z)))
-        return spherical_coords
+
+        return gs.stack((coords_x, coords_y, coords_z), axis=-1)
 
     def add_points(self, points):
         """Add points to draw on the Kendall sphere."""
@@ -364,8 +364,7 @@ class KendallDisk:
         coords_r, coords_theta = self.convert_to_polar_coordinates(points)
         coords_x = coords_r * gs.cos(coords_theta)
         coords_y = coords_r * gs.sin(coords_theta)
-        planar_coords = gs.transpose(gs.stack((coords_x, coords_y)))
-        return planar_coords
+        return gs.stack((coords_x, coords_y), axis=-1)
 
     def add_points(self, points):
         """Add points to draw on the Kendall disk."""

--- a/notebooks/09_practical_methods__implement_your_own_riemannian_geometry.ipynb
+++ b/notebooks/09_practical_methods__implement_your_own_riemannian_geometry.ipynb
@@ -434,7 +434,7 @@
     "        \"\"\"Immersion.\"\"\"\n",
     "        x = point[..., 0]\n",
     "        y = point[..., 1]\n",
-    "        return gs.transpose(gs.stack([x, y, self.graph(x, y)]))"
+    "        return gs.stack([x, y, self.graph(x, y)], axis=-1)"
    ]
   },
   {

--- a/tests/tests_geomstats/test_geometry/test_matrices.py
+++ b/tests/tests_geomstats/test_geometry/test_matrices.py
@@ -117,7 +117,7 @@ class MatrixOperationsDataGenerator:
         return LowerTriangularMatrices(*shape).random_point(n_points)
 
     def random_upper_triangular_mat(self, n_points=1, shape=None):
-        return Matrices.transpose(self.random_lower_triangular_mat(n_points, shape))
+        return gs.transpose(self.random_lower_triangular_mat(n_points, shape))
 
     def random_spd_mat(self, n_points=1, shape=None):
         if shape is None:


### PR DESCRIPTION
This PR fixes #2116.

`permute_dims` (see [numpy](https://numpy.org/doc/2.2/reference/generated/numpy.permute_dims.html) and [torch](https://docs.pytorch.org/docs/2.12/generated/torch.permute.html)) is also added to the backend to replace misuses of `gs.transpose`.