### PR TITLE
Add RiemannianMetric.laplacian (Laplace-Beltrami operator)

### DIFF
--- a/geomstats/geometry/product_manifold.py
+++ b/geomstats/geometry/product_manifold.py
@@ -20,22 +20,15 @@ COMPLEX_OBJECTS = (ComplexRiemannianMetric, ComplexManifold)
 
 
 def _factor_is_complex(factor):
-    if (
-        isinstance(factor, COMPLEX_OBJECTS)
-        or hasattr(factor, "underlying_metric")
+    return isinstance(factor, COMPLEX_OBJECTS) or (
+        hasattr(factor, "underlying_metric")
         and isinstance(factor.underlying_metric, COMPLEX_OBJECTS)
-    ):
-        return True
-
-    return False
+    )
 
 
 def _has_mixed_fields(factors):
     bools = [_factor_is_complex(factor) for factor in factors]
-    if len(set(bools)) == 2:
-        return True
-
-    return False
+    return len(set(bools)) == 2
 
 
 def _all_equal(arg):

--- a/geomstats/geometry/product_manifold.py
+++ b/geomstats/geometry/product_manifold.py
@@ -9,8 +9,11 @@ import geomstats.backend as gs
 import geomstats.errors
 from geomstats.geometry.complex_manifold import ComplexManifold
 from geomstats.geometry.complex_riemannian_metric import ComplexRiemannianMetric
+from geomstats.geometry.connection import Connection
 from geomstats.geometry.manifold import Manifold
 from geomstats.geometry.riemannian_metric import RiemannianMetric
+from geomstats.numerics.geodesic import ExpODESolver, LogShootingSolver
+from geomstats.numerics.ivp import GSIVPIntegrator
 from geomstats.vectorization import get_batch_shape
 
 COMPLEX_OBJECTS = (ComplexRiemannianMetric, ComplexManifold)
@@ -730,3 +733,277 @@ class ProductRiemannianMetric(_IterateOverFactorsMixins, RiemannianMetric):
             return self._space.embed_to_product(values)
 
         return geod_fun
