### PR TITLE
bug: raise clear error in log for antipodal points

### DIFF
--- a/geomstats/geometry/hypersphere.py
+++ b/geomstats/geometry/hypersphere.py
@@ -766,6 +766,11 @@ class HypersphereMetric(RiemannianMetric):
             of point at the base point.
         """
         inner_prod = self._space.embedding_space.metric.inner_product(base_point, point)
+        if gs.any(gs.isclose(inner_prod, -1.0)):
+            raise ValueError(
+                "The Logarithm is not well-defined for antipodal points: "
+                f"{point} and {base_point}."
+            )
         cos_angle = gs.clip(inner_prod, -1.0, 1.0)
         squared_angle = gs.arccos(cos_angle) ** 2
         coef_1_ = utils.taylor_exp_even_func(

--- a/geomstats/geometry/stiefel.py
+++ b/geomstats/geometry/stiefel.py
@@ -551,6 +551,12 @@ class _StiefelLogSolver(LogSolver):
         transpose_base_point = gs.transpose(base_point)
         matrix_m = gs.matmul(transpose_base_point, point)
 
+        if gs.any(gs.all(gs.isclose(matrix_m, -gs.eye(p)), axis=(-2, -1))):
+            raise ValueError(
+                "The Logarithm is not well-defined for antipodal points: "
+                f"{point} and {base_point}."
+            )
+
         matrix_q, matrix_n = self._normal_component_qr(point, base_point, matrix_m)
 
         matrix_v = self._orthogonal_completion(matrix_m, matrix_n)

--- a/tests/tests_geomstats/test_geometry/test_hypersphere.py
+++ b/tests/tests_geomstats/test_geometry/test_hypersphere.py
@@ -166,6 +166,12 @@ class TestHypersphere2ExtrinsicMetric(
 
     testing_data = Hypersphere2ExtrinsicMetricTestData()
 
+    def test_log_antipodal_raises(self):
+        """Log of antipodal points is not well-defined."""
+        x = gs.array([1.0, 0.0, 0.0])
+        with pytest.raises(ValueError, match="antipodal"):
+            self.space.metric.log(-x, x)
+
 
 @pytest.mark.smoke
 class TestHypersphere4ExtrinsicMetric(

--- a/tests/tests_geomstats/test_geometry/test_stiefel.py
+++ b/tests/tests_geomstats/test_geometry/test_stiefel.py
@@ -2,6 +2,7 @@ import random
 
 import pytest
 
+import geomstats.backend as gs
 from geomstats.geometry.stiefel import Stiefel, StiefelCanonicalMetric
 from geomstats.test.parametrizers import DataBasedParametrizer, Parametrizer
 from geomstats.test_cases.geometry.stiefel import (
@@ -75,6 +76,13 @@ class TestStiefelCanonicalMetric(
     StiefelCanonicalMetricTestCase, metaclass=DataBasedParametrizer
 ):
     testing_data = StiefelCanonicalMetricTestData()
+
+    def test_log_antipodal_raises(self):
+        """Log of antipodal points is not well-defined."""
+        space = Stiefel(n=3, p=2)
+        point = gs.array([[1.0, 0.0], [0.0, 1.0], [0.0, 0.0]])
+        with pytest.raises(ValueError, match="antipodal"):
+            space.metric.log(-point, point)
 
 
 class TestStiefelCanonicalMetricSquare(


### PR DESCRIPTION
## Summary

Fixes #1218: the logarithm is not well-defined for antipodal points, but `Hypersphere.log` silently returned zero vectors and `Stiefel.log` failed with an obscure complex-matrix error.

Now both raise a clear `ValueError`, consistent with the existing `SOn.log` behaviour (which already checks `are_antipodals`).

## Changes

- **Hypersphere.log**: check `inner_product(base_point, point) ~ -1` before the Taylor expansion (which diverges at antipodal points: `sinc(pi) = tanc(pi) = 0`)
- **Stiefel.log**: check `X^T Y ~ -I_p`, complementing the existing determinant/sheet check (which only covers the `p == n` disconnected case)
- **Tests**: `pytest.raises(ValueError, match="antipodal")` for both spaces

## Verification

- Manual repro before fix: `Hypersphere(2).log(-x, x)` -> `[0, 0, 0]` (silent); `Stiefel(3, 2).log(-X, X)` -> `ValueError: Non-neglible imaginary part` (obscure)
- After fix: both raise `ValueError: The Logarithm is not well-defined for antipodal points`
- Non-antipodal regression: `exp(log(y, x)) == y` preserved
- Full test files: **654 passed, 8 skipped** (test_hypersphere.py + test_stiefel.py)