+
+
+class WarpedProductMetric(ProductRiemannianMetric):
+    r"""Metric on a warped product manifold.
+
+    The warped product :math:`M = B \times_f F` of a base manifold
+    :math:`(B, g_B)` and a fibre manifold :math:`(F, g_F)`, with smooth
+    positive warping function :math:`f: B \to \mathbb{R}_{>0}`, carries
+    the Riemannian metric
+
+    .. math::
+
+        g_{(b, x)}((v_b, v_x), (w_b, w_x))
+        = g_B(v_b, w_b) + f(b)^2\, g_F(v_x, w_x),
+
+    i.e. the metric is a product metric on the base, while the fibre
+    metric is rescaled by the square of the warping function evaluated
+    at the base point.
+
+    Parameters
+    ----------
+    space : ProductManifold
+        Product manifold with exactly two factors: the base manifold
+        (first factor) and the fibre manifold (second factor).
+    warping_function : callable
+        Smooth positive function on the base manifold. It maps a base
+        point of shape ``(..., base.shape)`` to a positive scalar (or an
+        array of shape ``(...,)``). It should be built from differentiable
+        operations (e.g. through the backend :mod:`geomstats.backend`) so
+        that the Christoffel symbols can be obtained by automatic
+        differentiation.
+
+    Notes
+    -----
+    The exponential and logarithm maps and the geodesics are obtained by
+    integrating the geodesic equation associated with the Levi-Civita
+    connection of the warped metric, whose Christoffel symbols are
+    derived from :func:`metric_matrix` by automatic differentiation. This
+    requires a backend with automatic differentiation (e.g. ``autograd``
+    or ``pytorch``), and only vector points (``point_ndim == 1``) are
+    currently supported.
+
+    The connection is derived from the :func:`metric_matrix` of the two
+    factor metrics, which must therefore be expressed in the intrinsic
+    coordinates of the factors. Metrics whose ``metric_matrix`` is that
+    of an embedding space (e.g. the extrinsic
+    :class:`~geomstats.geometry.hypersphere.HypersphereMetric`) are not
+    supported as factors.
+    """
+
+    def __init__(self, space, warping_function):
+        if len(space.factors) != 2:
+            raise ValueError(
+                "The warped product metric is defined on a product of exactly "
+                "two manifolds (base and fibre); got "
+                f"{len(space.factors)} factors."
+            )
+        super().__init__(space)
+        self.warping_function = warping_function
+        self._instantiate_solvers()
+
+    def _instantiate_solvers(self):
+        """Instantiate solvers for the exponential and logarithm maps."""
+        self.exp_solver = ExpODESolver(
+            self._space, integrator=GSIVPIntegrator(n_steps=100, step_type="rk4")
+        )
+        if gs.has_autodiff():
+            self.log_solver = LogShootingSolver(self._space)
+
+    def _warping_factor(self, base_point):
+        """Evaluate the warping function on the base component of a point."""
+        if base_point is None:
+            raise ValueError("A base point is required for a warped product metric.")
+        base_component, _ = self._space.project_from_product(base_point)
+        f = self.warping_function(base_component)
+        if not gs.is_array(f):
+            f = gs.array(f)
+        batch_shape = base_point.shape[: -self._space.point_ndim]
+        if gs.ndim(f) == 0:
+            return gs.broadcast_to(f, batch_shape) if batch_shape else f
+        return gs.reshape(f, batch_shape)
+
+    def metric_matrix(self, base_point=None):
+        """Compute the matrix of the inner-product.
+
+        Matrix of the inner-product defined by the Riemmanian metric
+        at point ``base_point`` of the manifold. It is block diagonal,
+        with the block of the fibre rescaled by the square of the
+        warping function evaluated at the base component of
+        ``base_point``.
+
+        Parameters
+        ----------
+        base_point : array-like, shape=[..., self.shape]
+            Point on the manifold at which to compute the inner-product
+            matrix. Optional, default: None.
+
+        Returns
+        -------
+        matrix : array-like, shape=[..., dim, dim]
+            Matrix of the inner-product at the base point.
+        """
+        factor_matrices = self._iterate_over_factors(
+            "metric_matrix", {"base_point": base_point}
+        )
+        f = self._warping_factor(base_point)
+        factor_matrices[1] = gs.einsum("...,...ij->...ij", f**2, factor_matrices[1])
+        return _block_diagonal(factor_matrices)
+
+    def inner_product(self, tangent_vec_a, tangent_vec_b, base_point):
+        r"""Compute the inner-product of two tangent vectors at a base point.
+
+        Inner product defined by the Riemannian metric at point
+        ``base_point`` between tangent vectors ``tangent_vec_a`` and
+        ``tangent_vec_b``:
+
+        .. math::
+
+            g(v, w) = g_B(v_b, w_b) + f(b)^2\, g_F(v_f, w_f).
+
+        Parameters
+        ----------
+        tangent_vec_a : array-like, shape=[..., self.shape]
+            First tangent vector at base point.
+        tangent_vec_b : array-like, shape=[..., self.shape]
+            Second tangent vector at base point.
+        base_point : array-like, shape=[..., self.shape]
+            Point on the manifold.
+
+        Returns
+        -------
+        inner_prod : array-like, shape=[...,]
+            Inner-product of the two tangent vectors.
+        """
+        args = {
+            "tangent_vec_a": tangent_vec_a,
+            "tangent_vec_b": tangent_vec_b,
+            "base_point": base_point,
+        }
+        inner_products = self._iterate_over_factors("inner_product", args)
+        f = self._warping_factor(base_point)
+        return inner_products[0] + f**2 * inner_products[1]
+
+    def squared_norm(self, vector, base_point=None):
+        """Compute the square of the norm of a vector.
+
+        Parameters
+        ----------
+        vector : array-like, shape=[..., self.shape]
+            Vector.
+        base_point : array-like, shape=[..., self.shape]
+            Base point. Optional, default: None.
+
+        Returns
+        -------
+        sq_norm : array-like, shape=[...,]
+            Squared norm.
+        """
+        return self.inner_product(vector, vector, base_point)
+
+    def exp(self, tangent_vec, base_point):
+        """Compute the Riemannian exponential of a tangent vector.
+
+        The exponential map is obtained by integrating the geodesic
+        equation of the warped metric (see the class notes).
+
+        Parameters
+        ----------
+        tangent_vec : array-like, shape=[..., self.shape]
+            Tangent vector at a base point.
+        base_point : array-like, shape=[..., self.shape]
+            Point on the manifold.
+
+        Returns
+        -------
+        exp : array-like, shape=[..., self.shape]
+            Point on the manifold equal to the Riemannian exponential
+            of ``tangent_vec`` at the base point.
+        """
+        return Connection.exp(self, tangent_vec, base_point)
+
+    def log(self, point, base_point):
+        """Compute the Riemannian logarithm of a point.
+
+        The logarithm map is computed by shooting (see the class notes).
+
+        Parameters
+        ----------
+        point : array-like, shape=[..., self.shape]
+            Point on the manifold.
+        base_point : array-like, shape=[..., self.shape]
+            Point on the manifold.
+
+        Returns
+        -------
+        log : array-like, shape=[..., self.shape]
+            Tangent vector at the base point equal to the Riemannian
+            logarithm of ``point`` at the base point.
+        """
+        return Connection.log(self, point, base_point)
+
+    def dist(self, point_a, point_b):
+        """Geodesic distance between two points.
+
+        Parameters
+        ----------
+        point_a : array-like, shape=[..., self.shape]
+            Point.
+        point_b : array-like, shape=[..., self.shape]
+            Point.
+
+        Returns
+        -------
+        dist : array-like, shape=[...,]
+            Distance.
+        """
+        return RiemannianMetric.dist(self, point_a, point_b)
+
+    def geodesic(self, initial_point, end_point=None, initial_tangent_vec=None):
+        """Generate parameterized function for the geodesic curve.
+
+        Geodesic curve defined by either:
+
+        - an initial point and an initial tangent vector,
+        - an initial point and an end point.
+
+        Parameters
+        ----------
+        initial_point : array-like, shape=[..., dim]
+            Point on the manifold, initial point of the geodesic.
+        end_point : array-like, shape=[..., dim], optional
+            Point on the manifold, end point of the geodesic. If None,
+            an initial tangent vector must be given.
+        initial_tangent_vec : array-like, shape=[..., dim], optional
+            Tangent vector at base point, the initial speed of the
+            geodesics. If None, an end point must be given and a
+            logarithm is computed.
+
+        Returns
+        -------
+        path : callable
+            Time parameterized geodesic curve.
+        """
+        return Connection.geodesic(self, initial_point, end_point, initial_tangent_vec)
+
+
+class WarpedProductManifold(ProductManifold):
+    r"""Warped product manifold :math:`M = B \times_f F`.
+
+    Convenience class equipping the product manifold of a base and a
+    fibre manifold with the corresponding warped product metric.
+
+    Parameters
+    ----------
+    base : Manifold
+        Base manifold :math:`(B, g_B)`.
+    fiber : Manifold
+        Fibre manifold :math:`(F, g_F)`.
+    warping_function : callable
+        Smooth positive function on the base manifold; see
+        :class:`WarpedProductMetric`.
+    point_ndim : int
+        Point type of the product manifold. Optional, default: 1.
+    equip : bool
+        Whether to equip the manifold with the warped product metric.
+        Optional, default: True.
+    """
+
+    def __init__(self, base, fiber, warping_function, point_ndim=1, equip=True):
+        super().__init__(factors=[base, fiber], point_ndim=point_ndim, equip=False)
+        if equip:
+            self.equip_with_metric(
+                WarpedProductMetric, warping_function=warping_function
+            )

--- a/geomstats/geometry/riemannian_metric.py
+++ b/geomstats/geometry/riemannian_metric.py
@@ -628,6 +628,55 @@ class RiemannianMetric(Connection, ABC):
         cometric_matrix = self.cometric_matrix(base_point)
         return gs.einsum("...ij, ...ij -> ...", cometric_matrix, ricci_tensor)
 
+    def laplacian(self, function, base_point):
+        r"""Compute the Laplace-Beltrami operator applied to a function.
+
+        The Laplace-Beltrami operator (or scalar Laplacian) of a smooth
+        function :math:`f: M \to \mathbb{R}` is the divergence of its
+        gradient. In local coordinates it writes
+
+        .. math::
+
+            \Delta f = g^{ij} (\partial_i \partial_j f
+            - \Gamma^k_{ij} \partial_k f),
+
+        where :math:`g^{ij}` are the components of the cometric matrix
+        and :math:`\Gamma^k_{ij}` the Christoffel symbols of the
+        Levi-Civita connection (with the contravariant index first).
+
+        Parameters
+        ----------
+        function : callable
+            A smooth function on the manifold, mapping a point of shape
+            ``(..., dim)`` to a scalar (or an array of shape ``(...,)``).
+            It should be built from differentiable operations (e.g.
+            through the backend :mod:`geomstats.backend`).
+        base_point : array-like, shape=[..., dim]
+            Point on the manifold at which the Laplacian is evaluated.
+
+        Returns
+        -------
+        laplacian : array-like, shape=[...,]
+            Value of :math:`\Delta f` at ``base_point``.
+
+        Notes
+        -----
+        Requires a backend with automatic differentiation (e.g.
+        ``autograd`` or ``pytorch``), and points represented by vectors
+        (``point_ndim == 1``).
+        """
+        grad = gs.autodiff.jacobian_vec(function)(base_point)
+        hess = gs.autodiff.jacobian_vec(
+            lambda point: gs.autodiff.jacobian_vec(function)(point)
+        )(base_point)
+        cometric = self.cometric_matrix(base_point)
+        christoffels = self.christoffels(base_point)
+        first_term = gs.einsum("...ij,...ij->...", cometric, hess)
+        second_term = gs.einsum(
+            "...ij,...kij,...k->...", cometric, christoffels, grad
+        )
+        return first_term - second_term
+
     def injectivity_radius(self, base_point=None):
         """Compute the radius of the injectivity domain.
 

--- a/tests/tests_geomstats/test_geometry/test_laplacian.py
+++ b/tests/tests_geomstats/test_geometry/test_laplacian.py
@@ -1,0 +1,106 @@
+"""Tests for the Laplace-Beltrami operator.
+
+Lead author: sdoygb.
+"""
+
+import pytest
+
+import geomstats.backend as gs
+from geomstats.exceptions import AutodiffNotImplementedError
+from geomstats.geometry.euclidean import Euclidean
+from geomstats.geometry.product_manifold import WarpedProductManifold
+from geomstats.test.test_case import assert_allclose
+
+AUTODIFF_PRESENT = gs.has_autodiff()
+
+
+@pytest.mark.smoke
+@pytest.mark.skipif(
+    not AUTODIFF_PRESENT, reason="requires an automatic differentiation backend"
+)
+class TestLaplacian:
+    """Tests of the scalar Laplacian against closed forms."""
+
+    @staticmethod
+    def _sphere_like_warped():
+        """g = dtheta^2 + sin^2(theta) dphi^2: the round sphere, local chart."""
+        return WarpedProductManifold(
+            Euclidean(dim=1), Euclidean(dim=1), lambda theta: gs.sin(theta)
+        )
+
+    @staticmethod
+    def _polar_warped():
+        """g = dr^2 + r^2 dy^2: the Euclidean plane in polar-like coordinates."""
+        return WarpedProductManifold(
+            Euclidean(dim=1), Euclidean(dim=1), lambda r: r
+        )
+
+    def test_euclidean_quadratic(self):
+        """On Euclidean space, Delta(x^2 + y^2) = 4."""
+        metric = Euclidean(dim=2).metric
+        function = lambda point: point[0] ** 2 + point[1] ** 2
+        for point in [(1.0, 2.0), (-0.5, 3.0), (2.0, -1.0)]:
+            result = metric.laplacian(function, gs.array(point))
+            assert_allclose(result, 4.0, atol=1e-10)
+
+    def test_sphere_spherical_harmonic(self):
+        """On the round sphere, Delta(cos theta) = -2 cos theta (ell = 1)."""
+        metric = self._sphere_like_warped().metric
+        function = lambda point: gs.cos(point[0])
+        for point in [(1.0, 0.5), (0.6, 2.0), (1.4, -0.8)]:
+            result = metric.laplacian(function, gs.array(point))
+            expected = -2.0 * gs.cos(point[0])
+            assert_allclose(result, expected, atol=1e-8)
+
+    def test_warped_polar_decomposition(self):
+        """Warped-product Laplacian decomposition on g = dr^2 + r^2 dy^2.
+
+        For M = B x_f F the Laplacian splits as
+        Delta_M = Delta_B + f^{-2} Delta_F + m <grad_B ln f, grad_B .>,
+        with m = dim F = 1. For f_M(r, y) = r^2 + cos(y) this gives
+        Delta f = 4 - cos(y) / r^2.
+        """
+        metric = self._polar_warped().metric
+        function = lambda point: point[0] ** 2 + gs.cos(point[1])
+        for point in [(2.0, 0.5), (1.5, 1.2), (3.0, -0.7)]:
+            result = metric.laplacian(function, gs.array(point))
+            expected = 4.0 - gs.cos(point[1]) / point[0] ** 2
+            assert_allclose(result, expected, atol=1e-8)
+
+    def test_linearity(self):
+        """Delta(f + g) = Delta f + Delta g."""
+        metric = Euclidean(dim=2).metric
+        f = lambda point: point[0] ** 2
+        g = lambda point: gs.sin(point[1])
+        base_point = gs.array([1.2, 0.9])
+        result = metric.laplacian(lambda p: f(p) + g(p), base_point)
+        expected = metric.laplacian(f, base_point) + metric.laplacian(g, base_point)
+        assert_allclose(result, expected, atol=1e-10)
+
+    def test_constant_vanishes(self):
+        """Delta of a constant function vanishes."""
+        metric = Euclidean(dim=2).metric
+        base_point = gs.array([1.2, 0.9])
+        result = metric.laplacian(
+            lambda point: 3.0 + 0.0 * point[0], base_point
+        )
+        assert_allclose(result, 0.0, atol=1e-10)
+
+    def test_batched(self):
+        """Batched base points give batched Laplacian values."""
+        metric = Euclidean(dim=2).metric
+        function = lambda point: point[0] ** 2 + point[1] ** 2
+        base_points = gs.array([[1.0, 2.0], [0.5, -1.0]])
+        result = metric.laplacian(function, base_points)
+        assert_allclose(result, gs.array([4.0, 4.0]), atol=1e-10)
+
+
+@pytest.mark.smoke
+@pytest.mark.skipif(AUTODIFF_PRESENT, reason="requires a non-autodiff backend")
+class TestLaplacianWithoutAutodiff:
+    """Without autodiff, the Laplacian raises a clear error."""
+
+    def test_requires_autodiff(self):
+        metric = Euclidean(dim=2).metric
+        with pytest.raises(AutodiffNotImplementedError):
+            metric.laplacian(lambda p: p[0] ** 2, gs.array([1.0, 2.0]))

--- a/tests/tests_geomstats/test_geometry/test_warped_product_metric.py
+++ b/tests/tests_geomstats/test_geometry/test_warped_product_metric.py
@@ -136,7 +136,7 @@ class TestWarpedProductMetricStructure:
             warp.metric.metric_matrix()
 
 
-@pytest.mark.slow
+@pytest.mark.smoke
 @pytest.mark.skipif(
     not AUTODIFF_PRESENT, reason="requires an automatic differentiation backend"
 )

--- a/tests/tests_geomstats/test_geometry/test_warped_product_metric.py
+++ b/tests/tests_geomstats/test_geometry/test_warped_product_metric.py
@@ -1,0 +1,294 @@
+"""Tests for the warped product metric.
+
+Lead author: sdoygb.
+"""
+
+import pytest
+
+import geomstats.backend as gs
+from geomstats.geometry.euclidean import Euclidean
+from geomstats.geometry.product_manifold import (
+    ProductManifold,
+    WarpedProductManifold,
+    WarpedProductMetric,
+)
+from geomstats.test.test_case import assert_allclose
+
+AUTODIFF_PRESENT = gs.has_autodiff()
+
+
+class TestWarpedProductMetricStructure:
+    """Tests of the metric structure, valid on any backend."""
+
+    @staticmethod
+    def _euclidean_warped(base_dim=1, fiber_dim=2, warping=None):
+        if warping is None:
+            warping = lambda r: 1.0 + r**2
+        return WarpedProductManifold(
+            Euclidean(dim=base_dim), Euclidean(dim=fiber_dim), warping
+        )
+
+    def test_inner_product_matches_analytic(self):
+        """inner_product equals g_B + f(b)^2 g_F."""
+        warp = self._euclidean_warped()
+        metric = warp.metric
+        base_point = gs.array([1.5, 0.3, -0.7])
+        tangent_vec_a = gs.array([0.2, 1.0, -0.5])
+        tangent_vec_b = gs.array([-0.4, 0.3, 2.0])
+        f = 1.0 + base_point[0] ** 2
+
+        expected = tangent_vec_a[0] * tangent_vec_b[0] + f**2 * gs.dot(
+            tangent_vec_a[1:], tangent_vec_b[1:]
+        )
+        result = metric.inner_product(tangent_vec_a, tangent_vec_b, base_point)
+        assert_allclose(result, expected)
+
+    def test_inner_product_batched(self):
+        """Batched inner products match the per-point results."""
+        warp = self._euclidean_warped()
+        metric = warp.metric
+        base_point = gs.array([1.5, 0.3, -0.7])
+        tangent_vec_a = gs.array([0.2, 1.0, -0.5])
+        tangent_vec_b = gs.array([-0.4, 0.3, 2.0])
+
+        base_points = gs.stack([base_point, 2.0 * base_point])
+        tangent_vecs_a = gs.stack([tangent_vec_a, 2.0 * tangent_vec_a])
+        tangent_vecs_b = gs.stack([tangent_vec_b, tangent_vec_b])
+
+        result = metric.inner_product(tangent_vecs_a, tangent_vecs_b, base_points)
+        expected = gs.stack(
+            [
+                metric.inner_product(tangent_vec_a, tangent_vec_b, base_point),
+                metric.inner_product(
+                    2.0 * tangent_vec_a, tangent_vec_b, 2.0 * base_point
+                ),
+            ]
+        )
+        assert_allclose(result, expected)
+
+    def test_squared_norm_matches_inner_product(self):
+        """squared_norm is the inner product of a vector with itself."""
+        warp = self._euclidean_warped()
+        metric = warp.metric
+        base_point = gs.array([1.5, 0.3, -0.7])
+        vector = gs.array([0.2, 1.0, -0.5])
+        result = metric.squared_norm(vector, base_point)
+        expected = metric.inner_product(vector, vector, base_point)
+        assert_allclose(result, expected)
+
+    def test_metric_matrix_block_structure(self):
+        """The metric matrix is block diagonal with the fibre rescaled by f^2."""
+        warp = self._euclidean_warped()
+        metric = warp.metric
+        base_point = gs.array([1.5, 0.3, -0.7])
+        f = 1.0 + base_point[0] ** 2
+        expected = gs.array(
+            [[1.0, 0.0, 0.0], [0.0, f**2, 0.0], [0.0, 0.0, f**2]]
+        )
+        result = metric.metric_matrix(base_point)
+        assert_allclose(result, expected)
+
+    def test_constant_warping_scales_fibre(self):
+        """A constant warping f == c rescales the fibre block by c^2."""
+        warp = self._euclidean_warped(warping=lambda r: 3.0)
+        metric = warp.metric
+        base_point = gs.array([1.5, 0.3, -0.7])
+        expected = gs.array(
+            [[1.0, 0.0, 0.0], [0.0, 9.0, 0.0], [0.0, 0.0, 9.0]]
+        )
+        result = metric.metric_matrix(base_point)
+        assert_allclose(result, expected)
+
+    def test_warping_scales_fibre_norm(self):
+        """The norm of a fibre vector is rescaled by f (and f^2 in sq. norm)."""
+        warp = self._euclidean_warped()
+        metric = warp.metric
+        fiber_vec = gs.array([0.0, 1.0, 0.0])
+        base_1 = gs.array([1.0, 0.0, 0.0])
+        base_2 = gs.array([2.0, 0.0, 0.0])
+        f1, f2 = 1.0 + 1.0, 1.0 + 4.0
+        result = metric.norm(fiber_vec, base_2) / metric.norm(fiber_vec, base_1)
+        assert_allclose(result, f2 / f1)
+
+    def test_polar_metric_matrix(self):
+        """g = dr^2 + r^2 dy^2 for the warping f(r) = r."""
+        warp = WarpedProductManifold(
+            Euclidean(dim=1), Euclidean(dim=1), lambda r: r
+        )
+        metric = warp.metric
+        for r, y in [(2.0, 0.5), (1.3, -0.7), (0.7, 1.9)]:
+            expected = gs.array([[1.0, 0.0], [0.0, r**2]])
+            result = metric.metric_matrix(gs.array([r, y]))
+            assert_allclose(result, expected)
+
+    def test_requires_two_factors(self):
+        """The warped product metric requires exactly two factors."""
+        space = ProductManifold(
+            [Euclidean(dim=1), Euclidean(dim=1), Euclidean(dim=1)], equip=False
+        )
+        with pytest.raises(ValueError):
+            WarpedProductMetric(space, lambda r: 1.0 + r**2)
+
+    def test_base_point_is_required(self):
+        """The metric matrix requires a base point."""
+        warp = self._euclidean_warped()
+        with pytest.raises(ValueError):
+            warp.metric.metric_matrix()
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(
+    not AUTODIFF_PRESENT, reason="requires an automatic differentiation backend"
+)
+class TestWarpedProductMetricDifferential:
+    """Tests of exp, log and geodesics (require autodiff)."""
+
+    @staticmethod
+    def _polar_warped():
+        """g = dr^2 + r^2 dy^2: the Euclidean plane in polar-like coordinates."""
+        return WarpedProductManifold(
+            Euclidean(dim=1), Euclidean(dim=1), lambda r: r
+        )
+
+    @staticmethod
+    def _sphere_like_warped():
+        """g = dtheta^2 + sin^2(theta) dphi^2: the round sphere, local chart."""
+        return WarpedProductManifold(
+            Euclidean(dim=1), Euclidean(dim=1), lambda theta: gs.sin(theta)
+        )
+
+    @staticmethod
+    def _polar_to_cartesian(r, y):
+        return r * gs.cos(y), r * gs.sin(y)
+
+    @staticmethod
+    def _cartesian_to_polar(x, y):
+        return gs.sqrt(x**2 + y**2), gs.arctan2(y, x)
+
+    def test_exp_matches_euclidean_polar(self):
+        """For g = dr^2 + r^2 dy^2, exp is a straight line in cartesian coords."""
+        metric = self._polar_warped().metric
+        r0, y0, v_r, v_y = 2.0, 0.6, 0.2, 0.35
+        base_point = gs.array([r0, y0])
+        tangent_vec = gs.array([v_r, v_y])
+
+        x0, cart_y0 = self._polar_to_cartesian(r0, y0)
+        vx = v_r * gs.cos(y0) - r0 * v_y * gs.sin(y0)
+        vy = v_r * gs.sin(y0) + r0 * v_y * gs.cos(y0)
+        r1, y1 = self._cartesian_to_polar(x0 + vx, cart_y0 + vy)
+
+        result = metric.exp(tangent_vec, base_point)
+        expected = gs.array([r1, y1])
+        assert_allclose(result, expected, atol=1e-3)
+
+    def test_log_matches_euclidean_polar(self):
+        """log inverts the straight-line exp of the polar metric."""
+        metric = self._polar_warped().metric
+        r0, y0, v_r, v_y = 2.0, 0.6, 0.2, 0.35
+        base_point = gs.array([r0, y0])
+        tangent_vec = gs.array([v_r, v_y])
+        end_point = metric.exp(tangent_vec, base_point)
+
+        result = metric.log(end_point, base_point)
+        assert_allclose(result, tangent_vec, atol=1e-2)
+
+    def test_geodesic_matches_euclidean_polar(self):
+        """Midpoints of warped geodesics are straight lines in cartesian coords."""
+        metric = self._polar_warped().metric
+        r0, y0, v_r, v_y = 2.0, 0.6, 0.2, 0.35
+        base_point = gs.array([r0, y0])
+        tangent_vec = gs.array([v_r, v_y])
+
+        x0, cart_y0 = self._polar_to_cartesian(r0, y0)
+        vx = v_r * gs.cos(y0) - r0 * v_y * gs.sin(y0)
+        vy = v_r * gs.sin(y0) + r0 * v_y * gs.cos(y0)
+
+        t = 0.4
+        point = gs.squeeze(
+            metric.geodesic(
+                initial_point=base_point, initial_tangent_vec=tangent_vec
+            )(t)
+        )
+        r_t, y_t = self._cartesian_to_polar(x0 + t * vx, cart_y0 + t * vy)
+        expected = gs.array([r_t, y_t])
+        assert_allclose(point, expected, atol=1e-3)
+
+    def test_exp_log_roundtrip(self):
+        """exp(log(q, p), p) recovers q for a non-constant warping."""
+        warp = WarpedProductManifold(
+            Euclidean(dim=1), Euclidean(dim=2), lambda r: 1.0 + r**2
+        )
+        metric = warp.metric
+        base_point = gs.array([1.5, 0.3, -0.7])
+        point = gs.array([1.9, -0.4, 0.8])
+        tangent_vec = metric.log(point, base_point)
+        result = metric.exp(tangent_vec, base_point)
+        assert_allclose(result, point, atol=1e-2)
+
+    def test_geodesic_length_matches_initial_speed(self):
+        """The length of a warped geodesic over [0, 1] equals |v|."""
+        warp = WarpedProductManifold(
+            Euclidean(dim=1), Euclidean(dim=2), lambda r: 1.0 + r**2
+        )
+        metric = warp.metric
+        base_point = gs.array([1.5, 0.3, -0.7])
+        tangent_vec = gs.array([0.2, 1.0, -0.5])
+        geodesic = metric.geodesic(
+            initial_point=base_point, initial_tangent_vec=tangent_vec
+        )
+        end_point = geodesic(1.0)
+        distance = metric.dist(base_point, end_point)
+        speed = metric.norm(tangent_vec, base_point)
+        assert_allclose(distance, speed, atol=1e-2)
+
+    def test_meridian_geodesic_sphere_like(self):
+        """For g = dtheta^2 + sin^2theta dphi^2, a meridian is a geodesic."""
+        metric = self._sphere_like_warped().metric
+        theta0, phi0, v_theta = 1.0, 0.7, 0.4
+        base_point = gs.array([theta0, phi0])
+        tangent_vec = gs.array([v_theta, 0.0])
+        geodesic = metric.geodesic(
+            initial_point=base_point, initial_tangent_vec=tangent_vec
+        )
+        for t in (0.3, 0.6, 1.0):
+            expected = gs.array([theta0 + v_theta * t, phi0])
+            assert_allclose(gs.squeeze(geodesic(t)), expected, atol=1e-3)
+
+    def test_equator_geodesic_sphere_like(self):
+        """For g = dtheta^2 + sin^2theta dphi^2, the equator is a geodesic."""
+        metric = self._sphere_like_warped().metric
+        base_point = gs.array([gs.pi / 2, 0.4])
+        tangent_vec = gs.array([0.0, 0.5])
+        point = gs.squeeze(
+            metric.geodesic(
+                initial_point=base_point, initial_tangent_vec=tangent_vec
+            )(0.7)
+        )
+        expected = gs.array([gs.pi / 2, 0.4 + 0.5 * 0.7])
+        assert_allclose(point, expected, atol=1e-3)
+
+    def test_constant_warping_geodesics_are_linear(self):
+        """For constant f, geodesics are straight lines in product coords."""
+        warp = WarpedProductManifold(
+            Euclidean(dim=1), Euclidean(dim=1), lambda r: 3.0
+        )
+        metric = warp.metric
+        base_point = gs.array([1.0, 0.5])
+        tangent_vec = gs.array([0.3, -0.2])
+        end_point = metric.exp(tangent_vec, base_point)
+        expected = base_point + tangent_vec
+        assert_allclose(end_point, expected, atol=1e-3)
+
+    def test_warping_couples_base_and_fibre(self):
+        """A pure-fibre velocity curves the base component (unlike a product)."""
+        metric = self._polar_warped().metric
+        base_point = gs.array([2.0, 0.0])
+        tangent_vec = gs.array([0.0, 0.5])
+        point = gs.squeeze(
+            metric.geodesic(
+                initial_point=base_point, initial_tangent_vec=tangent_vec
+            )(0.5)
+        )
+
+        # a product metric would keep r = 2 constant; the warped one curves it
+        assert point[0] > base_point[0]


### PR DESCRIPTION
### Description

Implements the **scalar Laplacian (Laplace–Beltrami operator)** on `RiemannianMetric`, per the design discussion in #1871:

```python
metric.laplacian(function, base_point)
```

with

$$\Delta f = g^{ij}\left(\partial_i \partial_j f - \Gamma^k_{ij} \partial_k f\right),$$

computed pointwise by automatic differentiation, reusing the existing `cometric_matrix` and `christoffels` machinery — no new function-domain abstraction needed (as discussed with @juanitorduz and @luisfpereira). Requires an autodiff backend and vector points, consistent with the rest of the connection machinery.

**Validation with machine-precision closed forms:**

| Manifold | Function | Closed form |
|---|---|---|
| Euclidean E² | x² + y² | Δf = 4 |
| Round sphere (as sphere-like warped metric dθ² + sin²θ dφ²) | cos θ | Δf = −2 cos θ (the ℓ = 1 spherical harmonic) |
| Polar metric dr² + r² dy² (warped product) | r² + cos y | Δf = 4 − cos(y)/r² — verifies the warped-product decomposition Δ = Δ_B + f⁻²Δ_F + m⟨grad_B ln f, grad_B ·⟩ |
| Euclidean E² | f + g, constants, batched | linearity, Δ(const) = 0, vectorization |

The sphere and polar cases cross-validate the **warped product metrics of #2125** (this PR is stacked on it and uses `WarpedProductManifold` as a test ground; once #2125 merges, the diff reduces to the Laplacian alone).

### Checklist

- [x] Clear and explanatory title
- [x] Vectorized implementation
- [x] Appropriate unit tests added (autograd: 6 passed; numpy: autodiff-gated skip + clear-error test)
- [x] PEP8 / ruff clean on touched files
- [x] Properly documented

Closes #1871
